### PR TITLE
feat(instance_server): always default to sbs volume root volume

### DIFF
--- a/internal/services/block/snapshot_data_source_test.go
+++ b/internal/services/block/snapshot_data_source_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/acctest"
-	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/block/testfuncs"
+	blocktestfuncs "github.com/scaleway/terraform-provider-scaleway/v2/internal/services/block/testfuncs"
 )
 
 func TestAccDataSourceSnapshot_Basic(t *testing.T) {

--- a/internal/services/block/snapshot_data_source_test.go
+++ b/internal/services/block/snapshot_data_source_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/acctest"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/block/testfuncs"
 )
 
 func TestAccDataSourceSnapshot_Basic(t *testing.T) {
@@ -14,7 +15,7 @@ func TestAccDataSourceSnapshot_Basic(t *testing.T) {
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: tt.ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
-			isSnapshotDestroyed(tt),
+			blocktestfuncs.IsSnapshotDestroyed(tt),
 		),
 		Steps: []resource.TestStep{
 			{
@@ -38,7 +39,7 @@ func TestAccDataSourceSnapshot_Basic(t *testing.T) {
 					}
 				`,
 				Check: resource.ComposeTestCheckFunc(
-					isSnapshotPresent(tt, "scaleway_block_snapshot.main"),
+					blocktestfuncs.IsSnapshotPresent(tt, "scaleway_block_snapshot.main"),
 
 					resource.TestCheckResourceAttrPair("scaleway_block_snapshot.main", "name", "data.scaleway_block_snapshot.find_by_name", "name"),
 					resource.TestCheckResourceAttrPair("scaleway_block_snapshot.main", "name", "data.scaleway_block_snapshot.find_by_id", "name"),

--- a/internal/services/block/snapshot_test.go
+++ b/internal/services/block/snapshot_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/acctest"
-	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/block/testfuncs"
+	blocktestfuncs "github.com/scaleway/terraform-provider-scaleway/v2/internal/services/block/testfuncs"
 )
 
 func TestAccSnapshot_Basic(t *testing.T) {

--- a/internal/services/block/snapshot_test.go
+++ b/internal/services/block/snapshot_test.go
@@ -1,15 +1,11 @@
 package block_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	blockSDK "github.com/scaleway/scaleway-sdk-go/api/block/v1alpha1"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/acctest"
-	"github.com/scaleway/terraform-provider-scaleway/v2/internal/httperrors"
-	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/block"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/block/testfuncs"
 )
 
 func TestAccSnapshot_Basic(t *testing.T) {
@@ -19,7 +15,7 @@ func TestAccSnapshot_Basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: tt.ProviderFactories,
-		CheckDestroy:      isSnapshotDestroyed(tt),
+		CheckDestroy:      blocktestfuncs.IsSnapshotDestroyed(tt),
 		Steps: []resource.TestStep{
 			{
 				Config: `
@@ -34,65 +30,11 @@ func TestAccSnapshot_Basic(t *testing.T) {
 					}
 				`,
 				Check: resource.ComposeTestCheckFunc(
-					isSnapshotPresent(tt, "scaleway_block_snapshot.main"),
+					blocktestfuncs.IsSnapshotPresent(tt, "scaleway_block_snapshot.main"),
 					acctest.CheckResourceAttrUUID("scaleway_block_snapshot.main", "id"),
 					resource.TestCheckResourceAttr("scaleway_block_snapshot.main", "name", "test-block-snapshot-basic"),
 				),
 			},
 		},
 	})
-}
-
-func isSnapshotPresent(tt *acctest.TestTools, n string) resource.TestCheckFunc {
-	return func(state *terraform.State) error {
-		rs, ok := state.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("resource not found: %s", n)
-		}
-
-		api, zone, id, err := block.NewAPIWithZoneAndID(tt.Meta, rs.Primary.ID)
-		if err != nil {
-			return err
-		}
-
-		_, err = api.GetSnapshot(&blockSDK.GetSnapshotRequest{
-			SnapshotID: id,
-			Zone:       zone,
-		})
-		if err != nil {
-			return err
-		}
-
-		return nil
-	}
-}
-
-func isSnapshotDestroyed(tt *acctest.TestTools) resource.TestCheckFunc {
-	return func(state *terraform.State) error {
-		for _, rs := range state.RootModule().Resources {
-			if rs.Type != "scaleway_block_snapshot" {
-				continue
-			}
-
-			api, zone, id, err := block.NewAPIWithZoneAndID(tt.Meta, rs.Primary.ID)
-			if err != nil {
-				return err
-			}
-
-			err = api.DeleteSnapshot(&blockSDK.DeleteSnapshotRequest{
-				SnapshotID: id,
-				Zone:       zone,
-			})
-
-			if err == nil {
-				return fmt.Errorf("block snapshot (%s) still exists", rs.Primary.ID)
-			}
-
-			if !httperrors.Is404(err) {
-				return err
-			}
-		}
-
-		return nil
-	}
 }

--- a/internal/services/block/testfuncs/checks.go
+++ b/internal/services/block/testfuncs/checks.go
@@ -1,0 +1,120 @@
+package blocktestfuncs
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	blockSDK "github.com/scaleway/scaleway-sdk-go/api/block/v1alpha1"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/acctest"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/httperrors"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/block"
+)
+
+func IsSnapshotPresent(tt *acctest.TestTools, n string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		rs, ok := state.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", n)
+		}
+
+		api, zone, id, err := block.NewAPIWithZoneAndID(tt.Meta, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		_, err = api.GetSnapshot(&blockSDK.GetSnapshotRequest{
+			SnapshotID: id,
+			Zone:       zone,
+		})
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+func IsVolumePresent(tt *acctest.TestTools, n string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		rs, ok := state.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", n)
+		}
+
+		api, zone, id, err := block.NewAPIWithZoneAndID(tt.Meta, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		_, err = api.GetVolume(&blockSDK.GetVolumeRequest{
+			VolumeID: id,
+			Zone:     zone,
+		})
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+func IsVolumeDestroyed(tt *acctest.TestTools) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		for _, rs := range state.RootModule().Resources {
+			if rs.Type != "scaleway_block_volume" {
+				continue
+			}
+
+			api, zone, id, err := block.NewAPIWithZoneAndID(tt.Meta, rs.Primary.ID)
+			if err != nil {
+				return err
+			}
+
+			err = api.DeleteVolume(&blockSDK.DeleteVolumeRequest{
+				VolumeID: id,
+				Zone:     zone,
+			})
+
+			if err == nil {
+				return fmt.Errorf("block volume (%s) still exists", rs.Primary.ID)
+			}
+
+			if !httperrors.Is404(err) && !httperrors.Is410(err) {
+				return err
+			}
+		}
+
+		return nil
+	}
+}
+
+func IsSnapshotDestroyed(tt *acctest.TestTools) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		for _, rs := range state.RootModule().Resources {
+			if rs.Type != "scaleway_block_snapshot" {
+				continue
+			}
+
+			api, zone, id, err := block.NewAPIWithZoneAndID(tt.Meta, rs.Primary.ID)
+			if err != nil {
+				return err
+			}
+
+			err = api.DeleteSnapshot(&blockSDK.DeleteSnapshotRequest{
+				SnapshotID: id,
+				Zone:       zone,
+			})
+
+			if err == nil {
+				return fmt.Errorf("block snapshot (%s) still exists", rs.Primary.ID)
+			}
+
+			if !httperrors.Is404(err) {
+				return err
+			}
+		}
+
+		return nil
+	}
+}

--- a/internal/services/block/volume_data_source_test.go
+++ b/internal/services/block/volume_data_source_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/acctest"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/block/testfuncs"
 )
 
 func TestAccDataSourceVolume_Basic(t *testing.T) {
@@ -14,7 +15,7 @@ func TestAccDataSourceVolume_Basic(t *testing.T) {
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: tt.ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
-			isVolumeDestroyed(tt),
+			blocktestfuncs.IsVolumeDestroyed(tt),
 		),
 		Steps: []resource.TestStep{
 			{
@@ -34,7 +35,7 @@ func TestAccDataSourceVolume_Basic(t *testing.T) {
 					}
 				`,
 				Check: resource.ComposeTestCheckFunc(
-					isVolumePresent(tt, "scaleway_block_volume.main"),
+					blocktestfuncs.IsVolumePresent(tt, "scaleway_block_volume.main"),
 
 					resource.TestCheckResourceAttrPair("scaleway_block_volume.main", "name", "data.scaleway_block_volume.find_by_name", "name"),
 					resource.TestCheckResourceAttrPair("scaleway_block_volume.main", "name", "data.scaleway_block_volume.find_by_id", "name"),

--- a/internal/services/block/volume_data_source_test.go
+++ b/internal/services/block/volume_data_source_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/acctest"
-	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/block/testfuncs"
+	blocktestfuncs "github.com/scaleway/terraform-provider-scaleway/v2/internal/services/block/testfuncs"
 )
 
 func TestAccDataSourceVolume_Basic(t *testing.T) {

--- a/internal/services/block/volume_test.go
+++ b/internal/services/block/volume_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/acctest"
-	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/block/testfuncs"
+	blocktestfuncs "github.com/scaleway/terraform-provider-scaleway/v2/internal/services/block/testfuncs"
 )
 
 func TestAccVolume_Basic(t *testing.T) {

--- a/internal/services/instance/helpers_instance.go
+++ b/internal/services/instance/helpers_instance.go
@@ -508,21 +508,10 @@ func instanceServerAdditionalVolumeTemplate(api *BlockAndInstanceAPI, zone scw.Z
 }
 
 func prepareRootVolume(rootVolumeI map[string]any, serverType *instance.ServerType, image string) *UnknownVolume {
-	serverTypeCanBootOnBlock := serverType.VolumesConstraint.MaxSize == 0
-
 	rootVolumeIsBootVolume := types.ExpandBoolPtr(types.GetMapValue[bool](rootVolumeI, "boot"))
 	rootVolumeType := types.GetMapValue[string](rootVolumeI, "volume_type")
 	sizeInput := types.GetMapValue[int](rootVolumeI, "size_in_gb")
 	rootVolumeID := zonal.ExpandID(types.GetMapValue[string](rootVolumeI, "volume_id")).ID
-
-	// If the rootVolumeType is not defined, define it depending on the offer
-	if rootVolumeType == "" {
-		if serverTypeCanBootOnBlock {
-			rootVolumeType = instance.VolumeVolumeTypeSbsVolume.String()
-		} else {
-			rootVolumeType = instance.VolumeVolumeTypeLSSD.String()
-		}
-	}
 
 	rootVolumeName := ""
 	if image == "" { // When creating an instance from an image, volume should not have a name

--- a/internal/services/instance/image_test.go
+++ b/internal/services/instance/image_test.go
@@ -9,6 +9,7 @@ import (
 	instanceSDK "github.com/scaleway/scaleway-sdk-go/api/instance/v1"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/acctest"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/httperrors"
+	blocktestfuncs "github.com/scaleway/terraform-provider-scaleway/v2/internal/services/block/testfuncs"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/instance"
 	instancechecks "github.com/scaleway/terraform-provider-scaleway/v2/internal/services/instance/testfuncs"
 )
@@ -223,22 +224,21 @@ func TestAccImage_Server(t *testing.T) {
 						type 	= "DEV1-S"
 					}
 
-					resource "scaleway_instance_snapshot" "main" {
+					resource "scaleway_block_snapshot" "main" {
 						volume_id	= scaleway_instance_server.main.root_volume.0.volume_id
 						depends_on 	= [ scaleway_instance_server.main ]
 					}
 
 					resource "scaleway_instance_image" "main" {
-						root_volume_id 			= scaleway_instance_snapshot.main.id
+						root_volume_id 			= scaleway_block_snapshot.main.id
 						tags 					= ["test_remove_tags"]
-						depends_on 				= [ scaleway_instance_snapshot.main ]
 					}
 				`,
 				Check: resource.ComposeTestCheckFunc(
 					isServerPresent(tt, "scaleway_instance_server.main"),
-					isSnapshotPresent(tt, "scaleway_instance_snapshot.main"),
+					blocktestfuncs.IsSnapshotPresent(tt, "scaleway_block_snapshot.main"),
 					instancechecks.DoesImageExists(tt, "scaleway_instance_image.main"),
-					resource.TestCheckResourceAttrPair("scaleway_instance_image.main", "root_volume_id", "scaleway_instance_snapshot.main", "id"),
+					resource.TestCheckResourceAttrPair("scaleway_instance_image.main", "root_volume_id", "scaleway_block_snapshot.main", "id"),
 					resource.TestCheckResourceAttr("scaleway_instance_image.main", "tags.0", "test_remove_tags"),
 					resource.TestCheckResourceAttrSet("scaleway_instance_image.main", "name"),
 					resource.TestCheckResourceAttr("scaleway_instance_image.main", "architecture", "x86_64"),
@@ -252,21 +252,20 @@ func TestAccImage_Server(t *testing.T) {
 						type 	= "DEV1-S"
 					}
 
-					resource "scaleway_instance_snapshot" "main" {
+					resource "scaleway_block_snapshot" "main" {
 						volume_id 	= scaleway_instance_server.main.root_volume.0.volume_id
 						depends_on	= [ scaleway_instance_server.main ]
 					}
 
 					resource "scaleway_instance_image" "main" {
-						root_volume_id 			= scaleway_instance_snapshot.main.id
-						depends_on 				= [ scaleway_instance_snapshot.main ]
+						root_volume_id 			= scaleway_block_snapshot.main.id
 					}
 				`,
 				Check: resource.ComposeTestCheckFunc(
 					isServerPresent(tt, "scaleway_instance_server.main"),
-					isSnapshotPresent(tt, "scaleway_instance_snapshot.main"),
+					blocktestfuncs.IsSnapshotPresent(tt, "scaleway_block_snapshot.main"),
 					instancechecks.DoesImageExists(tt, "scaleway_instance_image.main"),
-					resource.TestCheckResourceAttrPair("scaleway_instance_image.main", "root_volume_id", "scaleway_instance_snapshot.main", "id"),
+					resource.TestCheckResourceAttrPair("scaleway_instance_image.main", "root_volume_id", "scaleway_block_snapshot.main", "id"),
 					resource.TestCheckResourceAttr("scaleway_instance_image.main", "tags.#", "0"),
 					resource.TestCheckNoResourceAttr("scaleway_instance_image.main", "tags.0"),
 					resource.TestCheckResourceAttrSet("scaleway_instance_image.main", "name"),
@@ -305,6 +304,9 @@ func TestAccImage_ServerWithBlockVolume(t *testing.T) {
 					resource "scaleway_instance_server" "server" {
 						image	= "ubuntu_focal"
 						type 	= "DEV1-S"
+						root_volume {
+							volume_type = "l_ssd"
+						}
 					}
 				`,
 				Check: resource.ComposeTestCheckFunc(
@@ -328,6 +330,9 @@ func TestAccImage_ServerWithBlockVolume(t *testing.T) {
 					resource "scaleway_instance_server" "server" {
 						image	= "ubuntu_focal"
 						type 	= "DEV1-S"
+						root_volume {
+							volume_type = "l_ssd"
+						}
 					}
 					resource "scaleway_instance_snapshot" "server" {
 						volume_id 	= scaleway_instance_server.server.root_volume.0.volume_id
@@ -383,6 +388,9 @@ func TestAccImage_ServerWithBlockVolume(t *testing.T) {
 					resource "scaleway_instance_server" "server" {
 						image	= "ubuntu_focal"
 						type 	= "DEV1-S"
+						root_volume {
+							volume_type = "l_ssd"
+						}
 					}
 					resource "scaleway_instance_snapshot" "server" {
 						volume_id 	= scaleway_instance_server.server.root_volume.0.volume_id

--- a/internal/services/instance/snapshot_test.go
+++ b/internal/services/instance/snapshot_test.go
@@ -94,6 +94,9 @@ func TestAccSnapshot_Server(t *testing.T) {
 					resource "scaleway_instance_server" "main" {
 						image = "ubuntu_focal"
 						type = "DEV1-S"
+						root_volume {
+							volume_type = "l_ssd"
+						}
 					}
 
 					resource "scaleway_instance_snapshot" "main" {

--- a/internal/services/instance/testdata/data-source-private-nic-basic.cassette.yaml
+++ b/internal/services/instance/testdata/data-source-private-nic-basic.cassette.yaml
@@ -16,7 +16,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
         method: GET
       response:
@@ -25,22 +25,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 38539
+        content_length: 35639
         uncompressed: false
-        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
+        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
         headers:
             Content-Length:
-                - "38539"
+                - "35639"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:02 GMT
+                - Wed, 12 Feb 2025 16:13:03 GMT
             Link:
                 - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,12 +48,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7654b6b2-c2bb-496b-bedc-434720b38e47
+                - 821519f8-d5e2-4217-bc85-364a08e0297b
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 60.030833ms
+        duration: 1.068491958s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -69,7 +69,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
         method: GET
       response:
@@ -78,22 +78,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 14208
+        content_length: 13164
         uncompressed: false
-        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
         headers:
             Content-Length:
-                - "14208"
+                - "13164"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:03 GMT
+                - Wed, 12 Feb 2025 16:13:03 GMT
             Link:
                 - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -101,12 +101,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a150b931-7cce-430e-a082-30f739b6f6b6
+                - f93b2811-671e-4d39-81bf-adcdd1e7b670
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 52.534ms
+        duration: 73.738416ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -122,8 +122,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=type_asc&type=instance_local&zone=fr-par-1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=type_asc&type=instance_sbs&zone=fr-par-1
         method: GET
       response:
         proto: HTTP/2.0
@@ -131,20 +131,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1300
+        content_length: 1296
         uncompressed: false
-        body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"2982a1c0-be7e-4114-af3d-a8af8aa7aec5","label":"ubuntu_jammy","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","label":"ubuntu_jammy","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
+        body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","label":"ubuntu_jammy","type":"instance_sbs","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"7044ae1e-a35d-4364-a962-93811c845f2f","label":"ubuntu_jammy","type":"instance_sbs","zone":"fr-par-1"}],"total_count":2}'
         headers:
             Content-Length:
-                - "1300"
+                - "1296"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:03 GMT
+                - Wed, 12 Feb 2025 16:13:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -152,28 +152,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 42eefd8c-6057-4d63-b0af-816e4deb47bb
+                - 3c5b85b2-6656-4a59-8d91-36766ff3f38a
         status: 200 OK
         code: 200
-        duration: 108.209458ms
+        duration: 112.58025ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 112
+        content_length: 111
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-pn-vigorous-chaplygin","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"subnets":null}'
+        body: '{"name":"tf-pn-elastic-chebyshev","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"subnets":null}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
         method: POST
       response:
@@ -182,20 +182,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1051
+        content_length: 1050
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:47:03.421659Z","dhcp_enabled":true,"id":"838a9738-7cef-4308-bbee-25ff53b20ce5","name":"tf-pn-vigorous-chaplygin","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:47:03.421659Z","id":"f2d8d666-f472-44be-b06e-d76965dbf0e6","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.12.0/22","updated_at":"2025-01-27T13:47:03.421659Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:47:03.421659Z","id":"0be85e76-3de9-4eab-9ce6-20ff83b7b805","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:ae0f::/64","updated_at":"2025-01-27T13:47:03.421659Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:47:03.421659Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"created_at":"2025-02-12T16:13:03.623130Z","dhcp_enabled":true,"id":"922af88d-e868-402d-a480-8efe90285dee","name":"tf-pn-elastic-chebyshev","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:13:03.623130Z","id":"72d2b814-5717-4572-a1a4-5f65fde886c4","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.16.0/22","updated_at":"2025-02-12T16:13:03.623130Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-12T16:13:03.623130Z","id":"8cb49209-9d7e-4a24-9d71-3d74339464f8","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:e334::/64","updated_at":"2025-02-12T16:13:03.623130Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-12T16:13:03.623130Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "1051"
+                - "1050"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:03 GMT
+                - Wed, 12 Feb 2025 16:13:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -203,10 +203,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0ddf2276-8659-4493-90e5-d36bf5700f29
+                - daca3f9b-360d-4d57-ba8a-78ed340e646a
         status: 200 OK
         code: 200
-        duration: 639.876875ms
+        duration: 1.786145541s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -222,8 +222,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/838a9738-7cef-4308-bbee-25ff53b20ce5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/922af88d-e868-402d-a480-8efe90285dee
         method: GET
       response:
         proto: HTTP/2.0
@@ -231,20 +231,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1051
+        content_length: 1050
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:47:03.421659Z","dhcp_enabled":true,"id":"838a9738-7cef-4308-bbee-25ff53b20ce5","name":"tf-pn-vigorous-chaplygin","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:47:03.421659Z","id":"f2d8d666-f472-44be-b06e-d76965dbf0e6","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.12.0/22","updated_at":"2025-01-27T13:47:03.421659Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:47:03.421659Z","id":"0be85e76-3de9-4eab-9ce6-20ff83b7b805","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:ae0f::/64","updated_at":"2025-01-27T13:47:03.421659Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:47:03.421659Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"created_at":"2025-02-12T16:13:03.623130Z","dhcp_enabled":true,"id":"922af88d-e868-402d-a480-8efe90285dee","name":"tf-pn-elastic-chebyshev","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:13:03.623130Z","id":"72d2b814-5717-4572-a1a4-5f65fde886c4","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.16.0/22","updated_at":"2025-02-12T16:13:03.623130Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-12T16:13:03.623130Z","id":"8cb49209-9d7e-4a24-9d71-3d74339464f8","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:e334::/64","updated_at":"2025-02-12T16:13:03.623130Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-12T16:13:03.623130Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "1051"
+                - "1050"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:04 GMT
+                - Wed, 12 Feb 2025 16:13:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -252,28 +252,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 512cbc6c-1d59-432d-8ea4-b845fcbb3a1e
+                - b9c615e3-edf9-40b8-866d-a0a12ebd9aa1
         status: 200 OK
         code: 200
-        duration: 77.114583ms
+        duration: 115.523334ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 291
+        content_length: 250
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"test-terraform-datasource-private-nic","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+        body: '{"name":"test-terraform-datasource-private-nic","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","volumes":{"0":{"boot":false}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
         method: POST
       response:
@@ -282,22 +282,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2175
+        content_length: 1708
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:04.067582+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"9702915e-780d-491c-9233-c816e7bf2a49","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:6f","maintenances":[],"modification_date":"2025-01-27T13:47:04.067582+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:04.067582+00:00","export_uri":null,"id":"69f5d7f0-b2c1-4e91-9fbd-0915f4cd7d07","modification_date":"2025-01-27T13:47:04.067582+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9702915e-780d-491c-9233-c816e7bf2a49","name":"test-terraform-datasource-private-nic"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:13:04.071661+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:bd","maintenances":[],"modification_date":"2025-02-12T16:13:04.071661+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"6c17af6a-f9fb-446b-a884-9f709b8b2cd4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2175"
+                - "1708"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:04 GMT
+                - Wed, 12 Feb 2025 16:13:05 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -305,10 +305,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 33cfaf1e-80a1-409e-ba23-d95515556baa
+                - 6ac80ce2-bb09-4816-a1be-9a953cf8b0b9
         status: 201 Created
         code: 201
-        duration: 767.80925ms
+        duration: 1.51794925s
     - id: 6
       request:
         proto: HTTP/1.1
@@ -324,8 +324,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b
         method: GET
       response:
         proto: HTTP/2.0
@@ -333,20 +333,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2175
+        content_length: 1708
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:04.067582+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"9702915e-780d-491c-9233-c816e7bf2a49","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:6f","maintenances":[],"modification_date":"2025-01-27T13:47:04.067582+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:04.067582+00:00","export_uri":null,"id":"69f5d7f0-b2c1-4e91-9fbd-0915f4cd7d07","modification_date":"2025-01-27T13:47:04.067582+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9702915e-780d-491c-9233-c816e7bf2a49","name":"test-terraform-datasource-private-nic"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:13:04.071661+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:bd","maintenances":[],"modification_date":"2025-02-12T16:13:04.071661+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"6c17af6a-f9fb-446b-a884-9f709b8b2cd4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2175"
+                - "1708"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:04 GMT
+                - Wed, 12 Feb 2025 16:13:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -354,10 +354,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 55d36cf8-37f2-4f73-a899-39737ffbe7ff
+                - d59ba19b-03cd-488c-a6c5-f5ce98a1f863
         status: 200 OK
         code: 200
-        duration: 143.201375ms
+        duration: 289.577417ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -373,8 +373,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b
         method: GET
       response:
         proto: HTTP/2.0
@@ -382,20 +382,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2175
+        content_length: 1708
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:04.067582+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"9702915e-780d-491c-9233-c816e7bf2a49","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:6f","maintenances":[],"modification_date":"2025-01-27T13:47:04.067582+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:04.067582+00:00","export_uri":null,"id":"69f5d7f0-b2c1-4e91-9fbd-0915f4cd7d07","modification_date":"2025-01-27T13:47:04.067582+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9702915e-780d-491c-9233-c816e7bf2a49","name":"test-terraform-datasource-private-nic"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:13:04.071661+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:bd","maintenances":[],"modification_date":"2025-02-12T16:13:04.071661+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"6c17af6a-f9fb-446b-a884-9f709b8b2cd4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2175"
+                - "1708"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:04 GMT
+                - Wed, 12 Feb 2025 16:13:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -403,11 +403,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8ca13ea9-0bda-4fbb-93b7-c6d564b8c648
+                - fd4b73b1-a048-4e24-abb9-58153fa47ec9
         status: 200 OK
         code: 200
-        duration: 155.933042ms
+        duration: 345.210041ms
     - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/6c17af6a-f9fb-446b-a884-9f709b8b2cd4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 705
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:13:04.306062Z","id":"6c17af6a-f9fb-446b-a884-9f709b8b2cd4","last_detached_at":null,"name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:13:04.306062Z","id":"e309c4e2-cdf5-4660-9b20-36d774cc6519","product_resource_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:13:04.306062Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "705"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:13:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e3aed5c4-5858-4d7d-9713-50febd4e998c
+        status: 200 OK
+        code: 200
+        duration: 148.048459ms
+    - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -424,8 +473,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -435,7 +484,7 @@ interactions:
         trailer: {}
         content_length: 357
         uncompressed: false
-        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/9702915e-780d-491c-9233-c816e7bf2a49/action","href_result":"/servers/9702915e-780d-491c-9233-c816e7bf2a49","id":"d8821963-2e70-4fd6-9ed8-a0f38a76e739","progress":0,"started_at":"2025-01-27T13:47:04.917419+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/action","href_result":"/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b","id":"2465220f-1972-4a6d-bb63-efd01fee8c5d","progress":0,"started_at":"2025-02-12T16:13:06.948264+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -444,11 +493,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:04 GMT
+                - Wed, 12 Feb 2025 16:13:06 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/d8821963-2e70-4fd6-9ed8-a0f38a76e739
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/2465220f-1972-4a6d-bb63-efd01fee8c5d
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -456,59 +505,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7811febc-2c26-44b2-b2f5-7319ed11ada4
+                - 9327d840-3f74-409c-942b-c491d09c5c01
         status: 202 Accepted
         code: 202
-        duration: 287.225958ms
-    - id: 9
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2197
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:04.067582+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"9702915e-780d-491c-9233-c816e7bf2a49","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:6f","maintenances":[],"modification_date":"2025-01-27T13:47:04.690966+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:04.067582+00:00","export_uri":null,"id":"69f5d7f0-b2c1-4e91-9fbd-0915f4cd7d07","modification_date":"2025-01-27T13:47:04.067582+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9702915e-780d-491c-9233-c816e7bf2a49","name":"test-terraform-datasource-private-nic"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2197"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:47:04 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 40905985-8181-4c5b-88ff-23ad8eed9964
-        status: 200 OK
-        code: 200
-        duration: 197.661917ms
+        duration: 903.999708ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -524,8 +524,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b
         method: GET
       response:
         proto: HTTP/2.0
@@ -533,20 +533,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2300
+        content_length: 1730
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:04.067582+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"9702915e-780d-491c-9233-c816e7bf2a49","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"404","node_id":"42","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:6f","maintenances":[],"modification_date":"2025-01-27T13:47:04.690966+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:04.067582+00:00","export_uri":null,"id":"69f5d7f0-b2c1-4e91-9fbd-0915f4cd7d07","modification_date":"2025-01-27T13:47:04.067582+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9702915e-780d-491c-9233-c816e7bf2a49","name":"test-terraform-datasource-private-nic"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:13:04.071661+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:bd","maintenances":[],"modification_date":"2025-02-12T16:13:06.399485+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"id":"6c17af6a-f9fb-446b-a884-9f709b8b2cd4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2300"
+                - "1730"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:10 GMT
+                - Wed, 12 Feb 2025 16:13:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -554,10 +554,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 409fb523-86fc-4e09-9177-2b3cf5338e65
+                - be89f2ba-07a0-4d13-b880-ab2f8725a9fa
         status: 200 OK
         code: 200
-        duration: 232.977125ms
+        duration: 236.594667ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -573,8 +573,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b
         method: GET
       response:
         proto: HTTP/2.0
@@ -582,20 +582,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2300
+        content_length: 1864
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:04.067582+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"9702915e-780d-491c-9233-c816e7bf2a49","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"404","node_id":"42","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:6f","maintenances":[],"modification_date":"2025-01-27T13:47:04.690966+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:04.067582+00:00","export_uri":null,"id":"69f5d7f0-b2c1-4e91-9fbd-0915f4cd7d07","modification_date":"2025-01-27T13:47:04.067582+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9702915e-780d-491c-9233-c816e7bf2a49","name":"test-terraform-datasource-private-nic"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:13:04.071661+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"601","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:bd","maintenances":[],"modification_date":"2025-02-12T16:13:12.148815+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"6c17af6a-f9fb-446b-a884-9f709b8b2cd4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2300"
+                - "1864"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:15 GMT
+                - Wed, 12 Feb 2025 16:13:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -603,10 +603,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9d9a4d2e-906a-4b68-812c-f4b2e039829e
+                - 65f41f97-8fc6-44f5-a3e9-9d7597e0259f
         status: 200 OK
         code: 200
-        duration: 134.031125ms
+        duration: 239.95725ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -622,8 +622,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b
         method: GET
       response:
         proto: HTTP/2.0
@@ -631,20 +631,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2331
+        content_length: 1864
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:04.067582+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"9702915e-780d-491c-9233-c816e7bf2a49","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"404","node_id":"42","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:6f","maintenances":[],"modification_date":"2025-01-27T13:47:20.301287+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:04.067582+00:00","export_uri":null,"id":"69f5d7f0-b2c1-4e91-9fbd-0915f4cd7d07","modification_date":"2025-01-27T13:47:04.067582+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9702915e-780d-491c-9233-c816e7bf2a49","name":"test-terraform-datasource-private-nic"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:13:04.071661+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"601","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:bd","maintenances":[],"modification_date":"2025-02-12T16:13:12.148815+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"6c17af6a-f9fb-446b-a884-9f709b8b2cd4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2331"
+                - "1864"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:20 GMT
+                - Wed, 12 Feb 2025 16:13:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -652,10 +652,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4cc11122-e2f6-41bb-97c7-615835ab0097
+                - 4e7648a9-3186-40eb-b13c-1af469a6c113
         status: 200 OK
         code: 200
-        duration: 139.315916ms
+        duration: 304.956083ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -671,8 +671,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/6c17af6a-f9fb-446b-a884-9f709b8b2cd4
         method: GET
       response:
         proto: HTTP/2.0
@@ -680,20 +680,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2331
+        content_length: 143
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:04.067582+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"9702915e-780d-491c-9233-c816e7bf2a49","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"404","node_id":"42","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:6f","maintenances":[],"modification_date":"2025-01-27T13:47:20.301287+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:04.067582+00:00","export_uri":null,"id":"69f5d7f0-b2c1-4e91-9fbd-0915f4cd7d07","modification_date":"2025-01-27T13:47:04.067582+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9702915e-780d-491c-9233-c816e7bf2a49","name":"test-terraform-datasource-private-nic"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"6c17af6a-f9fb-446b-a884-9f709b8b2cd4","type":"not_found"}'
         headers:
             Content-Length:
-                - "2331"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:20 GMT
+                - Wed, 12 Feb 2025 16:13:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -701,10 +701,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8b5d389f-da2a-43a9-9f7a-0c9d36273548
-        status: 200 OK
-        code: 200
-        duration: 191.942ms
+                - dced52aa-2a48-4535-ad96-49b08550a40a
+        status: 404 Not Found
+        code: 404
+        duration: 58.461458ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -720,8 +720,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/69f5d7f0-b2c1-4e91-9fbd-0915f4cd7d07
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/6c17af6a-f9fb-446b-a884-9f709b8b2cd4
         method: GET
       response:
         proto: HTTP/2.0
@@ -729,20 +729,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 541
+        content_length: 705
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:47:04.067582+00:00","export_uri":null,"id":"69f5d7f0-b2c1-4e91-9fbd-0915f4cd7d07","modification_date":"2025-01-27T13:47:04.067582+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9702915e-780d-491c-9233-c816e7bf2a49","name":"test-terraform-datasource-private-nic"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-12T16:13:04.306062Z","id":"6c17af6a-f9fb-446b-a884-9f709b8b2cd4","last_detached_at":null,"name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:13:04.306062Z","id":"e309c4e2-cdf5-4660-9b20-36d774cc6519","product_resource_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:13:04.306062Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "541"
+                - "705"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:20 GMT
+                - Wed, 12 Feb 2025 16:13:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -750,10 +750,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d8f79372-bf63-4f0f-9fef-9b4e3dc87b42
+                - bad52ed4-77cd-4767-a002-c05cfa7d9abc
         status: 200 OK
         code: 200
-        duration: 86.387375ms
+        duration: 81.263541ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -769,8 +769,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -789,9 +789,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:20 GMT
+                - Wed, 12 Feb 2025 16:13:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -799,10 +799,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e665a695-d2c6-41f5-b539-cf4b446d1a3b
+                - 5fe99b31-5c7a-480f-8f23-a8a79f26cd8e
         status: 200 OK
         code: 200
-        duration: 112.700708ms
+        duration: 108.841ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -818,8 +818,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -838,11 +838,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:20 GMT
+                - Wed, 12 Feb 2025 16:13:13 GMT
             Link:
-                - </servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -850,12 +850,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7a2cf9d1-af48-4520-84ce-b5ad75272cef
+                - 126e431b-11b1-40ac-b9d8-5244687d1915
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 81.336166ms
+        duration: 97.964167ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -871,8 +871,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b
         method: GET
       response:
         proto: HTTP/2.0
@@ -880,20 +880,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2331
+        content_length: 1864
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:04.067582+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"9702915e-780d-491c-9233-c816e7bf2a49","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"404","node_id":"42","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:6f","maintenances":[],"modification_date":"2025-01-27T13:47:20.301287+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:04.067582+00:00","export_uri":null,"id":"69f5d7f0-b2c1-4e91-9fbd-0915f4cd7d07","modification_date":"2025-01-27T13:47:04.067582+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9702915e-780d-491c-9233-c816e7bf2a49","name":"test-terraform-datasource-private-nic"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:13:04.071661+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"601","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:bd","maintenances":[],"modification_date":"2025-02-12T16:13:12.148815+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"6c17af6a-f9fb-446b-a884-9f709b8b2cd4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2331"
+                - "1864"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:21 GMT
+                - Wed, 12 Feb 2025 16:13:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -901,10 +901,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fbb39883-3c3a-495e-bbe9-6e2204453966
+                - c300ca0b-0f6d-4d60-ad24-8c2aa541c1dd
         status: 200 OK
         code: 200
-        duration: 157.449209ms
+        duration: 214.219333ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -916,14 +916,14 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","tags":["test-terraform-datasource-private-nic"]}'
+        body: '{"private_network_id":"922af88d-e868-402d-a480-8efe90285dee","tags":["test-terraform-datasource-private-nic"]}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics
         method: POST
       response:
         proto: HTTP/2.0
@@ -933,7 +933,7 @@ interactions:
         trailer: {}
         content_length: 512
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:21.525727+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"syncing","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:13.878468+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"syncing","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "512"
@@ -942,9 +942,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:22 GMT
+                - Wed, 12 Feb 2025 16:13:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -952,10 +952,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 65b19037-cd36-4460-bc28-1971b237473a
+                - a96120e5-cbb6-4f94-b607-a6a76a6f332d
         status: 201 Created
         code: 201
-        duration: 1.179009167s
+        duration: 1.458350292s
     - id: 19
       request:
         proto: HTTP/1.1
@@ -971,8 +971,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics/90475127-fcc5-495f-90d8-db3cf5cd69b0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics/c2ae68ad-1142-41a1-a244-6caa7484490e
         method: GET
       response:
         proto: HTTP/2.0
@@ -982,7 +982,7 @@ interactions:
         trailer: {}
         content_length: 512
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:21.525727+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"syncing","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:13.878468+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"syncing","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "512"
@@ -991,9 +991,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:22 GMT
+                - Wed, 12 Feb 2025 16:13:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1001,10 +1001,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1a6c5ae2-3dfb-42b1-a27b-bd3c5615b26c
+                - ce76d794-85e2-4fbf-b2d1-58bb20a94a23
         status: 200 OK
         code: 200
-        duration: 92.204792ms
+        duration: 112.562541ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1020,8 +1020,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics/90475127-fcc5-495f-90d8-db3cf5cd69b0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics/c2ae68ad-1142-41a1-a244-6caa7484490e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1031,7 +1031,7 @@ interactions:
         trailer: {}
         content_length: 512
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:21.525727+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"syncing","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:13.878468+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"syncing","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "512"
@@ -1040,9 +1040,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:27 GMT
+                - Wed, 12 Feb 2025 16:13:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1050,10 +1050,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7ecce0cb-94f5-4708-ae67-132ba66421eb
+                - 8318fef3-c97a-44be-9eee-d46f7dfe7c39
         status: 200 OK
         code: 200
-        duration: 77.552541ms
+        duration: 122.727708ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1069,8 +1069,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics/90475127-fcc5-495f-90d8-db3cf5cd69b0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics/c2ae68ad-1142-41a1-a244-6caa7484490e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1080,7 +1080,7 @@ interactions:
         trailer: {}
         content_length: 512
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:21.525727+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"syncing","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:13.878468+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"syncing","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "512"
@@ -1089,9 +1089,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:32 GMT
+                - Wed, 12 Feb 2025 16:13:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1099,10 +1099,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 44d3f545-8a71-407d-8986-9bbd9eaf8154
+                - 5a014c99-a86c-4e2a-84a7-b91317803b3a
         status: 200 OK
         code: 200
-        duration: 87.288916ms
+        duration: 120.875541ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1118,8 +1118,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics/90475127-fcc5-495f-90d8-db3cf5cd69b0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics/c2ae68ad-1142-41a1-a244-6caa7484490e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1129,7 +1129,7 @@ interactions:
         trailer: {}
         content_length: 512
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:21.525727+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"syncing","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:13.878468+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"syncing","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "512"
@@ -1138,9 +1138,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:37 GMT
+                - Wed, 12 Feb 2025 16:13:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1148,10 +1148,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 43c9e2d3-47cc-4f21-b233-175694bc9367
+                - a95c044a-e831-49a9-b62f-6783aee221e4
         status: 200 OK
         code: 200
-        duration: 90.577041ms
+        duration: 122.435084ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1167,8 +1167,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics/90475127-fcc5-495f-90d8-db3cf5cd69b0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics/c2ae68ad-1142-41a1-a244-6caa7484490e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1178,7 +1178,7 @@ interactions:
         trailer: {}
         content_length: 512
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:21.525727+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"syncing","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:13.878468+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"syncing","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "512"
@@ -1187,9 +1187,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:42 GMT
+                - Wed, 12 Feb 2025 16:13:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1197,10 +1197,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e4cd48af-3f07-4d43-83e6-17247db416c3
+                - 6d6af827-1bd3-4c3b-8556-29bfe165ca84
         status: 200 OK
         code: 200
-        duration: 92.143791ms
+        duration: 129.78425ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1216,8 +1216,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics/90475127-fcc5-495f-90d8-db3cf5cd69b0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics/c2ae68ad-1142-41a1-a244-6caa7484490e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1227,7 +1227,7 @@ interactions:
         trailer: {}
         content_length: 512
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:21.525727+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"syncing","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:13.878468+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"syncing","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "512"
@@ -1236,9 +1236,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:47 GMT
+                - Wed, 12 Feb 2025 16:13:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1246,10 +1246,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e63f0aa6-c548-464e-ac88-787db0af6cc5
+                - 232beb6a-77b8-4df7-9d17-54bcd3d27749
         status: 200 OK
         code: 200
-        duration: 95.958583ms
+        duration: 112.195625ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1265,8 +1265,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics/90475127-fcc5-495f-90d8-db3cf5cd69b0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics/c2ae68ad-1142-41a1-a244-6caa7484490e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1274,20 +1274,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 512
+        content_length: 514
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:21.525727+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"syncing","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "512"
+                - "514"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:52 GMT
+                - Wed, 12 Feb 2025 16:13:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1295,10 +1295,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 706eece3-3453-4ba0-8e7c-2363624bfb39
+                - 2733bc7d-b9a2-42ec-bb5f-771dde252ad5
         status: 200 OK
         code: 200
-        duration: 101.940084ms
+        duration: 104.420666ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1314,8 +1314,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics/90475127-fcc5-495f-90d8-db3cf5cd69b0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics/c2ae68ad-1142-41a1-a244-6caa7484490e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1325,7 +1325,7 @@ interactions:
         trailer: {}
         content_length: 514
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "514"
@@ -1334,9 +1334,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:57 GMT
+                - Wed, 12 Feb 2025 16:13:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1344,10 +1344,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ae9d6c91-c7eb-4668-b376-1dbba8df7635
+                - 674112ba-4b72-4271-a966-9b7cbed0ee38
         status: 200 OK
         code: 200
-        duration: 102.468167ms
+        duration: 117.976875ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1363,8 +1363,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics/90475127-fcc5-495f-90d8-db3cf5cd69b0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/922af88d-e868-402d-a480-8efe90285dee
         method: GET
       response:
         proto: HTTP/2.0
@@ -1372,20 +1372,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 514
+        content_length: 1050
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-12T16:13:03.623130Z","dhcp_enabled":true,"id":"922af88d-e868-402d-a480-8efe90285dee","name":"tf-pn-elastic-chebyshev","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:13:03.623130Z","id":"72d2b814-5717-4572-a1a4-5f65fde886c4","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.16.0/22","updated_at":"2025-02-12T16:13:03.623130Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-12T16:13:03.623130Z","id":"8cb49209-9d7e-4a24-9d71-3d74339464f8","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:e334::/64","updated_at":"2025-02-12T16:13:03.623130Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-12T16:13:03.623130Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "514"
+                - "1050"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:57 GMT
+                - Wed, 12 Feb 2025 16:13:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1393,10 +1393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9c681096-87ed-46d5-985c-dfff90cd89b6
+                - 7891d419-ad59-48fd-87be-be8bd2d834c1
         status: 200 OK
         code: 200
-        duration: 110.738916ms
+        duration: 45.04175ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1412,8 +1412,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/838a9738-7cef-4308-bbee-25ff53b20ce5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1421,20 +1421,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1051
+        content_length: 2361
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:47:03.421659Z","dhcp_enabled":true,"id":"838a9738-7cef-4308-bbee-25ff53b20ce5","name":"tf-pn-vigorous-chaplygin","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:47:03.421659Z","id":"f2d8d666-f472-44be-b06e-d76965dbf0e6","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.12.0/22","updated_at":"2025-01-27T13:47:03.421659Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:47:03.421659Z","id":"0be85e76-3de9-4eab-9ce6-20ff83b7b805","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:ae0f::/64","updated_at":"2025-01-27T13:47:03.421659Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:47:03.421659Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:13:04.071661+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"601","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:bd","maintenances":[],"modification_date":"2025-02-12T16:13:12.148815+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"6c17af6a-f9fb-446b-a884-9f709b8b2cd4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1051"
+                - "2361"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:58 GMT
+                - Wed, 12 Feb 2025 16:13:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1442,10 +1442,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 18c7a63b-bb93-4dd3-94aa-ea006e651975
+                - 8bc4297c-c07f-404c-8ab1-bb4cb6cdd0af
         status: 200 OK
         code: 200
-        duration: 34.615917ms
+        duration: 193.910792ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1461,8 +1461,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/6c17af6a-f9fb-446b-a884-9f709b8b2cd4
         method: GET
       response:
         proto: HTTP/2.0
@@ -1470,20 +1470,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2828
+        content_length: 143
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:04.067582+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"9702915e-780d-491c-9233-c816e7bf2a49","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"404","node_id":"42","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:6f","maintenances":[],"modification_date":"2025-01-27T13:47:20.301287+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:04.067582+00:00","export_uri":null,"id":"69f5d7f0-b2c1-4e91-9fbd-0915f4cd7d07","modification_date":"2025-01-27T13:47:04.067582+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9702915e-780d-491c-9233-c816e7bf2a49","name":"test-terraform-datasource-private-nic"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"6c17af6a-f9fb-446b-a884-9f709b8b2cd4","type":"not_found"}'
         headers:
             Content-Length:
-                - "2828"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:58 GMT
+                - Wed, 12 Feb 2025 16:13:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1491,10 +1491,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dc91cf74-302e-42e6-820c-03c12e250edb
-        status: 200 OK
-        code: 200
-        duration: 149.900625ms
+                - 6a4ded88-65a3-41ec-8940-d5e130579234
+        status: 404 Not Found
+        code: 404
+        duration: 44.904375ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1510,8 +1510,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/69f5d7f0-b2c1-4e91-9fbd-0915f4cd7d07
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/6c17af6a-f9fb-446b-a884-9f709b8b2cd4
         method: GET
       response:
         proto: HTTP/2.0
@@ -1519,20 +1519,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 541
+        content_length: 705
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:47:04.067582+00:00","export_uri":null,"id":"69f5d7f0-b2c1-4e91-9fbd-0915f4cd7d07","modification_date":"2025-01-27T13:47:04.067582+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9702915e-780d-491c-9233-c816e7bf2a49","name":"test-terraform-datasource-private-nic"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-12T16:13:04.306062Z","id":"6c17af6a-f9fb-446b-a884-9f709b8b2cd4","last_detached_at":null,"name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:13:04.306062Z","id":"e309c4e2-cdf5-4660-9b20-36d774cc6519","product_resource_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:13:04.306062Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "541"
+                - "705"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:58 GMT
+                - Wed, 12 Feb 2025 16:13:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1540,10 +1540,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 92f62d40-8cb1-4c5b-817b-713e377d5e24
+                - 1b054e53-8642-4836-8f44-4078c40495ca
         status: 200 OK
         code: 200
-        duration: 89.455583ms
+        duration: 77.087166ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1559,8 +1559,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1579,9 +1579,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:58 GMT
+                - Wed, 12 Feb 2025 16:13:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1589,10 +1589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 43b05aba-6b23-4af4-b4eb-b9c3b9d49d6d
+                - 29e41815-9c1b-481e-992e-5e39cb93cc44
         status: 200 OK
         code: 200
-        duration: 100.738875ms
+        duration: 108.831625ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1608,8 +1608,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1619,7 +1619,7 @@ interactions:
         trailer: {}
         content_length: 517
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}]}'
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
                 - "517"
@@ -1628,11 +1628,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:58 GMT
+                - Wed, 12 Feb 2025 16:13:46 GMT
             Link:
-                - </servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics?page=1&per_page=50&>; rel="last"
+                - </servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics?page=1&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1640,12 +1640,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 77db73a4-25ca-4152-b51a-a59bb60b2b8c
+                - 46f7fd9f-4b4c-4e9e-ba6f-9a2161ca94bf
             X-Total-Count:
                 - "1"
         status: 200 OK
         code: 200
-        duration: 120.739ms
+        duration: 105.861958ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1661,8 +1661,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics/90475127-fcc5-495f-90d8-db3cf5cd69b0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics/c2ae68ad-1142-41a1-a244-6caa7484490e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1672,7 +1672,7 @@ interactions:
         trailer: {}
         content_length: 514
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "514"
@@ -1681,9 +1681,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:59 GMT
+                - Wed, 12 Feb 2025 16:13:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1691,10 +1691,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a098cd90-4a28-4bf2-9cf7-a16b39f793fe
+                - df69845c-7ac7-4e11-86fa-512f1f843fc5
         status: 200 OK
         code: 200
-        duration: 113.284708ms
+        duration: 112.736125ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1710,8 +1710,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/838a9738-7cef-4308-bbee-25ff53b20ce5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/922af88d-e868-402d-a480-8efe90285dee
         method: GET
       response:
         proto: HTTP/2.0
@@ -1719,20 +1719,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1051
+        content_length: 1050
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:47:03.421659Z","dhcp_enabled":true,"id":"838a9738-7cef-4308-bbee-25ff53b20ce5","name":"tf-pn-vigorous-chaplygin","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:47:03.421659Z","id":"f2d8d666-f472-44be-b06e-d76965dbf0e6","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.12.0/22","updated_at":"2025-01-27T13:47:03.421659Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:47:03.421659Z","id":"0be85e76-3de9-4eab-9ce6-20ff83b7b805","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:ae0f::/64","updated_at":"2025-01-27T13:47:03.421659Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:47:03.421659Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"created_at":"2025-02-12T16:13:03.623130Z","dhcp_enabled":true,"id":"922af88d-e868-402d-a480-8efe90285dee","name":"tf-pn-elastic-chebyshev","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:13:03.623130Z","id":"72d2b814-5717-4572-a1a4-5f65fde886c4","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.16.0/22","updated_at":"2025-02-12T16:13:03.623130Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-12T16:13:03.623130Z","id":"8cb49209-9d7e-4a24-9d71-3d74339464f8","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:e334::/64","updated_at":"2025-02-12T16:13:03.623130Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-12T16:13:03.623130Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "1051"
+                - "1050"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:59 GMT
+                - Wed, 12 Feb 2025 16:13:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1740,10 +1740,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5be9b2ea-7f77-45eb-882a-0b7f9734f9da
+                - fbfb22f0-842c-496b-bb0f-b2bf11265dd6
         status: 200 OK
         code: 200
-        duration: 26.094542ms
+        duration: 88.845834ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1759,8 +1759,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1768,20 +1768,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2828
+        content_length: 2361
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:04.067582+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"9702915e-780d-491c-9233-c816e7bf2a49","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"404","node_id":"42","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:6f","maintenances":[],"modification_date":"2025-01-27T13:47:20.301287+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:04.067582+00:00","export_uri":null,"id":"69f5d7f0-b2c1-4e91-9fbd-0915f4cd7d07","modification_date":"2025-01-27T13:47:04.067582+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9702915e-780d-491c-9233-c816e7bf2a49","name":"test-terraform-datasource-private-nic"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:13:04.071661+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"601","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:bd","maintenances":[],"modification_date":"2025-02-12T16:13:12.148815+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"6c17af6a-f9fb-446b-a884-9f709b8b2cd4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2828"
+                - "2361"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:59 GMT
+                - Wed, 12 Feb 2025 16:13:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1789,10 +1789,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - add7ddba-1a34-4bf6-abc3-de18635c73ec
+                - acd8040c-2ba9-4c22-9f3f-925faaa5684f
         status: 200 OK
         code: 200
-        duration: 155.927334ms
+        duration: 187.828625ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1808,8 +1808,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/69f5d7f0-b2c1-4e91-9fbd-0915f4cd7d07
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/6c17af6a-f9fb-446b-a884-9f709b8b2cd4
         method: GET
       response:
         proto: HTTP/2.0
@@ -1817,20 +1817,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 541
+        content_length: 143
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:47:04.067582+00:00","export_uri":null,"id":"69f5d7f0-b2c1-4e91-9fbd-0915f4cd7d07","modification_date":"2025-01-27T13:47:04.067582+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9702915e-780d-491c-9233-c816e7bf2a49","name":"test-terraform-datasource-private-nic"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"6c17af6a-f9fb-446b-a884-9f709b8b2cd4","type":"not_found"}'
         headers:
             Content-Length:
-                - "541"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:59 GMT
+                - Wed, 12 Feb 2025 16:13:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1838,10 +1838,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ca10601f-fc65-4b1a-a941-be2d4ba9ad39
-        status: 200 OK
-        code: 200
-        duration: 72.0545ms
+                - 4b5b13c4-988e-4d48-8721-529a49b3d1d6
+        status: 404 Not Found
+        code: 404
+        duration: 54.937292ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1857,8 +1857,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/6c17af6a-f9fb-446b-a884-9f709b8b2cd4
         method: GET
       response:
         proto: HTTP/2.0
@@ -1866,20 +1866,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 705
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"created_at":"2025-02-12T16:13:04.306062Z","id":"6c17af6a-f9fb-446b-a884-9f709b8b2cd4","last_detached_at":null,"name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:13:04.306062Z","id":"e309c4e2-cdf5-4660-9b20-36d774cc6519","product_resource_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:13:04.306062Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "17"
+                - "705"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:59 GMT
+                - Wed, 12 Feb 2025 16:13:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1887,10 +1887,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2379a7ca-990c-46f2-ba88-48a23349a23d
+                - cc203675-58e1-4352-8f17-57914a856608
         status: 200 OK
         code: 200
-        duration: 77.501166ms
+        duration: 88.054375ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1906,1065 +1906,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 517
-        uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}]}'
-        headers:
-            Content-Length:
-                - "517"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:47:59 GMT
-            Link:
-                - </servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics?page=1&per_page=50&>; rel="last"
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 2ab34480-5e10-4d7e-a4f2-ab5f1697f207
-            X-Total-Count:
-                - "1"
-        status: 200 OK
-        code: 200
-        duration: 86.32925ms
-    - id: 39
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics/90475127-fcc5-495f-90d8-db3cf5cd69b0
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 514
-        uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "514"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:47:59 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - d9f09ac7-1bef-4397-a4ac-d5fd2ac66ec2
-        status: 200 OK
-        code: 200
-        duration: 87.505833ms
-    - id: 40
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 517
-        uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}]}'
-        headers:
-            Content-Length:
-                - "517"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:47:59 GMT
-            Link:
-                - </servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics?page=1&per_page=50&>; rel="last"
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - c3b014ac-da5c-4423-9a45-9ae466d5c586
-            X-Total-Count:
-                - "1"
-        status: 200 OK
-        code: 200
-        duration: 91.293791ms
-    - id: 41
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics?tags=test-terraform-datasource-private-nic
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 517
-        uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}]}'
-        headers:
-            Content-Length:
-                - "517"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:47:59 GMT
-            Link:
-                - </servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics?page=1&per_page=50&tags=test-terraform-datasource-private-nic>; rel="last"
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - f0ccb6cd-6d16-4132-be97-469670f1130c
-            X-Total-Count:
-                - "1"
-        status: 200 OK
-        code: 200
-        duration: 95.616083ms
-    - id: 42
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics/90475127-fcc5-495f-90d8-db3cf5cd69b0
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 514
-        uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "514"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:47:59 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - e65f4159-aa97-408a-b891-33c8ae2dc8ea
-        status: 200 OK
-        code: 200
-        duration: 75.79625ms
-    - id: 43
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics/90475127-fcc5-495f-90d8-db3cf5cd69b0
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 514
-        uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "514"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:47:59 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - a9dff24b-1313-4e01-9f07-ae787695c28c
-        status: 200 OK
-        code: 200
-        duration: 84.474917ms
-    - id: 44
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics/90475127-fcc5-495f-90d8-db3cf5cd69b0
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 514
-        uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "514"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:47:59 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - a0110d9d-1a47-4797-a09a-2bd5eadddd24
-        status: 200 OK
-        code: 200
-        duration: 80.899833ms
-    - id: 45
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics?tags=test-terraform-datasource-private-nic
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 517
-        uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}]}'
-        headers:
-            Content-Length:
-                - "517"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:47:59 GMT
-            Link:
-                - </servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics?page=1&per_page=50&tags=test-terraform-datasource-private-nic>; rel="last"
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 08dfc6fc-adf4-4790-976c-2f795ae0973a
-            X-Total-Count:
-                - "1"
-        status: 200 OK
-        code: 200
-        duration: 82.587666ms
-    - id: 46
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 517
-        uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}]}'
-        headers:
-            Content-Length:
-                - "517"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:48:00 GMT
-            Link:
-                - </servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics?page=1&per_page=50&>; rel="last"
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 14df4f31-dee7-43f5-a552-9bd6033cdce1
-            X-Total-Count:
-                - "1"
-        status: 200 OK
-        code: 200
-        duration: 91.832959ms
-    - id: 47
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics/90475127-fcc5-495f-90d8-db3cf5cd69b0
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 514
-        uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "514"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:48:00 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - c7d87fd1-51c9-4023-b9a1-30fd79d58555
-        status: 200 OK
-        code: 200
-        duration: 109.81775ms
-    - id: 48
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics/90475127-fcc5-495f-90d8-db3cf5cd69b0
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 514
-        uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "514"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:47:59 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 413a4d51-a4d4-4409-95eb-4f51cc4375f2
-        status: 200 OK
-        code: 200
-        duration: 102.219375ms
-    - id: 49
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics/90475127-fcc5-495f-90d8-db3cf5cd69b0
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 514
-        uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "514"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:48:00 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 4d98585a-fc7d-4339-9e2b-cf14977f750b
-        status: 200 OK
-        code: 200
-        duration: 95.788ms
-    - id: 50
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics/90475127-fcc5-495f-90d8-db3cf5cd69b0
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 514
-        uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "514"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:48:00 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 94c105ec-8ade-416a-984e-261183a3ce73
-        status: 200 OK
-        code: 200
-        duration: 106.827416ms
-    - id: 51
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics/90475127-fcc5-495f-90d8-db3cf5cd69b0
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 514
-        uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "514"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:48:00 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 0afcef75-cc0c-4f7f-a8ce-0d62666447ab
-        status: 200 OK
-        code: 200
-        duration: 89.521291ms
-    - id: 52
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 517
-        uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}]}'
-        headers:
-            Content-Length:
-                - "517"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:48:00 GMT
-            Link:
-                - </servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics?page=1&per_page=50&>; rel="last"
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 77f9c350-eff2-4cd3-b8c4-6c28155e8b1a
-            X-Total-Count:
-                - "1"
-        status: 200 OK
-        code: 200
-        duration: 90.956458ms
-    - id: 53
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics?tags=test-terraform-datasource-private-nic
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 517
-        uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}]}'
-        headers:
-            Content-Length:
-                - "517"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:48:00 GMT
-            Link:
-                - </servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics?page=1&per_page=50&tags=test-terraform-datasource-private-nic>; rel="last"
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 6371f899-05a7-48b3-ae1f-e665d577f8fb
-            X-Total-Count:
-                - "1"
-        status: 200 OK
-        code: 200
-        duration: 98.370833ms
-    - id: 54
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics/90475127-fcc5-495f-90d8-db3cf5cd69b0
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 514
-        uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "514"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:48:00 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 9e14292c-fd52-49f2-8bc0-4b19fbd776c9
-        status: 200 OK
-        code: 200
-        duration: 77.902917ms
-    - id: 55
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics/90475127-fcc5-495f-90d8-db3cf5cd69b0
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 514
-        uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "514"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:48:00 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - ebffac59-bcfb-4b43-94e6-f8e2732c44bc
-        status: 200 OK
-        code: 200
-        duration: 89.617958ms
-    - id: 56
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/838a9738-7cef-4308-bbee-25ff53b20ce5
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1051
-        uncompressed: false
-        body: '{"created_at":"2025-01-27T13:47:03.421659Z","dhcp_enabled":true,"id":"838a9738-7cef-4308-bbee-25ff53b20ce5","name":"tf-pn-vigorous-chaplygin","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:47:03.421659Z","id":"f2d8d666-f472-44be-b06e-d76965dbf0e6","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.12.0/22","updated_at":"2025-01-27T13:47:03.421659Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:47:03.421659Z","id":"0be85e76-3de9-4eab-9ce6-20ff83b7b805","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:ae0f::/64","updated_at":"2025-01-27T13:47:03.421659Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:47:03.421659Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
-        headers:
-            Content-Length:
-                - "1051"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:48:00 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 80d71d31-9e66-466e-981d-ab6dea9f0bd2
-        status: 200 OK
-        code: 200
-        duration: 28.235583ms
-    - id: 57
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2828
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:04.067582+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"9702915e-780d-491c-9233-c816e7bf2a49","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"404","node_id":"42","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:6f","maintenances":[],"modification_date":"2025-01-27T13:47:20.301287+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:04.067582+00:00","export_uri":null,"id":"69f5d7f0-b2c1-4e91-9fbd-0915f4cd7d07","modification_date":"2025-01-27T13:47:04.067582+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9702915e-780d-491c-9233-c816e7bf2a49","name":"test-terraform-datasource-private-nic"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2828"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:48:00 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 7204dd7c-7d50-4023-b559-762758649c8e
-        status: 200 OK
-        code: 200
-        duration: 141.281708ms
-    - id: 58
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/69f5d7f0-b2c1-4e91-9fbd-0915f4cd7d07
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 541
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:47:04.067582+00:00","export_uri":null,"id":"69f5d7f0-b2c1-4e91-9fbd-0915f4cd7d07","modification_date":"2025-01-27T13:47:04.067582+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9702915e-780d-491c-9233-c816e7bf2a49","name":"test-terraform-datasource-private-nic"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "541"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:48:01 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 3629392b-4261-4514-a5a4-f667aef747e3
-        status: 200 OK
-        code: 200
-        duration: 83.79325ms
-    - id: 59
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -2983,9 +1926,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:00 GMT
+                - Wed, 12 Feb 2025 16:13:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2993,10 +1936,1067 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a8aef51f-1c45-4cf4-afab-5fb9788ec753
+                - b91ce860-c0ea-4aa2-96ff-f354e9dcb47e
         status: 200 OK
         code: 200
-        duration: 78.412125ms
+        duration: 115.852875ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 517
+        uncompressed: false
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}]}'
+        headers:
+            Content-Length:
+                - "517"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:13:47 GMT
+            Link:
+                - </servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics?page=1&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 59cefd5b-6007-4fda-bffe-1f7789011418
+            X-Total-Count:
+                - "1"
+        status: 200 OK
+        code: 200
+        duration: 101.634584ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics?tags=test-terraform-datasource-private-nic
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 517
+        uncompressed: false
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}]}'
+        headers:
+            Content-Length:
+                - "517"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:13:47 GMT
+            Link:
+                - </servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics?page=1&per_page=50&tags=test-terraform-datasource-private-nic>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0aef517d-4f7c-4de7-a32d-9d390a858ba5
+            X-Total-Count:
+                - "1"
+        status: 200 OK
+        code: 200
+        duration: 94.234834ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 517
+        uncompressed: false
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}]}'
+        headers:
+            Content-Length:
+                - "517"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:13:47 GMT
+            Link:
+                - </servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics?page=1&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 595fd137-5513-4ee3-b867-ad4aa2a0e1e1
+            X-Total-Count:
+                - "1"
+        status: 200 OK
+        code: 200
+        duration: 101.340375ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics/c2ae68ad-1142-41a1-a244-6caa7484490e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 514
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "514"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:13:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8bea3593-a3b5-4fdf-8930-b8133a0adcf8
+        status: 200 OK
+        code: 200
+        duration: 100.908875ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics/c2ae68ad-1142-41a1-a244-6caa7484490e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 514
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "514"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:13:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 69ff7ad4-65d6-4031-a127-5d1e68aa385b
+        status: 200 OK
+        code: 200
+        duration: 100.448583ms
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics/c2ae68ad-1142-41a1-a244-6caa7484490e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 514
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "514"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:13:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7ebae366-5cdc-4aa4-8d94-ff998da1d411
+        status: 200 OK
+        code: 200
+        duration: 98.347083ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics/c2ae68ad-1142-41a1-a244-6caa7484490e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 514
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "514"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:13:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 38174ed7-750a-4c1c-b9c6-e57c6110efc4
+        status: 200 OK
+        code: 200
+        duration: 117.943708ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics?tags=test-terraform-datasource-private-nic
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 517
+        uncompressed: false
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}]}'
+        headers:
+            Content-Length:
+                - "517"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:13:47 GMT
+            Link:
+                - </servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics?page=1&per_page=50&tags=test-terraform-datasource-private-nic>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a257ac68-9058-408e-a07b-27722abb3559
+            X-Total-Count:
+                - "1"
+        status: 200 OK
+        code: 200
+        duration: 111.480208ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics/c2ae68ad-1142-41a1-a244-6caa7484490e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 514
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "514"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:13:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 880d101c-6d52-4b70-a265-1cfd48227b3b
+        status: 200 OK
+        code: 200
+        duration: 109.716208ms
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 517
+        uncompressed: false
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}]}'
+        headers:
+            Content-Length:
+                - "517"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:13:47 GMT
+            Link:
+                - </servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics?page=1&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 717516c3-3446-4e8f-9f61-10469cbe1bdf
+            X-Total-Count:
+                - "1"
+        status: 200 OK
+        code: 200
+        duration: 111.08325ms
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics/c2ae68ad-1142-41a1-a244-6caa7484490e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 514
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "514"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:13:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7ba90247-55bf-424a-a6e8-ab95392f6b20
+        status: 200 OK
+        code: 200
+        duration: 105.9995ms
+    - id: 50
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics/c2ae68ad-1142-41a1-a244-6caa7484490e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 514
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "514"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:13:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - bff36993-494b-4c0d-a509-dbd4a46eb240
+        status: 200 OK
+        code: 200
+        duration: 107.716958ms
+    - id: 51
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics/c2ae68ad-1142-41a1-a244-6caa7484490e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 514
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "514"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:13:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 573148be-1ace-47c9-af16-93f26d1f41b1
+        status: 200 OK
+        code: 200
+        duration: 119.211542ms
+    - id: 52
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics/c2ae68ad-1142-41a1-a244-6caa7484490e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 514
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "514"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:13:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2d4eb7e7-fc94-4694-b5bc-155a1789bb7b
+        status: 200 OK
+        code: 200
+        duration: 107.119708ms
+    - id: 53
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics?tags=test-terraform-datasource-private-nic
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 517
+        uncompressed: false
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}]}'
+        headers:
+            Content-Length:
+                - "517"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:13:48 GMT
+            Link:
+                - </servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics?page=1&per_page=50&tags=test-terraform-datasource-private-nic>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a0baf869-22b1-45fb-b954-07164008f24a
+            X-Total-Count:
+                - "1"
+        status: 200 OK
+        code: 200
+        duration: 110.757292ms
+    - id: 54
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 517
+        uncompressed: false
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}]}'
+        headers:
+            Content-Length:
+                - "517"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:13:48 GMT
+            Link:
+                - </servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics?page=1&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 234ba77e-5551-4dd4-94f6-58ac676ad9df
+            X-Total-Count:
+                - "1"
+        status: 200 OK
+        code: 200
+        duration: 110.960875ms
+    - id: 55
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics/c2ae68ad-1142-41a1-a244-6caa7484490e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 514
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "514"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:13:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3db7a55d-a523-42a2-a46b-3116cc71a22b
+        status: 200 OK
+        code: 200
+        duration: 93.826875ms
+    - id: 56
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics/c2ae68ad-1142-41a1-a244-6caa7484490e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 514
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "514"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:13:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9b3188a2-32c3-4699-9681-d335de77729b
+        status: 200 OK
+        code: 200
+        duration: 106.373333ms
+    - id: 57
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/922af88d-e868-402d-a480-8efe90285dee
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1050
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:13:03.623130Z","dhcp_enabled":true,"id":"922af88d-e868-402d-a480-8efe90285dee","name":"tf-pn-elastic-chebyshev","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:13:03.623130Z","id":"72d2b814-5717-4572-a1a4-5f65fde886c4","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.16.0/22","updated_at":"2025-02-12T16:13:03.623130Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-12T16:13:03.623130Z","id":"8cb49209-9d7e-4a24-9d71-3d74339464f8","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:e334::/64","updated_at":"2025-02-12T16:13:03.623130Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-12T16:13:03.623130Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        headers:
+            Content-Length:
+                - "1050"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:13:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9778d7bb-41ad-4dc1-8744-74a30b58b2f8
+        status: 200 OK
+        code: 200
+        duration: 80.882375ms
+    - id: 58
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2361
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:13:04.071661+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"601","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:bd","maintenances":[],"modification_date":"2025-02-12T16:13:12.148815+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"6c17af6a-f9fb-446b-a884-9f709b8b2cd4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2361"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:13:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - dfbcc7b0-5abf-4071-9adb-bca21f439ceb
+        status: 200 OK
+        code: 200
+        duration: 201.654208ms
+    - id: 59
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/6c17af6a-f9fb-446b-a884-9f709b8b2cd4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"6c17af6a-f9fb-446b-a884-9f709b8b2cd4","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:13:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 68b131ec-2a39-4932-91b9-822f80206534
+        status: 404 Not Found
+        code: 404
+        duration: 52.185333ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -3012,8 +3012,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/6c17af6a-f9fb-446b-a884-9f709b8b2cd4
         method: GET
       response:
         proto: HTTP/2.0
@@ -3021,22 +3021,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 517
+        content_length: 705
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}]}'
+        body: '{"created_at":"2025-02-12T16:13:04.306062Z","id":"6c17af6a-f9fb-446b-a884-9f709b8b2cd4","last_detached_at":null,"name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:13:04.306062Z","id":"e309c4e2-cdf5-4660-9b20-36d774cc6519","product_resource_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:13:04.306062Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "517"
+                - "705"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:00 GMT
-            Link:
-                - </servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics?page=1&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 16:13:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3044,12 +3042,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 855ef6a6-659a-4f93-bc2e-39a661452915
-            X-Total-Count:
-                - "1"
+                - e377112e-d297-45ca-8f1c-cdb5b640bc99
         status: 200 OK
         code: 200
-        duration: 104.847875ms
+        duration: 86.740917ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -3065,8 +3061,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -3074,22 +3070,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 517
+        content_length: 17
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}]}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "517"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:00 GMT
-            Link:
-                - </servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics?page=1&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 16:13:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3097,12 +3091,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0681c7a6-28b0-4b18-9e6d-3cc37d45a3af
-            X-Total-Count:
-                - "1"
+                - 0cf371f5-027f-4b9f-9e15-4aecf12e1014
         status: 200 OK
         code: 200
-        duration: 72.717334ms
+        duration: 91.030084ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -3118,8 +3110,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics/90475127-fcc5-495f-90d8-db3cf5cd69b0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -3127,20 +3119,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 514
+        content_length: 517
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "514"
+                - "517"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:00 GMT
+                - Wed, 12 Feb 2025 16:13:49 GMT
+            Link:
+                - </servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics?page=1&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3148,10 +3142,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b0c07175-8ba7-48aa-a059-f5c4bf207981
+                - 51147865-525d-4d42-9c05-ba3b02fe8fe2
+            X-Total-Count:
+                - "1"
         status: 200 OK
         code: 200
-        duration: 85.2785ms
+        duration: 120.342459ms
     - id: 63
       request:
         proto: HTTP/1.1
@@ -3167,8 +3163,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics?tags=test-terraform-datasource-private-nic
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics/c2ae68ad-1142-41a1-a244-6caa7484490e
         method: GET
       response:
         proto: HTTP/2.0
@@ -3176,22 +3172,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 517
+        content_length: 514
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}]}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "517"
+                - "514"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:01 GMT
-            Link:
-                - </servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics?page=1&per_page=50&tags=test-terraform-datasource-private-nic>; rel="last"
+                - Wed, 12 Feb 2025 16:13:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3199,12 +3193,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a8935caf-82b5-43e8-afcc-61e57b28832c
-            X-Total-Count:
-                - "1"
+                - 1c73e51f-5e4d-45f9-adcb-abc0fc63e2cf
         status: 200 OK
         code: 200
-        duration: 94.287083ms
+        duration: 95.327125ms
     - id: 64
       request:
         proto: HTTP/1.1
@@ -3220,8 +3212,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics/90475127-fcc5-495f-90d8-db3cf5cd69b0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -3229,20 +3221,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 514
+        content_length: 517
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "514"
+                - "517"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:01 GMT
+                - Wed, 12 Feb 2025 16:13:49 GMT
+            Link:
+                - </servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics?page=1&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3250,10 +3244,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c142255a-ffcd-4a12-a9c4-65bc7e3eaf69
+                - adacfab9-7830-4292-8ef5-54508852e423
+            X-Total-Count:
+                - "1"
         status: 200 OK
         code: 200
-        duration: 80.121334ms
+        duration: 98.891ms
     - id: 65
       request:
         proto: HTTP/1.1
@@ -3269,8 +3265,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics/90475127-fcc5-495f-90d8-db3cf5cd69b0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics?tags=test-terraform-datasource-private-nic
         method: GET
       response:
         proto: HTTP/2.0
@@ -3278,20 +3274,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 514
+        content_length: 517
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "514"
+                - "517"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:01 GMT
+                - Wed, 12 Feb 2025 16:13:49 GMT
+            Link:
+                - </servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics?page=1&per_page=50&tags=test-terraform-datasource-private-nic>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3299,10 +3297,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2fb879d2-877a-48a6-95b4-2f4d02ef7f33
+                - 92135d85-6d0f-4c2d-96f3-143b5275ca9a
+            X-Total-Count:
+                - "1"
         status: 200 OK
         code: 200
-        duration: 81.24825ms
+        duration: 106.37875ms
     - id: 66
       request:
         proto: HTTP/1.1
@@ -3318,8 +3318,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics/90475127-fcc5-495f-90d8-db3cf5cd69b0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics/c2ae68ad-1142-41a1-a244-6caa7484490e
         method: GET
       response:
         proto: HTTP/2.0
@@ -3329,7 +3329,7 @@ interactions:
         trailer: {}
         content_length: 514
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "514"
@@ -3338,9 +3338,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:01 GMT
+                - Wed, 12 Feb 2025 16:13:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3348,10 +3348,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4e88bef5-d9e2-4bbf-8b6e-69f5a97d0aed
+                - c4184faf-6610-4ed8-8356-8e39268d8854
         status: 200 OK
         code: 200
-        duration: 104.193125ms
+        duration: 101.301ms
     - id: 67
       request:
         proto: HTTP/1.1
@@ -3367,8 +3367,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics?tags=test-terraform-datasource-private-nic
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics/c2ae68ad-1142-41a1-a244-6caa7484490e
         method: GET
       response:
         proto: HTTP/2.0
@@ -3376,22 +3376,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 517
+        content_length: 514
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}]}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "517"
+                - "514"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:01 GMT
-            Link:
-                - </servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics?page=1&per_page=50&tags=test-terraform-datasource-private-nic>; rel="last"
+                - Wed, 12 Feb 2025 16:13:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3399,12 +3397,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3728f833-66f7-4a2a-8e73-614f784b20d5
-            X-Total-Count:
-                - "1"
+                - 6cea7194-8b13-4ada-a3a7-69cfd2fe0276
         status: 200 OK
         code: 200
-        duration: 94.835917ms
+        duration: 109.681833ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -3420,8 +3416,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics/c2ae68ad-1142-41a1-a244-6caa7484490e
         method: GET
       response:
         proto: HTTP/2.0
@@ -3429,22 +3425,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 517
+        content_length: 514
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}]}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "517"
+                - "514"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:01 GMT
-            Link:
-                - </servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics?page=1&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 16:13:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3452,12 +3446,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 479bf939-2b1b-4d66-83ce-f700dca0134b
-            X-Total-Count:
-                - "1"
+                - 89d9f429-b708-4816-a6a4-0333a2032601
         status: 200 OK
         code: 200
-        duration: 101.418375ms
+        duration: 106.922125ms
     - id: 69
       request:
         proto: HTTP/1.1
@@ -3473,8 +3465,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics/90475127-fcc5-495f-90d8-db3cf5cd69b0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics/c2ae68ad-1142-41a1-a244-6caa7484490e
         method: GET
       response:
         proto: HTTP/2.0
@@ -3484,7 +3476,7 @@ interactions:
         trailer: {}
         content_length: 514
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "514"
@@ -3493,9 +3485,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:01 GMT
+                - Wed, 12 Feb 2025 16:13:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3503,10 +3495,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a16031a5-9e22-4576-b360-76bf7e31a3eb
+                - ca7bf120-401b-4028-8536-57ba23ae6dc8
         status: 200 OK
         code: 200
-        duration: 107.419125ms
+        duration: 93.149125ms
     - id: 70
       request:
         proto: HTTP/1.1
@@ -3522,8 +3514,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics/90475127-fcc5-495f-90d8-db3cf5cd69b0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics?tags=test-terraform-datasource-private-nic
         method: GET
       response:
         proto: HTTP/2.0
@@ -3531,20 +3523,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 514
+        content_length: 517
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "514"
+                - "517"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:01 GMT
+                - Wed, 12 Feb 2025 16:13:49 GMT
+            Link:
+                - </servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics?page=1&per_page=50&tags=test-terraform-datasource-private-nic>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3552,10 +3546,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 25a00d1b-b22f-40f7-a4d2-0f4afa20018f
+                - e21461ef-74e5-4b04-bc5f-0dbc722f1fb5
+            X-Total-Count:
+                - "1"
         status: 200 OK
         code: 200
-        duration: 88.1245ms
+        duration: 99.583041ms
     - id: 71
       request:
         proto: HTTP/1.1
@@ -3571,8 +3567,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics/90475127-fcc5-495f-90d8-db3cf5cd69b0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -3580,20 +3576,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 514
+        content_length: 517
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "514"
+                - "517"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:01 GMT
+                - Wed, 12 Feb 2025 16:13:49 GMT
+            Link:
+                - </servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics?page=1&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3601,10 +3599,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 12aef501-3fcd-4b5d-8af5-a8bd82e80ee3
+                - c33db6a8-3560-4fb3-a89a-6c7d6fea1722
+            X-Total-Count:
+                - "1"
         status: 200 OK
         code: 200
-        duration: 88.292917ms
+        duration: 99.596625ms
     - id: 72
       request:
         proto: HTTP/1.1
@@ -3620,8 +3620,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics/90475127-fcc5-495f-90d8-db3cf5cd69b0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics/c2ae68ad-1142-41a1-a244-6caa7484490e
         method: GET
       response:
         proto: HTTP/2.0
@@ -3631,7 +3631,7 @@ interactions:
         trailer: {}
         content_length: 514
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:47:21.315745+00:00","id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","ipam_ip_ids":["7eb86923-9a48-402b-aca9-dafd7dffea93","84a9403c-eb3a-456c-8410-ff4ee1fbb7f1"],"mac_address":"02:00:00:1c:f9:bb","modification_date":"2025-01-27T13:47:53.246492+00:00","private_network_id":"838a9738-7cef-4308-bbee-25ff53b20ce5","server_id":"9702915e-780d-491c-9233-c816e7bf2a49","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "514"
@@ -3640,9 +3640,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:01 GMT
+                - Wed, 12 Feb 2025 16:13:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3650,10 +3650,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 90f96dc7-62e3-490d-a8fc-15a378a85d54
+                - fa0c9cde-04ed-4399-94f3-5481fb0fadba
         status: 200 OK
         code: 200
-        duration: 96.347584ms
+        duration: 107.498375ms
     - id: 73
       request:
         proto: HTTP/1.1
@@ -3669,8 +3669,106 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics/90475127-fcc5-495f-90d8-db3cf5cd69b0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics/c2ae68ad-1142-41a1-a244-6caa7484490e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 514
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "514"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:13:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 45358bc3-a4e1-48b9-8b30-5f457c5b1fab
+        status: 200 OK
+        code: 200
+        duration: 111.649333ms
+    - id: 74
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics/c2ae68ad-1142-41a1-a244-6caa7484490e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 514
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:13:13.668034+00:00","id":"c2ae68ad-1142-41a1-a244-6caa7484490e","ipam_ip_ids":["35471064-932e-4956-b8ee-0793faec72ef","d22f0ce4-680f-4853-b629-3ac29930c0fb"],"mac_address":"02:00:00:1c:b6:86","modification_date":"2025-02-12T16:13:45.648321+00:00","private_network_id":"922af88d-e868-402d-a480-8efe90285dee","server_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","state":"available","tags":["test-terraform-datasource-private-nic"],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "514"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:13:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9476dab2-55b4-4671-b988-2c99a14d7d26
+        status: 200 OK
+        code: 200
+        duration: 106.449542ms
+    - id: 75
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics/c2ae68ad-1142-41a1-a244-6caa7484490e
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3687,9 +3785,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:02 GMT
+                - Wed, 12 Feb 2025 16:13:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3697,11 +3795,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 296cab29-3568-41ce-ae49-efb8eeed99d9
+                - 954e3bc9-51bd-46c8-be4a-864cd74ec6f3
         status: 204 No Content
         code: 204
-        duration: 521.722375ms
-    - id: 74
+        duration: 597.4395ms
+    - id: 76
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3716,8 +3814,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics/90475127-fcc5-495f-90d8-db3cf5cd69b0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics/c2ae68ad-1142-41a1-a244-6caa7484490e
         method: GET
       response:
         proto: HTTP/2.0
@@ -3727,7 +3825,7 @@ interactions:
         trailer: {}
         content_length: 148
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"90475127-fcc5-495f-90d8-db3cf5cd69b0","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"c2ae68ad-1142-41a1-a244-6caa7484490e","type":"not_found"}'
         headers:
             Content-Length:
                 - "148"
@@ -3736,9 +3834,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:02 GMT
+                - Wed, 12 Feb 2025 16:13:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3746,11 +3844,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5668209c-c9d0-4c2c-97ed-72989e5d73fa
+                - 2e3d3bb2-f0a3-4b82-bee6-5e08a02204ca
         status: 404 Not Found
         code: 404
-        duration: 110.295958ms
-    - id: 75
+        duration: 105.683208ms
+    - id: 77
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3765,8 +3863,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b
         method: GET
       response:
         proto: HTTP/2.0
@@ -3774,20 +3872,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2331
+        content_length: 1864
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:04.067582+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"9702915e-780d-491c-9233-c816e7bf2a49","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"404","node_id":"42","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:6f","maintenances":[],"modification_date":"2025-01-27T13:47:20.301287+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:04.067582+00:00","export_uri":null,"id":"69f5d7f0-b2c1-4e91-9fbd-0915f4cd7d07","modification_date":"2025-01-27T13:47:04.067582+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9702915e-780d-491c-9233-c816e7bf2a49","name":"test-terraform-datasource-private-nic"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:13:04.071661+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"601","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:bd","maintenances":[],"modification_date":"2025-02-12T16:13:12.148815+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"6c17af6a-f9fb-446b-a884-9f709b8b2cd4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2331"
+                - "1864"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:02 GMT
+                - Wed, 12 Feb 2025 16:13:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3795,11 +3893,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 726d3ca4-adf6-47a5-8a5e-0924aaf6ef77
+                - 5774f82a-cf19-4a2c-8816-fa40618ca455
         status: 200 OK
         code: 200
-        duration: 187.67125ms
-    - id: 76
+        duration: 298.256666ms
+    - id: 78
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/6c17af6a-f9fb-446b-a884-9f709b8b2cd4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 705
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:13:04.306062Z","id":"6c17af6a-f9fb-446b-a884-9f709b8b2cd4","last_detached_at":null,"name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:13:04.306062Z","id":"e309c4e2-cdf5-4660-9b20-36d774cc6519","product_resource_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:13:04.306062Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "705"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:13:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ea062c20-94d9-4cc6-a198-477d830c4f46
+        status: 200 OK
+        code: 200
+        duration: 104.543125ms
+    - id: 79
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3816,8 +3963,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -3827,7 +3974,7 @@ interactions:
         trailer: {}
         content_length: 352
         uncompressed: false
-        body: '{"task":{"description":"server_poweroff","href_from":"/servers/9702915e-780d-491c-9233-c816e7bf2a49/action","href_result":"/servers/9702915e-780d-491c-9233-c816e7bf2a49","id":"ccdbb335-05b7-4ed2-847f-98b7a026d3cf","progress":0,"started_at":"2025-01-27T13:48:03.229682+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_poweroff","href_from":"/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/action","href_result":"/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b","id":"904678d8-f597-4847-b53a-0d7e6d6193f6","progress":0,"started_at":"2025-02-12T16:13:51.697295+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "352"
@@ -3836,11 +3983,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:03 GMT
+                - Wed, 12 Feb 2025 16:13:51 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/ccdbb335-05b7-4ed2-847f-98b7a026d3cf
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/904678d8-f597-4847-b53a-0d7e6d6193f6
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3848,155 +3995,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5f5bdd7e-f14a-4e8c-b695-5e7819c705d6
+                - 3499df26-d4c6-4b1c-9140-f24396f36af3
         status: 202 Accepted
         code: 202
-        duration: 346.540875ms
-    - id: 77
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2291
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:04.067582+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"9702915e-780d-491c-9233-c816e7bf2a49","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"404","node_id":"42","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:6f","maintenances":[],"modification_date":"2025-01-27T13:48:02.965690+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:04.067582+00:00","export_uri":null,"id":"69f5d7f0-b2c1-4e91-9fbd-0915f4cd7d07","modification_date":"2025-01-27T13:47:04.067582+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9702915e-780d-491c-9233-c816e7bf2a49","name":"test-terraform-datasource-private-nic"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2291"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:48:03 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 221b47e6-693e-4132-b2f2-6e6df4333030
-        status: 200 OK
-        code: 200
-        duration: 208.68825ms
-    - id: 78
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/838a9738-7cef-4308-bbee-25ff53b20ce5
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:48:03 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 77773362-f7d1-42e7-8d23-72a30ffcc33c
-        status: 204 No Content
-        code: 204
-        duration: 1.2870915s
-    - id: 79
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2291
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:04.067582+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"9702915e-780d-491c-9233-c816e7bf2a49","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"404","node_id":"42","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:6f","maintenances":[],"modification_date":"2025-01-27T13:48:02.965690+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:04.067582+00:00","export_uri":null,"id":"69f5d7f0-b2c1-4e91-9fbd-0915f4cd7d07","modification_date":"2025-01-27T13:47:04.067582+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9702915e-780d-491c-9233-c816e7bf2a49","name":"test-terraform-datasource-private-nic"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2291"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:48:08 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 02741f50-ab51-4cef-b8ee-b10fd3812fd9
-        status: 200 OK
-        code: 200
-        duration: 175.677459ms
+        duration: 498.05325ms
     - id: 80
       request:
         proto: HTTP/1.1
@@ -4012,8 +4014,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b
         method: GET
       response:
         proto: HTTP/2.0
@@ -4021,20 +4023,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2291
+        content_length: 1824
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:04.067582+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"9702915e-780d-491c-9233-c816e7bf2a49","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"404","node_id":"42","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:6f","maintenances":[],"modification_date":"2025-01-27T13:48:02.965690+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:04.067582+00:00","export_uri":null,"id":"69f5d7f0-b2c1-4e91-9fbd-0915f4cd7d07","modification_date":"2025-01-27T13:47:04.067582+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9702915e-780d-491c-9233-c816e7bf2a49","name":"test-terraform-datasource-private-nic"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:13:04.071661+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"601","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:bd","maintenances":[],"modification_date":"2025-02-12T16:13:51.273874+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"6c17af6a-f9fb-446b-a884-9f709b8b2cd4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2291"
+                - "1824"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:13 GMT
+                - Wed, 12 Feb 2025 16:13:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4042,10 +4044,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8621cf70-1b01-4d7c-8f66-dd97cd335676
+                - 55dc8888-d28c-4dbe-8ad4-77c9c3cb9411
         status: 200 OK
         code: 200
-        duration: 158.387791ms
+        duration: 191.17ms
     - id: 81
       request:
         proto: HTTP/1.1
@@ -4061,29 +4063,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/922af88d-e868-402d-a480-8efe90285dee
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2291
+        content_length: 0
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:04.067582+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"9702915e-780d-491c-9233-c816e7bf2a49","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"404","node_id":"42","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:6f","maintenances":[],"modification_date":"2025-01-27T13:48:02.965690+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:04.067582+00:00","export_uri":null,"id":"69f5d7f0-b2c1-4e91-9fbd-0915f4cd7d07","modification_date":"2025-01-27T13:47:04.067582+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9702915e-780d-491c-9233-c816e7bf2a49","name":"test-terraform-datasource-private-nic"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: ""
         headers:
-            Content-Length:
-                - "2291"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:18 GMT
+                - Wed, 12 Feb 2025 16:13:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4091,10 +4091,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - df54e09a-40eb-48e2-9ecd-8eb4a2e90450
-        status: 200 OK
-        code: 200
-        duration: 153.071708ms
+                - 361e97fc-f33b-4998-91ed-dfd3716a39c8
+        status: 204 No Content
+        code: 204
+        duration: 1.131739708s
     - id: 82
       request:
         proto: HTTP/1.1
@@ -4110,8 +4110,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b
         method: GET
       response:
         proto: HTTP/2.0
@@ -4119,20 +4119,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2175
+        content_length: 1824
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:04.067582+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"9702915e-780d-491c-9233-c816e7bf2a49","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:6f","maintenances":[],"modification_date":"2025-01-27T13:48:33.442283+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:04.067582+00:00","export_uri":null,"id":"69f5d7f0-b2c1-4e91-9fbd-0915f4cd7d07","modification_date":"2025-01-27T13:47:04.067582+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9702915e-780d-491c-9233-c816e7bf2a49","name":"test-terraform-datasource-private-nic"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:13:04.071661+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"601","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:bd","maintenances":[],"modification_date":"2025-02-12T16:13:51.273874+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"6c17af6a-f9fb-446b-a884-9f709b8b2cd4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2175"
+                - "1824"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:38 GMT
+                - Wed, 12 Feb 2025 16:13:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4140,10 +4140,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fcbf8258-e0b8-4328-88de-c230c467b04e
+                - 0ed486ed-d2a8-477a-9880-516e01662b33
         status: 200 OK
         code: 200
-        duration: 15.834965s
+        duration: 402.373625ms
     - id: 83
       request:
         proto: HTTP/1.1
@@ -4159,8 +4159,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b
         method: GET
       response:
         proto: HTTP/2.0
@@ -4168,20 +4168,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2175
+        content_length: 1824
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:04.067582+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"9702915e-780d-491c-9233-c816e7bf2a49","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:6f","maintenances":[],"modification_date":"2025-01-27T13:48:33.442283+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:04.067582+00:00","export_uri":null,"id":"69f5d7f0-b2c1-4e91-9fbd-0915f4cd7d07","modification_date":"2025-01-27T13:47:04.067582+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9702915e-780d-491c-9233-c816e7bf2a49","name":"test-terraform-datasource-private-nic"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:13:04.071661+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"601","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:bd","maintenances":[],"modification_date":"2025-02-12T16:13:51.273874+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"6c17af6a-f9fb-446b-a884-9f709b8b2cd4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2175"
+                - "1824"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:39 GMT
+                - Wed, 12 Feb 2025 16:14:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4189,10 +4189,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4577ce77-cdbb-4c61-84d0-2872147211fd
+                - 3fdab1d9-7360-437f-9aab-38374831662d
         status: 200 OK
         code: 200
-        duration: 1.2740755s
+        duration: 363.361583ms
     - id: 84
       request:
         proto: HTTP/1.1
@@ -4208,27 +4208,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 1824
         uncompressed: false
-        body: ""
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:13:04.071661+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"601","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:bd","maintenances":[],"modification_date":"2025-02-12T16:13:51.273874+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"6c17af6a-f9fb-446b-a884-9f709b8b2cd4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
+            Content-Length:
+                - "1824"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:40 GMT
+                - Wed, 12 Feb 2025 16:14:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4236,10 +4238,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 983cba44-e6f1-4aed-881e-27486ac7385b
-        status: 204 No Content
-        code: 204
-        duration: 159.93475ms
+                - 7a6bf797-aef3-4ada-8389-bf2224a832e1
+        status: 200 OK
+        code: 200
+        duration: 191.075958ms
     - id: 85
       request:
         proto: HTTP/1.1
@@ -4255,8 +4257,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b
         method: GET
       response:
         proto: HTTP/2.0
@@ -4264,20 +4266,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 143
+        content_length: 1824
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"9702915e-780d-491c-9233-c816e7bf2a49","type":"not_found"}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:13:04.071661+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"601","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:bd","maintenances":[],"modification_date":"2025-02-12T16:13:51.273874+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"6c17af6a-f9fb-446b-a884-9f709b8b2cd4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "143"
+                - "1824"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:41 GMT
+                - Wed, 12 Feb 2025 16:14:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4285,10 +4287,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0ec7770f-1cd1-4b4e-962c-95f61ecb13d0
-        status: 404 Not Found
-        code: 404
-        duration: 99.71575ms
+                - 46c6f33e-0378-4ca2-9ef2-4b372a6d1488
+        status: 200 OK
+        code: 200
+        duration: 170.825041ms
     - id: 86
       request:
         proto: HTTP/1.1
@@ -4304,8 +4306,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/69f5d7f0-b2c1-4e91-9fbd-0915f4cd7d07
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b
         method: GET
       response:
         proto: HTTP/2.0
@@ -4313,20 +4315,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 450
+        content_length: 1824
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:47:04.067582+00:00","export_uri":null,"id":"69f5d7f0-b2c1-4e91-9fbd-0915f4cd7d07","modification_date":"2025-01-27T13:48:41.136247+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:13:04.071661+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"601","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:bd","maintenances":[],"modification_date":"2025-02-12T16:13:51.273874+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"6c17af6a-f9fb-446b-a884-9f709b8b2cd4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "450"
+                - "1824"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:40 GMT
+                - Wed, 12 Feb 2025 16:14:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4334,10 +4336,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5615df94-8299-4648-ad37-6b5dd21e41f0
+                - 75db2cb8-2459-4e7d-891e-fcca189d5689
         status: 200 OK
         code: 200
-        duration: 87.330958ms
+        duration: 205.70575ms
     - id: 87
       request:
         proto: HTTP/1.1
@@ -4353,8 +4355,204 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/69f5d7f0-b2c1-4e91-9fbd-0915f4cd7d07
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1824
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:13:04.071661+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"601","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:bd","maintenances":[],"modification_date":"2025-02-12T16:13:51.273874+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"6c17af6a-f9fb-446b-a884-9f709b8b2cd4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1824"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:14:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5b447a20-040a-43c6-b1d7-e2493c2a3a10
+        status: 200 OK
+        code: 200
+        duration: 184.128291ms
+    - id: 88
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1824
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:13:04.071661+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"601","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:bd","maintenances":[],"modification_date":"2025-02-12T16:13:51.273874+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"6c17af6a-f9fb-446b-a884-9f709b8b2cd4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1824"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:14:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 33960f4c-b95c-4ac0-a440-8aaf9e418b6b
+        status: 200 OK
+        code: 200
+        duration: 250.846917ms
+    - id: 89
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1708
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:13:04.071661+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:bd","maintenances":[],"modification_date":"2025-02-12T16:14:28.969195+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"6c17af6a-f9fb-446b-a884-9f709b8b2cd4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1708"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:14:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c81c7fd2-5519-40b6-b9ae-7674012c8c28
+        status: 200 OK
+        code: 200
+        duration: 188.108458ms
+    - id: 90
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1708
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:13:04.071661+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"test-terraform-datasource-private-nic","id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:bd","maintenances":[],"modification_date":"2025-02-12T16:14:28.969195+00:00","name":"test-terraform-datasource-private-nic","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"6c17af6a-f9fb-446b-a884-9f709b8b2cd4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1708"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:14:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 428724b6-d92b-4f5b-9ff1-3e70e4a0d46e
+        status: 200 OK
+        code: 200
+        duration: 202.56975ms
+    - id: 91
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -4371,9 +4569,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:41 GMT
+                - Wed, 12 Feb 2025 16:14:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4381,11 +4579,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - aed2860d-f31b-4413-a663-11f54d81d5a7
+                - 30b4c0b3-7cfc-443b-b854-95340852e097
         status: 204 No Content
         code: 204
-        duration: 185.731583ms
-    - id: 88
+        duration: 557.388833ms
+    - id: 92
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4400,8 +4598,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics/90475127-fcc5-495f-90d8-db3cf5cd69b0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b
         method: GET
       response:
         proto: HTTP/2.0
@@ -4411,7 +4609,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"9702915e-780d-491c-9233-c816e7bf2a49","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -4420,9 +4618,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:41 GMT
+                - Wed, 12 Feb 2025 16:14:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4430,11 +4628,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9080ca70-fd13-4c5c-b1ab-de748a0e4ef4
+                - f6cbaf21-5134-4535-b7cd-d3cccb404bab
         status: 404 Not Found
         code: 404
-        duration: 38.908125ms
-    - id: 89
+        duration: 128.528375ms
+    - id: 93
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4449,8 +4647,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics/90475127-fcc5-495f-90d8-db3cf5cd69b0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/6c17af6a-f9fb-446b-a884-9f709b8b2cd4
         method: GET
       response:
         proto: HTTP/2.0
@@ -4460,7 +4658,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"9702915e-780d-491c-9233-c816e7bf2a49","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"6c17af6a-f9fb-446b-a884-9f709b8b2cd4","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -4469,9 +4667,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:41 GMT
+                - Wed, 12 Feb 2025 16:14:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4479,11 +4677,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8e92253a-1f49-433c-8cc7-53f2a0a0cf5c
+                - 80647d52-b2c7-4b3e-bf03-93291fd00348
         status: 404 Not Found
         code: 404
-        duration: 34.843292ms
-    - id: 90
+        duration: 65.283833ms
+    - id: 94
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4498,8 +4696,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics/90475127-fcc5-495f-90d8-db3cf5cd69b0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/6c17af6a-f9fb-446b-a884-9f709b8b2cd4
         method: GET
       response:
         proto: HTTP/2.0
@@ -4507,20 +4705,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 143
+        content_length: 498
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"9702915e-780d-491c-9233-c816e7bf2a49","type":"not_found"}'
+        body: '{"created_at":"2025-02-12T16:13:04.306062Z","id":"6c17af6a-f9fb-446b-a884-9f709b8b2cd4","last_detached_at":"2025-02-12T16:14:34.638188Z","name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:14:34.638188Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "143"
+                - "498"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:41 GMT
+                - Wed, 12 Feb 2025 16:14:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4528,11 +4726,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 576b5fc2-d97f-4793-be65-c63728bfdff7
-        status: 404 Not Found
-        code: 404
-        duration: 36.845875ms
-    - id: 91
+                - 44d9785d-f489-4ca2-973e-3b8ffaf821d3
+        status: 200 OK
+        code: 200
+        duration: 100.822333ms
+    - id: 95
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4547,8 +4745,55 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9702915e-780d-491c-9233-c816e7bf2a49/private_nics/90475127-fcc5-495f-90d8-db3cf5cd69b0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/6c17af6a-f9fb-446b-a884-9f709b8b2cd4
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:14:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b450855f-fb1a-4157-a49c-612fbfad4c1d
+        status: 204 No Content
+        code: 204
+        duration: 131.9685ms
+    - id: 96
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics/c2ae68ad-1142-41a1-a244-6caa7484490e
         method: GET
       response:
         proto: HTTP/2.0
@@ -4558,7 +4803,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"9702915e-780d-491c-9233-c816e7bf2a49","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -4567,9 +4812,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:41 GMT
+                - Wed, 12 Feb 2025 16:14:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4577,7 +4822,154 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6f737885-431f-402b-98c1-0ce1c8a1442a
+                - 1a1b078a-f892-44c1-aa3e-6363c4f807a3
         status: 404 Not Found
         code: 404
-        duration: 39.34225ms
+        duration: 55.448709ms
+    - id: 97
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics/c2ae68ad-1142-41a1-a244-6caa7484490e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:14:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 88589ee1-3bc3-4e05-a97e-90db200b1e70
+        status: 404 Not Found
+        code: 404
+        duration: 54.555584ms
+    - id: 98
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics/c2ae68ad-1142-41a1-a244-6caa7484490e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:14:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 928e58da-a571-4ab9-8c01-b0435666a835
+        status: 404 Not Found
+        code: 404
+        duration: 53.458292ms
+    - id: 99
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ffa8b5ae-42d9-4349-9491-085a5cf10a6b/private_nics/c2ae68ad-1142-41a1-a244-6caa7484490e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"ffa8b5ae-42d9-4349-9491-085a5cf10a6b","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:14:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 031db32d-c093-4513-b418-5bf90bfbad44
+        status: 404 Not Found
+        code: 404
+        duration: 55.27325ms

--- a/internal/services/instance/testdata/data-source-server-basic.cassette.yaml
+++ b/internal/services/instance/testdata/data-source-server-basic.cassette.yaml
@@ -16,7 +16,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
         method: GET
       response:
@@ -25,22 +25,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 38539
+        content_length: 35639
         uncompressed: false
-        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
+        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
         headers:
             Content-Length:
-                - "38539"
+                - "35639"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:08 GMT
+                - Tue, 11 Feb 2025 14:23:21 GMT
             Link:
                 - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,12 +48,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ef6a16c2-e24d-4e30-9707-6b9e01c4cc8c
+                - 4a4ef0e1-f53d-4e91-afb9-dc7f38fd134b
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 43.168875ms
+        duration: 71.341792ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -69,7 +69,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
         method: GET
       response:
@@ -78,22 +78,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 14208
+        content_length: 13164
         uncompressed: false
-        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
         headers:
             Content-Length:
-                - "14208"
+                - "13164"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:08 GMT
+                - Tue, 11 Feb 2025 14:23:21 GMT
             Link:
                 - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -101,12 +101,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a341a91c-0a7f-421c-b84c-0d03142c30be
+                - 642b9ff3-2d2a-4290-841f-0972d8d7c67e
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 47.019416ms
+        duration: 53.861ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -122,8 +122,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_local&zone=fr-par-1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_sbs&zone=fr-par-1
         method: GET
       response:
         proto: HTTP/2.0
@@ -131,20 +131,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1300
+        content_length: 1296
         uncompressed: false
-        body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"56d4019c-8305-467a-a3f2-70498ad799df","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
+        body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"57509e82-ac3b-49b7-9970-97b60f40ff72","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"9b647e1e-253a-41e7-8c15-911c622ee2dc","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"}],"total_count":2}'
         headers:
             Content-Length:
-                - "1300"
+                - "1296"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:09 GMT
+                - Tue, 11 Feb 2025 14:23:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -152,28 +152,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9370df0d-df99-4935-8b10-5c36b9bafc0a
+                - 555c1277-4c31-411b-aed9-c8b76191586a
         status: 200 OK
         code: 200
-        duration: 67.696083ms
+        duration: 87.21825ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 329
+        content_length: 288
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-server","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":["terraform-test","data_scaleway_instance_server","basic"]}'
+        body: '{"name":"tf-server","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"57509e82-ac3b-49b7-9970-97b60f40ff72","volumes":{"0":{"boot":false}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":["terraform-test","data_scaleway_instance_server","basic"]}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
         method: POST
       response:
@@ -182,22 +182,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2137
+        content_length: 1706
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:09.587756+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:7d","maintenances":[],"modification_date":"2025-01-27T13:47:09.587756+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:22.754779+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e9","maintenances":[],"modification_date":"2025-02-11T14:23:22.754779+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2137"
+                - "1706"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:10 GMT
+                - Tue, 11 Feb 2025 14:23:23 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -205,10 +205,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 735a7ce4-ac01-4ab1-b386-4cda3315aac3
+                - 31ea844a-5dd2-4877-9ea9-1cfde4797f3c
         status: 201 Created
         code: 201
-        duration: 979.932792ms
+        duration: 1.01672975s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -224,8 +224,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2
         method: GET
       response:
         proto: HTTP/2.0
@@ -233,20 +233,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2137
+        content_length: 1706
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:09.587756+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:7d","maintenances":[],"modification_date":"2025-01-27T13:47:09.587756+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:22.754779+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e9","maintenances":[],"modification_date":"2025-02-11T14:23:22.754779+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2137"
+                - "1706"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:10 GMT
+                - Tue, 11 Feb 2025 14:23:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -254,10 +254,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bd03441c-aeb2-40f3-ac25-43f2c92c5203
+                - 8e32250f-f9e9-4006-9087-754ebe627d41
         status: 200 OK
         code: 200
-        duration: 209.380667ms
+        duration: 181.693208ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -273,8 +273,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2
         method: GET
       response:
         proto: HTTP/2.0
@@ -282,20 +282,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2137
+        content_length: 1706
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:09.587756+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:7d","maintenances":[],"modification_date":"2025-01-27T13:47:09.587756+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:22.754779+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e9","maintenances":[],"modification_date":"2025-02-11T14:23:22.754779+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2137"
+                - "1706"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:10 GMT
+                - Tue, 11 Feb 2025 14:23:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -303,10 +303,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 78e6d10c-f932-44fe-96b0-f3f618e0cb4a
+                - 954e4c41-abd2-4993-8335-41125388633c
         status: 200 OK
         code: 200
-        duration: 136.317584ms
+        duration: 131.379417ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -322,8 +322,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2
         method: GET
       response:
         proto: HTTP/2.0
@@ -331,20 +331,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2137
+        content_length: 1706
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:09.587756+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:7d","maintenances":[],"modification_date":"2025-01-27T13:47:09.587756+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:22.754779+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e9","maintenances":[],"modification_date":"2025-02-11T14:23:22.754779+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2137"
+                - "1706"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:10 GMT
+                - Tue, 11 Feb 2025 14:23:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -352,10 +352,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b0dff7be-a9f3-45a4-9c0f-3c8f6917904d
+                - 969b53a1-a98d-4698-8d2b-d9b8b9be0749
         status: 200 OK
         code: 200
-        duration: 178.100709ms
+        duration: 155.52025ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -371,8 +371,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/84aa2745-5ba7-4dd4-bc76-7391e0e07b77
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/adb01adb-bf06-4716-8a66-2a9c3c9c4a80
         method: GET
       response:
         proto: HTTP/2.0
@@ -380,20 +380,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 509
+        content_length: 143
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","type":"not_found"}'
         headers:
             Content-Length:
-                - "509"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:10 GMT
+                - Tue, 11 Feb 2025 14:23:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -401,10 +401,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - df9e72da-09bd-4222-8973-31336778a371
-        status: 200 OK
-        code: 200
-        duration: 101.517ms
+                - 1f1b2846-e228-49e1-acb1-3f19b6b14288
+        status: 404 Not Found
+        code: 404
+        duration: 24.423125ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -420,8 +420,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/adb01adb-bf06-4716-8a66-2a9c3c9c4a80
         method: GET
       response:
         proto: HTTP/2.0
@@ -429,20 +429,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 701
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"created_at":"2025-02-11T14:23:22.978570Z","id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:22.978570Z","id":"afe5d765-4963-41b7-b1da-2e8a0f756b3a","product_resource_id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:22.978570Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "17"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:10 GMT
+                - Tue, 11 Feb 2025 14:23:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -450,10 +450,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bf355059-1a8f-49e8-9796-8ae13441a3eb
+                - 46b4f1be-a28a-4d4b-936a-ccb049c055f1
         status: 200 OK
         code: 200
-        duration: 88.206416ms
+        duration: 65.407084ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -469,8 +469,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -478,22 +478,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 17
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "20"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:10 GMT
-            Link:
-                - </servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:23:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -501,12 +499,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 64f84ce7-e534-4219-a42e-b3b1711103ec
-            X-Total-Count:
-                - "0"
+                - 10bd3d38-c533-443d-8a5d-f9a5974caee1
         status: 200 OK
         code: 200
-        duration: 85.695042ms
+        duration: 88.234458ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -522,8 +518,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -531,20 +527,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2137
+        content_length: 20
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:09.587756+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:7d","maintenances":[],"modification_date":"2025-01-27T13:47:09.587756+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "2137"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:10 GMT
+                - Tue, 11 Feb 2025 14:23:24 GMT
+            Link:
+                - </servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -552,10 +550,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 50bb5bde-9bbf-4a0e-8162-e53cfd6b9c82
+                - 3a3acacd-73c0-49d0-8c4d-0bbaeee752c0
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 173.2145ms
+        duration: 85.2355ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -571,8 +571,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/84aa2745-5ba7-4dd4-bc76-7391e0e07b77
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2
         method: GET
       response:
         proto: HTTP/2.0
@@ -580,20 +580,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 509
+        content_length: 1706
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:22.754779+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e9","maintenances":[],"modification_date":"2025-02-11T14:23:22.754779+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "509"
+                - "1706"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:10 GMT
+                - Tue, 11 Feb 2025 14:23:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -601,10 +601,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5ba0691a-9d7d-473e-9661-fb6c836fa73d
+                - f088da9a-6c9e-448b-a659-0f10b372586b
         status: 200 OK
         code: 200
-        duration: 102.278958ms
+        duration: 183.966833ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -620,8 +620,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/adb01adb-bf06-4716-8a66-2a9c3c9c4a80
         method: GET
       response:
         proto: HTTP/2.0
@@ -629,20 +629,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 143
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","type":"not_found"}'
         headers:
             Content-Length:
-                - "17"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:11 GMT
+                - Tue, 11 Feb 2025 14:23:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -650,10 +650,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - aed96741-4c2f-40c4-b477-73e6aa865b64
-        status: 200 OK
-        code: 200
-        duration: 99.992208ms
+                - 7267da07-0146-451a-9e86-2c8dfcd552de
+        status: 404 Not Found
+        code: 404
+        duration: 31.415625ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -669,8 +669,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/adb01adb-bf06-4716-8a66-2a9c3c9c4a80
         method: GET
       response:
         proto: HTTP/2.0
@@ -678,22 +678,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 701
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"created_at":"2025-02-11T14:23:22.978570Z","id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:22.978570Z","id":"afe5d765-4963-41b7-b1da-2e8a0f756b3a","product_resource_id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:22.978570Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "20"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:11 GMT
-            Link:
-                - </servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:23:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -701,12 +699,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9ddc2395-8f1b-427a-a59b-22c7812003d8
-            X-Total-Count:
-                - "0"
+                - 00d1f264-a934-441b-b2e0-f7b5ce8faf3d
         status: 200 OK
         code: 200
-        duration: 109.740291ms
+        duration: 62.039625ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -722,8 +718,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -731,20 +727,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2137
+        content_length: 17
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:09.587756+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:7d","maintenances":[],"modification_date":"2025-01-27T13:47:09.587756+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "2137"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:11 GMT
+                - Tue, 11 Feb 2025 14:23:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -752,10 +748,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 732d5f79-df11-4a16-a0b7-84c87006326c
+                - de402a36-0efe-4ebe-80de-16f85518c268
         status: 200 OK
         code: 200
-        duration: 127.070542ms
+        duration: 93.830792ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -771,8 +767,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/84aa2745-5ba7-4dd4-bc76-7391e0e07b77
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -780,20 +776,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 509
+        content_length: 20
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "509"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:11 GMT
+                - Tue, 11 Feb 2025 14:23:24 GMT
+            Link:
+                - </servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -801,10 +799,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d064537c-d022-479b-9dfa-218c7c94cbc7
+                - ef7eb4b5-8916-4649-96cf-b08af42ec897
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 111.359042ms
+        duration: 103.242125ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -820,8 +820,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2
         method: GET
       response:
         proto: HTTP/2.0
@@ -829,20 +829,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 1706
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:22.754779+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e9","maintenances":[],"modification_date":"2025-02-11T14:23:22.754779+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "17"
+                - "1706"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:12 GMT
+                - Tue, 11 Feb 2025 14:23:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -850,10 +850,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b9497a26-9eb7-4ab2-a061-ac0079c996c6
+                - 6236705a-408c-45ff-bef2-f0c03314d0ff
         status: 200 OK
         code: 200
-        duration: 81.240875ms
+        duration: 134.935541ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -869,8 +869,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/adb01adb-bf06-4716-8a66-2a9c3c9c4a80
         method: GET
       response:
         proto: HTTP/2.0
@@ -878,22 +878,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 143
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","type":"not_found"}'
         headers:
             Content-Length:
-                - "20"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:11 GMT
-            Link:
-                - </servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:23:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -901,12 +899,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 65277a70-1092-4e3c-8128-b071e9757fcd
-            X-Total-Count:
-                - "0"
-        status: 200 OK
-        code: 200
-        duration: 105.118667ms
+                - eed5718a-cfc2-4f88-b991-67d8386957cb
+        status: 404 Not Found
+        code: 404
+        duration: 31.979458ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -922,8 +918,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/adb01adb-bf06-4716-8a66-2a9c3c9c4a80
         method: GET
       response:
         proto: HTTP/2.0
@@ -931,20 +927,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2137
+        content_length: 701
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:09.587756+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:7d","maintenances":[],"modification_date":"2025-01-27T13:47:09.587756+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T14:23:22.978570Z","id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:22.978570Z","id":"afe5d765-4963-41b7-b1da-2e8a0f756b3a","product_resource_id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:22.978570Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2137"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:11 GMT
+                - Tue, 11 Feb 2025 14:23:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -952,10 +948,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4ded9a0e-b5b3-421a-9823-743cd75f76fa
+                - 062ba397-76a1-4e91-9c03-003cdfd4460b
         status: 200 OK
         code: 200
-        duration: 168.579042ms
+        duration: 57.601583ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -971,8 +967,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers?name=tf-server&order=creation_date_desc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -980,22 +976,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2140
+        content_length: 17
         uncompressed: false
-        body: '{"servers":[{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:09.587756+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:7d","maintenances":[],"modification_date":"2025-01-27T13:47:09.587756+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}]}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "2140"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:12 GMT
-            Link:
-                - </servers?page=1&per_page=50&name=tf-server&order=creation_date_desc>; rel="last"
+                - Tue, 11 Feb 2025 14:23:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1003,12 +997,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2bc2f7d9-b5ce-4baa-9695-7ec825506359
-            X-Total-Count:
-                - "1"
+                - fbf61853-8a47-4e9d-8c27-44043c966019
         status: 200 OK
         code: 200
-        duration: 168.281708ms
+        duration: 97.430292ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1024,8 +1016,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/84aa2745-5ba7-4dd4-bc76-7391e0e07b77
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1033,20 +1025,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 509
+        content_length: 20
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "509"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:12 GMT
+                - Tue, 11 Feb 2025 14:23:25 GMT
+            Link:
+                - </servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1054,10 +1048,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1a4fb59a-3f0e-4151-9aa0-9823514965f4
+                - 3c34415d-5521-40b8-a914-75307b87bf66
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 128.744875ms
+        duration: 83.624584ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1073,8 +1069,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2
         method: GET
       response:
         proto: HTTP/2.0
@@ -1082,20 +1078,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2137
+        content_length: 1706
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:09.587756+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:7d","maintenances":[],"modification_date":"2025-01-27T13:47:09.587756+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:22.754779+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e9","maintenances":[],"modification_date":"2025-02-11T14:23:22.754779+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2137"
+                - "1706"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:12 GMT
+                - Tue, 11 Feb 2025 14:23:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1103,10 +1099,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 02c8a956-9fa6-48ae-a542-aa70e8f5fec5
+                - bc9d33e4-dad3-428a-af9a-95a46be5beac
         status: 200 OK
         code: 200
-        duration: 214.736583ms
+        duration: 143.84425ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1122,8 +1118,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/adb01adb-bf06-4716-8a66-2a9c3c9c4a80
         method: GET
       response:
         proto: HTTP/2.0
@@ -1131,20 +1127,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 143
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","type":"not_found"}'
         headers:
             Content-Length:
-                - "17"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:12 GMT
+                - Tue, 11 Feb 2025 14:23:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1152,10 +1148,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 95ed9ecf-80c2-4ba1-874f-170507b87350
-        status: 200 OK
-        code: 200
-        duration: 120.402791ms
+                - 840275a7-9775-42a8-9a5c-42064ee7a85d
+        status: 404 Not Found
+        code: 404
+        duration: 34.816541ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1171,8 +1167,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/84aa2745-5ba7-4dd4-bc76-7391e0e07b77
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers?name=tf-server&order=creation_date_desc
         method: GET
       response:
         proto: HTTP/2.0
@@ -1180,20 +1176,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 509
+        content_length: 1709
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"servers":[{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:22.754779+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e9","maintenances":[],"modification_date":"2025-02-11T14:23:22.754779+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "509"
+                - "1709"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:12 GMT
+                - Tue, 11 Feb 2025 14:23:25 GMT
+            Link:
+                - </servers?page=1&per_page=50&name=tf-server&order=creation_date_desc>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1201,10 +1199,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c77caa6f-2f3a-483d-b2db-d3524850b6a4
+                - 57a1139e-5c25-4ba2-a107-8c5b49b39d26
+            X-Total-Count:
+                - "1"
         status: 200 OK
         code: 200
-        duration: 119.930708ms
+        duration: 194.956583ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1220,8 +1220,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/adb01adb-bf06-4716-8a66-2a9c3c9c4a80
         method: GET
       response:
         proto: HTTP/2.0
@@ -1229,22 +1229,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 701
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"created_at":"2025-02-11T14:23:22.978570Z","id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:22.978570Z","id":"afe5d765-4963-41b7-b1da-2e8a0f756b3a","product_resource_id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:22.978570Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "20"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:12 GMT
-            Link:
-                - </servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:23:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1252,12 +1250,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - eb19bc30-108f-4e22-bf52-1453164f10fe
-            X-Total-Count:
-                - "0"
+                - 7a4a4a75-3f82-4f37-94db-28f55976a9f6
         status: 200 OK
         code: 200
-        duration: 104.28375ms
+        duration: 69.626417ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1273,8 +1269,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1293,9 +1289,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:12 GMT
+                - Tue, 11 Feb 2025 14:23:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1303,10 +1299,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 59f3fcf7-c0d6-4323-94ec-d9147dfff503
+                - e180f5f6-1a6d-4d9e-8cf9-ddaaf753b1f1
         status: 200 OK
         code: 200
-        duration: 113.794667ms
+        duration: 90.924583ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1322,8 +1318,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2
         method: GET
       response:
         proto: HTTP/2.0
@@ -1331,22 +1327,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 1706
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:22.754779+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e9","maintenances":[],"modification_date":"2025-02-11T14:23:22.754779+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "20"
+                - "1706"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:12 GMT
-            Link:
-                - </servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:23:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1354,12 +1348,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 942b24f7-c176-49e1-940c-31b9181b9d6e
-            X-Total-Count:
-                - "0"
+                - a0007faf-175e-4fbd-a8a1-b641ceb269e0
         status: 200 OK
         code: 200
-        duration: 97.668166ms
+        duration: 154.736416ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1375,8 +1367,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers?name=tf-server&order=creation_date_desc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/adb01adb-bf06-4716-8a66-2a9c3c9c4a80
         method: GET
       response:
         proto: HTTP/2.0
@@ -1384,22 +1376,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2140
+        content_length: 143
         uncompressed: false
-        body: '{"servers":[{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:09.587756+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:7d","maintenances":[],"modification_date":"2025-01-27T13:47:09.587756+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}]}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","type":"not_found"}'
         headers:
             Content-Length:
-                - "2140"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:12 GMT
-            Link:
-                - </servers?page=1&per_page=50&name=tf-server&order=creation_date_desc>; rel="last"
+                - Tue, 11 Feb 2025 14:23:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1407,12 +1397,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 316bf5f8-89e0-45cb-8a08-f91d185ef469
-            X-Total-Count:
-                - "1"
-        status: 200 OK
-        code: 200
-        duration: 158.095625ms
+                - 31783be4-5f4d-4136-931e-c8564c060a94
+        status: 404 Not Found
+        code: 404
+        duration: 34.214125ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1428,8 +1416,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1437,20 +1425,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2137
+        content_length: 20
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:09.587756+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:7d","maintenances":[],"modification_date":"2025-01-27T13:47:09.587756+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "2137"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:13 GMT
+                - Tue, 11 Feb 2025 14:23:25 GMT
+            Link:
+                - </servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1458,10 +1448,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ec68e7fa-46bf-45b6-b5c9-7dff564eef43
+                - 4dd08d91-c110-4766-a2b3-26fe713baad3
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 158.046708ms
+        duration: 81.556709ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1477,8 +1469,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/84aa2745-5ba7-4dd4-bc76-7391e0e07b77
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/adb01adb-bf06-4716-8a66-2a9c3c9c4a80
         method: GET
       response:
         proto: HTTP/2.0
@@ -1486,20 +1478,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 509
+        content_length: 701
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T14:23:22.978570Z","id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:22.978570Z","id":"afe5d765-4963-41b7-b1da-2e8a0f756b3a","product_resource_id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:22.978570Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "509"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:12 GMT
+                - Tue, 11 Feb 2025 14:23:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1507,10 +1499,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 03689f17-729e-490a-9e4e-76f6e0b48918
+                - 81a50f75-c025-42a0-bde9-9a91f509dd38
         status: 200 OK
         code: 200
-        duration: 110.530583ms
+        duration: 78.276833ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1526,8 +1518,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1535,20 +1527,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2137
+        content_length: 17
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:09.587756+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:7d","maintenances":[],"modification_date":"2025-01-27T13:47:09.587756+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "2137"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:13 GMT
+                - Tue, 11 Feb 2025 14:23:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1556,10 +1548,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b21a4bbe-4192-4566-92d5-9c82a9290705
+                - 780d8f4d-a2a7-43c2-aaba-1ad89d9c73d7
         status: 200 OK
         code: 200
-        duration: 162.344667ms
+        duration: 84.969916ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1575,8 +1567,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1584,20 +1576,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 20
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "17"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:13 GMT
+                - Tue, 11 Feb 2025 14:23:25 GMT
+            Link:
+                - </servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1605,10 +1599,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2b6f21d1-963d-49c5-ad3b-1c0516511f9f
+                - 89c941da-57b6-46a7-8cd9-c1f52ba12d05
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 95.251666ms
+        duration: 77.216625ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1624,8 +1620,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/84aa2745-5ba7-4dd4-bc76-7391e0e07b77
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2
         method: GET
       response:
         proto: HTTP/2.0
@@ -1633,20 +1629,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 509
+        content_length: 1706
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:22.754779+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e9","maintenances":[],"modification_date":"2025-02-11T14:23:22.754779+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "509"
+                - "1706"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:13 GMT
+                - Tue, 11 Feb 2025 14:23:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1654,10 +1650,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 46e8b837-87f7-4297-a937-82894079c016
+                - 3d4a0a61-96d0-43d1-9068-5294522e5624
         status: 200 OK
         code: 200
-        duration: 96.946584ms
+        duration: 175.122959ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1673,8 +1669,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/adb01adb-bf06-4716-8a66-2a9c3c9c4a80
         method: GET
       response:
         proto: HTTP/2.0
@@ -1682,22 +1678,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 143
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","type":"not_found"}'
         headers:
             Content-Length:
-                - "20"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:13 GMT
-            Link:
-                - </servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:23:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1705,12 +1699,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c3887974-da31-4277-9f1c-8b28a37e50af
-            X-Total-Count:
-                - "0"
-        status: 200 OK
-        code: 200
-        duration: 549.177208ms
+                - 0f3dbd93-b800-4d13-b5bf-d4f7a3d84b01
+        status: 404 Not Found
+        code: 404
+        duration: 32.791584ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1726,8 +1718,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers?name=tf-server&order=creation_date_desc
         method: GET
       response:
         proto: HTTP/2.0
@@ -1735,20 +1727,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 1709
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"servers":[{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:22.754779+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e9","maintenances":[],"modification_date":"2025-02-11T14:23:22.754779+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "17"
+                - "1709"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:13 GMT
+                - Tue, 11 Feb 2025 14:23:26 GMT
+            Link:
+                - </servers?page=1&per_page=50&name=tf-server&order=creation_date_desc>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1756,10 +1750,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ae57fa8e-0bea-4a00-b864-4aff443d3178
+                - 4988f860-f2a5-4403-a81c-8d97cbde3b49
+            X-Total-Count:
+                - "1"
         status: 200 OK
         code: 200
-        duration: 496.430084ms
+        duration: 218.269666ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1775,8 +1771,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/adb01adb-bf06-4716-8a66-2a9c3c9c4a80
         method: GET
       response:
         proto: HTTP/2.0
@@ -1784,22 +1780,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 701
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"created_at":"2025-02-11T14:23:22.978570Z","id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:22.978570Z","id":"afe5d765-4963-41b7-b1da-2e8a0f756b3a","product_resource_id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:22.978570Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "20"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:13 GMT
-            Link:
-                - </servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:23:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1807,12 +1801,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0a154689-2cbb-4c84-a652-cfde2bf02bb8
-            X-Total-Count:
-                - "0"
+                - 695ac8c1-8fb6-46b7-a8aa-ec9ba961c3f9
         status: 200 OK
         code: 200
-        duration: 88.60875ms
+        duration: 74.833875ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1828,8 +1820,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1837,20 +1829,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2137
+        content_length: 17
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:09.587756+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:7d","maintenances":[],"modification_date":"2025-01-27T13:47:09.587756+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "2137"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:14 GMT
+                - Tue, 11 Feb 2025 14:23:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1858,10 +1850,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 000fd0df-ffd9-4dec-8e73-39538087a353
+                - 10e5cc63-6dfb-4f85-88f9-963402e861bf
         status: 200 OK
         code: 200
-        duration: 137.317417ms
+        duration: 90.756917ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1877,8 +1869,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2
         method: GET
       response:
         proto: HTTP/2.0
@@ -1886,20 +1878,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2137
+        content_length: 1706
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:09.587756+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:7d","maintenances":[],"modification_date":"2025-01-27T13:47:09.587756+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:22.754779+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e9","maintenances":[],"modification_date":"2025-02-11T14:23:22.754779+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2137"
+                - "1706"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:14 GMT
+                - Tue, 11 Feb 2025 14:23:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1907,10 +1899,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a197d376-db57-4a44-994c-41c4c26200b3
+                - 068cf637-fd7b-4b19-a763-d48c9a2459f3
         status: 200 OK
         code: 200
-        duration: 142.391292ms
+        duration: 171.682333ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1926,8 +1918,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/adb01adb-bf06-4716-8a66-2a9c3c9c4a80
         method: GET
       response:
         proto: HTTP/2.0
@@ -1935,20 +1927,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2137
+        content_length: 143
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:09.587756+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:7d","maintenances":[],"modification_date":"2025-01-27T13:47:09.587756+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","type":"not_found"}'
         headers:
             Content-Length:
-                - "2137"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:14 GMT
+                - Tue, 11 Feb 2025 14:23:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1956,10 +1948,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 915f1f68-3941-414e-9a4e-e2158d0e45f9
-        status: 200 OK
-        code: 200
-        duration: 145.822959ms
+                - 13445704-5546-4ea5-a48a-3123a2460485
+        status: 404 Not Found
+        code: 404
+        duration: 40.11425ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1975,8 +1967,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/84aa2745-5ba7-4dd4-bc76-7391e0e07b77
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1984,20 +1976,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 509
+        content_length: 20
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "509"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:14 GMT
+                - Tue, 11 Feb 2025 14:23:26 GMT
+            Link:
+                - </servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2005,10 +1999,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9998c418-7235-4966-88e5-d97b08f3a009
+                - 06250a9c-eb5e-4229-9644-292c261b9371
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 96.173042ms
+        duration: 90.65925ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2024,8 +2020,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers?name=tf-server&order=creation_date_desc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/adb01adb-bf06-4716-8a66-2a9c3c9c4a80
         method: GET
       response:
         proto: HTTP/2.0
@@ -2033,22 +2029,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2140
+        content_length: 701
         uncompressed: false
-        body: '{"servers":[{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:09.587756+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:7d","maintenances":[],"modification_date":"2025-01-27T13:47:09.587756+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}]}'
+        body: '{"created_at":"2025-02-11T14:23:22.978570Z","id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:22.978570Z","id":"afe5d765-4963-41b7-b1da-2e8a0f756b3a","product_resource_id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:22.978570Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2140"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:14 GMT
-            Link:
-                - </servers?page=1&per_page=50&name=tf-server&order=creation_date_desc>; rel="last"
+                - Tue, 11 Feb 2025 14:23:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2056,12 +2050,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 576e2aa4-7e17-455d-b554-3889f14c9758
-            X-Total-Count:
-                - "1"
+                - 7fefbbb4-38e3-4747-8f5b-9e645a63d323
         status: 200 OK
         code: 200
-        duration: 271.392208ms
+        duration: 106.248ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2077,8 +2069,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -2097,9 +2089,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:14 GMT
+                - Tue, 11 Feb 2025 14:23:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2107,10 +2099,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9f1c1a5b-2ef2-4b1c-ba99-baa7fb9268c8
+                - 6603397f-2b82-442f-9202-d661569b5fa2
         status: 200 OK
         code: 200
-        duration: 84.805792ms
+        duration: 80.611209ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2126,8 +2118,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -2146,11 +2138,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:14 GMT
+                - Tue, 11 Feb 2025 14:23:26 GMT
             Link:
-                - </servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2158,12 +2150,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 98e45f08-5035-404a-a276-9ea01e5755d9
+                - 3ec27fbd-d7f2-4b35-885b-d0bf895b7124
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 89.671458ms
+        duration: 95.482584ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2179,8 +2171,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2
         method: GET
       response:
         proto: HTTP/2.0
@@ -2188,20 +2180,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2137
+        content_length: 1706
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:09.587756+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:7d","maintenances":[],"modification_date":"2025-01-27T13:47:09.587756+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:22.754779+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e9","maintenances":[],"modification_date":"2025-02-11T14:23:22.754779+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2137"
+                - "1706"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:14 GMT
+                - Tue, 11 Feb 2025 14:23:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2209,10 +2201,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5d9e6ba8-6072-426c-bf36-8fa5a897b0f2
+                - 73fafe42-6872-4a26-a95c-85b121b52406
         status: 200 OK
         code: 200
-        duration: 200.540208ms
+        duration: 191.653125ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2228,8 +2220,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/84aa2745-5ba7-4dd4-bc76-7391e0e07b77
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2
         method: GET
       response:
         proto: HTTP/2.0
@@ -2237,20 +2229,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 509
+        content_length: 1706
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:22.754779+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e9","maintenances":[],"modification_date":"2025-02-11T14:23:22.754779+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "509"
+                - "1706"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:15 GMT
+                - Tue, 11 Feb 2025 14:23:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2258,10 +2250,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6eee3007-43ee-44a5-aa31-7e59dde46986
+                - fe56ee69-3352-424a-9fa6-e1057134a8e3
         status: 200 OK
         code: 200
-        duration: 78.579958ms
+        duration: 174.8575ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2277,8 +2269,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2
         method: GET
       response:
         proto: HTTP/2.0
@@ -2286,20 +2278,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 1706
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:22.754779+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e9","maintenances":[],"modification_date":"2025-02-11T14:23:22.754779+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "17"
+                - "1706"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:14 GMT
+                - Tue, 11 Feb 2025 14:23:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2307,10 +2299,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b1721318-7793-4056-945c-8bd0d1a1b668
+                - 5f9f5611-2e42-44a3-b6ee-98f5f5cd7b40
         status: 200 OK
         code: 200
-        duration: 96.0345ms
+        duration: 178.956ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2326,8 +2318,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/adb01adb-bf06-4716-8a66-2a9c3c9c4a80
         method: GET
       response:
         proto: HTTP/2.0
@@ -2335,22 +2327,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 143
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","type":"not_found"}'
         headers:
             Content-Length:
-                - "20"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:14 GMT
-            Link:
-                - </servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:23:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2358,12 +2348,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d9c36182-ed5b-4fbd-8283-4982c6543d8c
-            X-Total-Count:
-                - "0"
-        status: 200 OK
-        code: 200
-        duration: 76.447959ms
+                - 2acf696b-6379-48e4-ad9e-a3a234b28082
+        status: 404 Not Found
+        code: 404
+        duration: 31.526083ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2379,8 +2367,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers?name=tf-server&order=creation_date_desc
         method: GET
       response:
         proto: HTTP/2.0
@@ -2388,20 +2376,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2137
+        content_length: 1709
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:09.587756+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:7d","maintenances":[],"modification_date":"2025-01-27T13:47:09.587756+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"servers":[{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:22.754779+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e9","maintenances":[],"modification_date":"2025-02-11T14:23:22.754779+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "2137"
+                - "1709"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:15 GMT
+                - Tue, 11 Feb 2025 14:23:27 GMT
+            Link:
+                - </servers?page=1&per_page=50&name=tf-server&order=creation_date_desc>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2409,10 +2399,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ee93a698-88f7-445b-b4cf-02ff92eb182e
+                - 57633e36-267d-4e0f-8055-a7ebb302ee97
+            X-Total-Count:
+                - "1"
         status: 200 OK
         code: 200
-        duration: 129.488917ms
+        duration: 231.155417ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2428,8 +2420,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/84aa2745-5ba7-4dd4-bc76-7391e0e07b77
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/adb01adb-bf06-4716-8a66-2a9c3c9c4a80
         method: GET
       response:
         proto: HTTP/2.0
@@ -2437,20 +2429,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 509
+        content_length: 701
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T14:23:22.978570Z","id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:22.978570Z","id":"afe5d765-4963-41b7-b1da-2e8a0f756b3a","product_resource_id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:22.978570Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "509"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:15 GMT
+                - Tue, 11 Feb 2025 14:23:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2458,10 +2450,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6ce93d64-f9cb-4154-a2b1-5f7a015eb387
+                - ddda76ba-bf5b-4ce9-a6e6-df51ccdc1a72
         status: 200 OK
         code: 200
-        duration: 84.722042ms
+        duration: 65.27725ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2477,8 +2469,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -2497,9 +2489,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:15 GMT
+                - Tue, 11 Feb 2025 14:23:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2507,10 +2499,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 66426731-7ddf-4a16-a3bb-80f6d0c3db23
+                - b0cfbc7e-dcd8-47a6-8d66-a750b1317604
         status: 200 OK
         code: 200
-        duration: 74.589917ms
+        duration: 79.940292ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -2526,8 +2518,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2
         method: GET
       response:
         proto: HTTP/2.0
@@ -2535,22 +2527,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 1706
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:22.754779+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e9","maintenances":[],"modification_date":"2025-02-11T14:23:22.754779+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "20"
+                - "1706"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:15 GMT
-            Link:
-                - </servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:23:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2558,12 +2548,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 06a332e7-aa4c-45b7-8ebe-37ecb9e3490d
-            X-Total-Count:
-                - "0"
+                - 6f6f3895-7e04-4b1a-b10a-a709897da255
         status: 200 OK
         code: 200
-        duration: 95.674042ms
+        duration: 139.674958ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2579,8 +2567,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/adb01adb-bf06-4716-8a66-2a9c3c9c4a80
         method: GET
       response:
         proto: HTTP/2.0
@@ -2588,20 +2576,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2137
+        content_length: 143
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:09.587756+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:7d","maintenances":[],"modification_date":"2025-01-27T13:47:09.587756+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","type":"not_found"}'
         headers:
             Content-Length:
-                - "2137"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:15 GMT
+                - Tue, 11 Feb 2025 14:23:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2609,10 +2597,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e718e049-7443-4b61-a2a8-9c3c66bd4d6c
-        status: 200 OK
-        code: 200
-        duration: 154.212875ms
+                - d4dbe4e6-583e-4e08-8d5a-795314e99bbf
+        status: 404 Not Found
+        code: 404
+        duration: 49.413375ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -2628,8 +2616,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/84aa2745-5ba7-4dd4-bc76-7391e0e07b77
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -2637,20 +2625,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 509
+        content_length: 20
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "509"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:15 GMT
+                - Tue, 11 Feb 2025 14:23:27 GMT
+            Link:
+                - </servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2658,10 +2648,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f43e4257-eadd-492b-95cb-1c7a474db19b
+                - 8f16732b-cd94-427e-b9cf-e2a3126d5983
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 93.337583ms
+        duration: 84.040916ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -2677,8 +2669,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers?name=tf-server&order=creation_date_desc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/adb01adb-bf06-4716-8a66-2a9c3c9c4a80
         method: GET
       response:
         proto: HTTP/2.0
@@ -2686,22 +2678,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2140
+        content_length: 701
         uncompressed: false
-        body: '{"servers":[{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:09.587756+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:7d","maintenances":[],"modification_date":"2025-01-27T13:47:09.587756+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}]}'
+        body: '{"created_at":"2025-02-11T14:23:22.978570Z","id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:22.978570Z","id":"afe5d765-4963-41b7-b1da-2e8a0f756b3a","product_resource_id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:22.978570Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2140"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:16 GMT
-            Link:
-                - </servers?page=1&per_page=50&name=tf-server&order=creation_date_desc>; rel="last"
+                - Tue, 11 Feb 2025 14:23:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2709,12 +2699,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6d755b8b-d554-445a-99de-f170a9a5ce9b
-            X-Total-Count:
-                - "1"
+                - 73795501-a216-4148-bc02-48d0b2b45a5b
         status: 200 OK
         code: 200
-        duration: 282.867625ms
+        duration: 65.606542ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -2730,8 +2718,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -2750,9 +2738,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:16 GMT
+                - Tue, 11 Feb 2025 14:23:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2760,10 +2748,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a55407ed-1e79-4275-a207-408feea60e23
+                - 6a674575-f5f7-449b-9122-f706ce03a5cb
         status: 200 OK
         code: 200
-        duration: 74.212166ms
+        duration: 80.332667ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -2779,8 +2767,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -2799,11 +2787,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:16 GMT
+                - Tue, 11 Feb 2025 14:23:28 GMT
             Link:
-                - </servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2811,12 +2799,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b75b0a5b-11c6-4b62-8ccf-306f193b5b83
+                - ae8c7764-82e4-4054-aea2-67dfd4ccac0f
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 81.70425ms
+        duration: 91.145875ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2832,8 +2820,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2
         method: GET
       response:
         proto: HTTP/2.0
@@ -2841,20 +2829,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2137
+        content_length: 1706
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:09.587756+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:7d","maintenances":[],"modification_date":"2025-01-27T13:47:09.587756+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:22.754779+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e9","maintenances":[],"modification_date":"2025-02-11T14:23:22.754779+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2137"
+                - "1706"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:15 GMT
+                - Tue, 11 Feb 2025 14:23:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2862,10 +2850,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 77832b0f-0ac8-4895-8e59-ddec517af898
+                - e60409e5-b20d-43c0-a92f-952b25f3dbad
         status: 200 OK
         code: 200
-        duration: 136.103958ms
+        duration: 150.534833ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2881,8 +2869,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/84aa2745-5ba7-4dd4-bc76-7391e0e07b77
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/adb01adb-bf06-4716-8a66-2a9c3c9c4a80
         method: GET
       response:
         proto: HTTP/2.0
@@ -2890,20 +2878,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 509
+        content_length: 143
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","type":"not_found"}'
         headers:
             Content-Length:
-                - "509"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:15 GMT
+                - Tue, 11 Feb 2025 14:23:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2911,10 +2899,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b0933f73-2baf-49b8-9879-315208ba7c72
-        status: 200 OK
-        code: 200
-        duration: 66.969292ms
+                - bb34082a-fc7a-4751-9676-c84365e5bf2b
+        status: 404 Not Found
+        code: 404
+        duration: 41.898166ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -2930,8 +2918,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/adb01adb-bf06-4716-8a66-2a9c3c9c4a80
         method: GET
       response:
         proto: HTTP/2.0
@@ -2939,20 +2927,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 701
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"created_at":"2025-02-11T14:23:22.978570Z","id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:22.978570Z","id":"afe5d765-4963-41b7-b1da-2e8a0f756b3a","product_resource_id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:22.978570Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "17"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:16 GMT
+                - Tue, 11 Feb 2025 14:23:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2960,10 +2948,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - abd83159-a8e0-4346-9c22-4927b56a25bf
+                - 0326b536-4881-4cf3-9916-65832b32f279
         status: 200 OK
         code: 200
-        duration: 82.180458ms
+        duration: 65.620333ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -2979,8 +2967,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -2988,22 +2976,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 17
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "20"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:16 GMT
-            Link:
-                - </servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:23:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3011,12 +2997,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f77f0a25-e90c-47ff-96ec-2ab6447be8a2
-            X-Total-Count:
-                - "0"
+                - 24f587fd-8afc-43b5-88df-1066b3880447
         status: 200 OK
         code: 200
-        duration: 98.98575ms
+        duration: 83.125666ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -3032,8 +3016,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -3041,20 +3025,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2137
+        content_length: 20
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:09.587756+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:7d","maintenances":[],"modification_date":"2025-01-27T13:47:09.587756+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "2137"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:16 GMT
+                - Tue, 11 Feb 2025 14:23:28 GMT
+            Link:
+                - </servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3062,10 +3048,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 83470b45-224f-43f9-bae8-971783885f8f
+                - b603e877-b878-4e02-a2ac-37bb47f009e2
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 167.369125ms
+        duration: 92.696375ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -3081,8 +3069,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers?name=tf-server&order=creation_date_desc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2
         method: GET
       response:
         proto: HTTP/2.0
@@ -3090,22 +3078,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2140
+        content_length: 1706
         uncompressed: false
-        body: '{"servers":[{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:09.587756+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:7d","maintenances":[],"modification_date":"2025-01-27T13:47:09.587756+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}]}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:22.754779+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e9","maintenances":[],"modification_date":"2025-02-11T14:23:22.754779+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2140"
+                - "1706"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:16 GMT
-            Link:
-                - </servers?page=1&per_page=50&name=tf-server&order=creation_date_desc>; rel="last"
+                - Tue, 11 Feb 2025 14:23:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3113,12 +3099,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c595c888-e1e3-4be1-8bdd-e891b9bfbabc
-            X-Total-Count:
-                - "1"
+                - 3ef91ccc-d5b2-4b71-a81c-c2c2243316eb
         status: 200 OK
         code: 200
-        duration: 222.931791ms
+        duration: 157.361916ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -3134,8 +3118,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/84aa2745-5ba7-4dd4-bc76-7391e0e07b77
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers?name=tf-server&order=creation_date_desc
         method: GET
       response:
         proto: HTTP/2.0
@@ -3143,20 +3127,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 509
+        content_length: 1709
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"servers":[{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:22.754779+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e9","maintenances":[],"modification_date":"2025-02-11T14:23:22.754779+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "509"
+                - "1709"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:16 GMT
+                - Tue, 11 Feb 2025 14:23:28 GMT
+            Link:
+                - </servers?page=1&per_page=50&name=tf-server&order=creation_date_desc>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3164,10 +3150,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6a288a79-0a72-4841-80ca-264e839cf23d
+                - 135845d3-eb3e-4433-abd5-14dc4fcd6e66
+            X-Total-Count:
+                - "1"
         status: 200 OK
         code: 200
-        duration: 81.141333ms
+        duration: 158.98075ms
     - id: 63
       request:
         proto: HTTP/1.1
@@ -3183,8 +3171,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/adb01adb-bf06-4716-8a66-2a9c3c9c4a80
         method: GET
       response:
         proto: HTTP/2.0
@@ -3192,20 +3180,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 143
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","type":"not_found"}'
         headers:
             Content-Length:
-                - "17"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:16 GMT
+                - Tue, 11 Feb 2025 14:23:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3213,10 +3201,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8909fff6-89ff-41e6-a198-d65976a4c9d3
-        status: 200 OK
-        code: 200
-        duration: 73.365625ms
+                - 69397bd3-75a9-4c12-a399-624435b8a811
+        status: 404 Not Found
+        code: 404
+        duration: 46.789ms
     - id: 64
       request:
         proto: HTTP/1.1
@@ -3232,8 +3220,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/adb01adb-bf06-4716-8a66-2a9c3c9c4a80
         method: GET
       response:
         proto: HTTP/2.0
@@ -3241,20 +3229,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2137
+        content_length: 701
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:09.587756+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:7d","maintenances":[],"modification_date":"2025-01-27T13:47:09.587756+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T14:23:22.978570Z","id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:22.978570Z","id":"afe5d765-4963-41b7-b1da-2e8a0f756b3a","product_resource_id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:22.978570Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2137"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:16 GMT
+                - Tue, 11 Feb 2025 14:23:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3262,10 +3250,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7ee4196a-cf99-49e0-bf41-8556f7bcc396
+                - 1886839e-2923-408f-bd4f-ed11c69a7cd9
         status: 200 OK
         code: 200
-        duration: 128.752083ms
+        duration: 62.790583ms
     - id: 65
       request:
         proto: HTTP/1.1
@@ -3281,8 +3269,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2
         method: GET
       response:
         proto: HTTP/2.0
@@ -3290,22 +3278,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 1706
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:22.754779+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e9","maintenances":[],"modification_date":"2025-02-11T14:23:22.754779+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "20"
+                - "1706"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:16 GMT
-            Link:
-                - </servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:23:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3313,12 +3299,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 493102d6-fc39-4845-95d3-7f9fc5a207e8
-            X-Total-Count:
-                - "0"
+                - 29974668-8ad0-47d0-a1ff-48b116029f25
         status: 200 OK
         code: 200
-        duration: 99.68575ms
+        duration: 162.521417ms
     - id: 66
       request:
         proto: HTTP/1.1
@@ -3334,57 +3318,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/84aa2745-5ba7-4dd4-bc76-7391e0e07b77
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 509
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "509"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:47:16 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 73ffaa46-7308-4d69-9e8a-0034afd0dbdf
-        status: 200 OK
-        code: 200
-        duration: 78.6345ms
-    - id: 67
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -3403,9 +3338,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:17 GMT
+                - Tue, 11 Feb 2025 14:23:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3413,10 +3348,59 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ce2af726-ede2-470e-9f14-8c729d6f4bfe
+                - 4c0f826d-fbc4-4d0d-b188-bf7afe1ecc02
         status: 200 OK
         code: 200
-        duration: 72.859625ms
+        duration: 101.09225ms
+    - id: 67
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/adb01adb-bf06-4716-8a66-2a9c3c9c4a80
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:29 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ebdfde08-3954-46f6-99d5-c82516dcb7e4
+        status: 404 Not Found
+        code: 404
+        duration: 49.642666ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -3432,8 +3416,57 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/adb01adb-bf06-4716-8a66-2a9c3c9c4a80
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:23:22.978570Z","id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:22.978570Z","id":"afe5d765-4963-41b7-b1da-2e8a0f756b3a","product_resource_id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:22.978570Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:29 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5b940702-e5b3-4b0f-b68d-a050468feaa2
+        status: 200 OK
+        code: 200
+        duration: 64.120125ms
+    - id: 69
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -3452,11 +3485,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:16 GMT
+                - Tue, 11 Feb 2025 14:23:29 GMT
             Link:
-                - </servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3464,61 +3497,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4e0dc645-323c-4aa4-a172-8a8c778cdd03
+                - e26c3eb6-cad0-4911-a6b1-873a1c4d0aec
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 93.147875ms
-    - id: 69
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2137
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:09.587756+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:7d","maintenances":[],"modification_date":"2025-01-27T13:47:09.587756+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2137"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:47:17 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 5ba7969a-c39b-46d7-b8ea-f4a0c5638cf3
-        status: 200 OK
-        code: 200
-        duration: 143.893292ms
+        duration: 102.264875ms
     - id: 70
       request:
         proto: HTTP/1.1
@@ -3534,8 +3518,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -3543,20 +3527,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2137
+        content_length: 17
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:09.587756+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:7d","maintenances":[],"modification_date":"2025-01-27T13:47:09.587756+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:09.587756+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","name":"tf-server"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "2137"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:17 GMT
+                - Tue, 11 Feb 2025 14:23:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3564,10 +3548,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c4c016bb-4f30-4a8e-9e20-4c928f20dcee
+                - e56118ef-0538-4c69-9ee9-397e35249108
         status: 200 OK
         code: 200
-        duration: 144.299542ms
+        duration: 76.049667ms
     - id: 71
       request:
         proto: HTTP/1.1
@@ -3583,27 +3567,31 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/private_nics
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 20
         uncompressed: false
-        body: ""
+        body: '{"private_nics":[]}'
         headers:
+            Content-Length:
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:17 GMT
+                - Tue, 11 Feb 2025 14:23:29 GMT
+            Link:
+                - </servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3611,10 +3599,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5cdbda36-419e-461b-a66d-ec082d6b5ea6
-        status: 204 No Content
-        code: 204
-        duration: 173.287083ms
+                - 5f2e917e-1697-4a76-8300-a85fb26ae345
+            X-Total-Count:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 85.120917ms
     - id: 72
       request:
         proto: HTTP/1.1
@@ -3630,8 +3620,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2
         method: GET
       response:
         proto: HTTP/2.0
@@ -3639,20 +3629,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 143
+        content_length: 1706
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","type":"not_found"}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:22.754779+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e9","maintenances":[],"modification_date":"2025-02-11T14:23:22.754779+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "143"
+                - "1706"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:17 GMT
+                - Tue, 11 Feb 2025 14:23:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3660,10 +3650,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 92dd97a1-d4a4-442a-b54d-8dda0b7dee8c
-        status: 404 Not Found
-        code: 404
-        duration: 80.271625ms
+                - a9e92ac7-b7a7-451e-8fb7-7b3f2cd60686
+        status: 200 OK
+        code: 200
+        duration: 185.751084ms
     - id: 73
       request:
         proto: HTTP/1.1
@@ -3679,8 +3669,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/84aa2745-5ba7-4dd4-bc76-7391e0e07b77
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers?name=tf-server&order=creation_date_desc
         method: GET
       response:
         proto: HTTP/2.0
@@ -3688,20 +3678,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 446
+        content_length: 1709
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:47:09.587756+00:00","export_uri":null,"id":"84aa2745-5ba7-4dd4-bc76-7391e0e07b77","modification_date":"2025-01-27T13:47:17.737716+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"servers":[{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:22.754779+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e9","maintenances":[],"modification_date":"2025-02-11T14:23:22.754779+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "446"
+                - "1709"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:17 GMT
+                - Tue, 11 Feb 2025 14:23:29 GMT
+            Link:
+                - </servers?page=1&per_page=50&name=tf-server&order=creation_date_desc>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3709,10 +3701,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dabe7efa-3528-4493-a93c-c435f2ef4669
+                - c22f658d-7bb2-4463-87b1-e356fff74494
+            X-Total-Count:
+                - "1"
         status: 200 OK
         code: 200
-        duration: 79.890125ms
+        duration: 194.790708ms
     - id: 74
       request:
         proto: HTTP/1.1
@@ -3728,8 +3722,555 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/84aa2745-5ba7-4dd4-bc76-7391e0e07b77
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/adb01adb-bf06-4716-8a66-2a9c3c9c4a80
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:29 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 57202c29-2eba-4adb-96a6-aa494aaf49f6
+        status: 404 Not Found
+        code: 404
+        duration: 34.609583ms
+    - id: 75
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/adb01adb-bf06-4716-8a66-2a9c3c9c4a80
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:23:22.978570Z","id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:22.978570Z","id":"afe5d765-4963-41b7-b1da-2e8a0f756b3a","product_resource_id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:22.978570Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:29 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ccc41932-4633-46e2-b401-348672299a9d
+        status: 200 OK
+        code: 200
+        duration: 66.80325ms
+    - id: 76
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1706
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:22.754779+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e9","maintenances":[],"modification_date":"2025-02-11T14:23:22.754779+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1706"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:29 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f827db64-1da6-405d-a3d4-1ac05fff4d02
+        status: 200 OK
+        code: 200
+        duration: 132.049541ms
+    - id: 77
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/user_data
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 17
+        uncompressed: false
+        body: '{"user_data":[]}'
+        headers:
+            Content-Length:
+                - "17"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:29 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f0a07963-4342-462b-995e-c81b108fcc07
+        status: 200 OK
+        code: 200
+        duration: 81.757291ms
+    - id: 78
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/adb01adb-bf06-4716-8a66-2a9c3c9c4a80
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:29 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - cfce26e6-9baa-49a6-b3ba-135f4463b722
+        status: 404 Not Found
+        code: 404
+        duration: 50.575875ms
+    - id: 79
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/adb01adb-bf06-4716-8a66-2a9c3c9c4a80
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:23:22.978570Z","id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:22.978570Z","id":"afe5d765-4963-41b7-b1da-2e8a0f756b3a","product_resource_id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:22.978570Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:29 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 85fdf0d3-fe9c-407f-8d10-b6fc2a50369b
+        status: 200 OK
+        code: 200
+        duration: 64.284208ms
+    - id: 80
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 20
+        uncompressed: false
+        body: '{"private_nics":[]}'
+        headers:
+            Content-Length:
+                - "20"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:29 GMT
+            Link:
+                - </servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/private_nics?page=0&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 14a0bbec-f082-4b4c-baad-f735b2336b66
+            X-Total-Count:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 80.589917ms
+    - id: 81
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/user_data
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 17
+        uncompressed: false
+        body: '{"user_data":[]}'
+        headers:
+            Content-Length:
+                - "17"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:29 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 53933e46-f78c-40cc-a3ef-b09f203786f6
+        status: 200 OK
+        code: 200
+        duration: 88.080333ms
+    - id: 82
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 20
+        uncompressed: false
+        body: '{"private_nics":[]}'
+        headers:
+            Content-Length:
+                - "20"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:30 GMT
+            Link:
+                - </servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2/private_nics?page=0&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3317bd06-2dbc-440f-80a1-0f2e4ccb1cb8
+            X-Total-Count:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 89.6675ms
+    - id: 83
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1706
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:22.754779+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e9","maintenances":[],"modification_date":"2025-02-11T14:23:22.754779+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1706"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 56734e9e-58d3-4693-b738-92563787c466
+        status: 200 OK
+        code: 200
+        duration: 559.624417ms
+    - id: 84
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1706
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:22.754779+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server","id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e9","maintenances":[],"modification_date":"2025-02-11T14:23:22.754779+00:00","name":"tf-server","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_server","basic"],"volumes":{"0":{"boot":false,"id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1706"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 301d7c2f-45e6-4808-aef4-34647b24588f
+        status: 200 OK
+        code: 200
+        duration: 271.895834ms
+    - id: 85
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3746,9 +4287,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:18 GMT
+                - Tue, 11 Feb 2025 14:23:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3756,11 +4297,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e8a5f28f-b08b-4c1c-95a2-b938af1f2906
+                - e24f5915-dc52-46b8-8519-9f60c5fa0501
         status: 204 No Content
         code: 204
-        duration: 172.057208ms
-    - id: 75
+        duration: 266.643ms
+    - id: 86
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3775,8 +4316,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2
         method: GET
       response:
         proto: HTTP/2.0
@@ -3786,7 +4327,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -3795,9 +4336,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:17 GMT
+                - Tue, 11 Feb 2025 14:23:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3805,11 +4346,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 784dd6ae-01a2-4bd5-8feb-41cb44d0c955
+                - f3eea32c-6b1c-476f-b799-525a29b4e299
         status: 404 Not Found
         code: 404
-        duration: 127.796792ms
-    - id: 76
+        duration: 114.369ms
+    - id: 87
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3824,8 +4365,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/adb01adb-bf06-4716-8a66-2a9c3c9c4a80
         method: GET
       response:
         proto: HTTP/2.0
@@ -3835,7 +4376,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -3844,9 +4385,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:18 GMT
+                - Tue, 11 Feb 2025 14:23:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3854,11 +4395,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ed0e3dfe-4847-426d-bbe8-c59b9622f38d
+                - 29fef45d-5532-4fd1-83dd-d233b690098a
         status: 404 Not Found
         code: 404
-        duration: 93.785458ms
-    - id: 77
+        duration: 31.250958ms
+    - id: 88
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3873,8 +4414,104 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f6ca5b86-51ae-4844-aef0-87bc6e24deae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/adb01adb-bf06-4716-8a66-2a9c3c9c4a80
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 494
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:23:22.978570Z","id":"adb01adb-bf06-4716-8a66-2a9c3c9c4a80","last_detached_at":"2025-02-11T14:23:31.484284Z","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:31.484284Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "494"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:31 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a38df076-85d1-4106-82b2-c2fa8236353b
+        status: 200 OK
+        code: 200
+        duration: 68.2625ms
+    - id: 89
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/adb01adb-bf06-4716-8a66-2a9c3c9c4a80
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:31 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3010d80d-7557-47cc-9b56-ddafbff80a1d
+        status: 204 No Content
+        code: 204
+        duration: 133.923583ms
+    - id: 90
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2
         method: GET
       response:
         proto: HTTP/2.0
@@ -3884,7 +4521,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"f6ca5b86-51ae-4844-aef0-87bc6e24deae","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -3893,9 +4530,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:18 GMT
+                - Tue, 11 Feb 2025 14:23:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3903,7 +4540,105 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8e736aad-097b-4b92-abc4-ce08ecad1304
+                - 179d9c30-e6ed-4712-b3a2-d703fd360f72
         status: 404 Not Found
         code: 404
-        duration: 126.286875ms
+        duration: 87.120417ms
+    - id: 91
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:31 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 235270ce-16f3-4539-89b1-e6b5156e8bcb
+        status: 404 Not Found
+        code: 404
+        duration: 198.377542ms
+    - id: 92
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"9b6d0abe-c2b6-4440-a0b1-4ea7546d0db2","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:31 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 322ae994-d9ab-4c40-a1ed-cb5e71e7f5a5
+        status: 404 Not Found
+        code: 404
+        duration: 114.991792ms

--- a/internal/services/instance/testdata/data-source-servers-basic.cassette.yaml
+++ b/internal/services/instance/testdata/data-source-servers-basic.cassette.yaml
@@ -16,7 +16,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
         method: GET
       response:
@@ -25,22 +25,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 38539
+        content_length: 35639
         uncompressed: false
-        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
+        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
         headers:
             Content-Length:
-                - "38539"
+                - "35639"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:45 GMT
+                - Tue, 11 Feb 2025 14:22:36 GMT
             Link:
                 - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,12 +48,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7807d469-8875-49e2-8c38-6a25d29d757f
+                - ec51d5db-e695-4908-8b5f-dd62690f7771
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 67.418667ms
+        duration: 347.362708ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -69,7 +69,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
         method: GET
       response:
@@ -78,22 +78,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 14208
+        content_length: 13164
         uncompressed: false
-        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
         headers:
             Content-Length:
-                - "14208"
+                - "13164"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:45 GMT
+                - Tue, 11 Feb 2025 14:22:36 GMT
             Link:
                 - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -101,12 +101,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 22d22cad-dadc-4fdc-a07f-e6b25b1f7089
+                - dd2542d7-0918-4072-8b6f-acde51376b32
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 42.200875ms
+        duration: 40.960125ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -122,8 +122,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_local&zone=fr-par-1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_sbs&zone=fr-par-1
         method: GET
       response:
         proto: HTTP/2.0
@@ -131,20 +131,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1300
+        content_length: 1296
         uncompressed: false
-        body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"56d4019c-8305-467a-a3f2-70498ad799df","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
+        body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"57509e82-ac3b-49b7-9970-97b60f40ff72","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"9b647e1e-253a-41e7-8c15-911c622ee2dc","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"}],"total_count":2}'
         headers:
             Content-Length:
-                - "1300"
+                - "1296"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:46 GMT
+                - Tue, 11 Feb 2025 14:22:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -152,28 +152,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4612a9c1-2fbd-438f-9444-9e346427b252
+                - ddf8120a-b8a6-4532-80bb-f8eb2e1f490c
         status: 200 OK
         code: 200
-        duration: 84.492458ms
+        duration: 95.748ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 342
+        content_length: 301
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-server-datasource0","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":["terraform-test","data_scaleway_instance_servers","basic"]}'
+        body: '{"name":"tf-server-datasource0","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"57509e82-ac3b-49b7-9970-97b60f40ff72","volumes":{"0":{"boot":false}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":["terraform-test","data_scaleway_instance_servers","basic"]}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
         method: POST
       response:
@@ -182,22 +182,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2174
+        content_length: 1731
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:46.579463+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f3","maintenances":[],"modification_date":"2025-01-27T13:48:46.579463+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:46.579463+00:00","export_uri":null,"id":"5b43bb7d-47c1-4019-ab73-951d65fd9abc","modification_date":"2025-01-27T13:48:46.579463+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","name":"tf-server-datasource0"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.434866+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"3846d0aa-faa7-4428-a529-c346f1844f99","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:d3","maintenances":[],"modification_date":"2025-02-11T14:22:36.434866+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"274105cd-669b-4ecf-88da-dde4900af880","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2174"
+                - "1731"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:46 GMT
+                - Tue, 11 Feb 2025 14:22:37 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4beaaeb5-58f6-40ce-ae0f-9637416f43df
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3846d0aa-faa7-4428-a529-c346f1844f99
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -205,10 +205,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2208569d-4600-42d1-b214-c4106d11ac59
+                - b442b872-e289-4cfc-bf0d-3e6c87bfbb74
         status: 201 Created
         code: 201
-        duration: 567.476625ms
+        duration: 1.186061209s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -224,8 +224,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4beaaeb5-58f6-40ce-ae0f-9637416f43df
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3846d0aa-faa7-4428-a529-c346f1844f99
         method: GET
       response:
         proto: HTTP/2.0
@@ -233,20 +233,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2174
+        content_length: 1731
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:46.579463+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f3","maintenances":[],"modification_date":"2025-01-27T13:48:46.579463+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:46.579463+00:00","export_uri":null,"id":"5b43bb7d-47c1-4019-ab73-951d65fd9abc","modification_date":"2025-01-27T13:48:46.579463+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","name":"tf-server-datasource0"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.434866+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"3846d0aa-faa7-4428-a529-c346f1844f99","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:d3","maintenances":[],"modification_date":"2025-02-11T14:22:36.434866+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"274105cd-669b-4ecf-88da-dde4900af880","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2174"
+                - "1731"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:46 GMT
+                - Tue, 11 Feb 2025 14:22:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -254,10 +254,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a9141a65-80b5-4028-9bb6-3f171885ae91
+                - 2554c3c1-402a-4824-bdfd-b4d3f4d5bae6
         status: 200 OK
         code: 200
-        duration: 151.24325ms
+        duration: 194.615375ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -273,8 +273,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4beaaeb5-58f6-40ce-ae0f-9637416f43df
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3846d0aa-faa7-4428-a529-c346f1844f99
         method: GET
       response:
         proto: HTTP/2.0
@@ -282,20 +282,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2174
+        content_length: 1731
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:46.579463+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f3","maintenances":[],"modification_date":"2025-01-27T13:48:46.579463+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:46.579463+00:00","export_uri":null,"id":"5b43bb7d-47c1-4019-ab73-951d65fd9abc","modification_date":"2025-01-27T13:48:46.579463+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","name":"tf-server-datasource0"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.434866+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"3846d0aa-faa7-4428-a529-c346f1844f99","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:d3","maintenances":[],"modification_date":"2025-02-11T14:22:36.434866+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"274105cd-669b-4ecf-88da-dde4900af880","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2174"
+                - "1731"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:46 GMT
+                - Tue, 11 Feb 2025 14:22:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -303,10 +303,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 61addb6f-84f2-4e00-8d06-93ac537e97b4
+                - c205d580-560d-4b74-9711-dcd1e8a73d41
         status: 200 OK
         code: 200
-        duration: 138.023ms
+        duration: 131.221583ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -322,8 +322,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4beaaeb5-58f6-40ce-ae0f-9637416f43df
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3846d0aa-faa7-4428-a529-c346f1844f99
         method: GET
       response:
         proto: HTTP/2.0
@@ -331,20 +331,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2174
+        content_length: 1731
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:46.579463+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f3","maintenances":[],"modification_date":"2025-01-27T13:48:46.579463+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:46.579463+00:00","export_uri":null,"id":"5b43bb7d-47c1-4019-ab73-951d65fd9abc","modification_date":"2025-01-27T13:48:46.579463+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","name":"tf-server-datasource0"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.434866+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"3846d0aa-faa7-4428-a529-c346f1844f99","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:d3","maintenances":[],"modification_date":"2025-02-11T14:22:36.434866+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"274105cd-669b-4ecf-88da-dde4900af880","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2174"
+                - "1731"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:46 GMT
+                - Tue, 11 Feb 2025 14:22:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -352,10 +352,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 07f84592-cf35-4030-bb3e-b948832d3adb
+                - 3f295d6b-2970-4426-bc37-75d69d3f745d
         status: 200 OK
         code: 200
-        duration: 130.349708ms
+        duration: 173.428709ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -371,8 +371,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/5b43bb7d-47c1-4019-ab73-951d65fd9abc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/274105cd-669b-4ecf-88da-dde4900af880
         method: GET
       response:
         proto: HTTP/2.0
@@ -380,20 +380,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 521
+        content_length: 143
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:46.579463+00:00","export_uri":null,"id":"5b43bb7d-47c1-4019-ab73-951d65fd9abc","modification_date":"2025-01-27T13:48:46.579463+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","name":"tf-server-datasource0"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"274105cd-669b-4ecf-88da-dde4900af880","type":"not_found"}'
         headers:
             Content-Length:
-                - "521"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:47 GMT
+                - Tue, 11 Feb 2025 14:22:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -401,10 +401,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4b53d186-286a-4a29-87aa-3ad55fed35bf
-        status: 200 OK
-        code: 200
-        duration: 84.307166ms
+                - 8659cc8d-b2a2-4035-953d-c8cc069f281d
+        status: 404 Not Found
+        code: 404
+        duration: 30.520917ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -420,8 +420,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4beaaeb5-58f6-40ce-ae0f-9637416f43df/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/274105cd-669b-4ecf-88da-dde4900af880
         method: GET
       response:
         proto: HTTP/2.0
@@ -429,20 +429,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 701
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"created_at":"2025-02-11T14:22:36.658729Z","id":"274105cd-669b-4ecf-88da-dde4900af880","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:36.658729Z","id":"91820de8-e3d1-492f-b47a-d28beeb6be60","product_resource_id":"3846d0aa-faa7-4428-a529-c346f1844f99","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:36.658729Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "17"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:47 GMT
+                - Tue, 11 Feb 2025 14:22:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -450,10 +450,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c47d02e5-eb2c-4391-bb56-1034c28c44a6
+                - 923e7bc8-d1b4-4199-91a6-d61d3ee4cbe0
         status: 200 OK
         code: 200
-        duration: 93.322416ms
+        duration: 75.113916ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -469,8 +469,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4beaaeb5-58f6-40ce-ae0f-9637416f43df/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3846d0aa-faa7-4428-a529-c346f1844f99/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -478,22 +478,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 17
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "20"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:47 GMT
-            Link:
-                - </servers/4beaaeb5-58f6-40ce-ae0f-9637416f43df/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:22:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -501,12 +499,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 25747118-d0e7-4b12-9e26-ad65146e9a53
-            X-Total-Count:
-                - "0"
+                - fd320fd8-d9f1-4cc4-b1c0-1b9aa4b5b0cd
         status: 200 OK
         code: 200
-        duration: 74.042333ms
+        duration: 130.360833ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -522,8 +518,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4beaaeb5-58f6-40ce-ae0f-9637416f43df
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3846d0aa-faa7-4428-a529-c346f1844f99/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -531,20 +527,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2174
+        content_length: 20
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:46.579463+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f3","maintenances":[],"modification_date":"2025-01-27T13:48:46.579463+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:46.579463+00:00","export_uri":null,"id":"5b43bb7d-47c1-4019-ab73-951d65fd9abc","modification_date":"2025-01-27T13:48:46.579463+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","name":"tf-server-datasource0"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "2174"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:48 GMT
+                - Tue, 11 Feb 2025 14:22:38 GMT
+            Link:
+                - </servers/3846d0aa-faa7-4428-a529-c346f1844f99/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -552,10 +550,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a31ee87a-44ab-40ae-abd3-7913594aec52
+                - 459e7e46-2233-46d8-b807-3523a964754c
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 450.935541ms
+        duration: 102.680167ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -571,8 +571,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/5b43bb7d-47c1-4019-ab73-951d65fd9abc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3846d0aa-faa7-4428-a529-c346f1844f99
         method: GET
       response:
         proto: HTTP/2.0
@@ -580,20 +580,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 521
+        content_length: 1731
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:46.579463+00:00","export_uri":null,"id":"5b43bb7d-47c1-4019-ab73-951d65fd9abc","modification_date":"2025-01-27T13:48:46.579463+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","name":"tf-server-datasource0"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.434866+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"3846d0aa-faa7-4428-a529-c346f1844f99","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:d3","maintenances":[],"modification_date":"2025-02-11T14:22:36.434866+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"274105cd-669b-4ecf-88da-dde4900af880","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "521"
+                - "1731"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:48 GMT
+                - Tue, 11 Feb 2025 14:22:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -601,10 +601,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5442df21-92fb-4c03-b7fa-541000a5f0f3
+                - 81b61d79-b821-4922-ae0b-b5744d7436d7
         status: 200 OK
         code: 200
-        duration: 81.350709ms
+        duration: 166.433542ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -620,8 +620,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4beaaeb5-58f6-40ce-ae0f-9637416f43df/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/274105cd-669b-4ecf-88da-dde4900af880
         method: GET
       response:
         proto: HTTP/2.0
@@ -629,20 +629,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 143
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"274105cd-669b-4ecf-88da-dde4900af880","type":"not_found"}'
         headers:
             Content-Length:
-                - "17"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:48 GMT
+                - Tue, 11 Feb 2025 14:22:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -650,10 +650,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3ce71662-0612-4885-aaf0-b9ee36270939
-        status: 200 OK
-        code: 200
-        duration: 91.50075ms
+                - 9a97b390-a109-4684-9b8e-136f05ebf49b
+        status: 404 Not Found
+        code: 404
+        duration: 35.931417ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -669,8 +669,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4beaaeb5-58f6-40ce-ae0f-9637416f43df/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/274105cd-669b-4ecf-88da-dde4900af880
         method: GET
       response:
         proto: HTTP/2.0
@@ -678,22 +678,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 701
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"created_at":"2025-02-11T14:22:36.658729Z","id":"274105cd-669b-4ecf-88da-dde4900af880","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:36.658729Z","id":"91820de8-e3d1-492f-b47a-d28beeb6be60","product_resource_id":"3846d0aa-faa7-4428-a529-c346f1844f99","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:36.658729Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "20"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:48 GMT
-            Link:
-                - </servers/4beaaeb5-58f6-40ce-ae0f-9637416f43df/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:22:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -701,12 +699,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - db685981-d984-4fc4-8904-ac2e5713ddb3
-            X-Total-Count:
-                - "0"
+                - 3420cf3b-bba5-4ff5-bfda-5610ec5343f2
         status: 200 OK
         code: 200
-        duration: 70.60875ms
+        duration: 67.346042ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -722,8 +718,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4beaaeb5-58f6-40ce-ae0f-9637416f43df
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3846d0aa-faa7-4428-a529-c346f1844f99/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -731,20 +727,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2174
+        content_length: 17
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:46.579463+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f3","maintenances":[],"modification_date":"2025-01-27T13:48:46.579463+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:46.579463+00:00","export_uri":null,"id":"5b43bb7d-47c1-4019-ab73-951d65fd9abc","modification_date":"2025-01-27T13:48:46.579463+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","name":"tf-server-datasource0"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "2174"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:48 GMT
+                - Tue, 11 Feb 2025 14:22:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -752,10 +748,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e0d419de-0997-4604-a46c-ab12e204d8c4
+                - 178efe9f-a44f-4560-9c0f-b1696d24bf51
         status: 200 OK
         code: 200
-        duration: 149.020583ms
+        duration: 74.625292ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -771,8 +767,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/5b43bb7d-47c1-4019-ab73-951d65fd9abc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3846d0aa-faa7-4428-a529-c346f1844f99/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -780,20 +776,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 521
+        content_length: 20
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:46.579463+00:00","export_uri":null,"id":"5b43bb7d-47c1-4019-ab73-951d65fd9abc","modification_date":"2025-01-27T13:48:46.579463+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","name":"tf-server-datasource0"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "521"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:48 GMT
+                - Tue, 11 Feb 2025 14:22:38 GMT
+            Link:
+                - </servers/3846d0aa-faa7-4428-a529-c346f1844f99/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -801,10 +799,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7160b915-f5b7-4d8f-ad78-3425c78fdd1f
+                - 7d0c1b13-3e0f-4480-8202-3cae174902d1
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 74.778625ms
+        duration: 118.319792ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -820,8 +820,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4beaaeb5-58f6-40ce-ae0f-9637416f43df/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3846d0aa-faa7-4428-a529-c346f1844f99
         method: GET
       response:
         proto: HTTP/2.0
@@ -829,20 +829,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 1731
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.434866+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"3846d0aa-faa7-4428-a529-c346f1844f99","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:d3","maintenances":[],"modification_date":"2025-02-11T14:22:36.434866+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"274105cd-669b-4ecf-88da-dde4900af880","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "17"
+                - "1731"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:48 GMT
+                - Tue, 11 Feb 2025 14:22:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -850,10 +850,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 13ccc7f4-e09c-4464-a4a5-10b421d75528
+                - 8a429aba-a5ba-44bc-bac9-56ffe3e01b6e
         status: 200 OK
         code: 200
-        duration: 74.17925ms
+        duration: 558.555583ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -869,8 +869,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4beaaeb5-58f6-40ce-ae0f-9637416f43df/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/274105cd-669b-4ecf-88da-dde4900af880
         method: GET
       response:
         proto: HTTP/2.0
@@ -878,22 +878,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 143
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"274105cd-669b-4ecf-88da-dde4900af880","type":"not_found"}'
         headers:
             Content-Length:
-                - "20"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:49 GMT
-            Link:
-                - </servers/4beaaeb5-58f6-40ce-ae0f-9637416f43df/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:22:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -901,12 +899,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e0aa743a-524f-476d-88fd-1bfcddcd9edb
-            X-Total-Count:
-                - "0"
-        status: 200 OK
-        code: 200
-        duration: 77.540833ms
+                - f7ba7801-5b20-40cc-9fbe-cd714c5fd0bf
+        status: 404 Not Found
+        code: 404
+        duration: 26.829041ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -922,8 +918,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/274105cd-669b-4ecf-88da-dde4900af880
         method: GET
       response:
         proto: HTTP/2.0
@@ -931,22 +927,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 38539
+        content_length: 701
         uncompressed: false
-        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
+        body: '{"created_at":"2025-02-11T14:22:36.658729Z","id":"274105cd-669b-4ecf-88da-dde4900af880","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:36.658729Z","id":"91820de8-e3d1-492f-b47a-d28beeb6be60","product_resource_id":"3846d0aa-faa7-4428-a529-c346f1844f99","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:36.658729Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "38539"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:49 GMT
-            Link:
-                - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:22:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -954,12 +948,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b0c99543-3069-480f-9c72-749d931bbe71
-            X-Total-Count:
-                - "68"
+                - e2553234-810f-4547-a732-8018c13a3dff
         status: 200 OK
         code: 200
-        duration: 60.07125ms
+        duration: 59.996667ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -975,8 +967,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3846d0aa-faa7-4428-a529-c346f1844f99/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -984,22 +976,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 14208
+        content_length: 17
         uncompressed: false
-        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "14208"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:49 GMT
-            Link:
-                - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:22:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1007,12 +997,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2357a5bb-bd05-4060-b36a-0ed5c9b55b72
-            X-Total-Count:
-                - "68"
+                - 28098a34-a084-4cc1-94ec-47ed9591604d
         status: 200 OK
         code: 200
-        duration: 42.581083ms
+        duration: 81.275292ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1028,8 +1016,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_local&zone=fr-par-1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3846d0aa-faa7-4428-a529-c346f1844f99/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1037,20 +1025,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1300
+        content_length: 20
         uncompressed: false
-        body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"56d4019c-8305-467a-a3f2-70498ad799df","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "1300"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:49 GMT
+                - Tue, 11 Feb 2025 14:22:39 GMT
+            Link:
+                - </servers/3846d0aa-faa7-4428-a529-c346f1844f99/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1058,52 +1048,52 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8e078d8c-032a-4690-b91d-4e4088f8b049
+                - 3f36a9f0-b8b5-4a69-aca3-4eb16103d14b
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 82.155792ms
+        duration: 88.507625ms
     - id: 21
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 342
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-server-datasource1","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":["terraform-test","data_scaleway_instance_servers","basic"]}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2174
+        content_length: 35639
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:50.248015+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"2baf4432-4f3a-465e-b391-99e2357c4540","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f5","maintenances":[],"modification_date":"2025-01-27T13:48:50.248015+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:50.248015+00:00","export_uri":null,"id":"7bd52425-5d15-4e2c-9f00-346f9ac926e2","modification_date":"2025-01-27T13:48:50.248015+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2baf4432-4f3a-465e-b391-99e2357c4540","name":"tf-server-datasource1"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
         headers:
             Content-Length:
-                - "2174"
+                - "35639"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:50 GMT
-            Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2baf4432-4f3a-465e-b391-99e2357c4540
+                - Tue, 11 Feb 2025 14:22:40 GMT
+            Link:
+                - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1111,10 +1101,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4f04dbe5-8e5b-442b-a20d-d1b66abe284e
-        status: 201 Created
-        code: 201
-        duration: 1.022678375s
+                - f0bd67c5-546b-459c-b3f8-46e93d89d552
+            X-Total-Count:
+                - "68"
+        status: 200 OK
+        code: 200
+        duration: 50.138042ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1130,8 +1122,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2baf4432-4f3a-465e-b391-99e2357c4540
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
         method: GET
       response:
         proto: HTTP/2.0
@@ -1139,20 +1131,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2174
+        content_length: 13164
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:50.248015+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"2baf4432-4f3a-465e-b391-99e2357c4540","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f5","maintenances":[],"modification_date":"2025-01-27T13:48:50.248015+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:50.248015+00:00","export_uri":null,"id":"7bd52425-5d15-4e2c-9f00-346f9ac926e2","modification_date":"2025-01-27T13:48:50.248015+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2baf4432-4f3a-465e-b391-99e2357c4540","name":"tf-server-datasource1"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
         headers:
             Content-Length:
-                - "2174"
+                - "13164"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:50 GMT
+                - Tue, 11 Feb 2025 14:22:40 GMT
+            Link:
+                - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1160,10 +1154,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1b088b54-c7b6-40a3-a111-8a868dd0ee39
+                - 43a062d6-b82d-4b53-b98e-648d3c187315
+            X-Total-Count:
+                - "68"
         status: 200 OK
         code: 200
-        duration: 171.874542ms
+        duration: 48.787042ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1179,8 +1175,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2baf4432-4f3a-465e-b391-99e2357c4540
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_sbs&zone=fr-par-1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1188,20 +1184,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2174
+        content_length: 1296
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:50.248015+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"2baf4432-4f3a-465e-b391-99e2357c4540","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f5","maintenances":[],"modification_date":"2025-01-27T13:48:50.248015+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:50.248015+00:00","export_uri":null,"id":"7bd52425-5d15-4e2c-9f00-346f9ac926e2","modification_date":"2025-01-27T13:48:50.248015+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2baf4432-4f3a-465e-b391-99e2357c4540","name":"tf-server-datasource1"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"57509e82-ac3b-49b7-9970-97b60f40ff72","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"9b647e1e-253a-41e7-8c15-911c622ee2dc","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"}],"total_count":2}'
         headers:
             Content-Length:
-                - "2174"
+                - "1296"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:50 GMT
+                - Tue, 11 Feb 2025 14:22:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1209,48 +1205,52 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1139e84b-62c4-40a0-9573-821293c40d23
+                - 5584d69a-1bdb-4a05-9be6-85add3ac08ef
         status: 200 OK
         code: 200
-        duration: 182.136125ms
+        duration: 79.426875ms
     - id: 24
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 301
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"name":"tf-server-datasource1","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"57509e82-ac3b-49b7-9970-97b60f40ff72","volumes":{"0":{"boot":false}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":["terraform-test","data_scaleway_instance_servers","basic"]}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2baf4432-4f3a-465e-b391-99e2357c4540
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2174
+        content_length: 1731
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:50.248015+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"2baf4432-4f3a-465e-b391-99e2357c4540","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f5","maintenances":[],"modification_date":"2025-01-27T13:48:50.248015+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:50.248015+00:00","export_uri":null,"id":"7bd52425-5d15-4e2c-9f00-346f9ac926e2","modification_date":"2025-01-27T13:48:50.248015+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2baf4432-4f3a-465e-b391-99e2357c4540","name":"tf-server-datasource1"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:40.652963+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e1","maintenances":[],"modification_date":"2025-02-11T14:22:40.652963+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"d2496d71-ba3f-420a-b64b-f363c1c3d7ba","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2174"
+                - "1731"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:50 GMT
+                - Tue, 11 Feb 2025 14:22:40 GMT
+            Location:
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1258,10 +1258,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 927cf02e-0fe7-4cbe-b1e4-5495e7ecc1c7
-        status: 200 OK
-        code: 200
-        duration: 148.747333ms
+                - 5fe2ff75-83ab-439e-a21a-c719b2bad5ae
+        status: 201 Created
+        code: 201
+        duration: 709.579792ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1277,8 +1277,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/7bd52425-5d15-4e2c-9f00-346f9ac926e2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93
         method: GET
       response:
         proto: HTTP/2.0
@@ -1286,20 +1286,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 521
+        content_length: 1731
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:50.248015+00:00","export_uri":null,"id":"7bd52425-5d15-4e2c-9f00-346f9ac926e2","modification_date":"2025-01-27T13:48:50.248015+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2baf4432-4f3a-465e-b391-99e2357c4540","name":"tf-server-datasource1"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:40.652963+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e1","maintenances":[],"modification_date":"2025-02-11T14:22:40.652963+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"d2496d71-ba3f-420a-b64b-f363c1c3d7ba","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "521"
+                - "1731"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:50 GMT
+                - Tue, 11 Feb 2025 14:22:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1307,10 +1307,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ac32557e-dec8-45c6-933d-671f7fe08181
+                - 90d1bc30-30d1-4b8d-b2f5-b66d62872ed0
         status: 200 OK
         code: 200
-        duration: 90.891708ms
+        duration: 168.8965ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1326,8 +1326,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2baf4432-4f3a-465e-b391-99e2357c4540/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93
         method: GET
       response:
         proto: HTTP/2.0
@@ -1335,20 +1335,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 1731
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:40.652963+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e1","maintenances":[],"modification_date":"2025-02-11T14:22:40.652963+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"d2496d71-ba3f-420a-b64b-f363c1c3d7ba","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "17"
+                - "1731"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:50 GMT
+                - Tue, 11 Feb 2025 14:22:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1356,10 +1356,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f77ed689-a1ce-470e-99c6-f371917e25d8
+                - ab0af29c-5fc4-4d47-8faa-a0a9200c800e
         status: 200 OK
         code: 200
-        duration: 90.892042ms
+        duration: 218.406959ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1375,8 +1375,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2baf4432-4f3a-465e-b391-99e2357c4540/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93
         method: GET
       response:
         proto: HTTP/2.0
@@ -1384,22 +1384,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 1731
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:40.652963+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e1","maintenances":[],"modification_date":"2025-02-11T14:22:40.652963+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"d2496d71-ba3f-420a-b64b-f363c1c3d7ba","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "20"
+                - "1731"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:51 GMT
-            Link:
-                - </servers/2baf4432-4f3a-465e-b391-99e2357c4540/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:22:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1407,12 +1405,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9e445695-47ca-4cec-91ab-7f485475ab1b
-            X-Total-Count:
-                - "0"
+                - 9e187e33-e69b-43e0-a4d3-fb990bd1f96d
         status: 200 OK
         code: 200
-        duration: 87.903834ms
+        duration: 162.567667ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1428,8 +1424,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2baf4432-4f3a-465e-b391-99e2357c4540
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/d2496d71-ba3f-420a-b64b-f363c1c3d7ba
         method: GET
       response:
         proto: HTTP/2.0
@@ -1437,20 +1433,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2174
+        content_length: 143
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:50.248015+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"2baf4432-4f3a-465e-b391-99e2357c4540","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f5","maintenances":[],"modification_date":"2025-01-27T13:48:50.248015+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:50.248015+00:00","export_uri":null,"id":"7bd52425-5d15-4e2c-9f00-346f9ac926e2","modification_date":"2025-01-27T13:48:50.248015+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2baf4432-4f3a-465e-b391-99e2357c4540","name":"tf-server-datasource1"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"d2496d71-ba3f-420a-b64b-f363c1c3d7ba","type":"not_found"}'
         headers:
             Content-Length:
-                - "2174"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:51 GMT
+                - Tue, 11 Feb 2025 14:22:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1458,10 +1454,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c1de201b-2dbd-470c-995c-780b72dac1fa
-        status: 200 OK
-        code: 200
-        duration: 129.273625ms
+                - 63b66976-9c1b-4cd7-bec8-e0266e607d03
+        status: 404 Not Found
+        code: 404
+        duration: 41.260208ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1477,8 +1473,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4beaaeb5-58f6-40ce-ae0f-9637416f43df
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/d2496d71-ba3f-420a-b64b-f363c1c3d7ba
         method: GET
       response:
         proto: HTTP/2.0
@@ -1486,20 +1482,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2174
+        content_length: 701
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:46.579463+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f3","maintenances":[],"modification_date":"2025-01-27T13:48:46.579463+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:46.579463+00:00","export_uri":null,"id":"5b43bb7d-47c1-4019-ab73-951d65fd9abc","modification_date":"2025-01-27T13:48:46.579463+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","name":"tf-server-datasource0"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T14:22:40.852865Z","id":"d2496d71-ba3f-420a-b64b-f363c1c3d7ba","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:40.852865Z","id":"a352cc34-604d-4c65-a637-95917c0ff61d","product_resource_id":"30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:40.852865Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2174"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:51 GMT
+                - Tue, 11 Feb 2025 14:22:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1507,10 +1503,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 66afcc53-6120-4100-b255-bece358028a1
+                - bdefaae4-bec4-418f-9d7d-2f2b745a29ce
         status: 200 OK
         code: 200
-        duration: 172.082875ms
+        duration: 69.626708ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1526,8 +1522,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/7bd52425-5d15-4e2c-9f00-346f9ac926e2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1535,20 +1531,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 521
+        content_length: 17
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:50.248015+00:00","export_uri":null,"id":"7bd52425-5d15-4e2c-9f00-346f9ac926e2","modification_date":"2025-01-27T13:48:50.248015+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2baf4432-4f3a-465e-b391-99e2357c4540","name":"tf-server-datasource1"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "521"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:51 GMT
+                - Tue, 11 Feb 2025 14:22:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1556,10 +1552,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cafc368c-65b8-4a06-ab6e-6350e8895a4d
+                - da3a14a0-11f5-41d9-87a7-f9457eb4548e
         status: 200 OK
         code: 200
-        duration: 92.994792ms
+        duration: 92.001583ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1575,8 +1571,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/5b43bb7d-47c1-4019-ab73-951d65fd9abc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1584,20 +1580,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 521
+        content_length: 20
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:46.579463+00:00","export_uri":null,"id":"5b43bb7d-47c1-4019-ab73-951d65fd9abc","modification_date":"2025-01-27T13:48:46.579463+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","name":"tf-server-datasource0"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "521"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:51 GMT
+                - Tue, 11 Feb 2025 14:22:41 GMT
+            Link:
+                - </servers/30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1605,10 +1603,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e652957b-8753-415e-a2f7-c7b9877937c4
+                - 74f7a291-0394-46c6-a802-59afc355d69e
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 85.524333ms
+        duration: 102.821333ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1624,8 +1624,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2baf4432-4f3a-465e-b391-99e2357c4540/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93
         method: GET
       response:
         proto: HTTP/2.0
@@ -1633,20 +1633,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 1731
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:40.652963+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e1","maintenances":[],"modification_date":"2025-02-11T14:22:40.652963+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"d2496d71-ba3f-420a-b64b-f363c1c3d7ba","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "17"
+                - "1731"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:51 GMT
+                - Tue, 11 Feb 2025 14:22:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1654,10 +1654,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4cc7f307-fc5f-4bd4-a6dc-1903d4564097
+                - 74d446ce-38c9-42f8-bae6-acb68c0e64a8
         status: 200 OK
         code: 200
-        duration: 87.92675ms
+        duration: 135.58375ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1673,8 +1673,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4beaaeb5-58f6-40ce-ae0f-9637416f43df/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/d2496d71-ba3f-420a-b64b-f363c1c3d7ba
         method: GET
       response:
         proto: HTTP/2.0
@@ -1682,20 +1682,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 143
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"d2496d71-ba3f-420a-b64b-f363c1c3d7ba","type":"not_found"}'
         headers:
             Content-Length:
-                - "17"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:51 GMT
+                - Tue, 11 Feb 2025 14:22:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1703,10 +1703,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0f9b5228-34c0-4857-978a-4aabbc29a205
-        status: 200 OK
-        code: 200
-        duration: 94.594334ms
+                - 6638bf5c-aafb-4332-9212-3a955767e3d5
+        status: 404 Not Found
+        code: 404
+        duration: 33.545ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1722,8 +1722,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2baf4432-4f3a-465e-b391-99e2357c4540/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3846d0aa-faa7-4428-a529-c346f1844f99
         method: GET
       response:
         proto: HTTP/2.0
@@ -1731,22 +1731,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 1731
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.434866+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"3846d0aa-faa7-4428-a529-c346f1844f99","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:d3","maintenances":[],"modification_date":"2025-02-11T14:22:36.434866+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"274105cd-669b-4ecf-88da-dde4900af880","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "20"
+                - "1731"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:51 GMT
-            Link:
-                - </servers/2baf4432-4f3a-465e-b391-99e2357c4540/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:22:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1754,12 +1752,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d1d7455d-7c54-4d16-90c3-e1b37066505a
-            X-Total-Count:
-                - "0"
+                - 6d4accb9-263b-4aff-a6dc-e62e912cf1ac
         status: 200 OK
         code: 200
-        duration: 76.885125ms
+        duration: 176.97625ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1775,8 +1771,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4beaaeb5-58f6-40ce-ae0f-9637416f43df/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/274105cd-669b-4ecf-88da-dde4900af880
         method: GET
       response:
         proto: HTTP/2.0
@@ -1784,22 +1780,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 143
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"274105cd-669b-4ecf-88da-dde4900af880","type":"not_found"}'
         headers:
             Content-Length:
-                - "20"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:51 GMT
-            Link:
-                - </servers/4beaaeb5-58f6-40ce-ae0f-9637416f43df/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:22:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1807,12 +1801,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 34675036-5a0a-4039-a1fc-99bcbe388a64
-            X-Total-Count:
-                - "0"
-        status: 200 OK
-        code: 200
-        duration: 81.328625ms
+                - c99b31ed-3a3c-416c-bc8d-c90fd267c459
+        status: 404 Not Found
+        code: 404
+        duration: 47.290875ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1828,8 +1820,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers?name=tf-server-datasource&order=creation_date_desc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/d2496d71-ba3f-420a-b64b-f363c1c3d7ba
         method: GET
       response:
         proto: HTTP/2.0
@@ -1837,22 +1829,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 15
+        content_length: 701
         uncompressed: false
-        body: '{"servers":[]}'
+        body: '{"created_at":"2025-02-11T14:22:40.852865Z","id":"d2496d71-ba3f-420a-b64b-f363c1c3d7ba","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:40.852865Z","id":"a352cc34-604d-4c65-a637-95917c0ff61d","product_resource_id":"30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:40.852865Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "15"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:52 GMT
-            Link:
-                - </servers?page=0&per_page=50&name=tf-server-datasource&order=creation_date_desc>; rel="last"
+                - Tue, 11 Feb 2025 14:22:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1860,12 +1850,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4324844e-49c5-469a-8c0b-1b4a1a48657a
-            X-Total-Count:
-                - "0"
+                - 5dfdf66c-727c-4603-b41c-6c48b11f091c
         status: 200 OK
         code: 200
-        duration: 118.585125ms
+        duration: 67.300291ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1881,8 +1869,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4beaaeb5-58f6-40ce-ae0f-9637416f43df
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/274105cd-669b-4ecf-88da-dde4900af880
         method: GET
       response:
         proto: HTTP/2.0
@@ -1890,20 +1878,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2174
+        content_length: 701
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:46.579463+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f3","maintenances":[],"modification_date":"2025-01-27T13:48:46.579463+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:46.579463+00:00","export_uri":null,"id":"5b43bb7d-47c1-4019-ab73-951d65fd9abc","modification_date":"2025-01-27T13:48:46.579463+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","name":"tf-server-datasource0"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T14:22:36.658729Z","id":"274105cd-669b-4ecf-88da-dde4900af880","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:36.658729Z","id":"91820de8-e3d1-492f-b47a-d28beeb6be60","product_resource_id":"3846d0aa-faa7-4428-a529-c346f1844f99","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:36.658729Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2174"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:51 GMT
+                - Tue, 11 Feb 2025 14:22:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1911,10 +1899,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d7b76168-4067-4c66-b70b-0b5d46943bf1
+                - 0161ed6c-dcd3-4bf2-be13-0733416040b6
         status: 200 OK
         code: 200
-        duration: 149.667959ms
+        duration: 66.131417ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1930,8 +1918,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2baf4432-4f3a-465e-b391-99e2357c4540
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1939,20 +1927,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2174
+        content_length: 17
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:50.248015+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"2baf4432-4f3a-465e-b391-99e2357c4540","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f5","maintenances":[],"modification_date":"2025-01-27T13:48:50.248015+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:50.248015+00:00","export_uri":null,"id":"7bd52425-5d15-4e2c-9f00-346f9ac926e2","modification_date":"2025-01-27T13:48:50.248015+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2baf4432-4f3a-465e-b391-99e2357c4540","name":"tf-server-datasource1"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "2174"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:52 GMT
+                - Tue, 11 Feb 2025 14:22:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1960,10 +1948,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4ca078eb-72b6-4ace-89cd-43eafe64602c
+                - 635a87c4-28dd-4dd7-97c1-8058efbb38df
         status: 200 OK
         code: 200
-        duration: 149.689875ms
+        duration: 99.066417ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1979,8 +1967,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers?order=creation_date_desc&tags=data_scaleway_instance_servers%2Cterraform-test
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3846d0aa-faa7-4428-a529-c346f1844f99/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1988,22 +1976,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 4341
+        content_length: 17
         uncompressed: false
-        body: '{"servers":[{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:50.248015+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"2baf4432-4f3a-465e-b391-99e2357c4540","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f5","maintenances":[],"modification_date":"2025-01-27T13:48:50.248015+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:50.248015+00:00","export_uri":null,"id":"7bd52425-5d15-4e2c-9f00-346f9ac926e2","modification_date":"2025-01-27T13:48:50.248015+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2baf4432-4f3a-465e-b391-99e2357c4540","name":"tf-server-datasource1"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"},{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:46.579463+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f3","maintenances":[],"modification_date":"2025-01-27T13:48:46.579463+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:46.579463+00:00","export_uri":null,"id":"5b43bb7d-47c1-4019-ab73-951d65fd9abc","modification_date":"2025-01-27T13:48:46.579463+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","name":"tf-server-datasource0"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}]}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "4341"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:52 GMT
-            Link:
-                - </servers?page=1&per_page=50&order=creation_date_desc&tags=data_scaleway_instance_servers%2Cterraform-test>; rel="last"
+                - Tue, 11 Feb 2025 14:22:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2011,12 +1997,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 02d4228c-95ad-4b4d-9faf-e50cfdb5a341
-            X-Total-Count:
-                - "2"
+                - 2e0b080c-791d-4c2a-aa8f-959184674041
         status: 200 OK
         code: 200
-        duration: 216.77ms
+        duration: 94.658875ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2032,8 +2016,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers?name=tf-server-datasource&order=creation_date_desc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -2041,22 +2025,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 4341
+        content_length: 20
         uncompressed: false
-        body: '{"servers":[{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:50.248015+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"2baf4432-4f3a-465e-b391-99e2357c4540","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f5","maintenances":[],"modification_date":"2025-01-27T13:48:50.248015+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:50.248015+00:00","export_uri":null,"id":"7bd52425-5d15-4e2c-9f00-346f9ac926e2","modification_date":"2025-01-27T13:48:50.248015+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2baf4432-4f3a-465e-b391-99e2357c4540","name":"tf-server-datasource1"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"},{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:46.579463+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f3","maintenances":[],"modification_date":"2025-01-27T13:48:46.579463+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:46.579463+00:00","export_uri":null,"id":"5b43bb7d-47c1-4019-ab73-951d65fd9abc","modification_date":"2025-01-27T13:48:46.579463+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","name":"tf-server-datasource0"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}]}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "4341"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:51 GMT
+                - Tue, 11 Feb 2025 14:22:42 GMT
             Link:
-                - </servers?page=1&per_page=50&name=tf-server-datasource&order=creation_date_desc>; rel="last"
+                - </servers/30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2064,12 +2048,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 71d04839-5d43-4b2d-906e-23a08f254ed8
+                - dd21000d-4c4b-4e84-831e-f706da5e2899
             X-Total-Count:
-                - "2"
+                - "0"
         status: 200 OK
         code: 200
-        duration: 216.88425ms
+        duration: 100.378375ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2085,8 +2069,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/5b43bb7d-47c1-4019-ab73-951d65fd9abc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3846d0aa-faa7-4428-a529-c346f1844f99/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -2094,20 +2078,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 521
+        content_length: 20
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:46.579463+00:00","export_uri":null,"id":"5b43bb7d-47c1-4019-ab73-951d65fd9abc","modification_date":"2025-01-27T13:48:46.579463+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","name":"tf-server-datasource0"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "521"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:52 GMT
+                - Tue, 11 Feb 2025 14:22:42 GMT
+            Link:
+                - </servers/3846d0aa-faa7-4428-a529-c346f1844f99/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2115,10 +2101,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 30643625-33c3-4dfe-8187-354c70fb77e6
+                - fae6f3eb-749b-4c90-92ec-eb1f480004d8
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 78.771833ms
+        duration: 79.752208ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2134,8 +2122,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/7bd52425-5d15-4e2c-9f00-346f9ac926e2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers?name=tf-server-datasource&order=creation_date_desc
         method: GET
       response:
         proto: HTTP/2.0
@@ -2143,20 +2131,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 521
+        content_length: 15
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:50.248015+00:00","export_uri":null,"id":"7bd52425-5d15-4e2c-9f00-346f9ac926e2","modification_date":"2025-01-27T13:48:50.248015+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2baf4432-4f3a-465e-b391-99e2357c4540","name":"tf-server-datasource1"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"servers":[]}'
         headers:
             Content-Length:
-                - "521"
+                - "15"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:52 GMT
+                - Tue, 11 Feb 2025 14:22:42 GMT
+            Link:
+                - </servers?page=0&per_page=50&name=tf-server-datasource&order=creation_date_desc>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2164,10 +2154,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8458e658-eb43-4fae-adab-a1245ae2fb44
+                - ced8eb3a-39c1-48c1-867f-6700b88cb952
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 95.259459ms
+        duration: 145.170125ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2183,8 +2175,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4beaaeb5-58f6-40ce-ae0f-9637416f43df/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3846d0aa-faa7-4428-a529-c346f1844f99
         method: GET
       response:
         proto: HTTP/2.0
@@ -2192,20 +2184,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 1731
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.434866+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"3846d0aa-faa7-4428-a529-c346f1844f99","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:d3","maintenances":[],"modification_date":"2025-02-11T14:22:36.434866+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"274105cd-669b-4ecf-88da-dde4900af880","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "17"
+                - "1731"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:52 GMT
+                - Tue, 11 Feb 2025 14:22:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2213,10 +2205,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 26194a96-e5d4-4d4c-a1b3-f0bead88e2bc
+                - 2112dc0a-47dc-489d-9af6-3be254774c78
         status: 200 OK
         code: 200
-        duration: 89.917625ms
+        duration: 162.317083ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2232,8 +2224,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2baf4432-4f3a-465e-b391-99e2357c4540/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93
         method: GET
       response:
         proto: HTTP/2.0
@@ -2241,20 +2233,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 1731
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:40.652963+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e1","maintenances":[],"modification_date":"2025-02-11T14:22:40.652963+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"d2496d71-ba3f-420a-b64b-f363c1c3d7ba","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "17"
+                - "1731"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:52 GMT
+                - Tue, 11 Feb 2025 14:22:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2262,10 +2254,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e027a5ca-c171-40e0-a7dc-a7acd2c1ed7c
+                - 419be664-d72c-45d8-9181-bc3c1c5bad55
         status: 200 OK
         code: 200
-        duration: 77.403916ms
+        duration: 193.621708ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2281,8 +2273,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4beaaeb5-58f6-40ce-ae0f-9637416f43df/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers?order=creation_date_desc&tags=data_scaleway_instance_servers%2Cterraform-test
         method: GET
       response:
         proto: HTTP/2.0
@@ -2290,22 +2282,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 3455
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"servers":[{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:40.652963+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e1","maintenances":[],"modification_date":"2025-02-11T14:22:40.652963+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"d2496d71-ba3f-420a-b64b-f363c1c3d7ba","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"},{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.434866+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"3846d0aa-faa7-4428-a529-c346f1844f99","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:d3","maintenances":[],"modification_date":"2025-02-11T14:22:36.434866+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"274105cd-669b-4ecf-88da-dde4900af880","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "20"
+                - "3455"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:52 GMT
+                - Tue, 11 Feb 2025 14:22:43 GMT
             Link:
-                - </servers/4beaaeb5-58f6-40ce-ae0f-9637416f43df/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers?page=1&per_page=50&order=creation_date_desc&tags=data_scaleway_instance_servers%2Cterraform-test>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2313,12 +2305,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2f37202a-a7dd-4540-90a2-470825beed61
+                - 91946f35-ccd0-4838-9c10-a660b0f317f8
             X-Total-Count:
-                - "0"
+                - "2"
         status: 200 OK
         code: 200
-        duration: 78.740458ms
+        duration: 198.881458ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2334,8 +2326,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2baf4432-4f3a-465e-b391-99e2357c4540/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/274105cd-669b-4ecf-88da-dde4900af880
         method: GET
       response:
         proto: HTTP/2.0
@@ -2343,22 +2335,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 143
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"274105cd-669b-4ecf-88da-dde4900af880","type":"not_found"}'
         headers:
             Content-Length:
-                - "20"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:52 GMT
-            Link:
-                - </servers/2baf4432-4f3a-465e-b391-99e2357c4540/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:22:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2366,12 +2356,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1516b1d3-109c-4b1b-90b2-cb7ce32e8dfe
-            X-Total-Count:
-                - "0"
-        status: 200 OK
-        code: 200
-        duration: 83.987125ms
+                - 2fe111bb-3d82-4e3c-954b-4d9e4fbd4b90
+        status: 404 Not Found
+        code: 404
+        duration: 37.596583ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2387,8 +2375,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers?name=tf-server-datasource&order=creation_date_desc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/d2496d71-ba3f-420a-b64b-f363c1c3d7ba
         method: GET
       response:
         proto: HTTP/2.0
@@ -2396,22 +2384,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 15
+        content_length: 143
         uncompressed: false
-        body: '{"servers":[]}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"d2496d71-ba3f-420a-b64b-f363c1c3d7ba","type":"not_found"}'
         headers:
             Content-Length:
-                - "15"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:52 GMT
-            Link:
-                - </servers?page=0&per_page=50&name=tf-server-datasource&order=creation_date_desc>; rel="last"
+                - Tue, 11 Feb 2025 14:22:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2419,12 +2405,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6bfdebd2-f02b-4ca1-a53c-d493828edf15
-            X-Total-Count:
-                - "0"
-        status: 200 OK
-        code: 200
-        duration: 126.179875ms
+                - 604abc62-8723-4384-b75b-c3c93e93f840
+        status: 404 Not Found
+        code: 404
+        duration: 32.997208ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2440,7 +2424,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers?name=tf-server-datasource&order=creation_date_desc
         method: GET
       response:
@@ -2449,22 +2433,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 4341
+        content_length: 3455
         uncompressed: false
-        body: '{"servers":[{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:50.248015+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"2baf4432-4f3a-465e-b391-99e2357c4540","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f5","maintenances":[],"modification_date":"2025-01-27T13:48:50.248015+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:50.248015+00:00","export_uri":null,"id":"7bd52425-5d15-4e2c-9f00-346f9ac926e2","modification_date":"2025-01-27T13:48:50.248015+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2baf4432-4f3a-465e-b391-99e2357c4540","name":"tf-server-datasource1"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"},{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:46.579463+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f3","maintenances":[],"modification_date":"2025-01-27T13:48:46.579463+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:46.579463+00:00","export_uri":null,"id":"5b43bb7d-47c1-4019-ab73-951d65fd9abc","modification_date":"2025-01-27T13:48:46.579463+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","name":"tf-server-datasource0"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}]}'
+        body: '{"servers":[{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:40.652963+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e1","maintenances":[],"modification_date":"2025-02-11T14:22:40.652963+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"d2496d71-ba3f-420a-b64b-f363c1c3d7ba","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"},{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.434866+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"3846d0aa-faa7-4428-a529-c346f1844f99","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:d3","maintenances":[],"modification_date":"2025-02-11T14:22:36.434866+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"274105cd-669b-4ecf-88da-dde4900af880","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "4341"
+                - "3455"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:52 GMT
+                - Tue, 11 Feb 2025 14:22:43 GMT
             Link:
                 - </servers?page=1&per_page=50&name=tf-server-datasource&order=creation_date_desc>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2472,12 +2456,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9ac0a6ab-f593-4f2c-97f3-5691aa161973
+                - 9b8ebfd1-bd4a-4a29-88e4-2554fb4d3ae2
             X-Total-Count:
                 - "2"
         status: 200 OK
         code: 200
-        duration: 161.640541ms
+        duration: 246.8435ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2493,8 +2477,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers?order=creation_date_desc&tags=data_scaleway_instance_servers%2Cterraform-test
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/274105cd-669b-4ecf-88da-dde4900af880
         method: GET
       response:
         proto: HTTP/2.0
@@ -2502,22 +2486,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 4341
+        content_length: 701
         uncompressed: false
-        body: '{"servers":[{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:50.248015+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"2baf4432-4f3a-465e-b391-99e2357c4540","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f5","maintenances":[],"modification_date":"2025-01-27T13:48:50.248015+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:50.248015+00:00","export_uri":null,"id":"7bd52425-5d15-4e2c-9f00-346f9ac926e2","modification_date":"2025-01-27T13:48:50.248015+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2baf4432-4f3a-465e-b391-99e2357c4540","name":"tf-server-datasource1"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"},{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:46.579463+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f3","maintenances":[],"modification_date":"2025-01-27T13:48:46.579463+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:46.579463+00:00","export_uri":null,"id":"5b43bb7d-47c1-4019-ab73-951d65fd9abc","modification_date":"2025-01-27T13:48:46.579463+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","name":"tf-server-datasource0"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}]}'
+        body: '{"created_at":"2025-02-11T14:22:36.658729Z","id":"274105cd-669b-4ecf-88da-dde4900af880","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:36.658729Z","id":"91820de8-e3d1-492f-b47a-d28beeb6be60","product_resource_id":"3846d0aa-faa7-4428-a529-c346f1844f99","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:36.658729Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "4341"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:52 GMT
-            Link:
-                - </servers?page=1&per_page=50&order=creation_date_desc&tags=data_scaleway_instance_servers%2Cterraform-test>; rel="last"
+                - Tue, 11 Feb 2025 14:22:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2525,12 +2507,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f564fc8c-bd49-420f-bf13-618649967591
-            X-Total-Count:
-                - "2"
+                - 628cb10b-98e8-4a6b-96ee-d3e48ec8f8a1
         status: 200 OK
         code: 200
-        duration: 221.885167ms
+        duration: 73.363708ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -2546,8 +2526,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers?name=tf-server-datasource&order=creation_date_desc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/d2496d71-ba3f-420a-b64b-f363c1c3d7ba
         method: GET
       response:
         proto: HTTP/2.0
@@ -2555,22 +2535,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 15
+        content_length: 701
         uncompressed: false
-        body: '{"servers":[]}'
+        body: '{"created_at":"2025-02-11T14:22:40.852865Z","id":"d2496d71-ba3f-420a-b64b-f363c1c3d7ba","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:40.852865Z","id":"a352cc34-604d-4c65-a637-95917c0ff61d","product_resource_id":"30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:40.852865Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "15"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:52 GMT
-            Link:
-                - </servers?page=0&per_page=50&name=tf-server-datasource&order=creation_date_desc>; rel="last"
+                - Tue, 11 Feb 2025 14:22:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2578,12 +2556,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ca93297a-e761-465e-bea4-66c97a0bf198
-            X-Total-Count:
-                - "0"
+                - cf5402e3-a70d-480b-ac8a-029150dee9fa
         status: 200 OK
         code: 200
-        duration: 157.022834ms
+        duration: 55.722625ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2599,8 +2575,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers?name=tf-server-datasource&order=creation_date_desc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -2608,22 +2584,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 4341
+        content_length: 17
         uncompressed: false
-        body: '{"servers":[{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:50.248015+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"2baf4432-4f3a-465e-b391-99e2357c4540","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f5","maintenances":[],"modification_date":"2025-01-27T13:48:50.248015+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:50.248015+00:00","export_uri":null,"id":"7bd52425-5d15-4e2c-9f00-346f9ac926e2","modification_date":"2025-01-27T13:48:50.248015+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2baf4432-4f3a-465e-b391-99e2357c4540","name":"tf-server-datasource1"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"},{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:46.579463+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f3","maintenances":[],"modification_date":"2025-01-27T13:48:46.579463+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:46.579463+00:00","export_uri":null,"id":"5b43bb7d-47c1-4019-ab73-951d65fd9abc","modification_date":"2025-01-27T13:48:46.579463+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","name":"tf-server-datasource0"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}]}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "4341"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:52 GMT
-            Link:
-                - </servers?page=1&per_page=50&name=tf-server-datasource&order=creation_date_desc>; rel="last"
+                - Tue, 11 Feb 2025 14:22:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2631,12 +2605,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 04079e0b-3b1b-4120-8d93-f424bcd6c8ab
-            X-Total-Count:
-                - "2"
+                - 51193bf9-cec9-4590-bc5e-1f1153dfe5f6
         status: 200 OK
         code: 200
-        duration: 174.463125ms
+        duration: 79.682708ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -2652,8 +2624,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers?order=creation_date_desc&tags=data_scaleway_instance_servers%2Cterraform-test
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3846d0aa-faa7-4428-a529-c346f1844f99/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -2661,22 +2633,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 4341
+        content_length: 17
         uncompressed: false
-        body: '{"servers":[{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:50.248015+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"2baf4432-4f3a-465e-b391-99e2357c4540","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f5","maintenances":[],"modification_date":"2025-01-27T13:48:50.248015+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:50.248015+00:00","export_uri":null,"id":"7bd52425-5d15-4e2c-9f00-346f9ac926e2","modification_date":"2025-01-27T13:48:50.248015+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2baf4432-4f3a-465e-b391-99e2357c4540","name":"tf-server-datasource1"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"},{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:46.579463+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f3","maintenances":[],"modification_date":"2025-01-27T13:48:46.579463+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:46.579463+00:00","export_uri":null,"id":"5b43bb7d-47c1-4019-ab73-951d65fd9abc","modification_date":"2025-01-27T13:48:46.579463+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","name":"tf-server-datasource0"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}]}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "4341"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:53 GMT
-            Link:
-                - </servers?page=1&per_page=50&order=creation_date_desc&tags=data_scaleway_instance_servers%2Cterraform-test>; rel="last"
+                - Tue, 11 Feb 2025 14:22:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2684,12 +2654,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d4a8a0dd-4245-4b88-9cb2-467190251117
-            X-Total-Count:
-                - "2"
+                - 5c361249-afce-4151-9680-6be26e80894b
         status: 200 OK
         code: 200
-        duration: 198.703792ms
+        duration: 98.8655ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -2705,8 +2673,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4beaaeb5-58f6-40ce-ae0f-9637416f43df
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -2714,20 +2682,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2174
+        content_length: 20
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:46.579463+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f3","maintenances":[],"modification_date":"2025-01-27T13:48:46.579463+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:46.579463+00:00","export_uri":null,"id":"5b43bb7d-47c1-4019-ab73-951d65fd9abc","modification_date":"2025-01-27T13:48:46.579463+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","name":"tf-server-datasource0"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "2174"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:53 GMT
+                - Tue, 11 Feb 2025 14:22:43 GMT
+            Link:
+                - </servers/30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2735,10 +2705,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a84ab628-bc8d-42cf-8354-8bea2df356e3
+                - df069606-0085-4bcd-a5ff-111e096229fa
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 118.167625ms
+        duration: 80.277041ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -2754,8 +2726,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2baf4432-4f3a-465e-b391-99e2357c4540
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3846d0aa-faa7-4428-a529-c346f1844f99/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -2763,20 +2735,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2174
+        content_length: 20
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:50.248015+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"2baf4432-4f3a-465e-b391-99e2357c4540","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f5","maintenances":[],"modification_date":"2025-01-27T13:48:50.248015+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:50.248015+00:00","export_uri":null,"id":"7bd52425-5d15-4e2c-9f00-346f9ac926e2","modification_date":"2025-01-27T13:48:50.248015+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2baf4432-4f3a-465e-b391-99e2357c4540","name":"tf-server-datasource1"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "2174"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:53 GMT
+                - Tue, 11 Feb 2025 14:22:43 GMT
+            Link:
+                - </servers/3846d0aa-faa7-4428-a529-c346f1844f99/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2784,10 +2758,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6921ba5a-7ace-4b17-b72a-9047aa6edd80
+                - 43617af8-5d1c-46bf-a495-5e175968c437
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 139.960958ms
+        duration: 83.994916ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -2803,7 +2779,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers?name=tf-server-datasource&order=creation_date_desc
         method: GET
       response:
@@ -2823,11 +2799,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:53 GMT
+                - Tue, 11 Feb 2025 14:22:43 GMT
             Link:
                 - </servers?page=0&per_page=50&name=tf-server-datasource&order=creation_date_desc>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2835,12 +2811,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fa321675-aa54-4045-9874-55b916a7024a
+                - e7d88285-a11b-4779-80a3-4716ff62f8cc
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 151.97725ms
+        duration: 129.957042ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2856,8 +2832,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers?name=tf-server-datasource&order=creation_date_desc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers?order=creation_date_desc&tags=data_scaleway_instance_servers%2Cterraform-test
         method: GET
       response:
         proto: HTTP/2.0
@@ -2865,22 +2841,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 4341
+        content_length: 3455
         uncompressed: false
-        body: '{"servers":[{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:50.248015+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"2baf4432-4f3a-465e-b391-99e2357c4540","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f5","maintenances":[],"modification_date":"2025-01-27T13:48:50.248015+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:50.248015+00:00","export_uri":null,"id":"7bd52425-5d15-4e2c-9f00-346f9ac926e2","modification_date":"2025-01-27T13:48:50.248015+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2baf4432-4f3a-465e-b391-99e2357c4540","name":"tf-server-datasource1"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"},{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:46.579463+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f3","maintenances":[],"modification_date":"2025-01-27T13:48:46.579463+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:46.579463+00:00","export_uri":null,"id":"5b43bb7d-47c1-4019-ab73-951d65fd9abc","modification_date":"2025-01-27T13:48:46.579463+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","name":"tf-server-datasource0"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}]}'
+        body: '{"servers":[{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:40.652963+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e1","maintenances":[],"modification_date":"2025-02-11T14:22:40.652963+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"d2496d71-ba3f-420a-b64b-f363c1c3d7ba","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"},{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.434866+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"3846d0aa-faa7-4428-a529-c346f1844f99","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:d3","maintenances":[],"modification_date":"2025-02-11T14:22:36.434866+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"274105cd-669b-4ecf-88da-dde4900af880","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "4341"
+                - "3455"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:53 GMT
+                - Tue, 11 Feb 2025 14:22:43 GMT
             Link:
-                - </servers?page=1&per_page=50&name=tf-server-datasource&order=creation_date_desc>; rel="last"
+                - </servers?page=1&per_page=50&order=creation_date_desc&tags=data_scaleway_instance_servers%2Cterraform-test>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2888,12 +2864,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 754f6c01-4ae6-450a-88d1-b427425678ac
+                - c010f24f-dcb9-42b4-a107-8a7c4d7ed593
             X-Total-Count:
                 - "2"
         status: 200 OK
         code: 200
-        duration: 186.657208ms
+        duration: 212.098ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2909,8 +2885,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers?order=creation_date_desc&tags=data_scaleway_instance_servers%2Cterraform-test
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers?name=tf-server-datasource&order=creation_date_desc
         method: GET
       response:
         proto: HTTP/2.0
@@ -2918,22 +2894,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 4341
+        content_length: 3455
         uncompressed: false
-        body: '{"servers":[{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:50.248015+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"2baf4432-4f3a-465e-b391-99e2357c4540","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f5","maintenances":[],"modification_date":"2025-01-27T13:48:50.248015+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:50.248015+00:00","export_uri":null,"id":"7bd52425-5d15-4e2c-9f00-346f9ac926e2","modification_date":"2025-01-27T13:48:50.248015+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2baf4432-4f3a-465e-b391-99e2357c4540","name":"tf-server-datasource1"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"},{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:46.579463+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f3","maintenances":[],"modification_date":"2025-01-27T13:48:46.579463+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:46.579463+00:00","export_uri":null,"id":"5b43bb7d-47c1-4019-ab73-951d65fd9abc","modification_date":"2025-01-27T13:48:46.579463+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","name":"tf-server-datasource0"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}]}'
+        body: '{"servers":[{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:40.652963+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e1","maintenances":[],"modification_date":"2025-02-11T14:22:40.652963+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"d2496d71-ba3f-420a-b64b-f363c1c3d7ba","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"},{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.434866+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"3846d0aa-faa7-4428-a529-c346f1844f99","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:d3","maintenances":[],"modification_date":"2025-02-11T14:22:36.434866+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"274105cd-669b-4ecf-88da-dde4900af880","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "4341"
+                - "3455"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:53 GMT
+                - Tue, 11 Feb 2025 14:22:43 GMT
             Link:
-                - </servers?page=1&per_page=50&order=creation_date_desc&tags=data_scaleway_instance_servers%2Cterraform-test>; rel="last"
+                - </servers?page=1&per_page=50&name=tf-server-datasource&order=creation_date_desc>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2941,12 +2917,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7930a4e6-e4d4-4562-9ee6-ac4e2be1b762
+                - fcfd9766-de80-43bb-b374-980ae25cf788
             X-Total-Count:
                 - "2"
         status: 200 OK
         code: 200
-        duration: 186.683833ms
+        duration: 215.691958ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -2962,309 +2938,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/5b43bb7d-47c1-4019-ab73-951d65fd9abc
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 521
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:46.579463+00:00","export_uri":null,"id":"5b43bb7d-47c1-4019-ab73-951d65fd9abc","modification_date":"2025-01-27T13:48:46.579463+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","name":"tf-server-datasource0"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "521"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:48:53 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 70af331f-a1ea-4368-909e-d4411d1a470e
-        status: 200 OK
-        code: 200
-        duration: 98.64875ms
-    - id: 59
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/7bd52425-5d15-4e2c-9f00-346f9ac926e2
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 521
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:50.248015+00:00","export_uri":null,"id":"7bd52425-5d15-4e2c-9f00-346f9ac926e2","modification_date":"2025-01-27T13:48:50.248015+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2baf4432-4f3a-465e-b391-99e2357c4540","name":"tf-server-datasource1"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "521"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:48:53 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - c5e6f415-f9b3-4f11-859b-c6525ef81da3
-        status: 200 OK
-        code: 200
-        duration: 84.539542ms
-    - id: 60
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4beaaeb5-58f6-40ce-ae0f-9637416f43df/user_data
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 17
-        uncompressed: false
-        body: '{"user_data":[]}'
-        headers:
-            Content-Length:
-                - "17"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:48:53 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 435a3034-5e1d-4eed-82cd-a559d057056c
-        status: 200 OK
-        code: 200
-        duration: 77.847792ms
-    - id: 61
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2baf4432-4f3a-465e-b391-99e2357c4540/user_data
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 17
-        uncompressed: false
-        body: '{"user_data":[]}'
-        headers:
-            Content-Length:
-                - "17"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:48:53 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - caa0f7aa-afb8-4cb3-b26c-3310812dca5f
-        status: 200 OK
-        code: 200
-        duration: 101.508208ms
-    - id: 62
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4beaaeb5-58f6-40ce-ae0f-9637416f43df/private_nics
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 20
-        uncompressed: false
-        body: '{"private_nics":[]}'
-        headers:
-            Content-Length:
-                - "20"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:48:53 GMT
-            Link:
-                - </servers/4beaaeb5-58f6-40ce-ae0f-9637416f43df/private_nics?page=0&per_page=50&>; rel="last"
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 8750ed3a-079a-4824-a2f1-b0d90f4ec0a3
-            X-Total-Count:
-                - "0"
-        status: 200 OK
-        code: 200
-        duration: 94.352708ms
-    - id: 63
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2baf4432-4f3a-465e-b391-99e2357c4540/private_nics
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 20
-        uncompressed: false
-        body: '{"private_nics":[]}'
-        headers:
-            Content-Length:
-                - "20"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:48:53 GMT
-            Link:
-                - </servers/2baf4432-4f3a-465e-b391-99e2357c4540/private_nics?page=0&per_page=50&>; rel="last"
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - cd468d24-e233-4c66-baa9-b5ec6ed898c7
-            X-Total-Count:
-                - "0"
-        status: 200 OK
-        code: 200
-        duration: 76.73775ms
-    - id: 64
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers?name=tf-server-datasource&order=creation_date_desc
         method: GET
       response:
@@ -3284,11 +2958,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:53 GMT
+                - Tue, 11 Feb 2025 14:22:44 GMT
             Link:
                 - </servers?page=0&per_page=50&name=tf-server-datasource&order=creation_date_desc>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3296,12 +2970,322 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 38686bbe-1be5-405e-807b-619e154a275c
+                - 3e9fb713-df64-4630-b9e9-ae4a8efc3aa0
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 118.705042ms
+        duration: 114.472291ms
+    - id: 59
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers?name=tf-server-datasource&order=creation_date_desc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3455
+        uncompressed: false
+        body: '{"servers":[{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:40.652963+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e1","maintenances":[],"modification_date":"2025-02-11T14:22:40.652963+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"d2496d71-ba3f-420a-b64b-f363c1c3d7ba","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"},{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.434866+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"3846d0aa-faa7-4428-a529-c346f1844f99","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:d3","maintenances":[],"modification_date":"2025-02-11T14:22:36.434866+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"274105cd-669b-4ecf-88da-dde4900af880","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}]}'
+        headers:
+            Content-Length:
+                - "3455"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:22:44 GMT
+            Link:
+                - </servers?page=1&per_page=50&name=tf-server-datasource&order=creation_date_desc>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d5024cfd-9dd7-4e01-b0da-2b320ff3f1bb
+            X-Total-Count:
+                - "2"
+        status: 200 OK
+        code: 200
+        duration: 198.338083ms
+    - id: 60
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers?order=creation_date_desc&tags=data_scaleway_instance_servers%2Cterraform-test
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3455
+        uncompressed: false
+        body: '{"servers":[{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:40.652963+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e1","maintenances":[],"modification_date":"2025-02-11T14:22:40.652963+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"d2496d71-ba3f-420a-b64b-f363c1c3d7ba","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"},{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.434866+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"3846d0aa-faa7-4428-a529-c346f1844f99","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:d3","maintenances":[],"modification_date":"2025-02-11T14:22:36.434866+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"274105cd-669b-4ecf-88da-dde4900af880","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}]}'
+        headers:
+            Content-Length:
+                - "3455"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:22:43 GMT
+            Link:
+                - </servers?page=1&per_page=50&order=creation_date_desc&tags=data_scaleway_instance_servers%2Cterraform-test>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8b59da10-5a8b-4929-abe7-c9f8ba17e4fd
+            X-Total-Count:
+                - "2"
+        status: 200 OK
+        code: 200
+        duration: 226.287708ms
+    - id: 61
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers?name=tf-server-datasource&order=creation_date_desc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 15
+        uncompressed: false
+        body: '{"servers":[]}'
+        headers:
+            Content-Length:
+                - "15"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:22:44 GMT
+            Link:
+                - </servers?page=0&per_page=50&name=tf-server-datasource&order=creation_date_desc>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - dd9199d7-2301-4f04-9bfa-cc2b3a7a5b15
+            X-Total-Count:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 112.948708ms
+    - id: 62
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3846d0aa-faa7-4428-a529-c346f1844f99
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1731
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.434866+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"3846d0aa-faa7-4428-a529-c346f1844f99","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:d3","maintenances":[],"modification_date":"2025-02-11T14:22:36.434866+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"274105cd-669b-4ecf-88da-dde4900af880","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1731"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:22:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 769cd539-57f5-4f30-ab08-9fb201ad3bca
+        status: 200 OK
+        code: 200
+        duration: 176.272875ms
+    - id: 63
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1731
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:40.652963+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e1","maintenances":[],"modification_date":"2025-02-11T14:22:40.652963+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"d2496d71-ba3f-420a-b64b-f363c1c3d7ba","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1731"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:22:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - de55abe4-a04f-416d-b8ad-461a2226ea25
+        status: 200 OK
+        code: 200
+        duration: 197.6325ms
+    - id: 64
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers?name=tf-server-datasource&order=creation_date_desc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3455
+        uncompressed: false
+        body: '{"servers":[{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:40.652963+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e1","maintenances":[],"modification_date":"2025-02-11T14:22:40.652963+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"d2496d71-ba3f-420a-b64b-f363c1c3d7ba","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"},{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.434866+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"3846d0aa-faa7-4428-a529-c346f1844f99","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:d3","maintenances":[],"modification_date":"2025-02-11T14:22:36.434866+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"274105cd-669b-4ecf-88da-dde4900af880","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}]}'
+        headers:
+            Content-Length:
+                - "3455"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:22:44 GMT
+            Link:
+                - </servers?page=1&per_page=50&name=tf-server-datasource&order=creation_date_desc>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 54f3c636-0b63-4e2b-a9fb-e89628bde73d
+            X-Total-Count:
+                - "2"
+        status: 200 OK
+        code: 200
+        duration: 199.114667ms
     - id: 65
       request:
         proto: HTTP/1.1
@@ -3317,8 +3301,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers?order=creation_date_desc&tags=data_scaleway_instance_servers%2Cterraform-test
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/274105cd-669b-4ecf-88da-dde4900af880
         method: GET
       response:
         proto: HTTP/2.0
@@ -3326,22 +3310,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 4341
+        content_length: 143
         uncompressed: false
-        body: '{"servers":[{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:50.248015+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"2baf4432-4f3a-465e-b391-99e2357c4540","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f5","maintenances":[],"modification_date":"2025-01-27T13:48:50.248015+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:50.248015+00:00","export_uri":null,"id":"7bd52425-5d15-4e2c-9f00-346f9ac926e2","modification_date":"2025-01-27T13:48:50.248015+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2baf4432-4f3a-465e-b391-99e2357c4540","name":"tf-server-datasource1"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"},{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:46.579463+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f3","maintenances":[],"modification_date":"2025-01-27T13:48:46.579463+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:46.579463+00:00","export_uri":null,"id":"5b43bb7d-47c1-4019-ab73-951d65fd9abc","modification_date":"2025-01-27T13:48:46.579463+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","name":"tf-server-datasource0"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}]}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"274105cd-669b-4ecf-88da-dde4900af880","type":"not_found"}'
         headers:
             Content-Length:
-                - "4341"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:53 GMT
-            Link:
-                - </servers?page=1&per_page=50&order=creation_date_desc&tags=data_scaleway_instance_servers%2Cterraform-test>; rel="last"
+                - Tue, 11 Feb 2025 14:22:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3349,12 +3331,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3523cd1a-8b84-4022-ad2b-7db5cf89a89e
-            X-Total-Count:
-                - "2"
-        status: 200 OK
-        code: 200
-        duration: 185.957667ms
+                - 0942885d-91a2-48c9-b54f-cd1e1c5f5e18
+        status: 404 Not Found
+        code: 404
+        duration: 42.898667ms
     - id: 66
       request:
         proto: HTTP/1.1
@@ -3370,8 +3350,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers?name=tf-server-datasource&order=creation_date_desc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/d2496d71-ba3f-420a-b64b-f363c1c3d7ba
         method: GET
       response:
         proto: HTTP/2.0
@@ -3379,22 +3359,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 4341
+        content_length: 143
         uncompressed: false
-        body: '{"servers":[{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:50.248015+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"2baf4432-4f3a-465e-b391-99e2357c4540","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f5","maintenances":[],"modification_date":"2025-01-27T13:48:50.248015+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:50.248015+00:00","export_uri":null,"id":"7bd52425-5d15-4e2c-9f00-346f9ac926e2","modification_date":"2025-01-27T13:48:50.248015+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2baf4432-4f3a-465e-b391-99e2357c4540","name":"tf-server-datasource1"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"},{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:46.579463+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f3","maintenances":[],"modification_date":"2025-01-27T13:48:46.579463+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:46.579463+00:00","export_uri":null,"id":"5b43bb7d-47c1-4019-ab73-951d65fd9abc","modification_date":"2025-01-27T13:48:46.579463+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","name":"tf-server-datasource0"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}]}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"d2496d71-ba3f-420a-b64b-f363c1c3d7ba","type":"not_found"}'
         headers:
             Content-Length:
-                - "4341"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:53 GMT
-            Link:
-                - </servers?page=1&per_page=50&name=tf-server-datasource&order=creation_date_desc>; rel="last"
+                - Tue, 11 Feb 2025 14:22:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3402,12 +3380,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 19b58d9d-bcb7-4148-ad43-7c1b46bf7664
-            X-Total-Count:
-                - "2"
-        status: 200 OK
-        code: 200
-        duration: 224.791916ms
+                - cdd95e9a-2559-4490-8d4d-10ba0d96306a
+        status: 404 Not Found
+        code: 404
+        duration: 39.446334ms
     - id: 67
       request:
         proto: HTTP/1.1
@@ -3423,8 +3399,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4beaaeb5-58f6-40ce-ae0f-9637416f43df
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers?order=creation_date_desc&tags=data_scaleway_instance_servers%2Cterraform-test
         method: GET
       response:
         proto: HTTP/2.0
@@ -3432,20 +3408,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2174
+        content_length: 3455
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:46.579463+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f3","maintenances":[],"modification_date":"2025-01-27T13:48:46.579463+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:46.579463+00:00","export_uri":null,"id":"5b43bb7d-47c1-4019-ab73-951d65fd9abc","modification_date":"2025-01-27T13:48:46.579463+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","name":"tf-server-datasource0"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"servers":[{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:40.652963+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e1","maintenances":[],"modification_date":"2025-02-11T14:22:40.652963+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"d2496d71-ba3f-420a-b64b-f363c1c3d7ba","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"},{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.434866+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"3846d0aa-faa7-4428-a529-c346f1844f99","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:d3","maintenances":[],"modification_date":"2025-02-11T14:22:36.434866+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"274105cd-669b-4ecf-88da-dde4900af880","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "2174"
+                - "3455"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:54 GMT
+                - Tue, 11 Feb 2025 14:22:44 GMT
+            Link:
+                - </servers?page=1&per_page=50&order=creation_date_desc&tags=data_scaleway_instance_servers%2Cterraform-test>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3453,10 +3431,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 600f745b-79a0-4c47-b618-b6d8e069f7e0
+                - 0efdc5d6-8a52-4243-80d0-81baed9fc380
+            X-Total-Count:
+                - "2"
         status: 200 OK
         code: 200
-        duration: 137.871959ms
+        duration: 243.606333ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -3472,8 +3452,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2baf4432-4f3a-465e-b391-99e2357c4540
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/274105cd-669b-4ecf-88da-dde4900af880
         method: GET
       response:
         proto: HTTP/2.0
@@ -3481,20 +3461,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2174
+        content_length: 701
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:50.248015+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"2baf4432-4f3a-465e-b391-99e2357c4540","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f5","maintenances":[],"modification_date":"2025-01-27T13:48:50.248015+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:50.248015+00:00","export_uri":null,"id":"7bd52425-5d15-4e2c-9f00-346f9ac926e2","modification_date":"2025-01-27T13:48:50.248015+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2baf4432-4f3a-465e-b391-99e2357c4540","name":"tf-server-datasource1"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T14:22:36.658729Z","id":"274105cd-669b-4ecf-88da-dde4900af880","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:36.658729Z","id":"91820de8-e3d1-492f-b47a-d28beeb6be60","product_resource_id":"3846d0aa-faa7-4428-a529-c346f1844f99","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:36.658729Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2174"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:54 GMT
+                - Tue, 11 Feb 2025 14:22:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3502,10 +3482,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2476aebb-743a-4e8b-be2e-5d118bcae625
+                - 3de73806-7a6e-4cad-9218-7b5e2abc12a9
         status: 200 OK
         code: 200
-        duration: 146.822292ms
+        duration: 68.885083ms
     - id: 69
       request:
         proto: HTTP/1.1
@@ -3521,8 +3501,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4beaaeb5-58f6-40ce-ae0f-9637416f43df
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/d2496d71-ba3f-420a-b64b-f363c1c3d7ba
         method: GET
       response:
         proto: HTTP/2.0
@@ -3530,20 +3510,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2174
+        content_length: 701
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:46.579463+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f3","maintenances":[],"modification_date":"2025-01-27T13:48:46.579463+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:46.579463+00:00","export_uri":null,"id":"5b43bb7d-47c1-4019-ab73-951d65fd9abc","modification_date":"2025-01-27T13:48:46.579463+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","name":"tf-server-datasource0"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T14:22:40.852865Z","id":"d2496d71-ba3f-420a-b64b-f363c1c3d7ba","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:40.852865Z","id":"a352cc34-604d-4c65-a637-95917c0ff61d","product_resource_id":"30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:40.852865Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2174"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:54 GMT
+                - Tue, 11 Feb 2025 14:22:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3551,10 +3531,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bdf91b68-2c18-42db-ac94-c2a8d1c09e82
+                - 8880614d-af1f-464c-9055-5bca15663d9b
         status: 200 OK
         code: 200
-        duration: 125.325792ms
+        duration: 59.074542ms
     - id: 70
       request:
         proto: HTTP/1.1
@@ -3570,8 +3550,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2baf4432-4f3a-465e-b391-99e2357c4540
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -3579,20 +3559,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2174
+        content_length: 17
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:50.248015+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"2baf4432-4f3a-465e-b391-99e2357c4540","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f5","maintenances":[],"modification_date":"2025-01-27T13:48:50.248015+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:50.248015+00:00","export_uri":null,"id":"7bd52425-5d15-4e2c-9f00-346f9ac926e2","modification_date":"2025-01-27T13:48:50.248015+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2baf4432-4f3a-465e-b391-99e2357c4540","name":"tf-server-datasource1"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "2174"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:54 GMT
+                - Tue, 11 Feb 2025 14:22:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3600,10 +3580,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 37991e77-795f-431c-a5c7-885f48396fcb
+                - c39ea0b4-3343-4b9a-9c90-9db8965a56cd
         status: 200 OK
         code: 200
-        duration: 148.1615ms
+        duration: 73.671667ms
     - id: 71
       request:
         proto: HTTP/1.1
@@ -3619,27 +3599,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4beaaeb5-58f6-40ce-ae0f-9637416f43df
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3846d0aa-faa7-4428-a529-c346f1844f99/user_data
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 17
         uncompressed: false
-        body: ""
+        body: '{"user_data":[]}'
         headers:
+            Content-Length:
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:54 GMT
+                - Tue, 11 Feb 2025 14:22:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3647,10 +3629,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bdcd76dc-364c-4251-b88d-534d8154ba10
-        status: 204 No Content
-        code: 204
-        duration: 158.880041ms
+                - 3a14875d-3a93-4292-9050-0ffca5e59eba
+        status: 200 OK
+        code: 200
+        duration: 87.558916ms
     - id: 72
       request:
         proto: HTTP/1.1
@@ -3666,27 +3648,31 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2baf4432-4f3a-465e-b391-99e2357c4540
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93/private_nics
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 20
         uncompressed: false
-        body: ""
+        body: '{"private_nics":[]}'
         headers:
+            Content-Length:
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:54 GMT
+                - Tue, 11 Feb 2025 14:22:44 GMT
+            Link:
+                - </servers/30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3694,10 +3680,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 43c22420-f092-4473-9df7-6a12e5a42487
-        status: 204 No Content
-        code: 204
-        duration: 165.942125ms
+                - 5f67f552-baab-4a08-bdfd-196594ec2952
+            X-Total-Count:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 82.9225ms
     - id: 73
       request:
         proto: HTTP/1.1
@@ -3713,8 +3701,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4beaaeb5-58f6-40ce-ae0f-9637416f43df
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3846d0aa-faa7-4428-a529-c346f1844f99/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -3722,20 +3710,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 143
+        content_length: 20
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","type":"not_found"}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "143"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:54 GMT
+                - Tue, 11 Feb 2025 14:22:44 GMT
+            Link:
+                - </servers/3846d0aa-faa7-4428-a529-c346f1844f99/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3743,10 +3733,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e651a6eb-9268-42a7-9b56-b78a7e6bfc9f
-        status: 404 Not Found
-        code: 404
-        duration: 93.251208ms
+                - 938cc8b0-bdc0-4dc4-84fe-9fe4c68681c0
+            X-Total-Count:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 81.709042ms
     - id: 74
       request:
         proto: HTTP/1.1
@@ -3762,8 +3754,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2baf4432-4f3a-465e-b391-99e2357c4540
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers?name=tf-server-datasource&order=creation_date_desc
         method: GET
       response:
         proto: HTTP/2.0
@@ -3771,20 +3763,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 143
+        content_length: 15
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"2baf4432-4f3a-465e-b391-99e2357c4540","type":"not_found"}'
+        body: '{"servers":[]}'
         headers:
             Content-Length:
-                - "143"
+                - "15"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:54 GMT
+                - Tue, 11 Feb 2025 14:22:44 GMT
+            Link:
+                - </servers?page=0&per_page=50&name=tf-server-datasource&order=creation_date_desc>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3792,10 +3786,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ee9c9d6c-ec20-49e1-a6e9-38ad98cdc764
-        status: 404 Not Found
-        code: 404
-        duration: 115.225458ms
+                - 28fc4feb-2eb7-4412-8205-6e9dc56a25c6
+            X-Total-Count:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 130.797584ms
     - id: 75
       request:
         proto: HTTP/1.1
@@ -3811,8 +3807,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/5b43bb7d-47c1-4019-ab73-951d65fd9abc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers?name=tf-server-datasource&order=creation_date_desc
         method: GET
       response:
         proto: HTTP/2.0
@@ -3820,20 +3816,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 446
+        content_length: 3455
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:46.579463+00:00","export_uri":null,"id":"5b43bb7d-47c1-4019-ab73-951d65fd9abc","modification_date":"2025-01-27T13:48:54.676329+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"servers":[{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:40.652963+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e1","maintenances":[],"modification_date":"2025-02-11T14:22:40.652963+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"d2496d71-ba3f-420a-b64b-f363c1c3d7ba","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"},{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.434866+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"3846d0aa-faa7-4428-a529-c346f1844f99","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:d3","maintenances":[],"modification_date":"2025-02-11T14:22:36.434866+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"274105cd-669b-4ecf-88da-dde4900af880","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "446"
+                - "3455"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:54 GMT
+                - Tue, 11 Feb 2025 14:22:45 GMT
+            Link:
+                - </servers?page=1&per_page=50&name=tf-server-datasource&order=creation_date_desc>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3841,10 +3839,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 95b3736f-545e-42a1-9f53-36d6e74e8475
+                - 1c4639b2-1439-480f-87bd-985857510c28
+            X-Total-Count:
+                - "2"
         status: 200 OK
         code: 200
-        duration: 81.129125ms
+        duration: 174.774542ms
     - id: 76
       request:
         proto: HTTP/1.1
@@ -3860,8 +3860,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/7bd52425-5d15-4e2c-9f00-346f9ac926e2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers?order=creation_date_desc&tags=data_scaleway_instance_servers%2Cterraform-test
         method: GET
       response:
         proto: HTTP/2.0
@@ -3869,20 +3869,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 446
+        content_length: 3455
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:50.248015+00:00","export_uri":null,"id":"7bd52425-5d15-4e2c-9f00-346f9ac926e2","modification_date":"2025-01-27T13:48:54.711061+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"servers":[{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:40.652963+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e1","maintenances":[],"modification_date":"2025-02-11T14:22:40.652963+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"d2496d71-ba3f-420a-b64b-f363c1c3d7ba","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"},{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.434866+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"3846d0aa-faa7-4428-a529-c346f1844f99","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:d3","maintenances":[],"modification_date":"2025-02-11T14:22:36.434866+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"274105cd-669b-4ecf-88da-dde4900af880","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "446"
+                - "3455"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:54 GMT
+                - Tue, 11 Feb 2025 14:22:44 GMT
+            Link:
+                - </servers?page=1&per_page=50&order=creation_date_desc&tags=data_scaleway_instance_servers%2Cterraform-test>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3890,10 +3892,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 49c10cb4-5822-45d7-9632-26302b08d224
+                - 82129f8d-053f-4387-845d-40c9c4e175bf
+            X-Total-Count:
+                - "2"
         status: 200 OK
         code: 200
-        duration: 111.552917ms
+        duration: 250.071167ms
     - id: 77
       request:
         proto: HTTP/1.1
@@ -3909,27 +3913,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/5b43bb7d-47c1-4019-ab73-951d65fd9abc
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3846d0aa-faa7-4428-a529-c346f1844f99
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 1731
         uncompressed: false
-        body: ""
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.434866+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"3846d0aa-faa7-4428-a529-c346f1844f99","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:d3","maintenances":[],"modification_date":"2025-02-11T14:22:36.434866+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"274105cd-669b-4ecf-88da-dde4900af880","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
+            Content-Length:
+                - "1731"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:54 GMT
+                - Tue, 11 Feb 2025 14:22:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3937,10 +3943,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 55ac1fb6-c430-44db-b641-7a6dcd547f07
-        status: 204 No Content
-        code: 204
-        duration: 146.029208ms
+                - c6abbf2c-1bf9-45d1-bc69-7bfcedeebd9a
+        status: 200 OK
+        code: 200
+        duration: 141.25075ms
     - id: 78
       request:
         proto: HTTP/1.1
@@ -3956,8 +3962,155 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/7bd52425-5d15-4e2c-9f00-346f9ac926e2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1731
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:40.652963+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e1","maintenances":[],"modification_date":"2025-02-11T14:22:40.652963+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"d2496d71-ba3f-420a-b64b-f363c1c3d7ba","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1731"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:22:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6e8b1c52-7c29-414a-9d04-ce303ba32fd9
+        status: 200 OK
+        code: 200
+        duration: 244.765459ms
+    - id: 79
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3846d0aa-faa7-4428-a529-c346f1844f99
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1731
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.434866+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource0","id":"3846d0aa-faa7-4428-a529-c346f1844f99","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:d3","maintenances":[],"modification_date":"2025-02-11T14:22:36.434866+00:00","name":"tf-server-datasource0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"274105cd-669b-4ecf-88da-dde4900af880","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1731"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:22:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1f78a5cc-a41d-4940-98b2-7d83fe3f7b96
+        status: 200 OK
+        code: 200
+        duration: 152.901708ms
+    - id: 80
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1731
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:40.652963+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-server-datasource1","id":"30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e1","maintenances":[],"modification_date":"2025-02-11T14:22:40.652963+00:00","name":"tf-server-datasource1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"id":"d2496d71-ba3f-420a-b64b-f363c1c3d7ba","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1731"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:22:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 46f095a1-f70f-402a-8a77-6129c0e26dad
+        status: 200 OK
+        code: 200
+        duration: 154.090291ms
+    - id: 81
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3846d0aa-faa7-4428-a529-c346f1844f99
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3974,9 +4127,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:54 GMT
+                - Tue, 11 Feb 2025 14:22:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3984,11 +4137,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bb6feca8-ab2f-43e6-82af-ddc8aa499d77
+                - 3a9c45fc-c041-4e26-8379-929dd2c49647
         status: 204 No Content
         code: 204
-        duration: 125.065417ms
-    - id: 79
+        duration: 419.13825ms
+    - id: 82
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4003,8 +4156,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4beaaeb5-58f6-40ce-ae0f-9637416f43df
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3846d0aa-faa7-4428-a529-c346f1844f99
         method: GET
       response:
         proto: HTTP/2.0
@@ -4014,7 +4167,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"4beaaeb5-58f6-40ce-ae0f-9637416f43df","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"3846d0aa-faa7-4428-a529-c346f1844f99","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -4023,9 +4176,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:55 GMT
+                - Tue, 11 Feb 2025 14:22:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4033,11 +4186,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e29e0cb4-4e77-437b-aaa4-dae6ff5789ac
+                - 183e8f1a-a3ae-4a6f-ade9-fac49515879c
         status: 404 Not Found
         code: 404
-        duration: 120.98425ms
-    - id: 80
+        duration: 104.730542ms
+    - id: 83
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4052,8 +4205,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2baf4432-4f3a-465e-b391-99e2357c4540
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/274105cd-669b-4ecf-88da-dde4900af880
         method: GET
       response:
         proto: HTTP/2.0
@@ -4063,7 +4216,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"2baf4432-4f3a-465e-b391-99e2357c4540","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"274105cd-669b-4ecf-88da-dde4900af880","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -4072,9 +4225,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:54 GMT
+                - Tue, 11 Feb 2025 14:22:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4082,7 +4235,442 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cf91ca6d-2440-408e-8ada-830137d084d0
+                - 2a8eb2ec-f426-4ccf-9610-5a1083879873
         status: 404 Not Found
         code: 404
-        duration: 101.964666ms
+        duration: 41.297ms
+    - id: 84
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:22:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 90934dd1-2291-4a5c-934d-87a936b56f8e
+        status: 204 No Content
+        code: 204
+        duration: 494.858208ms
+    - id: 85
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/274105cd-669b-4ecf-88da-dde4900af880
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 702
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:22:36.658729Z","id":"274105cd-669b-4ecf-88da-dde4900af880","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:36.658729Z","id":"91820de8-e3d1-492f-b47a-d28beeb6be60","product_resource_id":"3846d0aa-faa7-4428-a529-c346f1844f99","product_resource_type":"instance_server","status":"detaching","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:36.658729Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "702"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:22:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 67ec9405-81cd-4bad-b2a2-4e416d51d77b
+        status: 200 OK
+        code: 200
+        duration: 72.532125ms
+    - id: 86
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:22:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4672c4fa-6438-4341-b12e-2c98f40ba2ab
+        status: 404 Not Found
+        code: 404
+        duration: 119.75725ms
+    - id: 87
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/274105cd-669b-4ecf-88da-dde4900af880
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:22:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d74306b3-63c4-4b68-b7b1-c41c47d431fb
+        status: 204 No Content
+        code: 204
+        duration: 114.686291ms
+    - id: 88
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/d2496d71-ba3f-420a-b64b-f363c1c3d7ba
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"d2496d71-ba3f-420a-b64b-f363c1c3d7ba","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:22:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c956270a-eb11-4f38-be68-3e2141bc058d
+        status: 404 Not Found
+        code: 404
+        duration: 31.233208ms
+    - id: 89
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/d2496d71-ba3f-420a-b64b-f363c1c3d7ba
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 494
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:22:40.852865Z","id":"d2496d71-ba3f-420a-b64b-f363c1c3d7ba","last_detached_at":"2025-02-11T14:22:46.323392Z","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:46.323392Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "494"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:22:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c58eb865-ae58-427b-954f-ba3373ba1e8e
+        status: 200 OK
+        code: 200
+        duration: 60.1505ms
+    - id: 90
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/d2496d71-ba3f-420a-b64b-f363c1c3d7ba
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:22:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0953c8d1-20b0-4c3e-9dcc-6cd0a70deae6
+        status: 204 No Content
+        code: 204
+        duration: 122.68575ms
+    - id: 91
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3846d0aa-faa7-4428-a529-c346f1844f99
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"3846d0aa-faa7-4428-a529-c346f1844f99","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:22:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e5ffd1fd-4b0a-4e26-83e4-be6eaf2103be
+        status: 404 Not Found
+        code: 404
+        duration: 102.976417ms
+    - id: 92
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"30b1ed8f-dcfa-4f64-8e7b-da06dbec0f93","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:22:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 573c1ca7-16cb-4e66-ac1f-13d07460bb22
+        status: 404 Not Found
+        code: 404
+        duration: 78.974291ms

--- a/internal/services/instance/testdata/image-server-with-local-volume.cassette.yaml
+++ b/internal/services/instance/testdata/image-server-with-local-volume.cassette.yaml
@@ -16,7 +16,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
         method: GET
       response:
@@ -25,22 +25,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 38539
+        content_length: 35639
         uncompressed: false
-        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
+        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
         headers:
             Content-Length:
-                - "38539"
+                - "35639"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:04 GMT
+                - Wed, 12 Feb 2025 15:18:30 GMT
             Link:
                 - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,12 +48,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7e5abf2b-3e62-40b1-abdb-ce8c7158bd41
+                - d30f872a-009b-463e-9a76-17a4b6f9229d
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 42.956125ms
+        duration: 295.47125ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -69,7 +69,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
         method: GET
       response:
@@ -78,22 +78,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 14208
+        content_length: 13164
         uncompressed: false
-        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
         headers:
             Content-Length:
-                - "14208"
+                - "13164"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:04 GMT
+                - Wed, 12 Feb 2025 15:18:30 GMT
             Link:
                 - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -101,12 +101,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c82ac678-ea6b-43c2-9bd4-662d2061299d
+                - 37908e21-fb76-4de4-b954-cc907cb0ec5a
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 45.765917ms
+        duration: 53.345208ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -122,7 +122,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_local&zone=fr-par-1
         method: GET
       response:
@@ -142,9 +142,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:04 GMT
+                - Wed, 12 Feb 2025 15:18:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -152,28 +152,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cf2a7568-f5b8-4c28-9d73-b8d83ce5db63
+                - 26c27f97-b6a5-491c-a4e2-9cc24cca3d2c
         status: 200 OK
         code: 200
-        duration: 80.133917ms
+        duration: 88.757333ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 280
+        content_length: 277
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-srv-compassionate-morse","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","volumes":{"0":{"boot":false,"size":15000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+        body: '{"name":"tf-srv-nostalgic-jepsen","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","volumes":{"0":{"boot":false,"size":15000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
         method: POST
       response:
@@ -182,22 +182,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2130
+        content_length: 2121
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:05.301695+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-compassionate-morse","id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:2d","maintenances":[],"modification_date":"2025-01-27T13:53:05.301695+00:00","name":"tf-srv-compassionate-morse","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:05.301695+00:00","export_uri":null,"id":"561950ba-ca29-4da0-bdeb-77519a933904","modification_date":"2025-01-27T13:53:05.301695+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","name":"tf-srv-compassionate-morse"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.091541+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-jepsen","id":"f70dc134-72eb-4945-b2c7-eee228f649c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c4:41","maintenances":[],"modification_date":"2025-02-12T15:18:31.091541+00:00","name":"tf-srv-nostalgic-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.091541+00:00","export_uri":null,"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","modification_date":"2025-02-12T15:18:31.091541+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f70dc134-72eb-4945-b2c7-eee228f649c8","name":"tf-srv-nostalgic-jepsen"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2130"
+                - "2121"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:05 GMT
+                - Wed, 12 Feb 2025 15:18:31 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -205,10 +205,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c923caca-114d-4b38-acfe-2cacd591fcdd
+                - 86e8960c-2296-47c4-84a1-0b45d501ae07
         status: 201 Created
         code: 201
-        duration: 1.199051458s
+        duration: 706.3835ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -224,8 +224,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -233,20 +233,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2130
+        content_length: 2121
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:05.301695+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-compassionate-morse","id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:2d","maintenances":[],"modification_date":"2025-01-27T13:53:05.301695+00:00","name":"tf-srv-compassionate-morse","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:05.301695+00:00","export_uri":null,"id":"561950ba-ca29-4da0-bdeb-77519a933904","modification_date":"2025-01-27T13:53:05.301695+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","name":"tf-srv-compassionate-morse"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.091541+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-jepsen","id":"f70dc134-72eb-4945-b2c7-eee228f649c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c4:41","maintenances":[],"modification_date":"2025-02-12T15:18:31.091541+00:00","name":"tf-srv-nostalgic-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.091541+00:00","export_uri":null,"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","modification_date":"2025-02-12T15:18:31.091541+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f70dc134-72eb-4945-b2c7-eee228f649c8","name":"tf-srv-nostalgic-jepsen"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2130"
+                - "2121"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:06 GMT
+                - Wed, 12 Feb 2025 15:18:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -254,10 +254,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e778b752-d3a4-4ec5-9ffc-2c828a83814c
+                - 1dfe5300-89f9-4eb5-8560-17691a71fe7a
         status: 200 OK
         code: 200
-        duration: 161.120417ms
+        duration: 209.068333ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -273,8 +273,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -282,20 +282,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2130
+        content_length: 2121
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:05.301695+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-compassionate-morse","id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:2d","maintenances":[],"modification_date":"2025-01-27T13:53:05.301695+00:00","name":"tf-srv-compassionate-morse","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:05.301695+00:00","export_uri":null,"id":"561950ba-ca29-4da0-bdeb-77519a933904","modification_date":"2025-01-27T13:53:05.301695+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","name":"tf-srv-compassionate-morse"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.091541+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-jepsen","id":"f70dc134-72eb-4945-b2c7-eee228f649c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c4:41","maintenances":[],"modification_date":"2025-02-12T15:18:31.091541+00:00","name":"tf-srv-nostalgic-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.091541+00:00","export_uri":null,"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","modification_date":"2025-02-12T15:18:31.091541+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f70dc134-72eb-4945-b2c7-eee228f649c8","name":"tf-srv-nostalgic-jepsen"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2130"
+                - "2121"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:05 GMT
+                - Wed, 12 Feb 2025 15:18:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -303,10 +303,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3ad3cf33-0d03-46e3-a327-f6754d65a73e
+                - 6edb931b-3541-4666-bd8e-1ab71d48614b
         status: 200 OK
         code: 200
-        duration: 202.031042ms
+        duration: 136.891542ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -324,8 +324,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -335,7 +335,7 @@ interactions:
         trailer: {}
         content_length: 357
         uncompressed: false
-        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352/action","href_result":"/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352","id":"14243620-ca83-493f-81fa-cc0ffbbc47f6","progress":0,"started_at":"2025-01-27T13:53:06.797374+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/f70dc134-72eb-4945-b2c7-eee228f649c8/action","href_result":"/servers/f70dc134-72eb-4945-b2c7-eee228f649c8","id":"b784e3c1-cd13-4fce-a9f7-44f1f65b11ef","progress":0,"started_at":"2025-02-12T15:18:32.153817+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -344,11 +344,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:06 GMT
+                - Wed, 12 Feb 2025 15:18:32 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/14243620-ca83-493f-81fa-cc0ffbbc47f6
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/b784e3c1-cd13-4fce-a9f7-44f1f65b11ef
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -356,10 +356,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9662a835-8462-4ff0-af36-858c84e1130c
+                - 5ef59435-40a5-458b-8ad6-f587352b8199
         status: 202 Accepted
         code: 202
-        duration: 459.83675ms
+        duration: 286.606625ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -375,8 +375,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -384,20 +384,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2152
+        content_length: 2143
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:05.301695+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-compassionate-morse","id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:2d","maintenances":[],"modification_date":"2025-01-27T13:53:06.405604+00:00","name":"tf-srv-compassionate-morse","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:05.301695+00:00","export_uri":null,"id":"561950ba-ca29-4da0-bdeb-77519a933904","modification_date":"2025-01-27T13:53:05.301695+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","name":"tf-srv-compassionate-morse"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.091541+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-jepsen","id":"f70dc134-72eb-4945-b2c7-eee228f649c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c4:41","maintenances":[],"modification_date":"2025-02-12T15:18:31.940833+00:00","name":"tf-srv-nostalgic-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.091541+00:00","export_uri":null,"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","modification_date":"2025-02-12T15:18:31.091541+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f70dc134-72eb-4945-b2c7-eee228f649c8","name":"tf-srv-nostalgic-jepsen"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2152"
+                - "2143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:06 GMT
+                - Wed, 12 Feb 2025 15:18:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -405,10 +405,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ad9cddc1-a6ec-4543-bd7a-e3f4f3d57304
+                - 1bc36616-8b43-491b-928e-c8e215a711d9
         status: 200 OK
         code: 200
-        duration: 246.675334ms
+        duration: 158.941666ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -424,8 +424,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -433,20 +433,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2256
+        content_length: 2246
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:05.301695+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-compassionate-morse","id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1201","node_id":"29","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:2d","maintenances":[],"modification_date":"2025-01-27T13:53:06.405604+00:00","name":"tf-srv-compassionate-morse","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:05.301695+00:00","export_uri":null,"id":"561950ba-ca29-4da0-bdeb-77519a933904","modification_date":"2025-01-27T13:53:05.301695+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","name":"tf-srv-compassionate-morse"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.091541+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-jepsen","id":"f70dc134-72eb-4945-b2c7-eee228f649c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"601","node_id":"35","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:41","maintenances":[],"modification_date":"2025-02-12T15:18:31.940833+00:00","name":"tf-srv-nostalgic-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.091541+00:00","export_uri":null,"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","modification_date":"2025-02-12T15:18:31.091541+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f70dc134-72eb-4945-b2c7-eee228f649c8","name":"tf-srv-nostalgic-jepsen"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2256"
+                - "2246"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:12 GMT
+                - Wed, 12 Feb 2025 15:18:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -454,10 +454,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1b5179ec-289e-424b-8a41-42eab18de89a
+                - 07e39512-56e2-4bce-b13f-55b444755234
         status: 200 OK
         code: 200
-        duration: 178.566209ms
+        duration: 145.497625ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -473,8 +473,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -482,20 +482,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2256
+        content_length: 2246
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:05.301695+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-compassionate-morse","id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1201","node_id":"29","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:2d","maintenances":[],"modification_date":"2025-01-27T13:53:06.405604+00:00","name":"tf-srv-compassionate-morse","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:05.301695+00:00","export_uri":null,"id":"561950ba-ca29-4da0-bdeb-77519a933904","modification_date":"2025-01-27T13:53:05.301695+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","name":"tf-srv-compassionate-morse"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.091541+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-jepsen","id":"f70dc134-72eb-4945-b2c7-eee228f649c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"601","node_id":"35","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:41","maintenances":[],"modification_date":"2025-02-12T15:18:31.940833+00:00","name":"tf-srv-nostalgic-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.091541+00:00","export_uri":null,"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","modification_date":"2025-02-12T15:18:31.091541+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f70dc134-72eb-4945-b2c7-eee228f649c8","name":"tf-srv-nostalgic-jepsen"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2256"
+                - "2246"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:17 GMT
+                - Wed, 12 Feb 2025 15:18:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -503,10 +503,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5ac77f12-3efc-4e41-be54-636e03b41a5d
+                - 7e436897-8ede-4740-8ce7-6c710ec071cd
         status: 200 OK
         code: 200
-        duration: 165.043875ms
+        duration: 167.292625ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -522,8 +522,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -531,20 +531,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2287
+        content_length: 2246
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:05.301695+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-compassionate-morse","id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1201","node_id":"29","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:2d","maintenances":[],"modification_date":"2025-01-27T13:53:19.059739+00:00","name":"tf-srv-compassionate-morse","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:05.301695+00:00","export_uri":null,"id":"561950ba-ca29-4da0-bdeb-77519a933904","modification_date":"2025-01-27T13:53:05.301695+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","name":"tf-srv-compassionate-morse"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.091541+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-jepsen","id":"f70dc134-72eb-4945-b2c7-eee228f649c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"601","node_id":"35","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:41","maintenances":[],"modification_date":"2025-02-12T15:18:31.940833+00:00","name":"tf-srv-nostalgic-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.091541+00:00","export_uri":null,"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","modification_date":"2025-02-12T15:18:31.091541+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f70dc134-72eb-4945-b2c7-eee228f649c8","name":"tf-srv-nostalgic-jepsen"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2287"
+                - "2246"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:22 GMT
+                - Wed, 12 Feb 2025 15:18:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -552,10 +552,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 71b61b45-0a45-4144-884f-6861e5d5b743
+                - 5c7e78c3-22f2-4058-bd3a-8d7e4c4e67c0
         status: 200 OK
         code: 200
-        duration: 163.050209ms
+        duration: 170.590834ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -571,8 +571,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -580,20 +580,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2287
+        content_length: 2246
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:05.301695+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-compassionate-morse","id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1201","node_id":"29","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:2d","maintenances":[],"modification_date":"2025-01-27T13:53:19.059739+00:00","name":"tf-srv-compassionate-morse","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:05.301695+00:00","export_uri":null,"id":"561950ba-ca29-4da0-bdeb-77519a933904","modification_date":"2025-01-27T13:53:05.301695+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","name":"tf-srv-compassionate-morse"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.091541+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-jepsen","id":"f70dc134-72eb-4945-b2c7-eee228f649c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"601","node_id":"35","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:41","maintenances":[],"modification_date":"2025-02-12T15:18:31.940833+00:00","name":"tf-srv-nostalgic-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.091541+00:00","export_uri":null,"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","modification_date":"2025-02-12T15:18:31.091541+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f70dc134-72eb-4945-b2c7-eee228f649c8","name":"tf-srv-nostalgic-jepsen"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2287"
+                - "2246"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:22 GMT
+                - Wed, 12 Feb 2025 15:18:52 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -601,10 +601,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3e4469a0-1078-490e-9c1c-189848532b4f
+                - f8111677-ed12-49d9-8a86-8c2febf3bcc2
         status: 200 OK
         code: 200
-        duration: 189.772584ms
+        duration: 183.304875ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -620,8 +620,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/561950ba-ca29-4da0-bdeb-77519a933904
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -629,20 +629,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 526
+        content_length: 2277
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:53:05.301695+00:00","export_uri":null,"id":"561950ba-ca29-4da0-bdeb-77519a933904","modification_date":"2025-01-27T13:53:05.301695+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","name":"tf-srv-compassionate-morse"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.091541+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-jepsen","id":"f70dc134-72eb-4945-b2c7-eee228f649c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"601","node_id":"35","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:41","maintenances":[],"modification_date":"2025-02-12T15:18:53.569267+00:00","name":"tf-srv-nostalgic-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.091541+00:00","export_uri":null,"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","modification_date":"2025-02-12T15:18:31.091541+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f70dc134-72eb-4945-b2c7-eee228f649c8","name":"tf-srv-nostalgic-jepsen"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "526"
+                - "2277"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:22 GMT
+                - Wed, 12 Feb 2025 15:18:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -650,10 +650,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6b922148-6360-4177-af9a-9272fa8566c5
+                - 1facdfbd-7934-4832-aa28-85398a34df90
         status: 200 OK
         code: 200
-        duration: 85.86875ms
+        duration: 170.089583ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -669,8 +669,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -678,20 +678,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 2277
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.091541+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-jepsen","id":"f70dc134-72eb-4945-b2c7-eee228f649c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"601","node_id":"35","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:41","maintenances":[],"modification_date":"2025-02-12T15:18:53.569267+00:00","name":"tf-srv-nostalgic-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.091541+00:00","export_uri":null,"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","modification_date":"2025-02-12T15:18:31.091541+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f70dc134-72eb-4945-b2c7-eee228f649c8","name":"tf-srv-nostalgic-jepsen"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "17"
+                - "2277"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:22 GMT
+                - Wed, 12 Feb 2025 15:18:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -699,10 +699,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dafa86cf-5cd9-4bbc-a9dd-8a8580d1896c
+                - 9c56aea6-61d8-49b7-b666-2da3edcf3a4f
         status: 200 OK
         code: 200
-        duration: 103.929792ms
+        duration: 181.020458ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -718,8 +718,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/980893e6-9a6e-4450-bd2f-5742a21100c1
         method: GET
       response:
         proto: HTTP/2.0
@@ -727,22 +727,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 523
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"volume":{"creation_date":"2025-02-12T15:18:31.091541+00:00","export_uri":null,"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","modification_date":"2025-02-12T15:18:31.091541+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f70dc134-72eb-4945-b2c7-eee228f649c8","name":"tf-srv-nostalgic-jepsen"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "20"
+                - "523"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:22 GMT
-            Link:
-                - </servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352/private_nics?page=0&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 15:18:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -750,52 +748,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ef98a83b-39a0-49bd-b97a-e449d098d518
-            X-Total-Count:
-                - "0"
+                - 1b70a7b5-a955-4275-88f8-67c301b4e917
         status: 200 OK
         code: 200
-        duration: 90.144458ms
+        duration: 104.37675ms
     - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 135
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-snap-romantic-kapitsa","volume_id":"561950ba-ca29-4da0-bdeb-77519a933904","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8/user_data
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 848
+        content_length: 17
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"561950ba-ca29-4da0-bdeb-77519a933904","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:53:23.259517+00:00","error_details":null,"id":"42b8e84a-cfbc-451e-93f6-791ba8bf8518","modification_date":"2025-01-27T13:53:23.259517+00:00","name":"tf-snap-romantic-kapitsa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"task":{"description":"volume_snapshot","href_from":"/snapshots","href_result":"snapshots/42b8e84a-cfbc-451e-93f6-791ba8bf8518","id":"695e1ff0-d7dd-44bd-ac9a-5d77b16dd5cd","progress":0,"started_at":"2025-01-27T13:53:23.716726+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "848"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:23 GMT
+                - Wed, 12 Feb 2025 15:18:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -803,10 +797,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7975cb50-d544-4854-9c2c-de2bdc5afcc5
-        status: 201 Created
-        code: 201
-        duration: 869.058542ms
+                - 4bec4263-ccdb-420d-a6d6-ce2543cdf7e5
+        status: 200 OK
+        code: 200
+        duration: 127.638084ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -822,8 +816,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/42b8e84a-cfbc-451e-93f6-791ba8bf8518
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -831,20 +825,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 537
+        content_length: 20
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"561950ba-ca29-4da0-bdeb-77519a933904","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:53:23.259517+00:00","error_details":null,"id":"42b8e84a-cfbc-451e-93f6-791ba8bf8518","modification_date":"2025-01-27T13:53:23.259517+00:00","name":"tf-snap-romantic-kapitsa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "537"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:24 GMT
+                - Wed, 12 Feb 2025 15:18:58 GMT
+            Link:
+                - </servers/f70dc134-72eb-4945-b2c7-eee228f649c8/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -852,48 +848,52 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 00e19f3a-2550-49bc-a798-50e439e60cce
+                - 77e434e3-78a4-4afb-b28a-90ccaa7d9bdd
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 103.185375ms
+        duration: 249.193ms
     - id: 17
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 131
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"name":"tf-snap-dreamy-wiles","volume_id":"980893e6-9a6e-4450-bd2f-5742a21100c1","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/42b8e84a-cfbc-451e-93f6-791ba8bf8518
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 537
+        content_length: 844
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"561950ba-ca29-4da0-bdeb-77519a933904","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:53:23.259517+00:00","error_details":null,"id":"42b8e84a-cfbc-451e-93f6-791ba8bf8518","modification_date":"2025-01-27T13:53:23.259517+00:00","name":"tf-snap-romantic-kapitsa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:18:59.045820+00:00","error_details":null,"id":"cc090ec3-d43c-40d7-a17b-caf6b0c9b30e","modification_date":"2025-02-12T15:18:59.045820+00:00","name":"tf-snap-dreamy-wiles","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"task":{"description":"volume_snapshot","href_from":"/snapshots","href_result":"snapshots/cc090ec3-d43c-40d7-a17b-caf6b0c9b30e","id":"105d36af-a0fc-483a-a46d-6b8d22bbdf02","progress":0,"started_at":"2025-02-12T15:18:59.317678+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "537"
+                - "844"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:28 GMT
+                - Wed, 12 Feb 2025 15:18:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -901,10 +901,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 666efc58-56c0-4feb-a396-63fcff3739e8
-        status: 200 OK
-        code: 200
-        duration: 76.130542ms
+                - a3118672-671c-4c40-98f8-b77c1a52e02e
+        status: 201 Created
+        code: 201
+        duration: 640.907875ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -920,8 +920,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/42b8e84a-cfbc-451e-93f6-791ba8bf8518
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/cc090ec3-d43c-40d7-a17b-caf6b0c9b30e
         method: GET
       response:
         proto: HTTP/2.0
@@ -929,20 +929,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 537
+        content_length: 533
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"561950ba-ca29-4da0-bdeb-77519a933904","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:53:23.259517+00:00","error_details":null,"id":"42b8e84a-cfbc-451e-93f6-791ba8bf8518","modification_date":"2025-01-27T13:53:23.259517+00:00","name":"tf-snap-romantic-kapitsa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:18:59.045820+00:00","error_details":null,"id":"cc090ec3-d43c-40d7-a17b-caf6b0c9b30e","modification_date":"2025-02-12T15:18:59.045820+00:00","name":"tf-snap-dreamy-wiles","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "537"
+                - "533"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:34 GMT
+                - Wed, 12 Feb 2025 15:18:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -950,10 +950,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 918c18a8-d96f-47df-a2ce-b72e81d42a3e
+                - b7487c44-2955-45ce-a474-20bcfb772e28
         status: 200 OK
         code: 200
-        duration: 95.586083ms
+        duration: 126.626875ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -969,8 +969,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/42b8e84a-cfbc-451e-93f6-791ba8bf8518
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/cc090ec3-d43c-40d7-a17b-caf6b0c9b30e
         method: GET
       response:
         proto: HTTP/2.0
@@ -978,20 +978,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 537
+        content_length: 533
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"561950ba-ca29-4da0-bdeb-77519a933904","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:53:23.259517+00:00","error_details":null,"id":"42b8e84a-cfbc-451e-93f6-791ba8bf8518","modification_date":"2025-01-27T13:53:23.259517+00:00","name":"tf-snap-romantic-kapitsa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:18:59.045820+00:00","error_details":null,"id":"cc090ec3-d43c-40d7-a17b-caf6b0c9b30e","modification_date":"2025-02-12T15:18:59.045820+00:00","name":"tf-snap-dreamy-wiles","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "537"
+                - "533"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:38 GMT
+                - Wed, 12 Feb 2025 15:19:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -999,10 +999,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e61e5100-bfe6-4568-8361-a7d4e061c59d
+                - f2853916-39ed-4665-b34f-c531e3e8be16
         status: 200 OK
         code: 200
-        duration: 80.148ms
+        duration: 102.462083ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1018,8 +1018,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/42b8e84a-cfbc-451e-93f6-791ba8bf8518
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/cc090ec3-d43c-40d7-a17b-caf6b0c9b30e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1027,20 +1027,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 537
+        content_length: 533
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"561950ba-ca29-4da0-bdeb-77519a933904","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:53:23.259517+00:00","error_details":null,"id":"42b8e84a-cfbc-451e-93f6-791ba8bf8518","modification_date":"2025-01-27T13:53:23.259517+00:00","name":"tf-snap-romantic-kapitsa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:18:59.045820+00:00","error_details":null,"id":"cc090ec3-d43c-40d7-a17b-caf6b0c9b30e","modification_date":"2025-02-12T15:18:59.045820+00:00","name":"tf-snap-dreamy-wiles","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "537"
+                - "533"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:44 GMT
+                - Wed, 12 Feb 2025 15:19:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1048,10 +1048,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 321ad8fb-8385-4e31-b572-770b26fac4b3
+                - 65377bab-70ff-4ebb-b08d-f5b113fce06a
         status: 200 OK
         code: 200
-        duration: 93.709417ms
+        duration: 96.814625ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1067,8 +1067,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/42b8e84a-cfbc-451e-93f6-791ba8bf8518
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/cc090ec3-d43c-40d7-a17b-caf6b0c9b30e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1076,20 +1076,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 537
+        content_length: 533
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"561950ba-ca29-4da0-bdeb-77519a933904","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:53:23.259517+00:00","error_details":null,"id":"42b8e84a-cfbc-451e-93f6-791ba8bf8518","modification_date":"2025-01-27T13:53:23.259517+00:00","name":"tf-snap-romantic-kapitsa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:18:59.045820+00:00","error_details":null,"id":"cc090ec3-d43c-40d7-a17b-caf6b0c9b30e","modification_date":"2025-02-12T15:18:59.045820+00:00","name":"tf-snap-dreamy-wiles","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "537"
+                - "533"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:49 GMT
+                - Wed, 12 Feb 2025 15:19:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1097,10 +1097,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2f5533f7-3a97-4c66-8aff-c817f655868e
+                - 83d7cb09-f95a-4dcc-981c-8b9db99f662b
         status: 200 OK
         code: 200
-        duration: 128.29025ms
+        duration: 109.940375ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1116,8 +1116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/42b8e84a-cfbc-451e-93f6-791ba8bf8518
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/cc090ec3-d43c-40d7-a17b-caf6b0c9b30e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1125,20 +1125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 537
+        content_length: 533
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"561950ba-ca29-4da0-bdeb-77519a933904","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:53:23.259517+00:00","error_details":null,"id":"42b8e84a-cfbc-451e-93f6-791ba8bf8518","modification_date":"2025-01-27T13:53:23.259517+00:00","name":"tf-snap-romantic-kapitsa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:18:59.045820+00:00","error_details":null,"id":"cc090ec3-d43c-40d7-a17b-caf6b0c9b30e","modification_date":"2025-02-12T15:18:59.045820+00:00","name":"tf-snap-dreamy-wiles","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "537"
+                - "533"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:54 GMT
+                - Wed, 12 Feb 2025 15:19:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1146,10 +1146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0fb18441-b32b-4a76-8ce3-e1913a3790a7
+                - 80a7cc25-6320-435c-b15b-dce182152353
         status: 200 OK
         code: 200
-        duration: 118.014291ms
+        duration: 119.419875ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1165,8 +1165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/42b8e84a-cfbc-451e-93f6-791ba8bf8518
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/cc090ec3-d43c-40d7-a17b-caf6b0c9b30e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1174,20 +1174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 537
+        content_length: 533
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"561950ba-ca29-4da0-bdeb-77519a933904","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:53:23.259517+00:00","error_details":null,"id":"42b8e84a-cfbc-451e-93f6-791ba8bf8518","modification_date":"2025-01-27T13:53:23.259517+00:00","name":"tf-snap-romantic-kapitsa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:18:59.045820+00:00","error_details":null,"id":"cc090ec3-d43c-40d7-a17b-caf6b0c9b30e","modification_date":"2025-02-12T15:18:59.045820+00:00","name":"tf-snap-dreamy-wiles","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "537"
+                - "533"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:59 GMT
+                - Wed, 12 Feb 2025 15:19:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1195,10 +1195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 650c34c8-a4c2-4c96-9c04-9198e585fbda
+                - 2d849019-8d26-43ef-b456-3f495fef1f9a
         status: 200 OK
         code: 200
-        duration: 85.505583ms
+        duration: 104.477041ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1214,8 +1214,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/42b8e84a-cfbc-451e-93f6-791ba8bf8518
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/cc090ec3-d43c-40d7-a17b-caf6b0c9b30e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1223,20 +1223,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 534
+        content_length: 533
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"561950ba-ca29-4da0-bdeb-77519a933904","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:53:23.259517+00:00","error_details":null,"id":"42b8e84a-cfbc-451e-93f6-791ba8bf8518","modification_date":"2025-01-27T13:54:01.461499+00:00","name":"tf-snap-romantic-kapitsa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:18:59.045820+00:00","error_details":null,"id":"cc090ec3-d43c-40d7-a17b-caf6b0c9b30e","modification_date":"2025-02-12T15:18:59.045820+00:00","name":"tf-snap-dreamy-wiles","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "534"
+                - "533"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:04 GMT
+                - Wed, 12 Feb 2025 15:19:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1244,10 +1244,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - afd9212e-9aaf-4312-8315-09bb7c9654be
+                - 985670fb-06dc-4137-a0ad-5f9f6da06c06
         status: 200 OK
         code: 200
-        duration: 94.31625ms
+        duration: 117.057833ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1263,8 +1263,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/42b8e84a-cfbc-451e-93f6-791ba8bf8518
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/cc090ec3-d43c-40d7-a17b-caf6b0c9b30e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1272,20 +1272,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 534
+        content_length: 533
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"561950ba-ca29-4da0-bdeb-77519a933904","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:53:23.259517+00:00","error_details":null,"id":"42b8e84a-cfbc-451e-93f6-791ba8bf8518","modification_date":"2025-01-27T13:54:01.461499+00:00","name":"tf-snap-romantic-kapitsa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:18:59.045820+00:00","error_details":null,"id":"cc090ec3-d43c-40d7-a17b-caf6b0c9b30e","modification_date":"2025-02-12T15:18:59.045820+00:00","name":"tf-snap-dreamy-wiles","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "534"
+                - "533"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:05 GMT
+                - Wed, 12 Feb 2025 15:19:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1293,10 +1293,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 85a2155a-6341-4565-9c51-1e69d1558be2
+                - 84e4aaf4-a7de-411e-901b-c2630a79b472
         status: 200 OK
         code: 200
-        duration: 89.11275ms
+        duration: 138.3035ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1312,8 +1312,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/cc090ec3-d43c-40d7-a17b-caf6b0c9b30e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1321,20 +1321,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2287
+        content_length: 530
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:05.301695+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-compassionate-morse","id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1201","node_id":"29","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:2d","maintenances":[],"modification_date":"2025-01-27T13:53:19.059739+00:00","name":"tf-srv-compassionate-morse","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:05.301695+00:00","export_uri":null,"id":"561950ba-ca29-4da0-bdeb-77519a933904","modification_date":"2025-01-27T13:54:01.461499+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","name":"tf-srv-compassionate-morse"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:18:59.045820+00:00","error_details":null,"id":"cc090ec3-d43c-40d7-a17b-caf6b0c9b30e","modification_date":"2025-02-12T15:19:37.283412+00:00","name":"tf-snap-dreamy-wiles","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2287"
+                - "530"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:06 GMT
+                - Wed, 12 Feb 2025 15:19:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1342,10 +1342,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 17171b45-662a-4985-8034-a8c3f0b74b9d
+                - cd9c87a5-de78-4210-aa32-a5af4c9be516
         status: 200 OK
         code: 200
-        duration: 167.779084ms
+        duration: 111.712834ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1361,8 +1361,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/42b8e84a-cfbc-451e-93f6-791ba8bf8518
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/cc090ec3-d43c-40d7-a17b-caf6b0c9b30e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1370,20 +1370,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 534
+        content_length: 530
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"561950ba-ca29-4da0-bdeb-77519a933904","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:53:23.259517+00:00","error_details":null,"id":"42b8e84a-cfbc-451e-93f6-791ba8bf8518","modification_date":"2025-01-27T13:54:01.461499+00:00","name":"tf-snap-romantic-kapitsa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:18:59.045820+00:00","error_details":null,"id":"cc090ec3-d43c-40d7-a17b-caf6b0c9b30e","modification_date":"2025-02-12T15:19:37.283412+00:00","name":"tf-snap-dreamy-wiles","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "534"
+                - "530"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:06 GMT
+                - Wed, 12 Feb 2025 15:19:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1391,10 +1391,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 40ecbb55-2fc3-409e-b2b7-93a07831f4d7
+                - 82581178-b5ae-48d4-8af4-bc6c503ae0f7
         status: 200 OK
         code: 200
-        duration: 79.813375ms
+        duration: 97.347833ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1410,8 +1410,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -1419,20 +1419,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2287
+        content_length: 2277
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:05.301695+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-compassionate-morse","id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1201","node_id":"29","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:2d","maintenances":[],"modification_date":"2025-01-27T13:53:19.059739+00:00","name":"tf-srv-compassionate-morse","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:05.301695+00:00","export_uri":null,"id":"561950ba-ca29-4da0-bdeb-77519a933904","modification_date":"2025-01-27T13:54:01.461499+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","name":"tf-srv-compassionate-morse"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.091541+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-jepsen","id":"f70dc134-72eb-4945-b2c7-eee228f649c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"601","node_id":"35","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:41","maintenances":[],"modification_date":"2025-02-12T15:18:53.569267+00:00","name":"tf-srv-nostalgic-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.091541+00:00","export_uri":null,"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","modification_date":"2025-02-12T15:19:37.283412+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f70dc134-72eb-4945-b2c7-eee228f649c8","name":"tf-srv-nostalgic-jepsen"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2287"
+                - "2277"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:06 GMT
+                - Wed, 12 Feb 2025 15:19:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1440,10 +1440,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f654cf0b-3ba5-4a3e-a3c4-1a255c2ddd89
+                - bcfb2550-fc3c-486f-9d33-8ed99b829d19
         status: 200 OK
         code: 200
-        duration: 160.697583ms
+        duration: 272.486ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1459,8 +1459,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/561950ba-ca29-4da0-bdeb-77519a933904
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/cc090ec3-d43c-40d7-a17b-caf6b0c9b30e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1468,20 +1468,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 526
+        content_length: 530
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:53:05.301695+00:00","export_uri":null,"id":"561950ba-ca29-4da0-bdeb-77519a933904","modification_date":"2025-01-27T13:54:01.461499+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","name":"tf-srv-compassionate-morse"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:18:59.045820+00:00","error_details":null,"id":"cc090ec3-d43c-40d7-a17b-caf6b0c9b30e","modification_date":"2025-02-12T15:19:37.283412+00:00","name":"tf-snap-dreamy-wiles","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "526"
+                - "530"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:06 GMT
+                - Wed, 12 Feb 2025 15:19:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1489,10 +1489,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a1d01e8a-8d11-46eb-a6ef-8392571fa02a
+                - 3ffa490e-ac04-4cf4-9c11-7d1545af36d7
         status: 200 OK
         code: 200
-        duration: 78.759167ms
+        duration: 104.748292ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1508,8 +1508,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -1517,20 +1517,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 2277
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.091541+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-jepsen","id":"f70dc134-72eb-4945-b2c7-eee228f649c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"601","node_id":"35","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:41","maintenances":[],"modification_date":"2025-02-12T15:18:53.569267+00:00","name":"tf-srv-nostalgic-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.091541+00:00","export_uri":null,"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","modification_date":"2025-02-12T15:19:37.283412+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f70dc134-72eb-4945-b2c7-eee228f649c8","name":"tf-srv-nostalgic-jepsen"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "17"
+                - "2277"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:06 GMT
+                - Wed, 12 Feb 2025 15:19:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1538,10 +1538,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 55641dd7-4f07-420d-8f35-d8c75f2960c0
+                - 96954a47-90c3-4173-a9d8-4cfa8b40a5d0
         status: 200 OK
         code: 200
-        duration: 95.496833ms
+        duration: 173.402458ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1557,8 +1557,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/980893e6-9a6e-4450-bd2f-5742a21100c1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1566,22 +1566,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 523
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"volume":{"creation_date":"2025-02-12T15:18:31.091541+00:00","export_uri":null,"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","modification_date":"2025-02-12T15:19:37.283412+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f70dc134-72eb-4945-b2c7-eee228f649c8","name":"tf-srv-nostalgic-jepsen"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "20"
+                - "523"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:06 GMT
-            Link:
-                - </servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352/private_nics?page=0&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 15:19:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1589,12 +1587,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c4731c72-134b-4ec9-a6ea-d0a5007628c1
-            X-Total-Count:
-                - "0"
+                - 8d047987-089f-4ca9-81d1-8bfd73291356
         status: 200 OK
         code: 200
-        duration: 83.1885ms
+        duration: 124.087ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1610,155 +1606,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/42b8e84a-cfbc-451e-93f6-791ba8bf8518
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 534
-        uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"561950ba-ca29-4da0-bdeb-77519a933904","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:53:23.259517+00:00","error_details":null,"id":"42b8e84a-cfbc-451e-93f6-791ba8bf8518","modification_date":"2025-01-27T13:54:01.461499+00:00","name":"tf-snap-romantic-kapitsa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "534"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:54:07 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - b74d5e55-bf14-4690-ac05-3fba2d237c41
-        status: 200 OK
-        code: 200
-        duration: 72.561833ms
-    - id: 33
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2287
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:05.301695+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-compassionate-morse","id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1201","node_id":"29","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:2d","maintenances":[],"modification_date":"2025-01-27T13:53:19.059739+00:00","name":"tf-srv-compassionate-morse","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:05.301695+00:00","export_uri":null,"id":"561950ba-ca29-4da0-bdeb-77519a933904","modification_date":"2025-01-27T13:54:01.461499+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","name":"tf-srv-compassionate-morse"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2287"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:54:07 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - bdf58ec8-0d18-4825-9c54-233b4a444bce
-        status: 200 OK
-        code: 200
-        duration: 166.059875ms
-    - id: 34
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/561950ba-ca29-4da0-bdeb-77519a933904
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 526
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:53:05.301695+00:00","export_uri":null,"id":"561950ba-ca29-4da0-bdeb-77519a933904","modification_date":"2025-01-27T13:54:01.461499+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","name":"tf-srv-compassionate-morse"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "526"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:54:07 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 6807be83-008a-46b7-86dd-190009152068
-        status: 200 OK
-        code: 200
-        duration: 91.539459ms
-    - id: 35
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1777,9 +1626,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:07 GMT
+                - Wed, 12 Feb 2025 15:19:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1787,11 +1636,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6e81c539-953d-4cde-9c22-271b151039f4
+                - 91da97a7-f118-47ae-9c00-d9f1c44846d2
         status: 200 OK
         code: 200
-        duration: 84.840042ms
-    - id: 36
+        duration: 106.811ms
+    - id: 33
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1806,8 +1655,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1826,11 +1675,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:07 GMT
+                - Wed, 12 Feb 2025 15:19:41 GMT
             Link:
-                - </servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/f70dc134-72eb-4945-b2c7-eee228f649c8/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1838,12 +1687,159 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 89fe038d-3f50-4752-bc54-41628d9f9561
+                - fe567642-7098-4b89-91fa-bb46dda4c7db
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 76.75225ms
+        duration: 120.302375ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/cc090ec3-d43c-40d7-a17b-caf6b0c9b30e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 530
+        uncompressed: false
+        body: '{"snapshot":{"base_volume":{"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:18:59.045820+00:00","error_details":null,"id":"cc090ec3-d43c-40d7-a17b-caf6b0c9b30e","modification_date":"2025-02-12T15:19:37.283412+00:00","name":"tf-snap-dreamy-wiles","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "530"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:19:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e97ebe18-7ad5-472f-838c-93d46420a5ce
+        status: 200 OK
+        code: 200
+        duration: 112.584708ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2277
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.091541+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-jepsen","id":"f70dc134-72eb-4945-b2c7-eee228f649c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"601","node_id":"35","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:41","maintenances":[],"modification_date":"2025-02-12T15:18:53.569267+00:00","name":"tf-srv-nostalgic-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.091541+00:00","export_uri":null,"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","modification_date":"2025-02-12T15:19:37.283412+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f70dc134-72eb-4945-b2c7-eee228f649c8","name":"tf-srv-nostalgic-jepsen"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2277"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:19:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 60b93943-c17c-4747-836d-41d6af59804e
+        status: 200 OK
+        code: 200
+        duration: 161.554666ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/980893e6-9a6e-4450-bd2f-5742a21100c1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 523
+        uncompressed: false
+        body: '{"volume":{"creation_date":"2025-02-12T15:18:31.091541+00:00","export_uri":null,"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","modification_date":"2025-02-12T15:19:37.283412+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f70dc134-72eb-4945-b2c7-eee228f649c8","name":"tf-srv-nostalgic-jepsen"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "523"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:19:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 685436f4-00ab-446f-a7c7-2918ab6cb89e
+        status: 200 OK
+        code: 200
+        duration: 109.794208ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1859,8 +1855,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/42b8e84a-cfbc-451e-93f6-791ba8bf8518
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1868,20 +1864,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 534
+        content_length: 17
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"561950ba-ca29-4da0-bdeb-77519a933904","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:53:23.259517+00:00","error_details":null,"id":"42b8e84a-cfbc-451e-93f6-791ba8bf8518","modification_date":"2025-01-27T13:54:01.461499+00:00","name":"tf-snap-romantic-kapitsa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "534"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:07 GMT
+                - Wed, 12 Feb 2025 15:19:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1889,10 +1885,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 53ec9ca1-e1d7-4684-bb51-9a00b657f63a
+                - ea2aa7c0-45ce-47a7-86d0-ff23988cdc15
         status: 200 OK
         code: 200
-        duration: 91.474708ms
+        duration: 101.408667ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1908,8 +1904,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1917,22 +1913,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 38539
+        content_length: 20
         uncompressed: false
-        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "38539"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:08 GMT
+                - Wed, 12 Feb 2025 15:19:42 GMT
             Link:
-                - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
+                - </servers/f70dc134-72eb-4945-b2c7-eee228f649c8/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1940,12 +1936,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 64991bb5-b0c2-4b09-a530-c4d889349ddc
+                - 8093cef1-c19d-47f0-9727-928eb5744e32
             X-Total-Count:
-                - "68"
+                - "0"
         status: 200 OK
         code: 200
-        duration: 39.848042ms
+        duration: 107.925584ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1961,8 +1957,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/cc090ec3-d43c-40d7-a17b-caf6b0c9b30e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1970,22 +1966,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 14208
+        content_length: 530
         uncompressed: false
-        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+        body: '{"snapshot":{"base_volume":{"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:18:59.045820+00:00","error_details":null,"id":"cc090ec3-d43c-40d7-a17b-caf6b0c9b30e","modification_date":"2025-02-12T15:19:37.283412+00:00","name":"tf-snap-dreamy-wiles","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "14208"
+                - "530"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:08 GMT
-            Link:
-                - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 15:19:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1993,12 +1987,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 69f319cb-ad99-4f42-b04e-b70ad4646242
-            X-Total-Count:
-                - "68"
+                - 535e36e0-a965-4b58-b88f-74ba8d1ccf9f
         status: 200 OK
         code: 200
-        duration: 54.632708ms
+        duration: 115.361166ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2014,7 +2006,113 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 35639
+        uncompressed: false
+        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
+        headers:
+            Content-Length:
+                - "35639"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:19:42 GMT
+            Link:
+                - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ef7701a5-7d09-44ee-a6eb-1f5f3649fce8
+            X-Total-Count:
+                - "68"
+        status: 200 OK
+        code: 200
+        duration: 112.713375ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 13164
+        uncompressed: false
+        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+        headers:
+            Content-Length:
+                - "13164"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:19:43 GMT
+            Link:
+                - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6bd2b2c6-e193-47f6-9b82-51f3e464a759
+            X-Total-Count:
+                - "68"
+        status: 200 OK
+        code: 200
+        duration: 121.794291ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_local&zone=fr-par-1
         method: GET
       response:
@@ -2034,9 +2132,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:08 GMT
+                - Wed, 12 Feb 2025 15:19:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2044,28 +2142,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 70384eec-0086-45de-8356-adaf0e8dcebe
+                - 4c63790e-9f6f-46fd-9808-e427bc5b51ee
         status: 200 OK
         code: 200
-        duration: 77.428292ms
-    - id: 41
+        duration: 95.68325ms
+    - id: 43
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 275
+        content_length: 276
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-srv-strange-mendel","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","volumes":{"0":{"boot":false,"size":10000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+        body: '{"name":"tf-srv-youthful-newton","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","volumes":{"0":{"boot":false,"size":10000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
         method: POST
       response:
@@ -2074,22 +2172,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2115
+        content_length: 2118
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:54:08.596175+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-mendel","id":"31170367-f180-4384-ae33-a445864aa67c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:7d","maintenances":[],"modification_date":"2025-01-27T13:54:08.596175+00:00","name":"tf-srv-strange-mendel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:54:08.596175+00:00","export_uri":null,"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","modification_date":"2025-01-27T13:54:08.596175+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"31170367-f180-4384-ae33-a445864aa67c","name":"tf-srv-strange-mendel"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:19:43.988010+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-newton","id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c4:67","maintenances":[],"modification_date":"2025-02-12T15:19:43.988010+00:00","name":"tf-srv-youthful-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:19:43.988010+00:00","export_uri":null,"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","modification_date":"2025-02-12T15:19:43.988010+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","name":"tf-srv-youthful-newton"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2115"
+                - "2118"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:08 GMT
+                - Wed, 12 Feb 2025 15:19:44 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31170367-f180-4384-ae33-a445864aa67c
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2097,109 +2195,109 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2a9c873b-ade1-4e96-8cb5-bb558f15ca82
+                - 91c70b00-4af8-494e-b566-c40c37a4bf15
         status: 201 Created
         code: 201
-        duration: 690.059833ms
-    - id: 42
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31170367-f180-4384-ae33-a445864aa67c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2115
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:54:08.596175+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-mendel","id":"31170367-f180-4384-ae33-a445864aa67c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:7d","maintenances":[],"modification_date":"2025-01-27T13:54:08.596175+00:00","name":"tf-srv-strange-mendel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:54:08.596175+00:00","export_uri":null,"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","modification_date":"2025-01-27T13:54:08.596175+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"31170367-f180-4384-ae33-a445864aa67c","name":"tf-srv-strange-mendel"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2115"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:54:09 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 7a4d3465-4dbd-4d95-af83-b18fe459e8ef
-        status: 200 OK
-        code: 200
-        duration: 139.807625ms
-    - id: 43
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31170367-f180-4384-ae33-a445864aa67c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2115
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:54:08.596175+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-mendel","id":"31170367-f180-4384-ae33-a445864aa67c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:7d","maintenances":[],"modification_date":"2025-01-27T13:54:08.596175+00:00","name":"tf-srv-strange-mendel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:54:08.596175+00:00","export_uri":null,"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","modification_date":"2025-01-27T13:54:08.596175+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"31170367-f180-4384-ae33-a445864aa67c","name":"tf-srv-strange-mendel"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2115"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:54:08 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - f4d2fad3-61b0-42b1-809d-75d8692b5bf5
-        status: 200 OK
-        code: 200
-        duration: 111.803125ms
+        duration: 1.054938667s
     - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2118
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:19:43.988010+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-newton","id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c4:67","maintenances":[],"modification_date":"2025-02-12T15:19:43.988010+00:00","name":"tf-srv-youthful-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:19:43.988010+00:00","export_uri":null,"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","modification_date":"2025-02-12T15:19:43.988010+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","name":"tf-srv-youthful-newton"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2118"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:19:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 13ccad80-d74f-45f8-9587-de699d599c4e
+        status: 200 OK
+        code: 200
+        duration: 145.093959ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2118
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:19:43.988010+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-newton","id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c4:67","maintenances":[],"modification_date":"2025-02-12T15:19:43.988010+00:00","name":"tf-srv-youthful-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:19:43.988010+00:00","export_uri":null,"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","modification_date":"2025-02-12T15:19:43.988010+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","name":"tf-srv-youthful-newton"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2118"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:19:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 31eb7260-41d4-49c6-91f6-d475bc8553cd
+        status: 200 OK
+        code: 200
+        duration: 160.360667ms
+    - id: 46
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2216,8 +2314,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31170367-f180-4384-ae33-a445864aa67c/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -2227,7 +2325,7 @@ interactions:
         trailer: {}
         content_length: 357
         uncompressed: false
-        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/31170367-f180-4384-ae33-a445864aa67c/action","href_result":"/servers/31170367-f180-4384-ae33-a445864aa67c","id":"44ae713c-44c9-4fd6-973f-7bbf7b239fac","progress":0,"started_at":"2025-01-27T13:54:09.545198+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55/action","href_result":"/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55","id":"85338216-df91-4700-a61e-21abd6b79096","progress":0,"started_at":"2025-02-12T15:19:45.200625+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -2236,11 +2334,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:09 GMT
+                - Wed, 12 Feb 2025 15:19:45 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/44ae713c-44c9-4fd6-973f-7bbf7b239fac
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/85338216-df91-4700-a61e-21abd6b79096
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2248,108 +2346,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a3a92156-c394-4b18-a0cc-eb91e06b3ee7
+                - 9b8e5a34-24c7-4626-a124-6dd88c806f68
         status: 202 Accepted
         code: 202
-        duration: 294.372333ms
-    - id: 45
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31170367-f180-4384-ae33-a445864aa67c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2137
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:54:08.596175+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-mendel","id":"31170367-f180-4384-ae33-a445864aa67c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:7d","maintenances":[],"modification_date":"2025-01-27T13:54:09.302877+00:00","name":"tf-srv-strange-mendel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:54:08.596175+00:00","export_uri":null,"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","modification_date":"2025-01-27T13:54:08.596175+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"31170367-f180-4384-ae33-a445864aa67c","name":"tf-srv-strange-mendel"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2137"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:54:09 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - c9b80488-9059-4cdf-b443-3b2b81527d2d
-        status: 200 OK
-        code: 200
-        duration: 144.096208ms
-    - id: 46
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31170367-f180-4384-ae33-a445864aa67c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2239
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:54:08.596175+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-mendel","id":"31170367-f180-4384-ae33-a445864aa67c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"102","node_id":"7","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:7d","maintenances":[],"modification_date":"2025-01-27T13:54:09.302877+00:00","name":"tf-srv-strange-mendel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:54:08.596175+00:00","export_uri":null,"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","modification_date":"2025-01-27T13:54:08.596175+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"31170367-f180-4384-ae33-a445864aa67c","name":"tf-srv-strange-mendel"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2239"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:54:14 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - cd2c6b1e-e072-45f6-b643-6fe10204e60b
-        status: 200 OK
-        code: 200
-        duration: 162.231042ms
+        duration: 381.843125ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2365,8 +2365,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31170367-f180-4384-ae33-a445864aa67c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55
         method: GET
       response:
         proto: HTTP/2.0
@@ -2374,20 +2374,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2270
+        content_length: 2140
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:54:08.596175+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-mendel","id":"31170367-f180-4384-ae33-a445864aa67c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"102","node_id":"7","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:7d","maintenances":[],"modification_date":"2025-01-27T13:54:19.277272+00:00","name":"tf-srv-strange-mendel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:54:08.596175+00:00","export_uri":null,"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","modification_date":"2025-01-27T13:54:08.596175+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"31170367-f180-4384-ae33-a445864aa67c","name":"tf-srv-strange-mendel"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:19:43.988010+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-newton","id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c4:67","maintenances":[],"modification_date":"2025-02-12T15:19:44.901020+00:00","name":"tf-srv-youthful-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:19:43.988010+00:00","export_uri":null,"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","modification_date":"2025-02-12T15:19:43.988010+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","name":"tf-srv-youthful-newton"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2270"
+                - "2140"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:19 GMT
+                - Wed, 12 Feb 2025 15:19:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2395,10 +2395,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5055797a-e6ec-4b22-b1c9-a9943b831204
+                - e287fe17-48b6-427e-acc6-2f4751762dfb
         status: 200 OK
         code: 200
-        duration: 175.393833ms
+        duration: 171.394875ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2414,8 +2414,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31170367-f180-4384-ae33-a445864aa67c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55
         method: GET
       response:
         proto: HTTP/2.0
@@ -2423,20 +2423,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2270
+        content_length: 2243
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:54:08.596175+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-mendel","id":"31170367-f180-4384-ae33-a445864aa67c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"102","node_id":"7","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:7d","maintenances":[],"modification_date":"2025-01-27T13:54:19.277272+00:00","name":"tf-srv-strange-mendel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:54:08.596175+00:00","export_uri":null,"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","modification_date":"2025-01-27T13:54:08.596175+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"31170367-f180-4384-ae33-a445864aa67c","name":"tf-srv-strange-mendel"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:19:43.988010+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-newton","id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"101","node_id":"31","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:67","maintenances":[],"modification_date":"2025-02-12T15:19:44.901020+00:00","name":"tf-srv-youthful-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:19:43.988010+00:00","export_uri":null,"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","modification_date":"2025-02-12T15:19:43.988010+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","name":"tf-srv-youthful-newton"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2270"
+                - "2243"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:20 GMT
+                - Wed, 12 Feb 2025 15:19:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2444,10 +2444,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 989f2e48-8842-489d-899b-18c102ea0d42
+                - 23fc82f9-5ec7-4fcb-8302-68b6d2542955
         status: 200 OK
         code: 200
-        duration: 191.928541ms
+        duration: 209.419209ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2463,8 +2463,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/4597e8be-20c1-4ff5-9164-4ffa89dda90f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55
         method: GET
       response:
         proto: HTTP/2.0
@@ -2472,20 +2472,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 521
+        content_length: 2243
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:54:08.596175+00:00","export_uri":null,"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","modification_date":"2025-01-27T13:54:08.596175+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"31170367-f180-4384-ae33-a445864aa67c","name":"tf-srv-strange-mendel"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:19:43.988010+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-newton","id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"101","node_id":"31","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:67","maintenances":[],"modification_date":"2025-02-12T15:19:44.901020+00:00","name":"tf-srv-youthful-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:19:43.988010+00:00","export_uri":null,"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","modification_date":"2025-02-12T15:19:43.988010+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","name":"tf-srv-youthful-newton"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "521"
+                - "2243"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:20 GMT
+                - Wed, 12 Feb 2025 15:19:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2493,10 +2493,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 93c35143-7911-46d5-b6e8-c660d9198b0a
+                - 4e4ad16e-8453-444a-ad8b-42ffc1086a63
         status: 200 OK
         code: 200
-        duration: 80.202042ms
+        duration: 173.036541ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -2512,8 +2512,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31170367-f180-4384-ae33-a445864aa67c/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55
         method: GET
       response:
         proto: HTTP/2.0
@@ -2521,20 +2521,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 2274
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:19:43.988010+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-newton","id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"101","node_id":"31","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:67","maintenances":[],"modification_date":"2025-02-12T15:20:00.589839+00:00","name":"tf-srv-youthful-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:19:43.988010+00:00","export_uri":null,"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","modification_date":"2025-02-12T15:19:43.988010+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","name":"tf-srv-youthful-newton"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "17"
+                - "2274"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:20 GMT
+                - Wed, 12 Feb 2025 15:20:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2542,10 +2542,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f5bcfbb4-5b94-4d0c-8d39-98b3d5933b82
+                - b7a69dc7-45f0-4917-bd3d-45d73c03283a
         status: 200 OK
         code: 200
-        duration: 82.682375ms
+        duration: 535.141792ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2561,8 +2561,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31170367-f180-4384-ae33-a445864aa67c/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55
         method: GET
       response:
         proto: HTTP/2.0
@@ -2570,22 +2570,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 2274
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:19:43.988010+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-newton","id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"101","node_id":"31","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:67","maintenances":[],"modification_date":"2025-02-12T15:20:00.589839+00:00","name":"tf-srv-youthful-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:19:43.988010+00:00","export_uri":null,"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","modification_date":"2025-02-12T15:19:43.988010+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","name":"tf-srv-youthful-newton"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "20"
+                - "2274"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:20 GMT
-            Link:
-                - </servers/31170367-f180-4384-ae33-a445864aa67c/private_nics?page=0&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 15:20:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2593,52 +2591,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a76ce97b-e029-4d5c-b698-1ad3a2eae06a
-            X-Total-Count:
-                - "0"
+                - 17f5a893-3288-455c-9f02-a4a1a1e311c3
         status: 200 OK
         code: 200
-        duration: 89.937542ms
+        duration: 184.507667ms
     - id: 52
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 134
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-snap-vigorous-austin","volume_id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 847
+        content_length: 522
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:54:20.662373+00:00","error_details":null,"id":"62fe3fe7-5d01-47ec-b845-a94bca403d44","modification_date":"2025-01-27T13:54:20.662373+00:00","name":"tf-snap-vigorous-austin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"task":{"description":"volume_snapshot","href_from":"/snapshots","href_result":"snapshots/62fe3fe7-5d01-47ec-b845-a94bca403d44","id":"291c9992-0404-49a3-b00d-bcae71db0711","progress":0,"started_at":"2025-01-27T13:54:20.939426+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-12T15:19:43.988010+00:00","export_uri":null,"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","modification_date":"2025-02-12T15:19:43.988010+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","name":"tf-srv-youthful-newton"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "847"
+                - "522"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:21 GMT
+                - Wed, 12 Feb 2025 15:20:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2646,10 +2640,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e1cfd5c8-71b8-47e7-a421-6fab85951055
-        status: 201 Created
-        code: 201
-        duration: 573.7005ms
+                - 075c70bd-20e4-490d-a467-f1f741789026
+        status: 200 OK
+        code: 200
+        duration: 112.293833ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -2665,8 +2659,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/62fe3fe7-5d01-47ec-b845-a94bca403d44
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -2674,20 +2668,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 536
+        content_length: 17
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:54:20.662373+00:00","error_details":null,"id":"62fe3fe7-5d01-47ec-b845-a94bca403d44","modification_date":"2025-01-27T13:54:20.662373+00:00","name":"tf-snap-vigorous-austin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "536"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:21 GMT
+                - Wed, 12 Feb 2025 15:20:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2695,10 +2689,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4c823656-7046-4cee-9b49-b2d78397592f
+                - 73a33e4a-a908-4551-8bd0-750505e6562e
         status: 200 OK
         code: 200
-        duration: 101.284958ms
+        duration: 116.658459ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -2714,8 +2708,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/62fe3fe7-5d01-47ec-b845-a94bca403d44
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -2723,20 +2717,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 536
+        content_length: 20
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:54:20.662373+00:00","error_details":null,"id":"62fe3fe7-5d01-47ec-b845-a94bca403d44","modification_date":"2025-01-27T13:54:20.662373+00:00","name":"tf-snap-vigorous-austin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "536"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:26 GMT
+                - Wed, 12 Feb 2025 15:20:01 GMT
+            Link:
+                - </servers/a316900a-417c-4c52-ba70-2ffa5f6afd55/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2744,48 +2740,52 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cdcd9df2-3bf8-4e3d-8863-2810cba050d9
+                - d921e5d5-4acb-46c4-867e-d6e5bf740f08
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 90.918083ms
+        duration: 113.777083ms
     - id: 55
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 131
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"name":"tf-snap-eager-shtern","volume_id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/62fe3fe7-5d01-47ec-b845-a94bca403d44
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 536
+        content_length: 844
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:54:20.662373+00:00","error_details":null,"id":"62fe3fe7-5d01-47ec-b845-a94bca403d44","modification_date":"2025-01-27T13:54:20.662373+00:00","name":"tf-snap-vigorous-austin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:20:02.089325+00:00","error_details":null,"id":"2d9e3825-218e-4822-b0eb-5cd76286fd79","modification_date":"2025-02-12T15:20:02.089325+00:00","name":"tf-snap-eager-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"task":{"description":"volume_snapshot","href_from":"/snapshots","href_result":"snapshots/2d9e3825-218e-4822-b0eb-5cd76286fd79","id":"35af0ced-8f14-45da-bdb3-5e7fe4eb1752","progress":0,"started_at":"2025-02-12T15:20:02.382091+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "536"
+                - "844"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:31 GMT
+                - Wed, 12 Feb 2025 15:20:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2793,10 +2793,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4e122008-1dba-428d-b22d-c66792c4a3a1
-        status: 200 OK
-        code: 200
-        duration: 117.790625ms
+                - 97894a57-359c-497b-90a2-f8fd62be645b
+        status: 201 Created
+        code: 201
+        duration: 706.969667ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2812,8 +2812,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/62fe3fe7-5d01-47ec-b845-a94bca403d44
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2d9e3825-218e-4822-b0eb-5cd76286fd79
         method: GET
       response:
         proto: HTTP/2.0
@@ -2821,20 +2821,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 536
+        content_length: 533
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:54:20.662373+00:00","error_details":null,"id":"62fe3fe7-5d01-47ec-b845-a94bca403d44","modification_date":"2025-01-27T13:54:20.662373+00:00","name":"tf-snap-vigorous-austin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:20:02.089325+00:00","error_details":null,"id":"2d9e3825-218e-4822-b0eb-5cd76286fd79","modification_date":"2025-02-12T15:20:02.089325+00:00","name":"tf-snap-eager-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "536"
+                - "533"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:36 GMT
+                - Wed, 12 Feb 2025 15:20:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2842,10 +2842,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c9273ed8-f28e-4473-b968-3f80d9b04554
+                - 11cfbabe-841a-48b4-b0bb-71097473a31f
         status: 200 OK
         code: 200
-        duration: 99.368292ms
+        duration: 128.57ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2861,8 +2861,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/62fe3fe7-5d01-47ec-b845-a94bca403d44
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2d9e3825-218e-4822-b0eb-5cd76286fd79
         method: GET
       response:
         proto: HTTP/2.0
@@ -2870,20 +2870,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 536
+        content_length: 533
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:54:20.662373+00:00","error_details":null,"id":"62fe3fe7-5d01-47ec-b845-a94bca403d44","modification_date":"2025-01-27T13:54:20.662373+00:00","name":"tf-snap-vigorous-austin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:20:02.089325+00:00","error_details":null,"id":"2d9e3825-218e-4822-b0eb-5cd76286fd79","modification_date":"2025-02-12T15:20:02.089325+00:00","name":"tf-snap-eager-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "536"
+                - "533"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:41 GMT
+                - Wed, 12 Feb 2025 15:20:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2891,10 +2891,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6f331d80-ebe1-496f-8acc-d406199c3a7e
+                - 58253a31-2da3-4eec-9a8f-fdb6db8e7fb7
         status: 200 OK
         code: 200
-        duration: 109.596583ms
+        duration: 196.496875ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -2910,8 +2910,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/62fe3fe7-5d01-47ec-b845-a94bca403d44
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2d9e3825-218e-4822-b0eb-5cd76286fd79
         method: GET
       response:
         proto: HTTP/2.0
@@ -2919,20 +2919,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 536
+        content_length: 533
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:54:20.662373+00:00","error_details":null,"id":"62fe3fe7-5d01-47ec-b845-a94bca403d44","modification_date":"2025-01-27T13:54:20.662373+00:00","name":"tf-snap-vigorous-austin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:20:02.089325+00:00","error_details":null,"id":"2d9e3825-218e-4822-b0eb-5cd76286fd79","modification_date":"2025-02-12T15:20:02.089325+00:00","name":"tf-snap-eager-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "536"
+                - "533"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:46 GMT
+                - Wed, 12 Feb 2025 15:20:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2940,10 +2940,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7f088c3f-62dc-44a3-a6bc-fde969bb4c6e
+                - 1fb4f77a-2619-40bd-9e50-629fe3d3fb46
         status: 200 OK
         code: 200
-        duration: 109.048666ms
+        duration: 110.932917ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -2959,8 +2959,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/62fe3fe7-5d01-47ec-b845-a94bca403d44
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2d9e3825-218e-4822-b0eb-5cd76286fd79
         method: GET
       response:
         proto: HTTP/2.0
@@ -2968,20 +2968,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 536
+        content_length: 533
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:54:20.662373+00:00","error_details":null,"id":"62fe3fe7-5d01-47ec-b845-a94bca403d44","modification_date":"2025-01-27T13:54:20.662373+00:00","name":"tf-snap-vigorous-austin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:20:02.089325+00:00","error_details":null,"id":"2d9e3825-218e-4822-b0eb-5cd76286fd79","modification_date":"2025-02-12T15:20:02.089325+00:00","name":"tf-snap-eager-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "536"
+                - "533"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:51 GMT
+                - Wed, 12 Feb 2025 15:20:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2989,10 +2989,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b8ba00ed-5d4b-4246-8078-aef9d814529a
+                - 94759fa1-caac-43dc-b7c4-a9cf9d70a3cb
         status: 200 OK
         code: 200
-        duration: 87.365875ms
+        duration: 127.790875ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -3008,8 +3008,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/62fe3fe7-5d01-47ec-b845-a94bca403d44
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2d9e3825-218e-4822-b0eb-5cd76286fd79
         method: GET
       response:
         proto: HTTP/2.0
@@ -3019,7 +3019,7 @@ interactions:
         trailer: {}
         content_length: 533
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:54:20.662373+00:00","error_details":null,"id":"62fe3fe7-5d01-47ec-b845-a94bca403d44","modification_date":"2025-01-27T13:54:55.587522+00:00","name":"tf-snap-vigorous-austin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:20:02.089325+00:00","error_details":null,"id":"2d9e3825-218e-4822-b0eb-5cd76286fd79","modification_date":"2025-02-12T15:20:02.089325+00:00","name":"tf-snap-eager-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "533"
@@ -3028,9 +3028,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:56 GMT
+                - Wed, 12 Feb 2025 15:20:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3038,10 +3038,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1c3b6ab5-8321-46b5-a23e-4182a63568a0
+                - a6e8eb99-2270-4188-8c9c-4c3b2c6cfce0
         status: 200 OK
         code: 200
-        duration: 79.49525ms
+        duration: 109.899667ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -3057,8 +3057,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/62fe3fe7-5d01-47ec-b845-a94bca403d44
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2d9e3825-218e-4822-b0eb-5cd76286fd79
         method: GET
       response:
         proto: HTTP/2.0
@@ -3068,7 +3068,7 @@ interactions:
         trailer: {}
         content_length: 533
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:54:20.662373+00:00","error_details":null,"id":"62fe3fe7-5d01-47ec-b845-a94bca403d44","modification_date":"2025-01-27T13:54:55.587522+00:00","name":"tf-snap-vigorous-austin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:20:02.089325+00:00","error_details":null,"id":"2d9e3825-218e-4822-b0eb-5cd76286fd79","modification_date":"2025-02-12T15:20:02.089325+00:00","name":"tf-snap-eager-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "533"
@@ -3077,9 +3077,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:56 GMT
+                - Wed, 12 Feb 2025 15:20:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3087,10 +3087,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 82721357-329e-491b-acd9-b04abe1992b1
+                - ab587b45-2583-4272-b795-518f4990b1b2
         status: 200 OK
         code: 200
-        duration: 106.437333ms
+        duration: 120.895542ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -3106,8 +3106,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2d9e3825-218e-4822-b0eb-5cd76286fd79
         method: GET
       response:
         proto: HTTP/2.0
@@ -3115,20 +3115,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2287
+        content_length: 533
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:05.301695+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-compassionate-morse","id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1201","node_id":"29","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:2d","maintenances":[],"modification_date":"2025-01-27T13:53:19.059739+00:00","name":"tf-srv-compassionate-morse","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:05.301695+00:00","export_uri":null,"id":"561950ba-ca29-4da0-bdeb-77519a933904","modification_date":"2025-01-27T13:54:01.461499+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","name":"tf-srv-compassionate-morse"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:20:02.089325+00:00","error_details":null,"id":"2d9e3825-218e-4822-b0eb-5cd76286fd79","modification_date":"2025-02-12T15:20:02.089325+00:00","name":"tf-snap-eager-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2287"
+                - "533"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:57 GMT
+                - Wed, 12 Feb 2025 15:20:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3136,10 +3136,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f0a50932-def7-4fcd-a36e-2f0ed6afad82
+                - 68c7dd0a-2e7f-42a7-8599-ff060a6860a0
         status: 200 OK
         code: 200
-        duration: 211.700917ms
+        duration: 145.590416ms
     - id: 63
       request:
         proto: HTTP/1.1
@@ -3155,8 +3155,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31170367-f180-4384-ae33-a445864aa67c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2d9e3825-218e-4822-b0eb-5cd76286fd79
         method: GET
       response:
         proto: HTTP/2.0
@@ -3164,20 +3164,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2270
+        content_length: 533
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:54:08.596175+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-mendel","id":"31170367-f180-4384-ae33-a445864aa67c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"102","node_id":"7","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:7d","maintenances":[],"modification_date":"2025-01-27T13:54:19.277272+00:00","name":"tf-srv-strange-mendel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:54:08.596175+00:00","export_uri":null,"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","modification_date":"2025-01-27T13:54:55.587522+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"31170367-f180-4384-ae33-a445864aa67c","name":"tf-srv-strange-mendel"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:20:02.089325+00:00","error_details":null,"id":"2d9e3825-218e-4822-b0eb-5cd76286fd79","modification_date":"2025-02-12T15:20:02.089325+00:00","name":"tf-snap-eager-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2270"
+                - "533"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:57 GMT
+                - Wed, 12 Feb 2025 15:20:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3185,10 +3185,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 610b5c10-a35d-459d-ad05-bb9ac547650e
+                - d29f74fb-ff0d-4bcf-a368-d1166a0a6040
         status: 200 OK
         code: 200
-        duration: 162.196542ms
+        duration: 100.389875ms
     - id: 64
       request:
         proto: HTTP/1.1
@@ -3204,8 +3204,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/42b8e84a-cfbc-451e-93f6-791ba8bf8518
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2d9e3825-218e-4822-b0eb-5cd76286fd79
         method: GET
       response:
         proto: HTTP/2.0
@@ -3213,20 +3213,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 534
+        content_length: 530
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"561950ba-ca29-4da0-bdeb-77519a933904","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:53:23.259517+00:00","error_details":null,"id":"42b8e84a-cfbc-451e-93f6-791ba8bf8518","modification_date":"2025-01-27T13:54:01.461499+00:00","name":"tf-snap-romantic-kapitsa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:20:02.089325+00:00","error_details":null,"id":"2d9e3825-218e-4822-b0eb-5cd76286fd79","modification_date":"2025-02-12T15:20:39.792802+00:00","name":"tf-snap-eager-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "534"
+                - "530"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:57 GMT
+                - Wed, 12 Feb 2025 15:20:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3234,10 +3234,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 180ae2b0-91dd-411d-805d-a61f61761ad4
+                - c4d6a5c3-9abb-45db-bc86-50828c3dc996
         status: 200 OK
         code: 200
-        duration: 79.090709ms
+        duration: 111.867541ms
     - id: 65
       request:
         proto: HTTP/1.1
@@ -3253,8 +3253,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/62fe3fe7-5d01-47ec-b845-a94bca403d44
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2d9e3825-218e-4822-b0eb-5cd76286fd79
         method: GET
       response:
         proto: HTTP/2.0
@@ -3262,20 +3262,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 533
+        content_length: 530
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:54:20.662373+00:00","error_details":null,"id":"62fe3fe7-5d01-47ec-b845-a94bca403d44","modification_date":"2025-01-27T13:54:55.587522+00:00","name":"tf-snap-vigorous-austin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:20:02.089325+00:00","error_details":null,"id":"2d9e3825-218e-4822-b0eb-5cd76286fd79","modification_date":"2025-02-12T15:20:39.792802+00:00","name":"tf-snap-eager-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "533"
+                - "530"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:57 GMT
+                - Wed, 12 Feb 2025 15:20:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3283,10 +3283,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 91bb54df-c121-4472-a4fc-f8b97d253cf5
+                - bf454939-3a43-4823-8a79-dc502409922b
         status: 200 OK
         code: 200
-        duration: 86.080542ms
+        duration: 95.643083ms
     - id: 66
       request:
         proto: HTTP/1.1
@@ -3302,8 +3302,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -3311,20 +3311,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2287
+        content_length: 2277
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:05.301695+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-compassionate-morse","id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1201","node_id":"29","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:2d","maintenances":[],"modification_date":"2025-01-27T13:53:19.059739+00:00","name":"tf-srv-compassionate-morse","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:05.301695+00:00","export_uri":null,"id":"561950ba-ca29-4da0-bdeb-77519a933904","modification_date":"2025-01-27T13:54:01.461499+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","name":"tf-srv-compassionate-morse"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.091541+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-jepsen","id":"f70dc134-72eb-4945-b2c7-eee228f649c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"601","node_id":"35","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:41","maintenances":[],"modification_date":"2025-02-12T15:18:53.569267+00:00","name":"tf-srv-nostalgic-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.091541+00:00","export_uri":null,"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","modification_date":"2025-02-12T15:19:37.283412+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f70dc134-72eb-4945-b2c7-eee228f649c8","name":"tf-srv-nostalgic-jepsen"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2287"
+                - "2277"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:57 GMT
+                - Wed, 12 Feb 2025 15:20:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3332,10 +3332,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2c22eb95-8c86-46e9-b558-3c0923b98215
+                - 464e57c6-8bc5-46a7-b536-8e97180b344d
         status: 200 OK
         code: 200
-        duration: 156.6ms
+        duration: 333.943958ms
     - id: 67
       request:
         proto: HTTP/1.1
@@ -3351,8 +3351,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31170367-f180-4384-ae33-a445864aa67c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55
         method: GET
       response:
         proto: HTTP/2.0
@@ -3360,20 +3360,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2270
+        content_length: 2274
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:54:08.596175+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-mendel","id":"31170367-f180-4384-ae33-a445864aa67c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"102","node_id":"7","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:7d","maintenances":[],"modification_date":"2025-01-27T13:54:19.277272+00:00","name":"tf-srv-strange-mendel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:54:08.596175+00:00","export_uri":null,"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","modification_date":"2025-01-27T13:54:55.587522+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"31170367-f180-4384-ae33-a445864aa67c","name":"tf-srv-strange-mendel"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:19:43.988010+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-newton","id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"101","node_id":"31","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:67","maintenances":[],"modification_date":"2025-02-12T15:20:00.589839+00:00","name":"tf-srv-youthful-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:19:43.988010+00:00","export_uri":null,"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","modification_date":"2025-02-12T15:20:39.792802+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","name":"tf-srv-youthful-newton"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2270"
+                - "2274"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:57 GMT
+                - Wed, 12 Feb 2025 15:20:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3381,10 +3381,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - be7794d2-164f-46e1-8faa-7449b0829a6b
+                - 40736ad6-c616-4dc6-9d37-dfe56818937e
         status: 200 OK
         code: 200
-        duration: 194.116125ms
+        duration: 207.575958ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -3400,8 +3400,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/561950ba-ca29-4da0-bdeb-77519a933904
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/cc090ec3-d43c-40d7-a17b-caf6b0c9b30e
         method: GET
       response:
         proto: HTTP/2.0
@@ -3409,20 +3409,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 526
+        content_length: 530
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:53:05.301695+00:00","export_uri":null,"id":"561950ba-ca29-4da0-bdeb-77519a933904","modification_date":"2025-01-27T13:54:01.461499+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","name":"tf-srv-compassionate-morse"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:18:59.045820+00:00","error_details":null,"id":"cc090ec3-d43c-40d7-a17b-caf6b0c9b30e","modification_date":"2025-02-12T15:19:37.283412+00:00","name":"tf-snap-dreamy-wiles","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "526"
+                - "530"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:57 GMT
+                - Wed, 12 Feb 2025 15:20:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3430,10 +3430,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 32000b70-6e1a-4584-bd1d-4c4ca98db416
+                - 0e4539b9-c7d1-41f3-8dc4-b77e94602112
         status: 200 OK
         code: 200
-        duration: 90.879208ms
+        duration: 99.05925ms
     - id: 69
       request:
         proto: HTTP/1.1
@@ -3449,8 +3449,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/4597e8be-20c1-4ff5-9164-4ffa89dda90f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2d9e3825-218e-4822-b0eb-5cd76286fd79
         method: GET
       response:
         proto: HTTP/2.0
@@ -3458,20 +3458,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 521
+        content_length: 530
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:54:08.596175+00:00","export_uri":null,"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","modification_date":"2025-01-27T13:54:55.587522+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"31170367-f180-4384-ae33-a445864aa67c","name":"tf-srv-strange-mendel"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:20:02.089325+00:00","error_details":null,"id":"2d9e3825-218e-4822-b0eb-5cd76286fd79","modification_date":"2025-02-12T15:20:39.792802+00:00","name":"tf-snap-eager-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "521"
+                - "530"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:57 GMT
+                - Wed, 12 Feb 2025 15:20:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3479,10 +3479,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bc876636-3603-4763-aebf-a95830eaf04f
+                - 5ccb62c9-2ad3-4290-8aab-812eb5b4c0d7
         status: 200 OK
         code: 200
-        duration: 117.592292ms
+        duration: 112.670542ms
     - id: 70
       request:
         proto: HTTP/1.1
@@ -3498,8 +3498,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -3507,20 +3507,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 2277
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.091541+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-jepsen","id":"f70dc134-72eb-4945-b2c7-eee228f649c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"601","node_id":"35","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:41","maintenances":[],"modification_date":"2025-02-12T15:18:53.569267+00:00","name":"tf-srv-nostalgic-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.091541+00:00","export_uri":null,"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","modification_date":"2025-02-12T15:19:37.283412+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f70dc134-72eb-4945-b2c7-eee228f649c8","name":"tf-srv-nostalgic-jepsen"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "17"
+                - "2277"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:58 GMT
+                - Wed, 12 Feb 2025 15:20:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3528,10 +3528,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 65633f56-0abf-4113-ad09-b801dc13f1fa
+                - a8fe8998-ccc2-41ba-b939-ab46a3eabaaf
         status: 200 OK
         code: 200
-        duration: 118.172375ms
+        duration: 173.001542ms
     - id: 71
       request:
         proto: HTTP/1.1
@@ -3547,8 +3547,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31170367-f180-4384-ae33-a445864aa67c/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55
         method: GET
       response:
         proto: HTTP/2.0
@@ -3556,20 +3556,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 2274
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:19:43.988010+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-newton","id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"101","node_id":"31","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:67","maintenances":[],"modification_date":"2025-02-12T15:20:00.589839+00:00","name":"tf-srv-youthful-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:19:43.988010+00:00","export_uri":null,"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","modification_date":"2025-02-12T15:20:39.792802+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","name":"tf-srv-youthful-newton"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "17"
+                - "2274"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:58 GMT
+                - Wed, 12 Feb 2025 15:20:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3577,10 +3577,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2e7f71af-8f32-45fd-8dab-3f147a0feeb6
+                - 7f8fa1da-18a8-408f-af3b-193083d14a94
         status: 200 OK
         code: 200
-        duration: 81.248375ms
+        duration: 195.112542ms
     - id: 72
       request:
         proto: HTTP/1.1
@@ -3596,8 +3596,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc
         method: GET
       response:
         proto: HTTP/2.0
@@ -3605,22 +3605,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 522
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"volume":{"creation_date":"2025-02-12T15:19:43.988010+00:00","export_uri":null,"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","modification_date":"2025-02-12T15:20:39.792802+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","name":"tf-srv-youthful-newton"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "20"
+                - "522"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:58 GMT
-            Link:
-                - </servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352/private_nics?page=0&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 15:20:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3628,12 +3626,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 453d88ad-d9ef-49a6-a5f7-452c360c869b
-            X-Total-Count:
-                - "0"
+                - 2bf99245-b113-49f9-b1f7-189fefd74cf1
         status: 200 OK
         code: 200
-        duration: 99.729917ms
+        duration: 98.671541ms
     - id: 73
       request:
         proto: HTTP/1.1
@@ -3649,8 +3645,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31170367-f180-4384-ae33-a445864aa67c/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/980893e6-9a6e-4450-bd2f-5742a21100c1
         method: GET
       response:
         proto: HTTP/2.0
@@ -3658,22 +3654,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 523
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"volume":{"creation_date":"2025-02-12T15:18:31.091541+00:00","export_uri":null,"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","modification_date":"2025-02-12T15:19:37.283412+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f70dc134-72eb-4945-b2c7-eee228f649c8","name":"tf-srv-nostalgic-jepsen"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "20"
+                - "523"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:58 GMT
-            Link:
-                - </servers/31170367-f180-4384-ae33-a445864aa67c/private_nics?page=0&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 15:20:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3681,12 +3675,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 96868aa8-c599-4003-b62f-91635f406de1
-            X-Total-Count:
-                - "0"
+                - 6b55880a-62d7-4aca-9649-fd4f23eba1e3
         status: 200 OK
         code: 200
-        duration: 114.245334ms
+        duration: 126.986125ms
     - id: 74
       request:
         proto: HTTP/1.1
@@ -3702,8 +3694,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/42b8e84a-cfbc-451e-93f6-791ba8bf8518
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -3711,20 +3703,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 534
+        content_length: 17
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"561950ba-ca29-4da0-bdeb-77519a933904","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:53:23.259517+00:00","error_details":null,"id":"42b8e84a-cfbc-451e-93f6-791ba8bf8518","modification_date":"2025-01-27T13:54:01.461499+00:00","name":"tf-snap-romantic-kapitsa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "534"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:58 GMT
+                - Wed, 12 Feb 2025 15:20:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3732,10 +3724,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a6d546d6-5a50-4c91-9f80-489eb06bf189
+                - d8d96a0c-0a19-4d4b-ac23-3a0f0c2cafc7
         status: 200 OK
         code: 200
-        duration: 86.092416ms
+        duration: 109.873541ms
     - id: 75
       request:
         proto: HTTP/1.1
@@ -3751,8 +3743,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/62fe3fe7-5d01-47ec-b845-a94bca403d44
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -3760,20 +3752,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 533
+        content_length: 17
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:54:20.662373+00:00","error_details":null,"id":"62fe3fe7-5d01-47ec-b845-a94bca403d44","modification_date":"2025-01-27T13:54:55.587522+00:00","name":"tf-snap-vigorous-austin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "533"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:58 GMT
+                - Wed, 12 Feb 2025 15:20:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3781,10 +3773,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6af3472d-2a28-49cc-9bbf-46d6665cb9c7
+                - 21285224-3cb7-4764-9373-e53b51eae6af
         status: 200 OK
         code: 200
-        duration: 132.040542ms
+        duration: 103.85375ms
     - id: 76
       request:
         proto: HTTP/1.1
@@ -3800,8 +3792,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31170367-f180-4384-ae33-a445864aa67c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -3809,20 +3801,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2270
+        content_length: 20
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:54:08.596175+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-mendel","id":"31170367-f180-4384-ae33-a445864aa67c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"102","node_id":"7","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:7d","maintenances":[],"modification_date":"2025-01-27T13:54:19.277272+00:00","name":"tf-srv-strange-mendel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:54:08.596175+00:00","export_uri":null,"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","modification_date":"2025-01-27T13:54:55.587522+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"31170367-f180-4384-ae33-a445864aa67c","name":"tf-srv-strange-mendel"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "2270"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:58 GMT
+                - Wed, 12 Feb 2025 15:20:45 GMT
+            Link:
+                - </servers/a316900a-417c-4c52-ba70-2ffa5f6afd55/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3830,10 +3824,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b3be81ed-7ade-4662-8238-023b65cf0d32
+                - a392062e-3098-48b5-aa27-495d1de6548d
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 153.516792ms
+        duration: 112.335625ms
     - id: 77
       request:
         proto: HTTP/1.1
@@ -3849,8 +3845,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -3858,20 +3854,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2287
+        content_length: 20
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:05.301695+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-compassionate-morse","id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1201","node_id":"29","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:2d","maintenances":[],"modification_date":"2025-01-27T13:53:19.059739+00:00","name":"tf-srv-compassionate-morse","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:05.301695+00:00","export_uri":null,"id":"561950ba-ca29-4da0-bdeb-77519a933904","modification_date":"2025-01-27T13:54:01.461499+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","name":"tf-srv-compassionate-morse"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "2287"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:58 GMT
+                - Wed, 12 Feb 2025 15:20:45 GMT
+            Link:
+                - </servers/f70dc134-72eb-4945-b2c7-eee228f649c8/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3879,10 +3877,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7f7a8b09-2315-414c-897a-b1e69d2c68b2
+                - 288c2cb8-08cc-4f5b-b4d1-467eddc96b6c
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 161.164ms
+        duration: 119.899417ms
     - id: 78
       request:
         proto: HTTP/1.1
@@ -3898,8 +3898,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/4597e8be-20c1-4ff5-9164-4ffa89dda90f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2d9e3825-218e-4822-b0eb-5cd76286fd79
         method: GET
       response:
         proto: HTTP/2.0
@@ -3907,20 +3907,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 521
+        content_length: 530
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:54:08.596175+00:00","export_uri":null,"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","modification_date":"2025-01-27T13:54:55.587522+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"31170367-f180-4384-ae33-a445864aa67c","name":"tf-srv-strange-mendel"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:20:02.089325+00:00","error_details":null,"id":"2d9e3825-218e-4822-b0eb-5cd76286fd79","modification_date":"2025-02-12T15:20:39.792802+00:00","name":"tf-snap-eager-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "521"
+                - "530"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:58 GMT
+                - Wed, 12 Feb 2025 15:20:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3928,10 +3928,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e6707118-2832-4ec4-8342-75fbcf7ecb04
+                - e2adb25f-faa4-4e11-bb62-d22ffb7e38c8
         status: 200 OK
         code: 200
-        duration: 96.418083ms
+        duration: 93.661459ms
     - id: 79
       request:
         proto: HTTP/1.1
@@ -3947,8 +3947,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/561950ba-ca29-4da0-bdeb-77519a933904
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/cc090ec3-d43c-40d7-a17b-caf6b0c9b30e
         method: GET
       response:
         proto: HTTP/2.0
@@ -3956,20 +3956,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 526
+        content_length: 530
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:53:05.301695+00:00","export_uri":null,"id":"561950ba-ca29-4da0-bdeb-77519a933904","modification_date":"2025-01-27T13:54:01.461499+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","name":"tf-srv-compassionate-morse"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:18:59.045820+00:00","error_details":null,"id":"cc090ec3-d43c-40d7-a17b-caf6b0c9b30e","modification_date":"2025-02-12T15:19:37.283412+00:00","name":"tf-snap-dreamy-wiles","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "526"
+                - "530"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:58 GMT
+                - Wed, 12 Feb 2025 15:20:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3977,10 +3977,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9992355b-dc8f-4a92-9af5-a265c4ac091e
+                - fcfef989-928c-4f62-bcf6-065423d3ea5e
         status: 200 OK
         code: 200
-        duration: 92.428125ms
+        duration: 110.266083ms
     - id: 80
       request:
         proto: HTTP/1.1
@@ -3996,8 +3996,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55
         method: GET
       response:
         proto: HTTP/2.0
@@ -4005,20 +4005,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 2274
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:19:43.988010+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-newton","id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"101","node_id":"31","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:67","maintenances":[],"modification_date":"2025-02-12T15:20:00.589839+00:00","name":"tf-srv-youthful-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:19:43.988010+00:00","export_uri":null,"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","modification_date":"2025-02-12T15:20:39.792802+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","name":"tf-srv-youthful-newton"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "17"
+                - "2274"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:58 GMT
+                - Wed, 12 Feb 2025 15:20:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4026,10 +4026,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 12a4d43c-1b3b-42e3-8901-9da1f786e9c2
+                - 8547402b-9703-4e08-b7b7-918ee5b91366
         status: 200 OK
         code: 200
-        duration: 78.659333ms
+        duration: 181.101792ms
     - id: 81
       request:
         proto: HTTP/1.1
@@ -4045,8 +4045,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31170367-f180-4384-ae33-a445864aa67c/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -4054,20 +4054,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 2277
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.091541+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-jepsen","id":"f70dc134-72eb-4945-b2c7-eee228f649c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"601","node_id":"35","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:41","maintenances":[],"modification_date":"2025-02-12T15:18:53.569267+00:00","name":"tf-srv-nostalgic-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.091541+00:00","export_uri":null,"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","modification_date":"2025-02-12T15:19:37.283412+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f70dc134-72eb-4945-b2c7-eee228f649c8","name":"tf-srv-nostalgic-jepsen"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "17"
+                - "2277"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:58 GMT
+                - Wed, 12 Feb 2025 15:20:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4075,10 +4075,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 03a55ded-d0cb-41ce-bbdd-5b67802bde0e
+                - a4a81814-c17c-45ed-aa84-14dc5444d15b
         status: 200 OK
         code: 200
-        duration: 86.482458ms
+        duration: 186.61175ms
     - id: 82
       request:
         proto: HTTP/1.1
@@ -4094,8 +4094,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/980893e6-9a6e-4450-bd2f-5742a21100c1
         method: GET
       response:
         proto: HTTP/2.0
@@ -4103,22 +4103,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 523
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"volume":{"creation_date":"2025-02-12T15:18:31.091541+00:00","export_uri":null,"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","modification_date":"2025-02-12T15:19:37.283412+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f70dc134-72eb-4945-b2c7-eee228f649c8","name":"tf-srv-nostalgic-jepsen"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "20"
+                - "523"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:58 GMT
-            Link:
-                - </servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352/private_nics?page=0&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 15:20:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4126,12 +4124,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2a6788e1-a6c4-4f67-a8ae-f59c962e7d4b
-            X-Total-Count:
-                - "0"
+                - 2988d650-0f6d-466a-9d48-383239f838b5
         status: 200 OK
         code: 200
-        duration: 91.838042ms
+        duration: 103.931125ms
     - id: 83
       request:
         proto: HTTP/1.1
@@ -4147,8 +4143,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31170367-f180-4384-ae33-a445864aa67c/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc
         method: GET
       response:
         proto: HTTP/2.0
@@ -4156,22 +4152,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 522
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"volume":{"creation_date":"2025-02-12T15:19:43.988010+00:00","export_uri":null,"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","modification_date":"2025-02-12T15:20:39.792802+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","name":"tf-srv-youthful-newton"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "20"
+                - "522"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:58 GMT
-            Link:
-                - </servers/31170367-f180-4384-ae33-a445864aa67c/private_nics?page=0&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 15:20:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4179,12 +4173,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 68551f80-9b19-4856-89f2-8fc4db48be1b
-            X-Total-Count:
-                - "0"
+                - cd136466-72f5-4748-97bc-cac50360462c
         status: 200 OK
         code: 200
-        duration: 111.074333ms
+        duration: 113.926ms
     - id: 84
       request:
         proto: HTTP/1.1
@@ -4200,8 +4192,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/42b8e84a-cfbc-451e-93f6-791ba8bf8518
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -4209,20 +4201,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 534
+        content_length: 17
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"561950ba-ca29-4da0-bdeb-77519a933904","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:53:23.259517+00:00","error_details":null,"id":"42b8e84a-cfbc-451e-93f6-791ba8bf8518","modification_date":"2025-01-27T13:54:01.461499+00:00","name":"tf-snap-romantic-kapitsa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "534"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:59 GMT
+                - Wed, 12 Feb 2025 15:20:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4230,10 +4222,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e87c684e-ec91-4492-b290-a1bee5e3694a
+                - 70ead0e0-3cb6-40e4-97e2-fbbd91a93dcc
         status: 200 OK
         code: 200
-        duration: 96.183375ms
+        duration: 491.444625ms
     - id: 85
       request:
         proto: HTTP/1.1
@@ -4249,8 +4241,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/62fe3fe7-5d01-47ec-b845-a94bca403d44
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -4258,20 +4250,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 533
+        content_length: 17
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:54:20.662373+00:00","error_details":null,"id":"62fe3fe7-5d01-47ec-b845-a94bca403d44","modification_date":"2025-01-27T13:54:55.587522+00:00","name":"tf-snap-vigorous-austin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "533"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:59 GMT
+                - Wed, 12 Feb 2025 15:20:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4279,52 +4271,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c028d9fa-519b-4f5b-a5c5-690b2688104f
+                - 0869c72c-1a85-4aab-a58e-13f31643e1b6
         status: 200 OK
         code: 200
-        duration: 85.360792ms
+        duration: 505.223375ms
     - id: 86
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 239
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-image-optimistic-leavitt","root_volume":"42b8e84a-cfbc-451e-93f6-791ba8bf8518","arch":"x86_64","extra_volumes":{"1":{"id":"62fe3fe7-5d01-47ec-b845-a94bca403d44"}},"project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55/private_nics
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 745
+        content_length: 20
         uncompressed: false
-        body: '{"image":{"arch":"x86_64","creation_date":"2025-01-27T13:54:59.609302+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"62fe3fe7-5d01-47ec-b845-a94bca403d44","name":"tf-snap-vigorous-austin","size":10000000000,"volume_type":"l_ssd"}},"from_server":"","id":"11ba9d59-125d-4438-a63f-c1657a98d812","modification_date":"2025-01-27T13:54:59.609302+00:00","name":"tf-image-optimistic-leavitt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"42b8e84a-cfbc-451e-93f6-791ba8bf8518","name":"tf-snap-romantic-kapitsa","size":15000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "745"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:59 GMT
-            Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/images/11ba9d59-125d-4438-a63f-c1657a98d812
+                - Wed, 12 Feb 2025 15:20:46 GMT
+            Link:
+                - </servers/a316900a-417c-4c52-ba70-2ffa5f6afd55/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4332,10 +4322,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 380279cf-2e39-47ff-880b-7c8c286092e6
-        status: 201 Created
-        code: 201
-        duration: 285.784542ms
+                - 407aa3b8-7564-4a57-b3d9-e2fecd19876a
+            X-Total-Count:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 103.146416ms
     - id: 87
       request:
         proto: HTTP/1.1
@@ -4351,8 +4343,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/11ba9d59-125d-4438-a63f-c1657a98d812
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -4360,20 +4352,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 745
+        content_length: 20
         uncompressed: false
-        body: '{"image":{"arch":"x86_64","creation_date":"2025-01-27T13:54:59.609302+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"62fe3fe7-5d01-47ec-b845-a94bca403d44","name":"tf-snap-vigorous-austin","size":10000000000,"volume_type":"l_ssd"}},"from_server":"","id":"11ba9d59-125d-4438-a63f-c1657a98d812","modification_date":"2025-01-27T13:54:59.609302+00:00","name":"tf-image-optimistic-leavitt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"42b8e84a-cfbc-451e-93f6-791ba8bf8518","name":"tf-snap-romantic-kapitsa","size":15000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "745"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:59 GMT
+                - Wed, 12 Feb 2025 15:20:46 GMT
+            Link:
+                - </servers/f70dc134-72eb-4945-b2c7-eee228f649c8/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4381,10 +4375,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 33f99019-22c4-4d57-a739-ae27e81117ae
+                - 116abd77-5542-4a57-839a-4f1fb6db726e
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 88.862708ms
+        duration: 121.120291ms
     - id: 88
       request:
         proto: HTTP/1.1
@@ -4400,8 +4396,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/11ba9d59-125d-4438-a63f-c1657a98d812
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2d9e3825-218e-4822-b0eb-5cd76286fd79
         method: GET
       response:
         proto: HTTP/2.0
@@ -4409,20 +4405,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 745
+        content_length: 530
         uncompressed: false
-        body: '{"image":{"arch":"x86_64","creation_date":"2025-01-27T13:54:59.609302+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"62fe3fe7-5d01-47ec-b845-a94bca403d44","name":"tf-snap-vigorous-austin","size":10000000000,"volume_type":"l_ssd"}},"from_server":"","id":"11ba9d59-125d-4438-a63f-c1657a98d812","modification_date":"2025-01-27T13:54:59.609302+00:00","name":"tf-image-optimistic-leavitt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"42b8e84a-cfbc-451e-93f6-791ba8bf8518","name":"tf-snap-romantic-kapitsa","size":15000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:20:02.089325+00:00","error_details":null,"id":"2d9e3825-218e-4822-b0eb-5cd76286fd79","modification_date":"2025-02-12T15:20:39.792802+00:00","name":"tf-snap-eager-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "745"
+                - "530"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:59 GMT
+                - Wed, 12 Feb 2025 15:20:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4430,10 +4426,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3f776e14-7d8f-475a-840b-d8a55f22c6dc
+                - 399d5668-6915-4659-bfd0-d12b7b7d8402
         status: 200 OK
         code: 200
-        duration: 101.596292ms
+        duration: 112.818917ms
     - id: 89
       request:
         proto: HTTP/1.1
@@ -4449,8 +4445,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/cc090ec3-d43c-40d7-a17b-caf6b0c9b30e
         method: GET
       response:
         proto: HTTP/2.0
@@ -4458,20 +4454,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2287
+        content_length: 530
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:05.301695+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-compassionate-morse","id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1201","node_id":"29","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:2d","maintenances":[],"modification_date":"2025-01-27T13:53:19.059739+00:00","name":"tf-srv-compassionate-morse","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:05.301695+00:00","export_uri":null,"id":"561950ba-ca29-4da0-bdeb-77519a933904","modification_date":"2025-01-27T13:54:01.461499+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","name":"tf-srv-compassionate-morse"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:18:59.045820+00:00","error_details":null,"id":"cc090ec3-d43c-40d7-a17b-caf6b0c9b30e","modification_date":"2025-02-12T15:19:37.283412+00:00","name":"tf-snap-dreamy-wiles","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2287"
+                - "530"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:59 GMT
+                - Wed, 12 Feb 2025 15:20:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4479,48 +4475,52 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 22c6ce02-6bcf-44a3-8434-0e4e9fce3a12
+                - 818d5438-87b4-4b64-8b8d-7b630bec0777
         status: 200 OK
         code: 200
-        duration: 204.108833ms
+        duration: 111.346916ms
     - id: 90
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 234
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"name":"tf-image-musing-wright","root_volume":"cc090ec3-d43c-40d7-a17b-caf6b0c9b30e","arch":"x86_64","extra_volumes":{"1":{"id":"2d9e3825-218e-4822-b0eb-5cd76286fd79"}},"project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31170367-f180-4384-ae33-a445864aa67c
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2270
+        content_length: 733
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:54:08.596175+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-mendel","id":"31170367-f180-4384-ae33-a445864aa67c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"102","node_id":"7","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:7d","maintenances":[],"modification_date":"2025-01-27T13:54:19.277272+00:00","name":"tf-srv-strange-mendel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:54:08.596175+00:00","export_uri":null,"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","modification_date":"2025-01-27T13:54:55.587522+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"31170367-f180-4384-ae33-a445864aa67c","name":"tf-srv-strange-mendel"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T15:20:47.254950+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"2d9e3825-218e-4822-b0eb-5cd76286fd79","name":"tf-snap-eager-shtern","size":10000000000,"volume_type":"l_ssd"}},"from_server":"","id":"f7ecdaf9-1eaf-4ac5-aaa0-550880299411","modification_date":"2025-02-12T15:20:47.254950+00:00","name":"tf-image-musing-wright","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"cc090ec3-d43c-40d7-a17b-caf6b0c9b30e","name":"tf-snap-dreamy-wiles","size":15000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2270"
+                - "733"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:00 GMT
+                - Wed, 12 Feb 2025 15:20:47 GMT
+            Location:
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/images/f7ecdaf9-1eaf-4ac5-aaa0-550880299411
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4528,10 +4528,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8a47dfad-8c5a-496d-bd63-36364ba302b2
-        status: 200 OK
-        code: 200
-        duration: 182.844541ms
+                - 2db29412-8292-42a3-881e-fafee74eb42d
+        status: 201 Created
+        code: 201
+        duration: 469.246334ms
     - id: 91
       request:
         proto: HTTP/1.1
@@ -4547,8 +4547,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/42b8e84a-cfbc-451e-93f6-791ba8bf8518
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/f7ecdaf9-1eaf-4ac5-aaa0-550880299411
         method: GET
       response:
         proto: HTTP/2.0
@@ -4556,20 +4556,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 534
+        content_length: 733
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"561950ba-ca29-4da0-bdeb-77519a933904","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:53:23.259517+00:00","error_details":null,"id":"42b8e84a-cfbc-451e-93f6-791ba8bf8518","modification_date":"2025-01-27T13:54:01.461499+00:00","name":"tf-snap-romantic-kapitsa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T15:20:47.254950+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"2d9e3825-218e-4822-b0eb-5cd76286fd79","name":"tf-snap-eager-shtern","size":10000000000,"volume_type":"l_ssd"}},"from_server":"","id":"f7ecdaf9-1eaf-4ac5-aaa0-550880299411","modification_date":"2025-02-12T15:20:47.254950+00:00","name":"tf-image-musing-wright","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"cc090ec3-d43c-40d7-a17b-caf6b0c9b30e","name":"tf-snap-dreamy-wiles","size":15000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "534"
+                - "733"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:00 GMT
+                - Wed, 12 Feb 2025 15:20:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4577,10 +4577,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 994014b0-ee4a-4d90-9d69-87c5456fcd41
+                - d69feedc-874f-47ee-b155-efb25438a090
         status: 200 OK
         code: 200
-        duration: 96.954625ms
+        duration: 134.404875ms
     - id: 92
       request:
         proto: HTTP/1.1
@@ -4596,8 +4596,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/62fe3fe7-5d01-47ec-b845-a94bca403d44
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/f7ecdaf9-1eaf-4ac5-aaa0-550880299411
         method: GET
       response:
         proto: HTTP/2.0
@@ -4605,20 +4605,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 533
+        content_length: 733
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:54:20.662373+00:00","error_details":null,"id":"62fe3fe7-5d01-47ec-b845-a94bca403d44","modification_date":"2025-01-27T13:54:55.587522+00:00","name":"tf-snap-vigorous-austin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T15:20:47.254950+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"2d9e3825-218e-4822-b0eb-5cd76286fd79","name":"tf-snap-eager-shtern","size":10000000000,"volume_type":"l_ssd"}},"from_server":"","id":"f7ecdaf9-1eaf-4ac5-aaa0-550880299411","modification_date":"2025-02-12T15:20:47.254950+00:00","name":"tf-image-musing-wright","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"cc090ec3-d43c-40d7-a17b-caf6b0c9b30e","name":"tf-snap-dreamy-wiles","size":15000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "533"
+                - "733"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:00 GMT
+                - Wed, 12 Feb 2025 15:20:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4626,10 +4626,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 32c07a9b-fd8d-4804-b655-cc986e411e5c
+                - d70cdecd-5e48-4d9e-b124-88002fc542d7
         status: 200 OK
         code: 200
-        duration: 86.042958ms
+        duration: 116.436125ms
     - id: 93
       request:
         proto: HTTP/1.1
@@ -4645,8 +4645,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/11ba9d59-125d-4438-a63f-c1657a98d812
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -4654,20 +4654,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 745
+        content_length: 2277
         uncompressed: false
-        body: '{"image":{"arch":"x86_64","creation_date":"2025-01-27T13:54:59.609302+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"62fe3fe7-5d01-47ec-b845-a94bca403d44","name":"tf-snap-vigorous-austin","size":10000000000,"volume_type":"l_ssd"}},"from_server":"","id":"11ba9d59-125d-4438-a63f-c1657a98d812","modification_date":"2025-01-27T13:54:59.609302+00:00","name":"tf-image-optimistic-leavitt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"42b8e84a-cfbc-451e-93f6-791ba8bf8518","name":"tf-snap-romantic-kapitsa","size":15000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.091541+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-jepsen","id":"f70dc134-72eb-4945-b2c7-eee228f649c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"601","node_id":"35","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:41","maintenances":[],"modification_date":"2025-02-12T15:18:53.569267+00:00","name":"tf-srv-nostalgic-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.091541+00:00","export_uri":null,"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","modification_date":"2025-02-12T15:19:37.283412+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f70dc134-72eb-4945-b2c7-eee228f649c8","name":"tf-srv-nostalgic-jepsen"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "745"
+                - "2277"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:00 GMT
+                - Wed, 12 Feb 2025 15:20:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4675,10 +4675,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8ab0bc82-b11e-4478-9948-c191f0fafb1a
+                - acc6b783-7617-481c-b4e3-ad5d6ddcc1f1
         status: 200 OK
         code: 200
-        duration: 98.600875ms
+        duration: 198.593833ms
     - id: 94
       request:
         proto: HTTP/1.1
@@ -4694,8 +4694,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55
         method: GET
       response:
         proto: HTTP/2.0
@@ -4703,20 +4703,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2287
+        content_length: 2274
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:05.301695+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-compassionate-morse","id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1201","node_id":"29","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:2d","maintenances":[],"modification_date":"2025-01-27T13:53:19.059739+00:00","name":"tf-srv-compassionate-morse","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:05.301695+00:00","export_uri":null,"id":"561950ba-ca29-4da0-bdeb-77519a933904","modification_date":"2025-01-27T13:54:01.461499+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","name":"tf-srv-compassionate-morse"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:19:43.988010+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-newton","id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"101","node_id":"31","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:67","maintenances":[],"modification_date":"2025-02-12T15:20:00.589839+00:00","name":"tf-srv-youthful-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:19:43.988010+00:00","export_uri":null,"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","modification_date":"2025-02-12T15:20:39.792802+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","name":"tf-srv-youthful-newton"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2287"
+                - "2274"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:00 GMT
+                - Wed, 12 Feb 2025 15:20:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4724,10 +4724,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d41dee59-e046-4927-b292-823e79c2f192
+                - db49f4d8-de7e-4cb6-8a7c-1c81e6bca979
         status: 200 OK
         code: 200
-        duration: 189.981292ms
+        duration: 307.312208ms
     - id: 95
       request:
         proto: HTTP/1.1
@@ -4743,8 +4743,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31170367-f180-4384-ae33-a445864aa67c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/cc090ec3-d43c-40d7-a17b-caf6b0c9b30e
         method: GET
       response:
         proto: HTTP/2.0
@@ -4752,20 +4752,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2270
+        content_length: 530
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:54:08.596175+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-mendel","id":"31170367-f180-4384-ae33-a445864aa67c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"102","node_id":"7","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:7d","maintenances":[],"modification_date":"2025-01-27T13:54:19.277272+00:00","name":"tf-srv-strange-mendel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:54:08.596175+00:00","export_uri":null,"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","modification_date":"2025-01-27T13:54:55.587522+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"31170367-f180-4384-ae33-a445864aa67c","name":"tf-srv-strange-mendel"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:18:59.045820+00:00","error_details":null,"id":"cc090ec3-d43c-40d7-a17b-caf6b0c9b30e","modification_date":"2025-02-12T15:19:37.283412+00:00","name":"tf-snap-dreamy-wiles","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2270"
+                - "530"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:01 GMT
+                - Wed, 12 Feb 2025 15:20:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4773,10 +4773,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7e2f75de-f502-475c-bde8-8a5d642a23cf
+                - 23d6977a-7b7d-456f-bd16-1738171748bd
         status: 200 OK
         code: 200
-        duration: 212.13625ms
+        duration: 120.288875ms
     - id: 96
       request:
         proto: HTTP/1.1
@@ -4792,8 +4792,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/561950ba-ca29-4da0-bdeb-77519a933904
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2d9e3825-218e-4822-b0eb-5cd76286fd79
         method: GET
       response:
         proto: HTTP/2.0
@@ -4801,20 +4801,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 526
+        content_length: 530
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:53:05.301695+00:00","export_uri":null,"id":"561950ba-ca29-4da0-bdeb-77519a933904","modification_date":"2025-01-27T13:54:01.461499+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","name":"tf-srv-compassionate-morse"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:20:02.089325+00:00","error_details":null,"id":"2d9e3825-218e-4822-b0eb-5cd76286fd79","modification_date":"2025-02-12T15:20:39.792802+00:00","name":"tf-snap-eager-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "526"
+                - "530"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:01 GMT
+                - Wed, 12 Feb 2025 15:20:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4822,10 +4822,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d633a02e-febe-469e-9143-d11d6f097e1a
+                - f54ec2a6-2308-4808-9c1e-a52b30b0113e
         status: 200 OK
         code: 200
-        duration: 116.616375ms
+        duration: 99.588458ms
     - id: 97
       request:
         proto: HTTP/1.1
@@ -4841,8 +4841,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/4597e8be-20c1-4ff5-9164-4ffa89dda90f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/f7ecdaf9-1eaf-4ac5-aaa0-550880299411
         method: GET
       response:
         proto: HTTP/2.0
@@ -4850,20 +4850,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 521
+        content_length: 733
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:54:08.596175+00:00","export_uri":null,"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","modification_date":"2025-01-27T13:54:55.587522+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"31170367-f180-4384-ae33-a445864aa67c","name":"tf-srv-strange-mendel"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T15:20:47.254950+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"2d9e3825-218e-4822-b0eb-5cd76286fd79","name":"tf-snap-eager-shtern","size":10000000000,"volume_type":"l_ssd"}},"from_server":"","id":"f7ecdaf9-1eaf-4ac5-aaa0-550880299411","modification_date":"2025-02-12T15:20:47.254950+00:00","name":"tf-image-musing-wright","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"cc090ec3-d43c-40d7-a17b-caf6b0c9b30e","name":"tf-snap-dreamy-wiles","size":15000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "521"
+                - "733"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:00 GMT
+                - Wed, 12 Feb 2025 15:20:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4871,10 +4871,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2fa7dab3-c5dd-49e5-af23-2e7afad742fc
+                - af20e7c1-68b7-41b2-b25d-fb6b9ee9e96a
         status: 200 OK
         code: 200
-        duration: 120.485209ms
+        duration: 106.550458ms
     - id: 98
       request:
         proto: HTTP/1.1
@@ -4890,8 +4890,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -4899,20 +4899,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 2277
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.091541+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-jepsen","id":"f70dc134-72eb-4945-b2c7-eee228f649c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"601","node_id":"35","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:41","maintenances":[],"modification_date":"2025-02-12T15:18:53.569267+00:00","name":"tf-srv-nostalgic-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.091541+00:00","export_uri":null,"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","modification_date":"2025-02-12T15:19:37.283412+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f70dc134-72eb-4945-b2c7-eee228f649c8","name":"tf-srv-nostalgic-jepsen"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "17"
+                - "2277"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:01 GMT
+                - Wed, 12 Feb 2025 15:20:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4920,10 +4920,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 22a94cd9-5e44-4f71-b3a5-375bc17fa3b1
+                - d9d41ba8-f608-445d-a841-248b0ef326b2
         status: 200 OK
         code: 200
-        duration: 101.688541ms
+        duration: 153.880541ms
     - id: 99
       request:
         proto: HTTP/1.1
@@ -4939,8 +4939,155 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31170367-f180-4384-ae33-a445864aa67c/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2274
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:19:43.988010+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-newton","id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"101","node_id":"31","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:67","maintenances":[],"modification_date":"2025-02-12T15:20:00.589839+00:00","name":"tf-srv-youthful-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:19:43.988010+00:00","export_uri":null,"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","modification_date":"2025-02-12T15:20:39.792802+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","name":"tf-srv-youthful-newton"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2274"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:20:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 62457e17-57d8-4d01-8c8e-6a845416aad4
+        status: 200 OK
+        code: 200
+        duration: 203.058875ms
+    - id: 100
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/980893e6-9a6e-4450-bd2f-5742a21100c1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 523
+        uncompressed: false
+        body: '{"volume":{"creation_date":"2025-02-12T15:18:31.091541+00:00","export_uri":null,"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","modification_date":"2025-02-12T15:19:37.283412+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f70dc134-72eb-4945-b2c7-eee228f649c8","name":"tf-srv-nostalgic-jepsen"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "523"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:20:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 733ee1ac-8110-4029-913e-9b8039993b6d
+        status: 200 OK
+        code: 200
+        duration: 95.952958ms
+    - id: 101
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 522
+        uncompressed: false
+        body: '{"volume":{"creation_date":"2025-02-12T15:19:43.988010+00:00","export_uri":null,"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","modification_date":"2025-02-12T15:20:39.792802+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","name":"tf-srv-youthful-newton"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "522"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:20:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5e1fff6a-d6b7-4696-9398-baac6b7c9df9
+        status: 200 OK
+        code: 200
+        duration: 108.747667ms
+    - id: 102
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -4959,9 +5106,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:01 GMT
+                - Wed, 12 Feb 2025 15:20:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4969,165 +5116,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 121ef11b-c821-40b6-aa5d-94aa51f58adb
+                - 19c68ca1-a714-4cf2-a1de-d57db1bc6cfe
         status: 200 OK
         code: 200
-        duration: 161.312708ms
-    - id: 100
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352/private_nics
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 20
-        uncompressed: false
-        body: '{"private_nics":[]}'
-        headers:
-            Content-Length:
-                - "20"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:55:01 GMT
-            Link:
-                - </servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352/private_nics?page=0&per_page=50&>; rel="last"
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - cb78c9a2-4c2a-4b29-a01d-4bb4844f6eb5
-            X-Total-Count:
-                - "0"
-        status: 200 OK
-        code: 200
-        duration: 100.320458ms
-    - id: 101
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/42b8e84a-cfbc-451e-93f6-791ba8bf8518
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 534
-        uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"561950ba-ca29-4da0-bdeb-77519a933904","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:53:23.259517+00:00","error_details":null,"id":"42b8e84a-cfbc-451e-93f6-791ba8bf8518","modification_date":"2025-01-27T13:54:01.461499+00:00","name":"tf-snap-romantic-kapitsa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "534"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:55:01 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 2abe8a44-7ba0-4923-95a8-bd7fc7308db1
-        status: 200 OK
-        code: 200
-        duration: 86.057625ms
-    - id: 102
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31170367-f180-4384-ae33-a445864aa67c/private_nics
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 20
-        uncompressed: false
-        body: '{"private_nics":[]}'
-        headers:
-            Content-Length:
-                - "20"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:55:01 GMT
-            Link:
-                - </servers/31170367-f180-4384-ae33-a445864aa67c/private_nics?page=0&per_page=50&>; rel="last"
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 3726f165-c4fd-44a8-b19b-7a1c213e76f3
-            X-Total-Count:
-                - "0"
-        status: 200 OK
-        code: 200
-        duration: 123.67675ms
+        duration: 103.005709ms
     - id: 103
       request:
         proto: HTTP/1.1
@@ -5143,8 +5135,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/62fe3fe7-5d01-47ec-b845-a94bca403d44
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -5152,20 +5144,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 533
+        content_length: 17
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:54:20.662373+00:00","error_details":null,"id":"62fe3fe7-5d01-47ec-b845-a94bca403d44","modification_date":"2025-01-27T13:54:55.587522+00:00","name":"tf-snap-vigorous-austin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "533"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:01 GMT
+                - Wed, 12 Feb 2025 15:20:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5173,10 +5165,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b9b4f368-a5f1-4c72-a871-1e2b2e7fe3c6
+                - 8e891dc4-3a57-4147-b5cc-73aff303b4ce
         status: 200 OK
         code: 200
-        duration: 111.205166ms
+        duration: 104.415708ms
     - id: 104
       request:
         proto: HTTP/1.1
@@ -5192,8 +5184,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/11ba9d59-125d-4438-a63f-c1657a98d812
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -5201,20 +5193,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 745
+        content_length: 20
         uncompressed: false
-        body: '{"image":{"arch":"x86_64","creation_date":"2025-01-27T13:54:59.609302+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"62fe3fe7-5d01-47ec-b845-a94bca403d44","name":"tf-snap-vigorous-austin","size":10000000000,"volume_type":"l_ssd"}},"from_server":"","id":"11ba9d59-125d-4438-a63f-c1657a98d812","modification_date":"2025-01-27T13:54:59.609302+00:00","name":"tf-image-optimistic-leavitt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"42b8e84a-cfbc-451e-93f6-791ba8bf8518","name":"tf-snap-romantic-kapitsa","size":15000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "745"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:01 GMT
+                - Wed, 12 Feb 2025 15:20:49 GMT
+            Link:
+                - </servers/f70dc134-72eb-4945-b2c7-eee228f649c8/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5222,10 +5216,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c4ea09ae-50af-418d-8016-bd7aa0a806b0
+                - 31aabbe0-b96b-485a-982e-73f9aab9d4bb
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 193.721708ms
+        duration: 101.074875ms
     - id: 105
       request:
         proto: HTTP/1.1
@@ -5241,8 +5237,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/11ba9d59-125d-4438-a63f-c1657a98d812
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -5250,20 +5246,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 745
+        content_length: 20
         uncompressed: false
-        body: '{"image":{"arch":"x86_64","creation_date":"2025-01-27T13:54:59.609302+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"62fe3fe7-5d01-47ec-b845-a94bca403d44","name":"tf-snap-vigorous-austin","size":10000000000,"volume_type":"l_ssd"}},"from_server":"","id":"11ba9d59-125d-4438-a63f-c1657a98d812","modification_date":"2025-01-27T13:54:59.609302+00:00","name":"tf-image-optimistic-leavitt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"42b8e84a-cfbc-451e-93f6-791ba8bf8518","name":"tf-snap-romantic-kapitsa","size":15000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "745"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:01 GMT
+                - Wed, 12 Feb 2025 15:20:49 GMT
+            Link:
+                - </servers/a316900a-417c-4c52-ba70-2ffa5f6afd55/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5271,10 +5269,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3ced17fb-25c9-478e-9787-d0529e6b50f9
+                - 305bf1c9-38e1-4aeb-b7bf-c8538111534d
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 117.59125ms
+        duration: 122.826084ms
     - id: 106
       request:
         proto: HTTP/1.1
@@ -5290,27 +5290,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/11ba9d59-125d-4438-a63f-c1657a98d812
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/cc090ec3-d43c-40d7-a17b-caf6b0c9b30e
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 530
         uncompressed: false
-        body: ""
+        body: '{"snapshot":{"base_volume":{"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:18:59.045820+00:00","error_details":null,"id":"cc090ec3-d43c-40d7-a17b-caf6b0c9b30e","modification_date":"2025-02-12T15:19:37.283412+00:00","name":"tf-snap-dreamy-wiles","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
+            Content-Length:
+                - "530"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:02 GMT
+                - Wed, 12 Feb 2025 15:20:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5318,10 +5320,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c1f3932e-9ced-4e9d-8eb5-db2e3e153a78
-        status: 204 No Content
-        code: 204
-        duration: 322.103084ms
+                - 304aba8e-50d0-4b9a-aa8a-5d71d84f59b2
+        status: 200 OK
+        code: 200
+        duration: 110.672917ms
     - id: 107
       request:
         proto: HTTP/1.1
@@ -5337,8 +5339,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/11ba9d59-125d-4438-a63f-c1657a98d812
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2d9e3825-218e-4822-b0eb-5cd76286fd79
         method: GET
       response:
         proto: HTTP/2.0
@@ -5346,20 +5348,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 142
+        content_length: 530
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_image","resource_id":"11ba9d59-125d-4438-a63f-c1657a98d812","type":"not_found"}'
+        body: '{"snapshot":{"base_volume":{"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:20:02.089325+00:00","error_details":null,"id":"2d9e3825-218e-4822-b0eb-5cd76286fd79","modification_date":"2025-02-12T15:20:39.792802+00:00","name":"tf-snap-eager-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "142"
+                - "530"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:02 GMT
+                - Wed, 12 Feb 2025 15:20:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5367,10 +5369,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 07864f63-9a6c-4055-a2ec-bb234fe770e1
-        status: 404 Not Found
-        code: 404
-        duration: 105.057708ms
+                - 564554ce-475f-4e1f-862b-dcd9a396a6aa
+        status: 200 OK
+        code: 200
+        duration: 118.16225ms
     - id: 108
       request:
         proto: HTTP/1.1
@@ -5386,8 +5388,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/42b8e84a-cfbc-451e-93f6-791ba8bf8518
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/f7ecdaf9-1eaf-4ac5-aaa0-550880299411
         method: GET
       response:
         proto: HTTP/2.0
@@ -5395,20 +5397,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 534
+        content_length: 733
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"561950ba-ca29-4da0-bdeb-77519a933904","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:53:23.259517+00:00","error_details":null,"id":"42b8e84a-cfbc-451e-93f6-791ba8bf8518","modification_date":"2025-01-27T13:54:01.461499+00:00","name":"tf-snap-romantic-kapitsa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T15:20:47.254950+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"2d9e3825-218e-4822-b0eb-5cd76286fd79","name":"tf-snap-eager-shtern","size":10000000000,"volume_type":"l_ssd"}},"from_server":"","id":"f7ecdaf9-1eaf-4ac5-aaa0-550880299411","modification_date":"2025-02-12T15:20:47.254950+00:00","name":"tf-image-musing-wright","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"cc090ec3-d43c-40d7-a17b-caf6b0c9b30e","name":"tf-snap-dreamy-wiles","size":15000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "534"
+                - "733"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:02 GMT
+                - Wed, 12 Feb 2025 15:20:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5416,10 +5418,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 77b23092-8c84-49fc-bd63-6cdee14031ae
+                - c2548116-0be9-46ea-b04e-f7a67252ccb1
         status: 200 OK
         code: 200
-        duration: 123.980375ms
+        duration: 114.334042ms
     - id: 109
       request:
         proto: HTTP/1.1
@@ -5435,8 +5437,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/62fe3fe7-5d01-47ec-b845-a94bca403d44
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/f7ecdaf9-1eaf-4ac5-aaa0-550880299411
         method: GET
       response:
         proto: HTTP/2.0
@@ -5444,20 +5446,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 533
+        content_length: 733
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:54:20.662373+00:00","error_details":null,"id":"62fe3fe7-5d01-47ec-b845-a94bca403d44","modification_date":"2025-01-27T13:54:55.587522+00:00","name":"tf-snap-vigorous-austin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T15:20:47.254950+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"2d9e3825-218e-4822-b0eb-5cd76286fd79","name":"tf-snap-eager-shtern","size":10000000000,"volume_type":"l_ssd"}},"from_server":"","id":"f7ecdaf9-1eaf-4ac5-aaa0-550880299411","modification_date":"2025-02-12T15:20:47.254950+00:00","name":"tf-image-musing-wright","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"cc090ec3-d43c-40d7-a17b-caf6b0c9b30e","name":"tf-snap-dreamy-wiles","size":15000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "533"
+                - "733"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:02 GMT
+                - Wed, 12 Feb 2025 15:20:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5465,10 +5467,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - eab54f0a-5f1f-43f9-bb37-26cba2f160b9
+                - cb0d7595-c681-47e7-97c0-fae37a8ae170
         status: 200 OK
         code: 200
-        duration: 145.222458ms
+        duration: 126.29275ms
     - id: 110
       request:
         proto: HTTP/1.1
@@ -5484,8 +5486,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/42b8e84a-cfbc-451e-93f6-791ba8bf8518
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/f7ecdaf9-1eaf-4ac5-aaa0-550880299411
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5502,9 +5504,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:02 GMT
+                - Wed, 12 Feb 2025 15:20:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5512,10 +5514,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 91795db7-f8ea-47c0-b95a-193c79e8e11f
+                - ac13093c-690f-42a3-93b1-017afe7f8fcf
         status: 204 No Content
         code: 204
-        duration: 209.496291ms
+        duration: 273.36625ms
     - id: 111
       request:
         proto: HTTP/1.1
@@ -5531,27 +5533,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/62fe3fe7-5d01-47ec-b845-a94bca403d44
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/f7ecdaf9-1eaf-4ac5-aaa0-550880299411
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 142
         uncompressed: false
-        body: ""
+        body: '{"message":"resource is not found","resource":"instance_image","resource_id":"f7ecdaf9-1eaf-4ac5-aaa0-550880299411","type":"not_found"}'
         headers:
+            Content-Length:
+                - "142"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:02 GMT
+                - Wed, 12 Feb 2025 15:20:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5559,10 +5563,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5f84d4cd-e78f-47c0-8a4d-ace1e020de28
-        status: 204 No Content
-        code: 204
-        duration: 197.014833ms
+                - 8caf1645-913e-44a9-9c16-165025472a14
+        status: 404 Not Found
+        code: 404
+        duration: 65.697042ms
     - id: 112
       request:
         proto: HTTP/1.1
@@ -5578,8 +5582,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/42b8e84a-cfbc-451e-93f6-791ba8bf8518
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/cc090ec3-d43c-40d7-a17b-caf6b0c9b30e
         method: GET
       response:
         proto: HTTP/2.0
@@ -5587,20 +5591,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 145
+        content_length: 530
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"42b8e84a-cfbc-451e-93f6-791ba8bf8518","type":"not_found"}'
+        body: '{"snapshot":{"base_volume":{"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:18:59.045820+00:00","error_details":null,"id":"cc090ec3-d43c-40d7-a17b-caf6b0c9b30e","modification_date":"2025-02-12T15:19:37.283412+00:00","name":"tf-snap-dreamy-wiles","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "145"
+                - "530"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:03 GMT
+                - Wed, 12 Feb 2025 15:20:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5608,10 +5612,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dad0e600-bdb2-4c5e-b6ae-10e22a70eb17
-        status: 404 Not Found
-        code: 404
-        duration: 69.308292ms
+                - 4b15c0b2-0da2-450b-bc77-bfdd26d07286
+        status: 200 OK
+        code: 200
+        duration: 100.665416ms
     - id: 113
       request:
         proto: HTTP/1.1
@@ -5627,8 +5631,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/62fe3fe7-5d01-47ec-b845-a94bca403d44
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2d9e3825-218e-4822-b0eb-5cd76286fd79
         method: GET
       response:
         proto: HTTP/2.0
@@ -5636,20 +5640,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 145
+        content_length: 530
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"62fe3fe7-5d01-47ec-b845-a94bca403d44","type":"not_found"}'
+        body: '{"snapshot":{"base_volume":{"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:20:02.089325+00:00","error_details":null,"id":"2d9e3825-218e-4822-b0eb-5cd76286fd79","modification_date":"2025-02-12T15:20:39.792802+00:00","name":"tf-snap-eager-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "145"
+                - "530"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:02 GMT
+                - Wed, 12 Feb 2025 15:20:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5657,10 +5661,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0a145eff-0ec4-4130-937a-10faa1d44564
-        status: 404 Not Found
-        code: 404
-        duration: 80.233834ms
+                - 21af1c27-0fdb-487f-b4c0-44799aba8a6b
+        status: 200 OK
+        code: 200
+        duration: 100.647666ms
     - id: 114
       request:
         proto: HTTP/1.1
@@ -5676,29 +5680,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2d9e3825-218e-4822-b0eb-5cd76286fd79
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2287
+        content_length: 0
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:05.301695+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-compassionate-morse","id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1201","node_id":"29","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:2d","maintenances":[],"modification_date":"2025-01-27T13:53:19.059739+00:00","name":"tf-srv-compassionate-morse","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:05.301695+00:00","export_uri":null,"id":"561950ba-ca29-4da0-bdeb-77519a933904","modification_date":"2025-01-27T13:54:01.461499+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","name":"tf-srv-compassionate-morse"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: ""
         headers:
-            Content-Length:
-                - "2287"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:02 GMT
+                - Wed, 12 Feb 2025 15:20:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5706,10 +5708,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 16cf501e-1f9b-419d-b633-c7f7ae3acf6a
-        status: 200 OK
-        code: 200
-        duration: 215.715958ms
+                - 49b4b050-a662-4293-92c6-2c03e79cdb58
+        status: 204 No Content
+        code: 204
+        duration: 172.761041ms
     - id: 115
       request:
         proto: HTTP/1.1
@@ -5725,8 +5727,55 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31170367-f180-4384-ae33-a445864aa67c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/cc090ec3-d43c-40d7-a17b-caf6b0c9b30e
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:20:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fd278cd4-0f09-4cf0-a059-947ec7e47510
+        status: 204 No Content
+        code: 204
+        duration: 187.173667ms
+    - id: 116
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2d9e3825-218e-4822-b0eb-5cd76286fd79
         method: GET
       response:
         proto: HTTP/2.0
@@ -5734,20 +5783,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2270
+        content_length: 145
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:54:08.596175+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-mendel","id":"31170367-f180-4384-ae33-a445864aa67c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"102","node_id":"7","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:7d","maintenances":[],"modification_date":"2025-01-27T13:54:19.277272+00:00","name":"tf-srv-strange-mendel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:54:08.596175+00:00","export_uri":null,"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","modification_date":"2025-01-27T13:54:55.587522+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"31170367-f180-4384-ae33-a445864aa67c","name":"tf-srv-strange-mendel"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"2d9e3825-218e-4822-b0eb-5cd76286fd79","type":"not_found"}'
         headers:
             Content-Length:
-                - "2270"
+                - "145"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:03 GMT
+                - Wed, 12 Feb 2025 15:20:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5755,105 +5804,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c2c913b2-3aea-4d6a-ac24-4bd6ebb2d558
-        status: 200 OK
-        code: 200
-        duration: 201.231167ms
-    - id: 116
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 21
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"action":"poweroff"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352/action
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 352
-        uncompressed: false
-        body: '{"task":{"description":"server_poweroff","href_from":"/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352/action","href_result":"/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352","id":"76fd5091-9358-4cf0-9ee0-4366c2f15e6a","progress":0,"started_at":"2025-01-27T13:55:03.541832+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "352"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:55:03 GMT
-            Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/76fd5091-9358-4cf0-9ee0-4366c2f15e6a
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 3563ff9f-ff24-453f-ab4f-c214cd87d684
-        status: 202 Accepted
-        code: 202
-        duration: 246.59475ms
+                - dddc4edb-31fc-4427-ad33-14c90089bea6
+        status: 404 Not Found
+        code: 404
+        duration: 52.929959ms
     - id: 117
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 21
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"action":"poweroff"}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31170367-f180-4384-ae33-a445864aa67c/action
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/cc090ec3-d43c-40d7-a17b-caf6b0c9b30e
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 352
+        content_length: 145
         uncompressed: false
-        body: '{"task":{"description":"server_poweroff","href_from":"/servers/31170367-f180-4384-ae33-a445864aa67c/action","href_result":"/servers/31170367-f180-4384-ae33-a445864aa67c","id":"c2eb4c22-125c-45af-8d98-1e296e7dcc4c","progress":0,"started_at":"2025-01-27T13:55:03.578752+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"cc090ec3-d43c-40d7-a17b-caf6b0c9b30e","type":"not_found"}'
         headers:
             Content-Length:
-                - "352"
+                - "145"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:03 GMT
-            Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/c2eb4c22-125c-45af-8d98-1e296e7dcc4c
+                - Wed, 12 Feb 2025 15:20:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5861,10 +5853,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6a924087-671a-4148-90c8-08653b86fcee
-        status: 202 Accepted
-        code: 202
-        duration: 268.232ms
+                - e6702f4a-261c-4da0-98fb-0d9515b9bd40
+        status: 404 Not Found
+        code: 404
+        duration: 52.240791ms
     - id: 118
       request:
         proto: HTTP/1.1
@@ -5880,8 +5872,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55
         method: GET
       response:
         proto: HTTP/2.0
@@ -5889,20 +5881,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2247
+        content_length: 2274
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:05.301695+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-compassionate-morse","id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1201","node_id":"29","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:2d","maintenances":[],"modification_date":"2025-01-27T13:55:03.354497+00:00","name":"tf-srv-compassionate-morse","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:05.301695+00:00","export_uri":null,"id":"561950ba-ca29-4da0-bdeb-77519a933904","modification_date":"2025-01-27T13:54:01.461499+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","name":"tf-srv-compassionate-morse"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:19:43.988010+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-newton","id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"101","node_id":"31","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:67","maintenances":[],"modification_date":"2025-02-12T15:20:00.589839+00:00","name":"tf-srv-youthful-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:19:43.988010+00:00","export_uri":null,"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","modification_date":"2025-02-12T15:20:39.792802+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","name":"tf-srv-youthful-newton"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2247"
+                - "2274"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:03 GMT
+                - Wed, 12 Feb 2025 15:20:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5910,10 +5902,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e51fbd2c-9c28-4f24-aade-801c14c2b63b
+                - f7ae1e18-4082-4d78-af06-20c7136fde30
         status: 200 OK
         code: 200
-        duration: 211.834916ms
+        duration: 235.543709ms
     - id: 119
       request:
         proto: HTTP/1.1
@@ -5929,8 +5921,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31170367-f180-4384-ae33-a445864aa67c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -5938,20 +5930,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2230
+        content_length: 2277
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:54:08.596175+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-mendel","id":"31170367-f180-4384-ae33-a445864aa67c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"102","node_id":"7","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:7d","maintenances":[],"modification_date":"2025-01-27T13:55:03.379368+00:00","name":"tf-srv-strange-mendel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:54:08.596175+00:00","export_uri":null,"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","modification_date":"2025-01-27T13:54:55.587522+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"31170367-f180-4384-ae33-a445864aa67c","name":"tf-srv-strange-mendel"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.091541+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-jepsen","id":"f70dc134-72eb-4945-b2c7-eee228f649c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"601","node_id":"35","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:41","maintenances":[],"modification_date":"2025-02-12T15:18:53.569267+00:00","name":"tf-srv-nostalgic-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.091541+00:00","export_uri":null,"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","modification_date":"2025-02-12T15:19:37.283412+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f70dc134-72eb-4945-b2c7-eee228f649c8","name":"tf-srv-nostalgic-jepsen"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2230"
+                - "2277"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:03 GMT
+                - Wed, 12 Feb 2025 15:20:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5959,48 +5951,52 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e54913d2-56fb-4024-9233-b53826159db4
+                - 3e2aa0b7-6137-4d84-8413-28ba1c8ff533
         status: 200 OK
         code: 200
-        duration: 227.852541ms
+        duration: 222.953333ms
     - id: 120
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 21
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"action":"poweroff"}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8/action
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2247
+        content_length: 352
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:05.301695+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-compassionate-morse","id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1201","node_id":"29","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:2d","maintenances":[],"modification_date":"2025-01-27T13:55:03.354497+00:00","name":"tf-srv-compassionate-morse","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:05.301695+00:00","export_uri":null,"id":"561950ba-ca29-4da0-bdeb-77519a933904","modification_date":"2025-01-27T13:54:01.461499+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","name":"tf-srv-compassionate-morse"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_poweroff","href_from":"/servers/f70dc134-72eb-4945-b2c7-eee228f649c8/action","href_result":"/servers/f70dc134-72eb-4945-b2c7-eee228f649c8","id":"6b36b41a-316f-47e4-aa77-eed5e3b12731","progress":0,"started_at":"2025-02-12T15:20:51.264682+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2247"
+                - "352"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:08 GMT
+                - Wed, 12 Feb 2025 15:20:50 GMT
+            Location:
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/6b36b41a-316f-47e4-aa77-eed5e3b12731
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6008,10 +6004,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5767af46-15a7-4bc3-a573-fbed15f3115e
-        status: 200 OK
-        code: 200
-        duration: 169.870625ms
+                - 4a7b943a-bd77-4f40-bd71-16236d9d651f
+        status: 202 Accepted
+        code: 202
+        duration: 306.311583ms
     - id: 121
       request:
         proto: HTTP/1.1
@@ -6027,8 +6023,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31170367-f180-4384-ae33-a445864aa67c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -6036,20 +6032,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2230
+        content_length: 2237
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:54:08.596175+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-mendel","id":"31170367-f180-4384-ae33-a445864aa67c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"102","node_id":"7","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:7d","maintenances":[],"modification_date":"2025-01-27T13:55:03.379368+00:00","name":"tf-srv-strange-mendel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:54:08.596175+00:00","export_uri":null,"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","modification_date":"2025-01-27T13:54:55.587522+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"31170367-f180-4384-ae33-a445864aa67c","name":"tf-srv-strange-mendel"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.091541+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-jepsen","id":"f70dc134-72eb-4945-b2c7-eee228f649c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"601","node_id":"35","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:41","maintenances":[],"modification_date":"2025-02-12T15:20:51.068112+00:00","name":"tf-srv-nostalgic-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.091541+00:00","export_uri":null,"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","modification_date":"2025-02-12T15:19:37.283412+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f70dc134-72eb-4945-b2c7-eee228f649c8","name":"tf-srv-nostalgic-jepsen"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2230"
+                - "2237"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:08 GMT
+                - Wed, 12 Feb 2025 15:20:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6057,48 +6053,52 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0d243a53-7845-4fc2-9385-ae30a99c1a18
+                - 8380438f-dafb-4f6c-8c62-c250da30a445
         status: 200 OK
         code: 200
-        duration: 186.2585ms
+        duration: 188.237083ms
     - id: 122
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 21
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"action":"poweroff"}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55/action
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2247
+        content_length: 352
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:05.301695+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-compassionate-morse","id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1201","node_id":"29","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:2d","maintenances":[],"modification_date":"2025-01-27T13:55:03.354497+00:00","name":"tf-srv-compassionate-morse","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:05.301695+00:00","export_uri":null,"id":"561950ba-ca29-4da0-bdeb-77519a933904","modification_date":"2025-01-27T13:54:01.461499+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","name":"tf-srv-compassionate-morse"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_poweroff","href_from":"/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55/action","href_result":"/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55","id":"1bb26d34-3e53-4159-a633-1b57c91865c5","progress":0,"started_at":"2025-02-12T15:20:51.562180+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2247"
+                - "352"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:14 GMT
+                - Wed, 12 Feb 2025 15:20:51 GMT
+            Location:
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/1bb26d34-3e53-4159-a633-1b57c91865c5
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6106,10 +6106,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e66e985b-136e-4f3b-a8c4-4065d94f54ad
-        status: 200 OK
-        code: 200
-        duration: 163.17075ms
+                - 5d5caf29-5646-4a59-99e1-1eb19c306579
+        status: 202 Accepted
+        code: 202
+        duration: 568.346541ms
     - id: 123
       request:
         proto: HTTP/1.1
@@ -6125,8 +6125,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31170367-f180-4384-ae33-a445864aa67c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55
         method: GET
       response:
         proto: HTTP/2.0
@@ -6134,20 +6134,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2230
+        content_length: 2234
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:54:08.596175+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-mendel","id":"31170367-f180-4384-ae33-a445864aa67c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"102","node_id":"7","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:7d","maintenances":[],"modification_date":"2025-01-27T13:55:03.379368+00:00","name":"tf-srv-strange-mendel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:54:08.596175+00:00","export_uri":null,"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","modification_date":"2025-01-27T13:54:55.587522+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"31170367-f180-4384-ae33-a445864aa67c","name":"tf-srv-strange-mendel"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:19:43.988010+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-newton","id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"101","node_id":"31","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:67","maintenances":[],"modification_date":"2025-02-12T15:20:51.075262+00:00","name":"tf-srv-youthful-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:19:43.988010+00:00","export_uri":null,"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","modification_date":"2025-02-12T15:20:39.792802+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","name":"tf-srv-youthful-newton"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2230"
+                - "2234"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:14 GMT
+                - Wed, 12 Feb 2025 15:20:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6155,10 +6155,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2dfb0c61-d3d3-45c6-9a38-1372502a0890
+                - 2a41143e-c2f3-4bd2-9887-4cb58f109ea6
         status: 200 OK
         code: 200
-        duration: 188.221416ms
+        duration: 1.192883541s
     - id: 124
       request:
         proto: HTTP/1.1
@@ -6174,8 +6174,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -6183,20 +6183,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2247
+        content_length: 2237
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:05.301695+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-compassionate-morse","id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1201","node_id":"29","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:2d","maintenances":[],"modification_date":"2025-01-27T13:55:03.354497+00:00","name":"tf-srv-compassionate-morse","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:05.301695+00:00","export_uri":null,"id":"561950ba-ca29-4da0-bdeb-77519a933904","modification_date":"2025-01-27T13:54:01.461499+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","name":"tf-srv-compassionate-morse"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.091541+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-jepsen","id":"f70dc134-72eb-4945-b2c7-eee228f649c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"601","node_id":"35","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:41","maintenances":[],"modification_date":"2025-02-12T15:20:51.068112+00:00","name":"tf-srv-nostalgic-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.091541+00:00","export_uri":null,"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","modification_date":"2025-02-12T15:19:37.283412+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f70dc134-72eb-4945-b2c7-eee228f649c8","name":"tf-srv-nostalgic-jepsen"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2247"
+                - "2237"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:18 GMT
+                - Wed, 12 Feb 2025 15:20:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6204,10 +6204,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 17cc0436-9837-42c0-8e4d-95e7ac0bf9c9
+                - f2ac14ec-11bd-4be3-a9c6-cbece080f66b
         status: 200 OK
         code: 200
-        duration: 172.116958ms
+        duration: 221.819916ms
     - id: 125
       request:
         proto: HTTP/1.1
@@ -6223,8 +6223,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31170367-f180-4384-ae33-a445864aa67c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55
         method: GET
       response:
         proto: HTTP/2.0
@@ -6232,20 +6232,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2230
+        content_length: 2234
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:54:08.596175+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-mendel","id":"31170367-f180-4384-ae33-a445864aa67c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"102","node_id":"7","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:7d","maintenances":[],"modification_date":"2025-01-27T13:55:03.379368+00:00","name":"tf-srv-strange-mendel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:54:08.596175+00:00","export_uri":null,"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","modification_date":"2025-01-27T13:54:55.587522+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"31170367-f180-4384-ae33-a445864aa67c","name":"tf-srv-strange-mendel"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:19:43.988010+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-newton","id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"101","node_id":"31","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:67","maintenances":[],"modification_date":"2025-02-12T15:20:51.075262+00:00","name":"tf-srv-youthful-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:19:43.988010+00:00","export_uri":null,"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","modification_date":"2025-02-12T15:20:39.792802+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","name":"tf-srv-youthful-newton"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2230"
+                - "2234"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:19 GMT
+                - Wed, 12 Feb 2025 15:20:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6253,10 +6253,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 318794b6-459d-4a20-8505-c428860ed1f0
+                - 439e065e-b7c1-44d9-9e37-2146be5306f8
         status: 200 OK
         code: 200
-        duration: 157.963417ms
+        duration: 196.148625ms
     - id: 126
       request:
         proto: HTTP/1.1
@@ -6272,8 +6272,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -6281,20 +6281,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2247
+        content_length: 2237
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:05.301695+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-compassionate-morse","id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1201","node_id":"29","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:2d","maintenances":[],"modification_date":"2025-01-27T13:55:03.354497+00:00","name":"tf-srv-compassionate-morse","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:05.301695+00:00","export_uri":null,"id":"561950ba-ca29-4da0-bdeb-77519a933904","modification_date":"2025-01-27T13:54:01.461499+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","name":"tf-srv-compassionate-morse"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.091541+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-jepsen","id":"f70dc134-72eb-4945-b2c7-eee228f649c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"601","node_id":"35","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:41","maintenances":[],"modification_date":"2025-02-12T15:20:51.068112+00:00","name":"tf-srv-nostalgic-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.091541+00:00","export_uri":null,"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","modification_date":"2025-02-12T15:19:37.283412+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f70dc134-72eb-4945-b2c7-eee228f649c8","name":"tf-srv-nostalgic-jepsen"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2247"
+                - "2237"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:24 GMT
+                - Wed, 12 Feb 2025 15:21:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6302,10 +6302,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fcfcfaa7-1ac3-4ea5-aae1-7b55ef7f1f3b
+                - 6a7065a7-5e1a-4ebc-b7d7-109d52228f8a
         status: 200 OK
         code: 200
-        duration: 148.316583ms
+        duration: 199.983916ms
     - id: 127
       request:
         proto: HTTP/1.1
@@ -6321,8 +6321,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31170367-f180-4384-ae33-a445864aa67c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55
         method: GET
       response:
         proto: HTTP/2.0
@@ -6330,20 +6330,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2230
+        content_length: 2234
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:54:08.596175+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-mendel","id":"31170367-f180-4384-ae33-a445864aa67c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"102","node_id":"7","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:7d","maintenances":[],"modification_date":"2025-01-27T13:55:03.379368+00:00","name":"tf-srv-strange-mendel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:54:08.596175+00:00","export_uri":null,"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","modification_date":"2025-01-27T13:54:55.587522+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"31170367-f180-4384-ae33-a445864aa67c","name":"tf-srv-strange-mendel"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:19:43.988010+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-newton","id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"101","node_id":"31","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:67","maintenances":[],"modification_date":"2025-02-12T15:20:51.075262+00:00","name":"tf-srv-youthful-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:19:43.988010+00:00","export_uri":null,"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","modification_date":"2025-02-12T15:20:39.792802+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","name":"tf-srv-youthful-newton"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2230"
+                - "2234"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:24 GMT
+                - Wed, 12 Feb 2025 15:21:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6351,10 +6351,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a087c777-6a8e-4954-9b82-690fe772de9b
+                - e77eb73f-61ba-4e5c-947e-b910c08d59dd
         status: 200 OK
         code: 200
-        duration: 173.67425ms
+        duration: 192.982875ms
     - id: 128
       request:
         proto: HTTP/1.1
@@ -6370,8 +6370,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -6379,20 +6379,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2247
+        content_length: 2237
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:05.301695+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-compassionate-morse","id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1201","node_id":"29","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:2d","maintenances":[],"modification_date":"2025-01-27T13:55:03.354497+00:00","name":"tf-srv-compassionate-morse","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:05.301695+00:00","export_uri":null,"id":"561950ba-ca29-4da0-bdeb-77519a933904","modification_date":"2025-01-27T13:54:01.461499+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","name":"tf-srv-compassionate-morse"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.091541+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-jepsen","id":"f70dc134-72eb-4945-b2c7-eee228f649c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"601","node_id":"35","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:41","maintenances":[],"modification_date":"2025-02-12T15:20:51.068112+00:00","name":"tf-srv-nostalgic-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.091541+00:00","export_uri":null,"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","modification_date":"2025-02-12T15:19:37.283412+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f70dc134-72eb-4945-b2c7-eee228f649c8","name":"tf-srv-nostalgic-jepsen"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2247"
+                - "2237"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:29 GMT
+                - Wed, 12 Feb 2025 15:21:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6400,10 +6400,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5e679752-ac62-4388-9acb-7bd0e2028adb
+                - 969a846f-350c-4fff-9cbd-fd994454c259
         status: 200 OK
         code: 200
-        duration: 203.854ms
+        duration: 184.796959ms
     - id: 129
       request:
         proto: HTTP/1.1
@@ -6419,8 +6419,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31170367-f180-4384-ae33-a445864aa67c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55
         method: GET
       response:
         proto: HTTP/2.0
@@ -6428,20 +6428,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2230
+        content_length: 2234
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:54:08.596175+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-mendel","id":"31170367-f180-4384-ae33-a445864aa67c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"102","node_id":"7","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:7d","maintenances":[],"modification_date":"2025-01-27T13:55:03.379368+00:00","name":"tf-srv-strange-mendel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:54:08.596175+00:00","export_uri":null,"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","modification_date":"2025-01-27T13:54:55.587522+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"31170367-f180-4384-ae33-a445864aa67c","name":"tf-srv-strange-mendel"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:19:43.988010+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-newton","id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"101","node_id":"31","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:67","maintenances":[],"modification_date":"2025-02-12T15:20:51.075262+00:00","name":"tf-srv-youthful-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:19:43.988010+00:00","export_uri":null,"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","modification_date":"2025-02-12T15:20:39.792802+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","name":"tf-srv-youthful-newton"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2230"
+                - "2234"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:29 GMT
+                - Wed, 12 Feb 2025 15:21:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6449,10 +6449,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bc807ff9-18a1-48e9-b905-43eef002cb9e
+                - 851ef9f7-ed5e-4f42-b83a-997ecbbea3a3
         status: 200 OK
         code: 200
-        duration: 200.943292ms
+        duration: 182.519ms
     - id: 130
       request:
         proto: HTTP/1.1
@@ -6468,8 +6468,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -6477,20 +6477,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2247
+        content_length: 2237
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:05.301695+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-compassionate-morse","id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1201","node_id":"29","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:2d","maintenances":[],"modification_date":"2025-01-27T13:55:03.354497+00:00","name":"tf-srv-compassionate-morse","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:05.301695+00:00","export_uri":null,"id":"561950ba-ca29-4da0-bdeb-77519a933904","modification_date":"2025-01-27T13:54:01.461499+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","name":"tf-srv-compassionate-morse"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.091541+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-jepsen","id":"f70dc134-72eb-4945-b2c7-eee228f649c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"601","node_id":"35","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:41","maintenances":[],"modification_date":"2025-02-12T15:20:51.068112+00:00","name":"tf-srv-nostalgic-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.091541+00:00","export_uri":null,"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","modification_date":"2025-02-12T15:19:37.283412+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f70dc134-72eb-4945-b2c7-eee228f649c8","name":"tf-srv-nostalgic-jepsen"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2247"
+                - "2237"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:34 GMT
+                - Wed, 12 Feb 2025 15:21:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6498,10 +6498,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6171c317-98b8-4ddb-b44f-618d68603022
+                - be1499c5-ac5b-4dc1-bfbf-df39434cdac1
         status: 200 OK
         code: 200
-        duration: 175.606ms
+        duration: 176.540458ms
     - id: 131
       request:
         proto: HTTP/1.1
@@ -6517,8 +6517,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31170367-f180-4384-ae33-a445864aa67c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55
         method: GET
       response:
         proto: HTTP/2.0
@@ -6526,20 +6526,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2115
+        content_length: 2234
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:54:08.596175+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-mendel","id":"31170367-f180-4384-ae33-a445864aa67c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:7d","maintenances":[],"modification_date":"2025-01-27T13:55:34.045921+00:00","name":"tf-srv-strange-mendel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:54:08.596175+00:00","export_uri":null,"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","modification_date":"2025-01-27T13:54:55.587522+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"31170367-f180-4384-ae33-a445864aa67c","name":"tf-srv-strange-mendel"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:19:43.988010+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-newton","id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"101","node_id":"31","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:67","maintenances":[],"modification_date":"2025-02-12T15:20:51.075262+00:00","name":"tf-srv-youthful-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:19:43.988010+00:00","export_uri":null,"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","modification_date":"2025-02-12T15:20:39.792802+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","name":"tf-srv-youthful-newton"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2115"
+                - "2234"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:34 GMT
+                - Wed, 12 Feb 2025 15:21:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6547,10 +6547,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8dc587cd-a4bf-4da0-851d-2063503dab35
+                - 11389b25-c79b-4b59-aba1-78b96151aae9
         status: 200 OK
         code: 200
-        duration: 177.55075ms
+        duration: 165.03125ms
     - id: 132
       request:
         proto: HTTP/1.1
@@ -6566,8 +6566,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31170367-f180-4384-ae33-a445864aa67c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -6575,20 +6575,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2115
+        content_length: 2121
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:54:08.596175+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-mendel","id":"31170367-f180-4384-ae33-a445864aa67c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:7d","maintenances":[],"modification_date":"2025-01-27T13:55:34.045921+00:00","name":"tf-srv-strange-mendel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:54:08.596175+00:00","export_uri":null,"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","modification_date":"2025-01-27T13:54:55.587522+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"31170367-f180-4384-ae33-a445864aa67c","name":"tf-srv-strange-mendel"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.091541+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-jepsen","id":"f70dc134-72eb-4945-b2c7-eee228f649c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c4:41","maintenances":[],"modification_date":"2025-02-12T15:21:16.222628+00:00","name":"tf-srv-nostalgic-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.091541+00:00","export_uri":null,"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","modification_date":"2025-02-12T15:19:37.283412+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f70dc134-72eb-4945-b2c7-eee228f649c8","name":"tf-srv-nostalgic-jepsen"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2115"
+                - "2121"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:34 GMT
+                - Wed, 12 Feb 2025 15:21:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6596,10 +6596,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 622a4034-6a6c-4da8-832e-771568a26b05
+                - 3f8a0898-ea47-483c-ad71-aa7588938ac4
         status: 200 OK
         code: 200
-        duration: 157.923833ms
+        duration: 158.692708ms
     - id: 133
       request:
         proto: HTTP/1.1
@@ -6615,27 +6615,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31170367-f180-4384-ae33-a445864aa67c
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 2121
         uncompressed: false
-        body: ""
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.091541+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-jepsen","id":"f70dc134-72eb-4945-b2c7-eee228f649c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c4:41","maintenances":[],"modification_date":"2025-02-12T15:21:16.222628+00:00","name":"tf-srv-nostalgic-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.091541+00:00","export_uri":null,"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","modification_date":"2025-02-12T15:19:37.283412+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f70dc134-72eb-4945-b2c7-eee228f649c8","name":"tf-srv-nostalgic-jepsen"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
+            Content-Length:
+                - "2121"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:35 GMT
+                - Wed, 12 Feb 2025 15:21:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6643,10 +6645,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fd0ab8d6-ad8b-420b-91b3-0e224e1b6a10
-        status: 204 No Content
-        code: 204
-        duration: 196.736875ms
+                - 51e9da9e-da9a-43c3-9bf2-fd16893819c0
+        status: 200 OK
+        code: 200
+        duration: 147.47125ms
     - id: 134
       request:
         proto: HTTP/1.1
@@ -6662,29 +6664,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31170367-f180-4384-ae33-a445864aa67c
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 143
+        content_length: 0
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"31170367-f180-4384-ae33-a445864aa67c","type":"not_found"}'
+        body: ""
         headers:
-            Content-Length:
-                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:34 GMT
+                - Wed, 12 Feb 2025 15:21:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6692,10 +6692,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - caeebeb8-156e-4521-9866-a43b238b3277
-        status: 404 Not Found
-        code: 404
-        duration: 117.861583ms
+                - a1b81f12-f50f-47cf-8a0d-40274b6dd448
+        status: 204 No Content
+        code: 204
+        duration: 193.517541ms
     - id: 135
       request:
         proto: HTTP/1.1
@@ -6711,8 +6711,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/4597e8be-20c1-4ff5-9164-4ffa89dda90f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -6720,20 +6720,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 446
+        content_length: 143
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:54:08.596175+00:00","export_uri":null,"id":"4597e8be-20c1-4ff5-9164-4ffa89dda90f","modification_date":"2025-01-27T13:55:35.121420+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"f70dc134-72eb-4945-b2c7-eee228f649c8","type":"not_found"}'
         headers:
             Content-Length:
-                - "446"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:35 GMT
+                - Wed, 12 Feb 2025 15:21:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6741,10 +6741,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 999256dd-56f6-465a-9532-95e6c7c13be4
-        status: 200 OK
-        code: 200
-        duration: 91.217416ms
+                - b78b76af-4e9c-41a2-a79e-a8e2c4f63865
+        status: 404 Not Found
+        code: 404
+        duration: 127.172083ms
     - id: 136
       request:
         proto: HTTP/1.1
@@ -6760,27 +6760,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/4597e8be-20c1-4ff5-9164-4ffa89dda90f
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/980893e6-9a6e-4450-bd2f-5742a21100c1
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 446
         uncompressed: false
-        body: ""
+        body: '{"volume":{"creation_date":"2025-02-12T15:18:31.091541+00:00","export_uri":null,"id":"980893e6-9a6e-4450-bd2f-5742a21100c1","modification_date":"2025-02-12T15:21:17.663920+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
+            Content-Length:
+                - "446"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:35 GMT
+                - Wed, 12 Feb 2025 15:21:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6788,10 +6790,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c3f073cd-1e20-45b2-805d-de45fb6664ef
-        status: 204 No Content
-        code: 204
-        duration: 192.7745ms
+                - ac56b116-50e1-4b20-a9cd-ebbac17453fa
+        status: 200 OK
+        code: 200
+        duration: 450.589334ms
     - id: 137
       request:
         proto: HTTP/1.1
@@ -6807,29 +6809,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/980893e6-9a6e-4450-bd2f-5742a21100c1
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2130
+        content_length: 0
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:05.301695+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-compassionate-morse","id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:2d","maintenances":[],"modification_date":"2025-01-27T13:55:37.884431+00:00","name":"tf-srv-compassionate-morse","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:05.301695+00:00","export_uri":null,"id":"561950ba-ca29-4da0-bdeb-77519a933904","modification_date":"2025-01-27T13:54:01.461499+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","name":"tf-srv-compassionate-morse"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: ""
         headers:
-            Content-Length:
-                - "2130"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:39 GMT
+                - Wed, 12 Feb 2025 15:21:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6837,10 +6837,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4a0e4750-2c05-4606-91b5-629ed80bb285
-        status: 200 OK
-        code: 200
-        duration: 166.221ms
+                - 0350d0f7-1a2c-4acb-b2c5-c7430a664592
+        status: 204 No Content
+        code: 204
+        duration: 166.488208ms
     - id: 138
       request:
         proto: HTTP/1.1
@@ -6856,8 +6856,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55
         method: GET
       response:
         proto: HTTP/2.0
@@ -6865,20 +6865,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2130
+        content_length: 2118
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:05.301695+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-compassionate-morse","id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:2d","maintenances":[],"modification_date":"2025-01-27T13:55:37.884431+00:00","name":"tf-srv-compassionate-morse","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:05.301695+00:00","export_uri":null,"id":"561950ba-ca29-4da0-bdeb-77519a933904","modification_date":"2025-01-27T13:54:01.461499+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","name":"tf-srv-compassionate-morse"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:19:43.988010+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-newton","id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c4:67","maintenances":[],"modification_date":"2025-02-12T15:21:16.657890+00:00","name":"tf-srv-youthful-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:19:43.988010+00:00","export_uri":null,"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","modification_date":"2025-02-12T15:20:39.792802+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","name":"tf-srv-youthful-newton"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2130"
+                - "2118"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:39 GMT
+                - Wed, 12 Feb 2025 15:21:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6886,10 +6886,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9eab21f6-6644-4bc4-83db-f67789fac335
+                - 914562bf-95b3-4f41-b55e-24a0caf7e9f9
         status: 200 OK
         code: 200
-        duration: 163.127833ms
+        duration: 149.503ms
     - id: 139
       request:
         proto: HTTP/1.1
@@ -6905,27 +6905,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 2118
         uncompressed: false
-        body: ""
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:19:43.988010+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-newton","id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c4:67","maintenances":[],"modification_date":"2025-02-12T15:21:16.657890+00:00","name":"tf-srv-youthful-newton","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:19:43.988010+00:00","export_uri":null,"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","modification_date":"2025-02-12T15:20:39.792802+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","name":"tf-srv-youthful-newton"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
+            Content-Length:
+                - "2118"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:40 GMT
+                - Wed, 12 Feb 2025 15:21:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6933,10 +6935,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6874f766-0c97-44df-8b76-53217326ac75
-        status: 204 No Content
-        code: 204
-        duration: 207.597ms
+                - 1992807d-c943-4114-b9a4-b62bdbf369cc
+        status: 200 OK
+        code: 200
+        duration: 146.277ms
     - id: 140
       request:
         proto: HTTP/1.1
@@ -6952,106 +6954,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 143
-        uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","type":"not_found"}'
-        headers:
-            Content-Length:
-                - "143"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:55:40 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 070d0dc0-923e-4342-b677-62bf86adf0a2
-        status: 404 Not Found
-        code: 404
-        duration: 155.092958ms
-    - id: 141
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/561950ba-ca29-4da0-bdeb-77519a933904
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 446
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:53:05.301695+00:00","export_uri":null,"id":"561950ba-ca29-4da0-bdeb-77519a933904","modification_date":"2025-01-27T13:55:40.209510+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "446"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:55:40 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - f6af2b1c-deca-4c80-91ab-4e6ea8f3df36
-        status: 200 OK
-        code: 200
-        duration: 82.672ms
-    - id: 142
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/561950ba-ca29-4da0-bdeb-77519a933904
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -7068,9 +6972,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:40 GMT
+                - Wed, 12 Feb 2025 15:21:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -7078,10 +6982,108 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b0da5bb5-8a50-422b-8c9a-5936101055ee
+                - 3a8f7bc6-423b-4232-ac51-c0146e98d4c4
         status: 204 No Content
         code: 204
-        duration: 234.009875ms
+        duration: 255.114584ms
+    - id: 141
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:21:19 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2b60b824-cce1-43a9-9118-7d56d3b023e6
+        status: 404 Not Found
+        code: 404
+        duration: 114.615ms
+    - id: 142
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 446
+        uncompressed: false
+        body: '{"volume":{"creation_date":"2025-02-12T15:19:43.988010+00:00","export_uri":null,"id":"0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc","modification_date":"2025-02-12T15:21:18.880146+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "446"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:21:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 087a3a03-a385-4e85-98f3-02547796c830
+        status: 200 OK
+        code: 200
+        duration: 99.783458ms
     - id: 143
       request:
         proto: HTTP/1.1
@@ -7097,29 +7099,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/11ba9d59-125d-4438-a63f-c1657a98d812
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0ef5b00c-3f5d-4ab8-9a31-bcd5ae2588dc
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 142
+        content_length: 0
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_image","resource_id":"11ba9d59-125d-4438-a63f-c1657a98d812","type":"not_found"}'
+        body: ""
         headers:
-            Content-Length:
-                - "142"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:40 GMT
+                - Wed, 12 Feb 2025 15:21:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -7127,10 +7127,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b4495ef6-d1cd-4808-a233-a617c6a0ff06
-        status: 404 Not Found
-        code: 404
-        duration: 40.80925ms
+                - eded4946-3acc-4ce2-abfe-e378a2e8696e
+        status: 204 No Content
+        code: 204
+        duration: 293.17925ms
     - id: 144
       request:
         proto: HTTP/1.1
@@ -7146,8 +7146,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/42b8e84a-cfbc-451e-93f6-791ba8bf8518
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/f7ecdaf9-1eaf-4ac5-aaa0-550880299411
         method: GET
       response:
         proto: HTTP/2.0
@@ -7155,20 +7155,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 145
+        content_length: 142
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"42b8e84a-cfbc-451e-93f6-791ba8bf8518","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_image","resource_id":"f7ecdaf9-1eaf-4ac5-aaa0-550880299411","type":"not_found"}'
         headers:
             Content-Length:
-                - "145"
+                - "142"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:40 GMT
+                - Wed, 12 Feb 2025 15:21:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -7176,10 +7176,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 90825fe3-1986-4edd-aa0b-ee8e557ec04f
+                - 9b741c30-605e-417e-bb5f-04594ea38554
         status: 404 Not Found
         code: 404
-        duration: 66.588583ms
+        duration: 51.217ms
     - id: 145
       request:
         proto: HTTP/1.1
@@ -7195,8 +7195,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/62fe3fe7-5d01-47ec-b845-a94bca403d44
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/cc090ec3-d43c-40d7-a17b-caf6b0c9b30e
         method: GET
       response:
         proto: HTTP/2.0
@@ -7206,7 +7206,7 @@ interactions:
         trailer: {}
         content_length: 145
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"62fe3fe7-5d01-47ec-b845-a94bca403d44","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"cc090ec3-d43c-40d7-a17b-caf6b0c9b30e","type":"not_found"}'
         headers:
             Content-Length:
                 - "145"
@@ -7215,9 +7215,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:40 GMT
+                - Wed, 12 Feb 2025 15:21:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -7225,10 +7225,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 438f6364-4d75-46bc-96d6-5e03d5b9d52a
+                - be5705ff-b4d7-4efc-a66a-efb81b99b4c9
         status: 404 Not Found
         code: 404
-        duration: 38.47825ms
+        duration: 63.323958ms
     - id: 146
       request:
         proto: HTTP/1.1
@@ -7244,8 +7244,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/97fdb9b2-ec3b-4ed2-b436-11b660bfa352
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2d9e3825-218e-4822-b0eb-5cd76286fd79
         method: GET
       response:
         proto: HTTP/2.0
@@ -7253,20 +7253,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 143
+        content_length: 145
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"97fdb9b2-ec3b-4ed2-b436-11b660bfa352","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"2d9e3825-218e-4822-b0eb-5cd76286fd79","type":"not_found"}'
         headers:
             Content-Length:
-                - "143"
+                - "145"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:40 GMT
+                - Wed, 12 Feb 2025 15:21:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -7274,10 +7274,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5b4f8413-4412-4a8b-a872-1cdbd3547350
+                - b8973369-9884-4819-8a46-15146286a52c
         status: 404 Not Found
         code: 404
-        duration: 178.799958ms
+        duration: 59.446833ms
     - id: 147
       request:
         proto: HTTP/1.1
@@ -7293,8 +7293,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31170367-f180-4384-ae33-a445864aa67c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f70dc134-72eb-4945-b2c7-eee228f649c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -7304,7 +7304,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"31170367-f180-4384-ae33-a445864aa67c","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"f70dc134-72eb-4945-b2c7-eee228f649c8","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -7313,9 +7313,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:41 GMT
+                - Wed, 12 Feb 2025 15:21:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -7323,7 +7323,56 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d751e8ef-4dcc-416f-929b-4fc815817dd1
+                - c61a4147-3159-4b45-b2fa-cd6bc281b464
         status: 404 Not Found
         code: 404
-        duration: 135.316875ms
+        duration: 88.510916ms
+    - id: 148
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a316900a-417c-4c52-ba70-2ffa5f6afd55
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"a316900a-417c-4c52-ba70-2ffa5f6afd55","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:21:19 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8403e5ba-1825-43d8-a517-c620f780bccb
+        status: 404 Not Found
+        code: 404
+        duration: 129.568292ms

--- a/internal/services/instance/testdata/image-server-with-sbs-volume.cassette.yaml
+++ b/internal/services/instance/testdata/image-server-with-sbs-volume.cassette.yaml
@@ -36,11 +36,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:18:30 GMT
+                - Wed, 12 Feb 2025 15:53:15 GMT
             Link:
                 - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,12 +48,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 33cb7d18-44bf-4739-aea5-51cb7e7ce7da
+                - 2a6407c0-ee3f-4fa1-b95a-418decf21bd6
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 322.657ms
+        duration: 236.761916ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -89,11 +89,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:18:30 GMT
+                - Wed, 12 Feb 2025 15:53:15 GMT
             Link:
                 - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -101,31 +101,31 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bc513a7b-7618-441a-af1e-544a61fc7370
+                - e211a83d-a398-4da1-a698-b4522bf83e9a
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 67.3675ms
+        duration: 61.193333ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 124
+        content_length: 150
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-vol-cranky-blackwell","project":"105bdce1-64c0-48ab-899d-868455867ecf","volume_type":"b_ssd","size":21000000000}'
+        body: '{"name":"tf-volume-reverent-almeida","perf_iops":5000,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","from_empty":{"size":21000000000},"tags":[]}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes
         method: POST
       response:
         proto: HTTP/2.0
@@ -133,22 +133,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 445
+        content_length: 423
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-02-12T15:18:30.774581+00:00","export_uri":null,"id":"89f83395-b4cf-4fee-9853-833f24fdd971","modification_date":"2025-02-12T15:18:30.774581+00:00","name":"tf-vol-cranky-blackwell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-12T15:53:15.665265Z","id":"9716a7b8-b692-4c04-8a07-aa6e723ed33c","last_detached_at":null,"name":"tf-volume-reverent-almeida","parent_snapshot_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":21000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"creating","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T15:53:15.665265Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "445"
+                - "423"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:18:30 GMT
-            Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/89f83395-b4cf-4fee-9853-833f24fdd971
+                - Wed, 12 Feb 2025 15:53:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -156,10 +154,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2c292021-7016-4bb2-b0fe-90f556715071
-        status: 201 Created
-        code: 201
-        duration: 425.594083ms
+                - 893c6fe5-62cd-44f6-8139-baecef4550e0
+        status: 200 OK
+        code: 200
+        duration: 363.804667ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -176,7 +174,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_local&zone=fr-par-1
+        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_sbs&zone=fr-par-1
         method: GET
       response:
         proto: HTTP/2.0
@@ -184,20 +182,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1300
+        content_length: 1296
         uncompressed: false
-        body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"56d4019c-8305-467a-a3f2-70498ad799df","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
+        body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"57509e82-ac3b-49b7-9970-97b60f40ff72","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"9b647e1e-253a-41e7-8c15-911c622ee2dc","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"}],"total_count":2}'
         headers:
             Content-Length:
-                - "1300"
+                - "1296"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:18:30 GMT
+                - Wed, 12 Feb 2025 15:53:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -205,10 +203,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a90788bc-4514-410f-9d84-65a12c995c5d
+                - 1540f8be-b191-4690-a397-12ce7c8a68f6
         status: 200 OK
         code: 200
-        duration: 99.220875ms
+        duration: 110.475375ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -225,7 +223,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/89f83395-b4cf-4fee-9853-833f24fdd971
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/9716a7b8-b692-4c04-8a07-aa6e723ed33c
         method: GET
       response:
         proto: HTTP/2.0
@@ -233,20 +231,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 445
+        content_length: 423
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-02-12T15:18:30.774581+00:00","export_uri":null,"id":"89f83395-b4cf-4fee-9853-833f24fdd971","modification_date":"2025-02-12T15:18:30.774581+00:00","name":"tf-vol-cranky-blackwell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-12T15:53:15.665265Z","id":"9716a7b8-b692-4c04-8a07-aa6e723ed33c","last_detached_at":null,"name":"tf-volume-reverent-almeida","parent_snapshot_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":21000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"creating","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T15:53:15.665265Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "445"
+                - "423"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:18:30 GMT
+                - Wed, 12 Feb 2025 15:53:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -254,11 +252,64 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6332e09c-9be6-4b0d-b05a-120fa6a5680a
+                - d195f097-0d50-477c-8540-4891c0efd3f2
         status: 200 OK
         code: 200
-        duration: 100.653416ms
+        duration: 85.089833ms
     - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 240
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf-srv-amazing-franklin","dynamic_ip_required":false,"commercial_type":"PLAY2-PICO","image":"57509e82-ac3b-49b7-9970-97b60f40ff72","volumes":{"0":{"boot":false}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1680
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-12T15:53:16.407771+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-amazing-franklin","id":"0bf0d0f8-fccc-497f-a665-43f0d549eddf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c6:8f","maintenances":[],"modification_date":"2025-02-12T15:53:16.407771+00:00","name":"tf-srv-amazing-franklin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1680"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:53:16 GMT
+            Location:
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - db270817-dec0-488a-8aa6-bbd5c8fd88dd
+        status: 201 Created
+        code: 201
+        duration: 1.304403084s
+    - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -274,7 +325,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/89f83395-b4cf-4fee-9853-833f24fdd971
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf
         method: GET
       response:
         proto: HTTP/2.0
@@ -282,20 +333,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 445
+        content_length: 1680
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-02-12T15:18:30.774581+00:00","export_uri":null,"id":"89f83395-b4cf-4fee-9853-833f24fdd971","modification_date":"2025-02-12T15:18:30.774581+00:00","name":"tf-vol-cranky-blackwell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-12T15:53:16.407771+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-amazing-franklin","id":"0bf0d0f8-fccc-497f-a665-43f0d549eddf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c6:8f","maintenances":[],"modification_date":"2025-02-12T15:53:16.407771+00:00","name":"tf-srv-amazing-franklin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "445"
+                - "1680"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:18:30 GMT
+                - Wed, 12 Feb 2025 15:53:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -303,61 +354,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0778dca1-6fa3-475d-b427-77ce3f5d93c5
+                - da493579-07dd-4e6e-8967-6db56558eaf5
         status: 200 OK
         code: 200
-        duration: 91.135292ms
-    - id: 6
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 138
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"name":"tf-snap-distracted-poincare","volume_id":"89f83395-b4cf-4fee-9853-833f24fdd971","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 850
-        uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"89f83395-b4cf-4fee-9853-833f24fdd971","name":"tf-vol-cranky-blackwell"},"creation_date":"2025-02-12T15:18:31.227612+00:00","error_details":null,"id":"f97824b7-3276-4224-b71a-d450304ed14c","modification_date":"2025-02-12T15:18:31.227612+00:00","name":"tf-snap-distracted-poincare","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"},"task":{"description":"volume_snapshot","href_from":"/snapshots","href_result":"snapshots/f97824b7-3276-4224-b71a-d450304ed14c","id":"ff9160c4-64cd-49b4-9dda-c891deea748b","progress":0,"started_at":"2025-02-12T15:18:31.419186+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "850"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:18:31 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 11a248c8-4295-48d1-b58b-6ae536c89560
-        status: 201 Created
-        code: 201
-        duration: 521.114583ms
+        duration: 199.497541ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -374,7 +374,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f97824b7-3276-4224-b71a-d450304ed14c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf
         method: GET
       response:
         proto: HTTP/2.0
@@ -382,20 +382,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 539
+        content_length: 1680
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"89f83395-b4cf-4fee-9853-833f24fdd971","name":"tf-vol-cranky-blackwell"},"creation_date":"2025-02-12T15:18:31.227612+00:00","error_details":null,"id":"f97824b7-3276-4224-b71a-d450304ed14c","modification_date":"2025-02-12T15:18:31.227612+00:00","name":"tf-snap-distracted-poincare","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-12T15:53:16.407771+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-amazing-franklin","id":"0bf0d0f8-fccc-497f-a665-43f0d549eddf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c6:8f","maintenances":[],"modification_date":"2025-02-12T15:53:16.407771+00:00","name":"tf-srv-amazing-franklin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "539"
+                - "1680"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:18:31 GMT
+                - Wed, 12 Feb 2025 15:53:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -403,52 +403,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f0b63f94-ab19-4300-aeae-f01b1a6ca690
+                - 0443236d-b312-44e4-b17a-43f7aeb5d264
         status: 200 OK
         code: 200
-        duration: 100.988708ms
+        duration: 300.657125ms
     - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 274
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-srv-reverent-cerf","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
-        method: POST
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/5d0109bc-940e-4bc6-b082-d7fa906ccea4
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2112
+        content_length: 701
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.373972+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-cerf","id":"1780c24c-59ed-4db8-bb22-7191af979336","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c4:43","maintenances":[],"modification_date":"2025-02-12T15:18:31.373972+00:00","name":"tf-srv-reverent-cerf","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.373972+00:00","export_uri":null,"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","modification_date":"2025-02-12T15:18:31.373972+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1780c24c-59ed-4db8-bb22-7191af979336","name":"tf-srv-reverent-cerf"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-12T15:53:16.620555Z","id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T15:53:16.620555Z","id":"bbe07d04-0b0e-4c8c-8bbf-c9693b5d4fce","product_resource_id":"0bf0d0f8-fccc-497f-a665-43f0d549eddf","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T15:53:16.620555Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2112"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:18:31 GMT
-            Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336
+                - Wed, 12 Feb 2025 15:53:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -456,109 +452,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d6bff40c-5492-4ee1-a24a-41df59df5bd8
-        status: 201 Created
-        code: 201
-        duration: 806.465084ms
+                - 424348bb-ce08-4273-91ea-a15d42be7c77
+        status: 200 OK
+        code: 200
+        duration: 82.595ms
     - id: 9
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2112
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.373972+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-cerf","id":"1780c24c-59ed-4db8-bb22-7191af979336","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c4:43","maintenances":[],"modification_date":"2025-02-12T15:18:31.373972+00:00","name":"tf-srv-reverent-cerf","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.373972+00:00","export_uri":null,"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","modification_date":"2025-02-12T15:18:31.373972+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1780c24c-59ed-4db8-bb22-7191af979336","name":"tf-srv-reverent-cerf"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2112"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:18:31 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 0b4ea924-489c-4ac7-831f-95d9ba92f99c
-        status: 200 OK
-        code: 200
-        duration: 167.925875ms
-    - id: 10
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2112
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.373972+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-cerf","id":"1780c24c-59ed-4db8-bb22-7191af979336","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c4:43","maintenances":[],"modification_date":"2025-02-12T15:18:31.373972+00:00","name":"tf-srv-reverent-cerf","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.373972+00:00","export_uri":null,"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","modification_date":"2025-02-12T15:18:31.373972+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1780c24c-59ed-4db8-bb22-7191af979336","name":"tf-srv-reverent-cerf"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2112"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:18:31 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - cb9f1afa-a6cf-4342-a2c3-29bd1afcff92
-        status: 200 OK
-        code: 200
-        duration: 172.073291ms
-    - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -576,7 +474,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336/action
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -586,7 +484,7 @@ interactions:
         trailer: {}
         content_length: 357
         uncompressed: false
-        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/1780c24c-59ed-4db8-bb22-7191af979336/action","href_result":"/servers/1780c24c-59ed-4db8-bb22-7191af979336","id":"b15ae153-23fb-4615-952d-1aaf14df7e89","progress":0,"started_at":"2025-02-12T15:18:32.353039+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf/action","href_result":"/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf","id":"6f1b03d0-a7df-46fb-bd1d-9bc48daa6f92","progress":0,"started_at":"2025-02-12T15:53:17.961873+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -595,11 +493,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:18:32 GMT
+                - Wed, 12 Feb 2025 15:53:17 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/b15ae153-23fb-4615-952d-1aaf14df7e89
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/6f1b03d0-a7df-46fb-bd1d-9bc48daa6f92
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -607,10 +505,108 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4cb7bb22-5dec-43da-a9bc-12f7b2119f61
+                - e3fc0b19-cb66-43b8-90a8-6a52b2443b69
         status: 202 Accepted
         code: 202
-        duration: 333.49975ms
+        duration: 702.454917ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1702
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-12T15:53:16.407771+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-amazing-franklin","id":"0bf0d0f8-fccc-497f-a665-43f0d549eddf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c6:8f","maintenances":[],"modification_date":"2025-02-12T15:53:17.704870+00:00","name":"tf-srv-amazing-franklin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1702"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:53:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2b63235f-b8ec-477b-a88d-f1499611fe04
+        status: 200 OK
+        code: 200
+        duration: 413.078959ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/9716a7b8-b692-4c04-8a07-aa6e723ed33c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 424
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T15:53:15.665265Z","id":"9716a7b8-b692-4c04-8a07-aa6e723ed33c","last_detached_at":null,"name":"tf-volume-reverent-almeida","parent_snapshot_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":21000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T15:53:15.665265Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "424"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:53:20 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e83db470-a303-4363-97b2-2f6bcc3f1dad
+        status: 200 OK
+        code: 200
+        duration: 95.334292ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -627,7 +623,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/9716a7b8-b692-4c04-8a07-aa6e723ed33c
         method: GET
       response:
         proto: HTTP/2.0
@@ -635,20 +631,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2134
+        content_length: 424
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.373972+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-cerf","id":"1780c24c-59ed-4db8-bb22-7191af979336","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c4:43","maintenances":[],"modification_date":"2025-02-12T15:18:32.116505+00:00","name":"tf-srv-reverent-cerf","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.373972+00:00","export_uri":null,"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","modification_date":"2025-02-12T15:18:31.373972+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1780c24c-59ed-4db8-bb22-7191af979336","name":"tf-srv-reverent-cerf"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-12T15:53:15.665265Z","id":"9716a7b8-b692-4c04-8a07-aa6e723ed33c","last_detached_at":null,"name":"tf-volume-reverent-almeida","parent_snapshot_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":21000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T15:53:15.665265Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2134"
+                - "424"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:18:32 GMT
+                - Wed, 12 Feb 2025 15:53:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -656,48 +652,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8ba2a9f4-4c2d-4fec-975f-fcf77d6b3b73
+                - 08644ce2-d73a-4f6f-a2f9-6fe6a6918728
         status: 200 OK
         code: 200
-        duration: 248.339541ms
+        duration: 85.845417ms
     - id: 13
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 152
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"volume_id":"9716a7b8-b692-4c04-8a07-aa6e723ed33c","name":"tf-snapshot-optimistic-noyce","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[]}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f97824b7-3276-4224-b71a-d450304ed14c
-        method: GET
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 536
+        content_length: 467
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"89f83395-b4cf-4fee-9853-833f24fdd971","name":"tf-vol-cranky-blackwell"},"creation_date":"2025-02-12T15:18:31.227612+00:00","error_details":null,"id":"f97824b7-3276-4224-b71a-d450304ed14c","modification_date":"2025-02-12T15:18:34.957281+00:00","name":"tf-snap-distracted-poincare","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"class":"sbs","created_at":"2025-02-12T15:53:21.153503Z","id":"c96574f5-f857-475c-a9f7-41677887eb70","name":"tf-snapshot-optimistic-noyce","parent_volume":{"id":"9716a7b8-b692-4c04-8a07-aa6e723ed33c","name":"tf-volume-reverent-almeida","status":"available","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":21000000000,"status":"creating","tags":[],"updated_at":"2025-02-12T15:53:21.153503Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "536"
+                - "467"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:18:36 GMT
+                - Wed, 12 Feb 2025 15:53:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -705,10 +703,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a5e34339-9feb-46dd-8880-7a0f9c1b0773
+                - cc17483a-37ff-4e50-b2b8-3ba5d51a896d
         status: 200 OK
         code: 200
-        duration: 111.807833ms
+        duration: 267.360834ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -725,7 +723,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f97824b7-3276-4224-b71a-d450304ed14c
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/c96574f5-f857-475c-a9f7-41677887eb70
         method: GET
       response:
         proto: HTTP/2.0
@@ -733,20 +731,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 536
+        content_length: 467
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"89f83395-b4cf-4fee-9853-833f24fdd971","name":"tf-vol-cranky-blackwell"},"creation_date":"2025-02-12T15:18:31.227612+00:00","error_details":null,"id":"f97824b7-3276-4224-b71a-d450304ed14c","modification_date":"2025-02-12T15:18:34.957281+00:00","name":"tf-snap-distracted-poincare","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"class":"sbs","created_at":"2025-02-12T15:53:21.153503Z","id":"c96574f5-f857-475c-a9f7-41677887eb70","name":"tf-snapshot-optimistic-noyce","parent_volume":{"id":"9716a7b8-b692-4c04-8a07-aa6e723ed33c","name":"tf-volume-reverent-almeida","status":"available","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":21000000000,"status":"creating","tags":[],"updated_at":"2025-02-12T15:53:21.153503Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "536"
+                - "467"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:18:36 GMT
+                - Wed, 12 Feb 2025 15:53:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -754,10 +752,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3fe19dba-03b7-4b7a-886e-bcb5e5bb95ba
+                - 275a65f7-9df0-4137-9e16-dc0e2f9ece54
         status: 200 OK
         code: 200
-        duration: 106.14475ms
+        duration: 126.149ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -774,7 +772,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf
         method: GET
       response:
         proto: HTTP/2.0
@@ -782,20 +780,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2238
+        content_length: 1836
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.373972+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-cerf","id":"1780c24c-59ed-4db8-bb22-7191af979336","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"2002","node_id":"21","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:43","maintenances":[],"modification_date":"2025-02-12T15:18:32.116505+00:00","name":"tf-srv-reverent-cerf","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.373972+00:00","export_uri":null,"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","modification_date":"2025-02-12T15:18:31.373972+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1780c24c-59ed-4db8-bb22-7191af979336","name":"tf-srv-reverent-cerf"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-12T15:53:16.407771+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-amazing-franklin","id":"0bf0d0f8-fccc-497f-a665-43f0d549eddf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"801","node_id":"145","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c6:8f","maintenances":[],"modification_date":"2025-02-12T15:53:22.468531+00:00","name":"tf-srv-amazing-franklin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2238"
+                - "1836"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:18:37 GMT
+                - Wed, 12 Feb 2025 15:53:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -803,10 +801,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 79a8c031-dae0-4bc8-ae1a-892a63b26d51
+                - 098fbcdb-9d2d-4d30-b5b8-07e4d95ff250
         status: 200 OK
         code: 200
-        duration: 698.2605ms
+        duration: 257.014208ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -823,7 +821,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf
         method: GET
       response:
         proto: HTTP/2.0
@@ -831,20 +829,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2238
+        content_length: 1836
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.373972+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-cerf","id":"1780c24c-59ed-4db8-bb22-7191af979336","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"2002","node_id":"21","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:43","maintenances":[],"modification_date":"2025-02-12T15:18:32.116505+00:00","name":"tf-srv-reverent-cerf","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.373972+00:00","export_uri":null,"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","modification_date":"2025-02-12T15:18:31.373972+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1780c24c-59ed-4db8-bb22-7191af979336","name":"tf-srv-reverent-cerf"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-12T15:53:16.407771+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-amazing-franklin","id":"0bf0d0f8-fccc-497f-a665-43f0d549eddf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"801","node_id":"145","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c6:8f","maintenances":[],"modification_date":"2025-02-12T15:53:22.468531+00:00","name":"tf-srv-amazing-franklin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2238"
+                - "1836"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:18:43 GMT
+                - Wed, 12 Feb 2025 15:53:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -852,10 +850,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a1832a64-fca1-47a6-bbfa-7e278859cf7d
+                - 3234b24d-724e-43b4-aed9-ef1702d489c6
         status: 200 OK
         code: 200
-        duration: 195.517917ms
+        duration: 304.002334ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -872,7 +870,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/5d0109bc-940e-4bc6-b082-d7fa906ccea4
         method: GET
       response:
         proto: HTTP/2.0
@@ -880,20 +878,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2238
+        content_length: 143
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.373972+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-cerf","id":"1780c24c-59ed-4db8-bb22-7191af979336","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"2002","node_id":"21","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:43","maintenances":[],"modification_date":"2025-02-12T15:18:32.116505+00:00","name":"tf-srv-reverent-cerf","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.373972+00:00","export_uri":null,"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","modification_date":"2025-02-12T15:18:31.373972+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1780c24c-59ed-4db8-bb22-7191af979336","name":"tf-srv-reverent-cerf"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","type":"not_found"}'
         headers:
             Content-Length:
-                - "2238"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:18:48 GMT
+                - Wed, 12 Feb 2025 15:53:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -901,10 +899,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 771d7796-cc7f-4f51-b77f-31d0f7985ba6
-        status: 200 OK
-        code: 200
-        duration: 191.616208ms
+                - 0b912c80-5e7b-44c2-980b-687f6b84e769
+        status: 404 Not Found
+        code: 404
+        duration: 55.74575ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -921,7 +919,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/5d0109bc-940e-4bc6-b082-d7fa906ccea4
         method: GET
       response:
         proto: HTTP/2.0
@@ -929,20 +927,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2269
+        content_length: 701
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.373972+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-cerf","id":"1780c24c-59ed-4db8-bb22-7191af979336","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"2002","node_id":"21","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:43","maintenances":[],"modification_date":"2025-02-12T15:18:48.907477+00:00","name":"tf-srv-reverent-cerf","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.373972+00:00","export_uri":null,"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","modification_date":"2025-02-12T15:18:31.373972+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1780c24c-59ed-4db8-bb22-7191af979336","name":"tf-srv-reverent-cerf"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-12T15:53:16.620555Z","id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T15:53:16.620555Z","id":"bbe07d04-0b0e-4c8c-8bbf-c9693b5d4fce","product_resource_id":"0bf0d0f8-fccc-497f-a665-43f0d549eddf","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T15:53:16.620555Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2269"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:18:53 GMT
+                - Wed, 12 Feb 2025 15:53:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -950,10 +948,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7a715de0-ecd6-4103-aca9-5693e29c9eab
+                - 4c8f8247-d19c-4338-b8fe-6f9ce073bc1f
         status: 200 OK
         code: 200
-        duration: 175.93825ms
+        duration: 97.812833ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -970,7 +968,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -978,20 +976,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2269
+        content_length: 17
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.373972+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-cerf","id":"1780c24c-59ed-4db8-bb22-7191af979336","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"2002","node_id":"21","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:43","maintenances":[],"modification_date":"2025-02-12T15:18:48.907477+00:00","name":"tf-srv-reverent-cerf","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.373972+00:00","export_uri":null,"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","modification_date":"2025-02-12T15:18:31.373972+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1780c24c-59ed-4db8-bb22-7191af979336","name":"tf-srv-reverent-cerf"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "2269"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:18:53 GMT
+                - Wed, 12 Feb 2025 15:53:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -999,10 +997,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 450fbed3-bb7a-408b-ab88-fc80928128f4
+                - ab4a2389-2f0b-4b3b-acbc-870c0004ca21
         status: 200 OK
         code: 200
-        duration: 189.422041ms
+        duration: 111.731583ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1019,7 +1017,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/55312258-0bc4-449f-b2a3-e95fcb3fa094
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1027,20 +1025,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 520
+        content_length: 20
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-02-12T15:18:31.373972+00:00","export_uri":null,"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","modification_date":"2025-02-12T15:18:31.373972+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1780c24c-59ed-4db8-bb22-7191af979336","name":"tf-srv-reverent-cerf"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "520"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:18:53 GMT
+                - Wed, 12 Feb 2025 15:53:24 GMT
+            Link:
+                - </servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1048,10 +1048,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 880f7027-e2a1-4b7d-bba7-049ac5fdbf8c
+                - 6dcc3d43-98c0-4b60-ba7c-c6128068230d
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 119.957958ms
+        duration: 116.431667ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1068,7 +1070,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336/user_data
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/c96574f5-f857-475c-a9f7-41677887eb70
         method: GET
       response:
         proto: HTTP/2.0
@@ -1076,20 +1078,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 468
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"class":"sbs","created_at":"2025-02-12T15:53:21.153503Z","id":"c96574f5-f857-475c-a9f7-41677887eb70","name":"tf-snapshot-optimistic-noyce","parent_volume":{"id":"9716a7b8-b692-4c04-8a07-aa6e723ed33c","name":"tf-volume-reverent-almeida","status":"available","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":21000000000,"status":"available","tags":[],"updated_at":"2025-02-12T15:53:21.153503Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "17"
+                - "468"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:18:54 GMT
+                - Wed, 12 Feb 2025 15:53:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1097,10 +1099,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e542fc9b-f477-4ea0-b261-7e8f172010bb
+                - 035199f1-d5c0-4579-94f9-ae4158fc6c75
         status: 200 OK
         code: 200
-        duration: 102.302333ms
+        duration: 122.655208ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1117,7 +1119,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336/private_nics
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/c96574f5-f857-475c-a9f7-41677887eb70
         method: GET
       response:
         proto: HTTP/2.0
@@ -1125,22 +1127,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 468
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"class":"sbs","created_at":"2025-02-12T15:53:21.153503Z","id":"c96574f5-f857-475c-a9f7-41677887eb70","name":"tf-snapshot-optimistic-noyce","parent_volume":{"id":"9716a7b8-b692-4c04-8a07-aa6e723ed33c","name":"tf-volume-reverent-almeida","status":"available","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":21000000000,"status":"available","tags":[],"updated_at":"2025-02-12T15:53:21.153503Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "20"
+                - "468"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:18:54 GMT
-            Link:
-                - </servers/1780c24c-59ed-4db8-bb22-7191af979336/private_nics?page=0&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 15:53:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1148,12 +1148,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b6b31786-5ff6-4b72-b9d8-8c51ccf89582
-            X-Total-Count:
-                - "0"
+                - 6cf8299d-65f1-4f0b-92c9-9268f9ea6798
         status: 200 OK
         code: 200
-        duration: 115.273666ms
+        duration: 110.694792ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1170,7 +1168,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/89f83395-b4cf-4fee-9853-833f24fdd971
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/9716a7b8-b692-4c04-8a07-aa6e723ed33c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1178,20 +1176,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 445
+        content_length: 424
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-02-12T15:18:30.774581+00:00","export_uri":null,"id":"89f83395-b4cf-4fee-9853-833f24fdd971","modification_date":"2025-02-12T15:18:34.957281+00:00","name":"tf-vol-cranky-blackwell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-12T15:53:15.665265Z","id":"9716a7b8-b692-4c04-8a07-aa6e723ed33c","last_detached_at":null,"name":"tf-volume-reverent-almeida","parent_snapshot_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":21000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T15:53:15.665265Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "445"
+                - "424"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:18:54 GMT
+                - Wed, 12 Feb 2025 15:53:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1199,10 +1197,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b48dfc47-63a6-4da1-b5f7-c4598a9d7d82
+                - fc743c77-a935-4c37-afcd-9a095e99e484
         status: 200 OK
         code: 200
-        duration: 101.158125ms
+        duration: 76.73325ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1219,7 +1217,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf
         method: GET
       response:
         proto: HTTP/2.0
@@ -1227,20 +1225,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2269
+        content_length: 1836
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.373972+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-cerf","id":"1780c24c-59ed-4db8-bb22-7191af979336","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"2002","node_id":"21","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:43","maintenances":[],"modification_date":"2025-02-12T15:18:48.907477+00:00","name":"tf-srv-reverent-cerf","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.373972+00:00","export_uri":null,"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","modification_date":"2025-02-12T15:18:31.373972+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1780c24c-59ed-4db8-bb22-7191af979336","name":"tf-srv-reverent-cerf"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-12T15:53:16.407771+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-amazing-franklin","id":"0bf0d0f8-fccc-497f-a665-43f0d549eddf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"801","node_id":"145","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c6:8f","maintenances":[],"modification_date":"2025-02-12T15:53:22.468531+00:00","name":"tf-srv-amazing-franklin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2269"
+                - "1836"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:18:54 GMT
+                - Wed, 12 Feb 2025 15:53:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1248,10 +1246,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 058fc16e-857b-4b18-905c-949ee267d256
+                - f15738db-2fe1-4679-9f6f-e6e6266a1ee2
         status: 200 OK
         code: 200
-        duration: 205.24325ms
+        duration: 267.254ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1268,7 +1266,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f97824b7-3276-4224-b71a-d450304ed14c
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/c96574f5-f857-475c-a9f7-41677887eb70
         method: GET
       response:
         proto: HTTP/2.0
@@ -1276,20 +1274,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 536
+        content_length: 468
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"89f83395-b4cf-4fee-9853-833f24fdd971","name":"tf-vol-cranky-blackwell"},"creation_date":"2025-02-12T15:18:31.227612+00:00","error_details":null,"id":"f97824b7-3276-4224-b71a-d450304ed14c","modification_date":"2025-02-12T15:18:34.957281+00:00","name":"tf-snap-distracted-poincare","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"class":"sbs","created_at":"2025-02-12T15:53:21.153503Z","id":"c96574f5-f857-475c-a9f7-41677887eb70","name":"tf-snapshot-optimistic-noyce","parent_volume":{"id":"9716a7b8-b692-4c04-8a07-aa6e723ed33c","name":"tf-volume-reverent-almeida","status":"available","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":21000000000,"status":"available","tags":[],"updated_at":"2025-02-12T15:53:21.153503Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "536"
+                - "468"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:18:54 GMT
+                - Wed, 12 Feb 2025 15:53:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1297,10 +1295,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0e1d395f-b979-43c3-b369-d3a22d836227
+                - 2954e6a0-e7b2-4167-993b-9e38bb04cfc1
         status: 200 OK
         code: 200
-        duration: 107.509833ms
+        duration: 99.952625ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1317,7 +1315,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/89f83395-b4cf-4fee-9853-833f24fdd971
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/9716a7b8-b692-4c04-8a07-aa6e723ed33c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1325,20 +1323,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 445
+        content_length: 424
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-02-12T15:18:30.774581+00:00","export_uri":null,"id":"89f83395-b4cf-4fee-9853-833f24fdd971","modification_date":"2025-02-12T15:18:34.957281+00:00","name":"tf-vol-cranky-blackwell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-12T15:53:15.665265Z","id":"9716a7b8-b692-4c04-8a07-aa6e723ed33c","last_detached_at":null,"name":"tf-volume-reverent-almeida","parent_snapshot_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":21000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T15:53:15.665265Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "445"
+                - "424"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:18:55 GMT
+                - Wed, 12 Feb 2025 15:53:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1346,10 +1344,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b61e889e-142a-4d54-b7e9-29a8d6f5bde9
+                - 0bfb59dc-e169-478c-a3c1-1304c9ae997e
         status: 200 OK
         code: 200
-        duration: 104.222917ms
+        duration: 80.177375ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1366,7 +1364,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf
         method: GET
       response:
         proto: HTTP/2.0
@@ -1374,20 +1372,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2269
+        content_length: 1836
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.373972+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-cerf","id":"1780c24c-59ed-4db8-bb22-7191af979336","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"2002","node_id":"21","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:43","maintenances":[],"modification_date":"2025-02-12T15:18:48.907477+00:00","name":"tf-srv-reverent-cerf","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.373972+00:00","export_uri":null,"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","modification_date":"2025-02-12T15:18:31.373972+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1780c24c-59ed-4db8-bb22-7191af979336","name":"tf-srv-reverent-cerf"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-12T15:53:16.407771+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-amazing-franklin","id":"0bf0d0f8-fccc-497f-a665-43f0d549eddf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"801","node_id":"145","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c6:8f","maintenances":[],"modification_date":"2025-02-12T15:53:22.468531+00:00","name":"tf-srv-amazing-franklin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2269"
+                - "1836"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:18:55 GMT
+                - Wed, 12 Feb 2025 15:53:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1395,10 +1393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - aea8ddaa-e629-4bcc-9ec8-00338efb1857
+                - 08ab9c5a-16b9-46e3-9ec4-a0f24bd9ec07
         status: 200 OK
         code: 200
-        duration: 178.394292ms
+        duration: 184.519041ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1415,7 +1413,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f97824b7-3276-4224-b71a-d450304ed14c
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/c96574f5-f857-475c-a9f7-41677887eb70
         method: GET
       response:
         proto: HTTP/2.0
@@ -1423,20 +1421,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 536
+        content_length: 468
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"89f83395-b4cf-4fee-9853-833f24fdd971","name":"tf-vol-cranky-blackwell"},"creation_date":"2025-02-12T15:18:31.227612+00:00","error_details":null,"id":"f97824b7-3276-4224-b71a-d450304ed14c","modification_date":"2025-02-12T15:18:34.957281+00:00","name":"tf-snap-distracted-poincare","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"class":"sbs","created_at":"2025-02-12T15:53:21.153503Z","id":"c96574f5-f857-475c-a9f7-41677887eb70","name":"tf-snapshot-optimistic-noyce","parent_volume":{"id":"9716a7b8-b692-4c04-8a07-aa6e723ed33c","name":"tf-volume-reverent-almeida","status":"available","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":21000000000,"status":"available","tags":[],"updated_at":"2025-02-12T15:53:21.153503Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "536"
+                - "468"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:18:55 GMT
+                - Wed, 12 Feb 2025 15:53:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1444,10 +1442,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6c0e14e6-c149-4c47-8054-25c944c850a5
+                - 80445dfe-dcf7-4d27-8a25-39947f62f696
         status: 200 OK
         code: 200
-        duration: 112.788625ms
+        duration: 119.545041ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1464,7 +1462,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/55312258-0bc4-449f-b2a3-e95fcb3fa094
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/5d0109bc-940e-4bc6-b082-d7fa906ccea4
         method: GET
       response:
         proto: HTTP/2.0
@@ -1472,20 +1470,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 520
+        content_length: 143
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-02-12T15:18:31.373972+00:00","export_uri":null,"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","modification_date":"2025-02-12T15:18:31.373972+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1780c24c-59ed-4db8-bb22-7191af979336","name":"tf-srv-reverent-cerf"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","type":"not_found"}'
         headers:
             Content-Length:
-                - "520"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:18:54 GMT
+                - Wed, 12 Feb 2025 15:53:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1493,10 +1491,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3c790b71-1e43-461e-987c-a9dd9cd953a7
-        status: 200 OK
-        code: 200
-        duration: 108.278542ms
+                - 15fe0d7b-43f1-465e-afc1-367fefb31069
+        status: 404 Not Found
+        code: 404
+        duration: 55.081667ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1513,7 +1511,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336/user_data
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/5d0109bc-940e-4bc6-b082-d7fa906ccea4
         method: GET
       response:
         proto: HTTP/2.0
@@ -1521,20 +1519,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 701
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"created_at":"2025-02-12T15:53:16.620555Z","id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T15:53:16.620555Z","id":"bbe07d04-0b0e-4c8c-8bbf-c9693b5d4fce","product_resource_id":"0bf0d0f8-fccc-497f-a665-43f0d549eddf","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T15:53:16.620555Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "17"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:18:55 GMT
+                - Wed, 12 Feb 2025 15:53:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1542,10 +1540,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e3a1d184-2748-4731-b515-82104a979025
+                - 5c18b7d6-553f-442c-ac74-c5eb4300acb6
         status: 200 OK
         code: 200
-        duration: 118.969042ms
+        duration: 91.077417ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1562,7 +1560,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336/private_nics
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1570,22 +1568,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 17
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "20"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:18:55 GMT
-            Link:
-                - </servers/1780c24c-59ed-4db8-bb22-7191af979336/private_nics?page=0&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 15:53:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1593,12 +1589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 30989539-d05e-4a21-b80d-4a564d06af0f
-            X-Total-Count:
-                - "0"
+                - d25b5e2b-e255-4b55-aefe-6b3ccf7ea82a
         status: 200 OK
         code: 200
-        duration: 104.178875ms
+        duration: 108.534083ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1615,7 +1609,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/89f83395-b4cf-4fee-9853-833f24fdd971
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1623,20 +1617,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 445
+        content_length: 20
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-02-12T15:18:30.774581+00:00","export_uri":null,"id":"89f83395-b4cf-4fee-9853-833f24fdd971","modification_date":"2025-02-12T15:18:34.957281+00:00","name":"tf-vol-cranky-blackwell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "445"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:18:55 GMT
+                - Wed, 12 Feb 2025 15:53:27 GMT
+            Link:
+                - </servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1644,10 +1640,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5f1e148a-f963-4737-abcc-ad336ad4600f
+                - 3134343e-2ae4-4c27-88d2-bfc15b815535
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 97.859667ms
+        duration: 100.229541ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1664,7 +1662,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/9716a7b8-b692-4c04-8a07-aa6e723ed33c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1672,20 +1670,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2269
+        content_length: 424
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.373972+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-cerf","id":"1780c24c-59ed-4db8-bb22-7191af979336","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"2002","node_id":"21","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:43","maintenances":[],"modification_date":"2025-02-12T15:18:48.907477+00:00","name":"tf-srv-reverent-cerf","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.373972+00:00","export_uri":null,"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","modification_date":"2025-02-12T15:18:31.373972+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1780c24c-59ed-4db8-bb22-7191af979336","name":"tf-srv-reverent-cerf"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-12T15:53:15.665265Z","id":"9716a7b8-b692-4c04-8a07-aa6e723ed33c","last_detached_at":null,"name":"tf-volume-reverent-almeida","parent_snapshot_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":21000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T15:53:15.665265Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2269"
+                - "424"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:18:55 GMT
+                - Wed, 12 Feb 2025 15:53:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1693,10 +1691,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d72b23b9-eac1-45cb-8b0f-5ad4e7c227c6
+                - c93abb38-a2a6-4344-9046-73ff372b0ff3
         status: 200 OK
         code: 200
-        duration: 190.794584ms
+        duration: 101.19725ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1713,7 +1711,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f97824b7-3276-4224-b71a-d450304ed14c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf
         method: GET
       response:
         proto: HTTP/2.0
@@ -1721,20 +1719,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 536
+        content_length: 1836
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"89f83395-b4cf-4fee-9853-833f24fdd971","name":"tf-vol-cranky-blackwell"},"creation_date":"2025-02-12T15:18:31.227612+00:00","error_details":null,"id":"f97824b7-3276-4224-b71a-d450304ed14c","modification_date":"2025-02-12T15:18:34.957281+00:00","name":"tf-snap-distracted-poincare","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-12T15:53:16.407771+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-amazing-franklin","id":"0bf0d0f8-fccc-497f-a665-43f0d549eddf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"801","node_id":"145","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c6:8f","maintenances":[],"modification_date":"2025-02-12T15:53:22.468531+00:00","name":"tf-srv-amazing-franklin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "536"
+                - "1836"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:18:55 GMT
+                - Wed, 12 Feb 2025 15:53:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1742,10 +1740,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 64fdbbdb-f489-47c6-9954-2721888a696a
+                - 9cb0b9a7-6639-446a-9d68-f0b32c991619
         status: 200 OK
         code: 200
-        duration: 113.199542ms
+        duration: 186.061875ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1762,7 +1760,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/55312258-0bc4-449f-b2a3-e95fcb3fa094
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/c96574f5-f857-475c-a9f7-41677887eb70
         method: GET
       response:
         proto: HTTP/2.0
@@ -1770,20 +1768,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 520
+        content_length: 468
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-02-12T15:18:31.373972+00:00","export_uri":null,"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","modification_date":"2025-02-12T15:18:31.373972+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1780c24c-59ed-4db8-bb22-7191af979336","name":"tf-srv-reverent-cerf"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"class":"sbs","created_at":"2025-02-12T15:53:21.153503Z","id":"c96574f5-f857-475c-a9f7-41677887eb70","name":"tf-snapshot-optimistic-noyce","parent_volume":{"id":"9716a7b8-b692-4c04-8a07-aa6e723ed33c","name":"tf-volume-reverent-almeida","status":"available","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":21000000000,"status":"available","tags":[],"updated_at":"2025-02-12T15:53:21.153503Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "520"
+                - "468"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:18:55 GMT
+                - Wed, 12 Feb 2025 15:53:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1791,10 +1789,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - afe37ee1-bf88-4095-b305-74ec9b253fe0
+                - 4c0579e2-4b8c-4887-9c1a-20faa1412429
         status: 200 OK
         code: 200
-        duration: 107.485791ms
+        duration: 97.0945ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1811,7 +1809,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336/user_data
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/5d0109bc-940e-4bc6-b082-d7fa906ccea4
         method: GET
       response:
         proto: HTTP/2.0
@@ -1819,20 +1817,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 143
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","type":"not_found"}'
         headers:
             Content-Length:
-                - "17"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:18:56 GMT
+                - Wed, 12 Feb 2025 15:53:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1840,10 +1838,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6fd54511-668c-4cb7-86d7-8cf3ee1407ca
-        status: 200 OK
-        code: 200
-        duration: 106.439ms
+                - ed83fbc2-c053-4b43-909c-103c5bc13a61
+        status: 404 Not Found
+        code: 404
+        duration: 53.938416ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1860,7 +1858,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336/private_nics
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/5d0109bc-940e-4bc6-b082-d7fa906ccea4
         method: GET
       response:
         proto: HTTP/2.0
@@ -1868,22 +1866,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 701
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"created_at":"2025-02-12T15:53:16.620555Z","id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T15:53:16.620555Z","id":"bbe07d04-0b0e-4c8c-8bbf-c9693b5d4fce","product_resource_id":"0bf0d0f8-fccc-497f-a665-43f0d549eddf","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T15:53:16.620555Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "20"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:18:56 GMT
-            Link:
-                - </servers/1780c24c-59ed-4db8-bb22-7191af979336/private_nics?page=0&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 15:53:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1891,52 +1887,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4dfbfd26-580b-40ee-a94a-3c448bfaf616
-            X-Total-Count:
-                - "0"
+                - c28f0e56-192a-45a7-874d-90d536798d33
         status: 200 OK
         code: 200
-        duration: 136.365167ms
+        duration: 100.638458ms
     - id: 38
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 136
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-snap-stupefied-hellman","volume_id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
-        method: POST
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf/user_data
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 849
+        content_length: 17
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:18:56.896267+00:00","error_details":null,"id":"1b0ce8dc-403d-4ab9-b326-d30ddee68e64","modification_date":"2025-02-12T15:18:56.896267+00:00","name":"tf-snap-stupefied-hellman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"task":{"description":"volume_snapshot","href_from":"/snapshots","href_result":"snapshots/1b0ce8dc-403d-4ab9-b326-d30ddee68e64","id":"16f90202-138e-4f2d-aefa-37f35a0366f2","progress":0,"started_at":"2025-02-12T15:18:57.157090+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "849"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:18:57 GMT
+                - Wed, 12 Feb 2025 15:53:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1944,10 +1936,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 937d8177-b2bb-42f1-a694-9c0f0c7a4d8c
-        status: 201 Created
-        code: 201
-        duration: 1.031219292s
+                - fe7f8af9-63f9-403a-9112-85e517951cf1
+        status: 200 OK
+        code: 200
+        duration: 112.213916ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1964,7 +1956,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/1b0ce8dc-403d-4ab9-b326-d30ddee68e64
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1972,20 +1964,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 538
+        content_length: 20
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:18:56.896267+00:00","error_details":null,"id":"1b0ce8dc-403d-4ab9-b326-d30ddee68e64","modification_date":"2025-02-12T15:18:56.896267+00:00","name":"tf-snap-stupefied-hellman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "538"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:18:57 GMT
+                - Wed, 12 Feb 2025 15:53:28 GMT
+            Link:
+                - </servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1993,48 +1987,52 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a616496b-c283-4536-aec1-99a61607f78b
+                - 4964eb89-ad7f-41ec-901b-8e25013f3f21
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 117.207458ms
+        duration: 112.245208ms
     - id: 40
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 145
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"volume_id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","name":"tf-snapshot-keen-pike","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[]}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/1b0ce8dc-403d-4ab9-b326-d30ddee68e64
-        method: GET
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 538
+        content_length: 468
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:18:56.896267+00:00","error_details":null,"id":"1b0ce8dc-403d-4ab9-b326-d30ddee68e64","modification_date":"2025-02-12T15:18:56.896267+00:00","name":"tf-snap-stupefied-hellman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"class":"sbs","created_at":"2025-02-12T15:53:29.101307Z","id":"ddfdab48-0b8a-4048-8233-5f8bd4fd950b","name":"tf-snapshot-keen-pike","parent_volume":{"id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","status":"in_use","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"status":"creating","tags":[],"updated_at":"2025-02-12T15:53:29.101307Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "538"
+                - "468"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:02 GMT
+                - Wed, 12 Feb 2025 15:53:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2042,10 +2040,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 485fae65-73f3-4565-8bd6-c08464de4b32
+                - 9580d8fa-55ab-4823-9b04-baa944ae12c1
         status: 200 OK
         code: 200
-        duration: 98.3555ms
+        duration: 226.463625ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2062,7 +2060,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/1b0ce8dc-403d-4ab9-b326-d30ddee68e64
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/ddfdab48-0b8a-4048-8233-5f8bd4fd950b
         method: GET
       response:
         proto: HTTP/2.0
@@ -2070,20 +2068,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 538
+        content_length: 699
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:18:56.896267+00:00","error_details":null,"id":"1b0ce8dc-403d-4ab9-b326-d30ddee68e64","modification_date":"2025-02-12T15:18:56.896267+00:00","name":"tf-snap-stupefied-hellman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"class":"sbs","created_at":"2025-02-12T15:53:29.101307Z","id":"ddfdab48-0b8a-4048-8233-5f8bd4fd950b","name":"tf-snapshot-keen-pike","parent_volume":{"id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","status":"in_use","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T15:53:29.130135Z","id":"6b6e434d-7eee-490d-9a68-5c0bfe76dd60","product_resource_id":"00000000-0000-0000-0000-000000000000","product_resource_type":"internal","status":"attached","type":"unknown_type"}],"size":10000000000,"status":"creating","tags":[],"updated_at":"2025-02-12T15:53:29.101307Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "538"
+                - "699"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:07 GMT
+                - Wed, 12 Feb 2025 15:53:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2091,10 +2089,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a816d69a-7f49-4ea2-ab56-06b59aab6685
+                - cb426d6d-8b7a-40cd-85bb-5bb00bd13ea6
         status: 200 OK
         code: 200
-        duration: 116.591125ms
+        duration: 151.319625ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2111,7 +2109,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/1b0ce8dc-403d-4ab9-b326-d30ddee68e64
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/ddfdab48-0b8a-4048-8233-5f8bd4fd950b
         method: GET
       response:
         proto: HTTP/2.0
@@ -2119,20 +2117,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 538
+        content_length: 699
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:18:56.896267+00:00","error_details":null,"id":"1b0ce8dc-403d-4ab9-b326-d30ddee68e64","modification_date":"2025-02-12T15:18:56.896267+00:00","name":"tf-snap-stupefied-hellman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"class":"sbs","created_at":"2025-02-12T15:53:29.101307Z","id":"ddfdab48-0b8a-4048-8233-5f8bd4fd950b","name":"tf-snapshot-keen-pike","parent_volume":{"id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","status":"in_use","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T15:53:29.130135Z","id":"6b6e434d-7eee-490d-9a68-5c0bfe76dd60","product_resource_id":"00000000-0000-0000-0000-000000000000","product_resource_type":"internal","status":"attached","type":"unknown_type"}],"size":10000000000,"status":"creating","tags":[],"updated_at":"2025-02-12T15:53:29.101307Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "538"
+                - "699"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:13 GMT
+                - Wed, 12 Feb 2025 15:53:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2140,10 +2138,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 571e69ac-2297-454f-aa4c-1a54d3ae2a07
+                - b54bdcda-e5c2-4462-b88b-81b3637c66e2
         status: 200 OK
         code: 200
-        duration: 100.041833ms
+        duration: 116.459417ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2160,7 +2158,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/1b0ce8dc-403d-4ab9-b326-d30ddee68e64
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/ddfdab48-0b8a-4048-8233-5f8bd4fd950b
         method: GET
       response:
         proto: HTTP/2.0
@@ -2168,20 +2166,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 538
+        content_length: 699
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:18:56.896267+00:00","error_details":null,"id":"1b0ce8dc-403d-4ab9-b326-d30ddee68e64","modification_date":"2025-02-12T15:18:56.896267+00:00","name":"tf-snap-stupefied-hellman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"class":"sbs","created_at":"2025-02-12T15:53:29.101307Z","id":"ddfdab48-0b8a-4048-8233-5f8bd4fd950b","name":"tf-snapshot-keen-pike","parent_volume":{"id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","status":"in_use","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T15:53:29.130135Z","id":"6b6e434d-7eee-490d-9a68-5c0bfe76dd60","product_resource_id":"00000000-0000-0000-0000-000000000000","product_resource_type":"internal","status":"attached","type":"unknown_type"}],"size":10000000000,"status":"creating","tags":[],"updated_at":"2025-02-12T15:53:29.101307Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "538"
+                - "699"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:18 GMT
+                - Wed, 12 Feb 2025 15:53:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2189,10 +2187,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c1932610-f8d3-4a70-a495-39feb89a21f1
+                - b6e98725-acf7-4527-91d0-ceebd34e25b3
         status: 200 OK
         code: 200
-        duration: 243.034292ms
+        duration: 219.137625ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2209,7 +2207,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/1b0ce8dc-403d-4ab9-b326-d30ddee68e64
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/ddfdab48-0b8a-4048-8233-5f8bd4fd950b
         method: GET
       response:
         proto: HTTP/2.0
@@ -2217,20 +2215,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 538
+        content_length: 699
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:18:56.896267+00:00","error_details":null,"id":"1b0ce8dc-403d-4ab9-b326-d30ddee68e64","modification_date":"2025-02-12T15:18:56.896267+00:00","name":"tf-snap-stupefied-hellman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"class":"sbs","created_at":"2025-02-12T15:53:29.101307Z","id":"ddfdab48-0b8a-4048-8233-5f8bd4fd950b","name":"tf-snapshot-keen-pike","parent_volume":{"id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","status":"in_use","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T15:53:29.130135Z","id":"6b6e434d-7eee-490d-9a68-5c0bfe76dd60","product_resource_id":"00000000-0000-0000-0000-000000000000","product_resource_type":"internal","status":"attached","type":"unknown_type"}],"size":10000000000,"status":"creating","tags":[],"updated_at":"2025-02-12T15:53:29.101307Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "538"
+                - "699"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:23 GMT
+                - Wed, 12 Feb 2025 15:53:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2238,10 +2236,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a093da12-7f57-4f54-abef-5260c23c7917
+                - f548936a-83ec-4520-8528-ab7da0efded4
         status: 200 OK
         code: 200
-        duration: 106.877291ms
+        duration: 123.348583ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2258,7 +2256,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/1b0ce8dc-403d-4ab9-b326-d30ddee68e64
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/ddfdab48-0b8a-4048-8233-5f8bd4fd950b
         method: GET
       response:
         proto: HTTP/2.0
@@ -2266,20 +2264,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 535
+        content_length: 699
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:18:56.896267+00:00","error_details":null,"id":"1b0ce8dc-403d-4ab9-b326-d30ddee68e64","modification_date":"2025-02-12T15:19:23.710368+00:00","name":"tf-snap-stupefied-hellman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"class":"sbs","created_at":"2025-02-12T15:53:29.101307Z","id":"ddfdab48-0b8a-4048-8233-5f8bd4fd950b","name":"tf-snapshot-keen-pike","parent_volume":{"id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","status":"in_use","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T15:53:29.130135Z","id":"6b6e434d-7eee-490d-9a68-5c0bfe76dd60","product_resource_id":"00000000-0000-0000-0000-000000000000","product_resource_type":"internal","status":"attached","type":"unknown_type"}],"size":10000000000,"status":"creating","tags":[],"updated_at":"2025-02-12T15:53:29.101307Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "535"
+                - "699"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:28 GMT
+                - Wed, 12 Feb 2025 15:53:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2287,10 +2285,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7f1e4550-80f6-496a-829e-b7ca64b36bdb
+                - 8a4b48a1-7d4e-4d06-9074-7272d96464cf
         status: 200 OK
         code: 200
-        duration: 104.735875ms
+        duration: 224.80875ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2307,7 +2305,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/1b0ce8dc-403d-4ab9-b326-d30ddee68e64
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/ddfdab48-0b8a-4048-8233-5f8bd4fd950b
         method: GET
       response:
         proto: HTTP/2.0
@@ -2315,20 +2313,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 535
+        content_length: 699
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:18:56.896267+00:00","error_details":null,"id":"1b0ce8dc-403d-4ab9-b326-d30ddee68e64","modification_date":"2025-02-12T15:19:23.710368+00:00","name":"tf-snap-stupefied-hellman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"class":"sbs","created_at":"2025-02-12T15:53:29.101307Z","id":"ddfdab48-0b8a-4048-8233-5f8bd4fd950b","name":"tf-snapshot-keen-pike","parent_volume":{"id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","status":"in_use","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T15:53:29.130135Z","id":"6b6e434d-7eee-490d-9a68-5c0bfe76dd60","product_resource_id":"00000000-0000-0000-0000-000000000000","product_resource_type":"internal","status":"attached","type":"unknown_type"}],"size":10000000000,"status":"creating","tags":[],"updated_at":"2025-02-12T15:53:29.101307Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "535"
+                - "699"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:28 GMT
+                - Wed, 12 Feb 2025 15:53:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2336,52 +2334,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1cc752de-cd25-44ef-8296-68014cc5567d
+                - ce6f5fa3-9070-40b9-aa01-500f171b1070
         status: 200 OK
         code: 200
-        duration: 119.489875ms
+        duration: 113.439292ms
     - id: 47
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 235
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-image-vigilant-hertz","root_volume":"1b0ce8dc-403d-4ab9-b326-d30ddee68e64","arch":"x86_64","extra_volumes":{"1":{"id":"f97824b7-3276-4224-b71a-d450304ed14c"}},"project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images
-        method: POST
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/ddfdab48-0b8a-4048-8233-5f8bd4fd950b
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 746
+        content_length: 699
         uncompressed: false
-        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T15:19:28.932980+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"f97824b7-3276-4224-b71a-d450304ed14c","name":"tf-snap-distracted-poincare","size":21000000000,"volume_type":"b_ssd"}},"from_server":"","id":"4955169c-7666-48cb-9e27-7ee608b717d5","modification_date":"2025-02-12T15:19:28.932980+00:00","name":"tf-image-vigilant-hertz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"1b0ce8dc-403d-4ab9-b326-d30ddee68e64","name":"tf-snap-stupefied-hellman","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"class":"sbs","created_at":"2025-02-12T15:53:29.101307Z","id":"ddfdab48-0b8a-4048-8233-5f8bd4fd950b","name":"tf-snapshot-keen-pike","parent_volume":{"id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","status":"in_use","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T15:53:29.130135Z","id":"6b6e434d-7eee-490d-9a68-5c0bfe76dd60","product_resource_id":"00000000-0000-0000-0000-000000000000","product_resource_type":"internal","status":"attached","type":"unknown_type"}],"size":10000000000,"status":"creating","tags":[],"updated_at":"2025-02-12T15:53:29.101307Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "746"
+                - "699"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:28 GMT
-            Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/images/4955169c-7666-48cb-9e27-7ee608b717d5
+                - Wed, 12 Feb 2025 15:54:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2389,10 +2383,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ac024b6e-c98b-4aca-ae97-22eb57e97c3a
-        status: 201 Created
-        code: 201
-        duration: 408.023333ms
+                - 75ad52f0-ea60-488b-aa94-8723c146832f
+        status: 200 OK
+        code: 200
+        duration: 207.208625ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2409,7 +2403,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/4955169c-7666-48cb-9e27-7ee608b717d5
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/ddfdab48-0b8a-4048-8233-5f8bd4fd950b
         method: GET
       response:
         proto: HTTP/2.0
@@ -2417,20 +2411,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 746
+        content_length: 469
         uncompressed: false
-        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T15:19:28.932980+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"f97824b7-3276-4224-b71a-d450304ed14c","name":"tf-snap-distracted-poincare","size":21000000000,"volume_type":"b_ssd"}},"from_server":"","id":"4955169c-7666-48cb-9e27-7ee608b717d5","modification_date":"2025-02-12T15:19:28.932980+00:00","name":"tf-image-vigilant-hertz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"1b0ce8dc-403d-4ab9-b326-d30ddee68e64","name":"tf-snap-stupefied-hellman","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"class":"sbs","created_at":"2025-02-12T15:53:29.101307Z","id":"ddfdab48-0b8a-4048-8233-5f8bd4fd950b","name":"tf-snapshot-keen-pike","parent_volume":{"id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","status":"in_use","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"status":"available","tags":[],"updated_at":"2025-02-12T15:53:29.101307Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "746"
+                - "469"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:28 GMT
+                - Wed, 12 Feb 2025 15:54:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2438,10 +2432,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5449a246-6080-444a-ae35-aa9b450d8501
+                - 45ecdd0b-08c1-4e2b-b8c6-8ecb868d3874
         status: 200 OK
         code: 200
-        duration: 104.912459ms
+        duration: 119.514667ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2458,7 +2452,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/4955169c-7666-48cb-9e27-7ee608b717d5
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/ddfdab48-0b8a-4048-8233-5f8bd4fd950b
         method: GET
       response:
         proto: HTTP/2.0
@@ -2466,20 +2460,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 746
+        content_length: 469
         uncompressed: false
-        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T15:19:28.932980+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"f97824b7-3276-4224-b71a-d450304ed14c","name":"tf-snap-distracted-poincare","size":21000000000,"volume_type":"b_ssd"}},"from_server":"","id":"4955169c-7666-48cb-9e27-7ee608b717d5","modification_date":"2025-02-12T15:19:28.932980+00:00","name":"tf-image-vigilant-hertz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"1b0ce8dc-403d-4ab9-b326-d30ddee68e64","name":"tf-snap-stupefied-hellman","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"class":"sbs","created_at":"2025-02-12T15:53:29.101307Z","id":"ddfdab48-0b8a-4048-8233-5f8bd4fd950b","name":"tf-snapshot-keen-pike","parent_volume":{"id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","status":"in_use","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"status":"available","tags":[],"updated_at":"2025-02-12T15:53:29.101307Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "746"
+                - "469"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:29 GMT
+                - Wed, 12 Feb 2025 15:54:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2487,48 +2481,52 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c5a6b5c1-71e6-4e14-b201-ee59119ca268
+                - ba250aae-5e92-48d1-a69c-5d1db15e341b
         status: 200 OK
         code: 200
-        duration: 132.159042ms
+        duration: 110.782792ms
     - id: 50
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 234
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"name":"tf-image-silly-wozniak","root_volume":"ddfdab48-0b8a-4048-8233-5f8bd4fd950b","arch":"x86_64","extra_volumes":{"1":{"id":"c96574f5-f857-475c-a9f7-41677887eb70"}},"project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/89f83395-b4cf-4fee-9853-833f24fdd971
-        method: GET
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 445
+        content_length: 687
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-02-12T15:18:30.774581+00:00","export_uri":null,"id":"89f83395-b4cf-4fee-9853-833f24fdd971","modification_date":"2025-02-12T15:18:34.957281+00:00","name":"tf-vol-cranky-blackwell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T15:54:05.720450+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"c96574f5-f857-475c-a9f7-41677887eb70","name":"","size":0,"volume_type":"sbs_snapshot"}},"from_server":"","id":"8995f9f0-67d5-43cd-9844-c11c3a5736e5","modification_date":"2025-02-12T15:54:05.720450+00:00","name":"tf-image-silly-wozniak","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"ddfdab48-0b8a-4048-8233-5f8bd4fd950b","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "445"
+                - "687"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:29 GMT
+                - Wed, 12 Feb 2025 15:54:05 GMT
+            Location:
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8995f9f0-67d5-43cd-9844-c11c3a5736e5
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2536,10 +2534,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 36cd6356-6e2f-4271-8a66-5deaaf8ea373
-        status: 200 OK
-        code: 200
-        duration: 90.020333ms
+                - 867606e0-09f9-46aa-ace4-0c27621d7c09
+        status: 201 Created
+        code: 201
+        duration: 604.6675ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2556,7 +2554,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8995f9f0-67d5-43cd-9844-c11c3a5736e5
         method: GET
       response:
         proto: HTTP/2.0
@@ -2564,20 +2562,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2269
+        content_length: 687
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.373972+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-cerf","id":"1780c24c-59ed-4db8-bb22-7191af979336","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"2002","node_id":"21","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:43","maintenances":[],"modification_date":"2025-02-12T15:18:48.907477+00:00","name":"tf-srv-reverent-cerf","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.373972+00:00","export_uri":null,"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","modification_date":"2025-02-12T15:19:23.710368+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1780c24c-59ed-4db8-bb22-7191af979336","name":"tf-srv-reverent-cerf"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T15:54:05.720450+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"c96574f5-f857-475c-a9f7-41677887eb70","name":"","size":0,"volume_type":"sbs_snapshot"}},"from_server":"","id":"8995f9f0-67d5-43cd-9844-c11c3a5736e5","modification_date":"2025-02-12T15:54:05.720450+00:00","name":"tf-image-silly-wozniak","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"ddfdab48-0b8a-4048-8233-5f8bd4fd950b","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2269"
+                - "687"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:29 GMT
+                - Wed, 12 Feb 2025 15:54:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2585,10 +2583,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 37e05813-ade1-4328-a475-7748607fe07d
+                - 347732be-7269-4f41-a8a2-02c81b6a5464
         status: 200 OK
         code: 200
-        duration: 174.361084ms
+        duration: 125.898209ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -2605,7 +2603,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f97824b7-3276-4224-b71a-d450304ed14c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8995f9f0-67d5-43cd-9844-c11c3a5736e5
         method: GET
       response:
         proto: HTTP/2.0
@@ -2613,20 +2611,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 536
+        content_length: 687
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"89f83395-b4cf-4fee-9853-833f24fdd971","name":"tf-vol-cranky-blackwell"},"creation_date":"2025-02-12T15:18:31.227612+00:00","error_details":null,"id":"f97824b7-3276-4224-b71a-d450304ed14c","modification_date":"2025-02-12T15:18:34.957281+00:00","name":"tf-snap-distracted-poincare","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T15:54:05.720450+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"c96574f5-f857-475c-a9f7-41677887eb70","name":"","size":0,"volume_type":"sbs_snapshot"}},"from_server":"","id":"8995f9f0-67d5-43cd-9844-c11c3a5736e5","modification_date":"2025-02-12T15:54:05.720450+00:00","name":"tf-image-silly-wozniak","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"ddfdab48-0b8a-4048-8233-5f8bd4fd950b","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "536"
+                - "687"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:29 GMT
+                - Wed, 12 Feb 2025 15:54:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2634,10 +2632,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b6afcd37-e40e-47dc-af74-9f35ae9e0969
+                - d2c6a16a-726f-4f5e-9ade-30954cc2cd0e
         status: 200 OK
         code: 200
-        duration: 108.2945ms
+        duration: 148.690209ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -2654,7 +2652,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/1b0ce8dc-403d-4ab9-b326-d30ddee68e64
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/9716a7b8-b692-4c04-8a07-aa6e723ed33c
         method: GET
       response:
         proto: HTTP/2.0
@@ -2662,20 +2660,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 535
+        content_length: 424
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:18:56.896267+00:00","error_details":null,"id":"1b0ce8dc-403d-4ab9-b326-d30ddee68e64","modification_date":"2025-02-12T15:19:23.710368+00:00","name":"tf-snap-stupefied-hellman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-12T15:53:15.665265Z","id":"9716a7b8-b692-4c04-8a07-aa6e723ed33c","last_detached_at":null,"name":"tf-volume-reverent-almeida","parent_snapshot_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":21000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T15:53:15.665265Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "535"
+                - "424"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:29 GMT
+                - Wed, 12 Feb 2025 15:54:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2683,10 +2681,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 15555486-356a-43fb-bdc4-687b869b8024
+                - 9a146b6d-5293-499a-826f-c856d7c0b993
         status: 200 OK
         code: 200
-        duration: 101.710666ms
+        duration: 83.024459ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -2703,7 +2701,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/4955169c-7666-48cb-9e27-7ee608b717d5
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf
         method: GET
       response:
         proto: HTTP/2.0
@@ -2711,20 +2709,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 746
+        content_length: 1836
         uncompressed: false
-        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T15:19:28.932980+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"f97824b7-3276-4224-b71a-d450304ed14c","name":"tf-snap-distracted-poincare","size":21000000000,"volume_type":"b_ssd"}},"from_server":"","id":"4955169c-7666-48cb-9e27-7ee608b717d5","modification_date":"2025-02-12T15:19:28.932980+00:00","name":"tf-image-vigilant-hertz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"1b0ce8dc-403d-4ab9-b326-d30ddee68e64","name":"tf-snap-stupefied-hellman","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-12T15:53:16.407771+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-amazing-franklin","id":"0bf0d0f8-fccc-497f-a665-43f0d549eddf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"801","node_id":"145","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c6:8f","maintenances":[],"modification_date":"2025-02-12T15:53:22.468531+00:00","name":"tf-srv-amazing-franklin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "746"
+                - "1836"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:29 GMT
+                - Wed, 12 Feb 2025 15:54:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2732,10 +2730,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b9f8adee-1d05-48e3-91ce-eb406511333b
+                - 8f5b62cf-d389-4c53-85d4-5931377a3c1b
         status: 200 OK
         code: 200
-        duration: 135.48725ms
+        duration: 204.077625ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -2752,7 +2750,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/c96574f5-f857-475c-a9f7-41677887eb70
         method: GET
       response:
         proto: HTTP/2.0
@@ -2760,20 +2758,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2269
+        content_length: 694
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.373972+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-cerf","id":"1780c24c-59ed-4db8-bb22-7191af979336","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"2002","node_id":"21","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:43","maintenances":[],"modification_date":"2025-02-12T15:18:48.907477+00:00","name":"tf-srv-reverent-cerf","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.373972+00:00","export_uri":null,"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","modification_date":"2025-02-12T15:19:23.710368+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1780c24c-59ed-4db8-bb22-7191af979336","name":"tf-srv-reverent-cerf"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"class":"sbs","created_at":"2025-02-12T15:53:21.153503Z","id":"c96574f5-f857-475c-a9f7-41677887eb70","name":"tf-snapshot-optimistic-noyce","parent_volume":{"id":"9716a7b8-b692-4c04-8a07-aa6e723ed33c","name":"tf-volume-reverent-almeida","status":"available","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T15:54:05.925300Z","id":"d2bf064c-9939-4f0e-8fcd-c728725b71a9","product_resource_id":"8995f9f0-67d5-43cd-9844-c11c3a5736e5","product_resource_type":"instance_image","status":"attached","type":"link"}],"size":21000000000,"status":"in_use","tags":[],"updated_at":"2025-02-12T15:54:05.925300Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2269"
+                - "694"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:30 GMT
+                - Wed, 12 Feb 2025 15:54:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2781,10 +2779,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 89c140e0-3738-4b92-9e1c-6d90d8fcc9ea
+                - e1227e86-db25-4e8e-b544-abb3172c1769
         status: 200 OK
         code: 200
-        duration: 708.625416ms
+        duration: 112.914292ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2801,7 +2799,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/55312258-0bc4-449f-b2a3-e95fcb3fa094
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/ddfdab48-0b8a-4048-8233-5f8bd4fd950b
         method: GET
       response:
         proto: HTTP/2.0
@@ -2809,20 +2807,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 520
+        content_length: 695
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-02-12T15:18:31.373972+00:00","export_uri":null,"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","modification_date":"2025-02-12T15:19:23.710368+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1780c24c-59ed-4db8-bb22-7191af979336","name":"tf-srv-reverent-cerf"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"class":"sbs","created_at":"2025-02-12T15:53:29.101307Z","id":"ddfdab48-0b8a-4048-8233-5f8bd4fd950b","name":"tf-snapshot-keen-pike","parent_volume":{"id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","status":"in_use","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T15:54:05.790877Z","id":"0dd3486b-e0c7-44c5-8995-8a7c23b4cfca","product_resource_id":"8995f9f0-67d5-43cd-9844-c11c3a5736e5","product_resource_type":"instance_image","status":"attached","type":"link"}],"size":10000000000,"status":"in_use","tags":[],"updated_at":"2025-02-12T15:54:05.790877Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "520"
+                - "695"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:30 GMT
+                - Wed, 12 Feb 2025 15:54:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2830,10 +2828,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c0cc7076-1ed6-4115-89d0-4d16b34caf49
+                - 8ee0489a-f17f-4006-afd3-9c5b256e5f0a
         status: 200 OK
         code: 200
-        duration: 281.376667ms
+        duration: 108.578416ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2850,7 +2848,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336/user_data
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8995f9f0-67d5-43cd-9844-c11c3a5736e5
         method: GET
       response:
         proto: HTTP/2.0
@@ -2858,20 +2856,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 687
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T15:54:05.720450+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"c96574f5-f857-475c-a9f7-41677887eb70","name":"","size":0,"volume_type":"sbs_snapshot"}},"from_server":"","id":"8995f9f0-67d5-43cd-9844-c11c3a5736e5","modification_date":"2025-02-12T15:54:05.720450+00:00","name":"tf-image-silly-wozniak","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"ddfdab48-0b8a-4048-8233-5f8bd4fd950b","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "17"
+                - "687"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:31 GMT
+                - Wed, 12 Feb 2025 15:54:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2879,10 +2877,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 391a975e-c494-4761-8904-f960bb26224a
+                - 0a53d40a-7d69-425d-874c-a9bdaadcee59
         status: 200 OK
         code: 200
-        duration: 121.922583ms
+        duration: 126.7875ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -2899,7 +2897,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336/private_nics
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/9716a7b8-b692-4c04-8a07-aa6e723ed33c
         method: GET
       response:
         proto: HTTP/2.0
@@ -2907,22 +2905,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 424
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"created_at":"2025-02-12T15:53:15.665265Z","id":"9716a7b8-b692-4c04-8a07-aa6e723ed33c","last_detached_at":null,"name":"tf-volume-reverent-almeida","parent_snapshot_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":21000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T15:53:15.665265Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "20"
+                - "424"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:31 GMT
-            Link:
-                - </servers/1780c24c-59ed-4db8-bb22-7191af979336/private_nics?page=0&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 15:54:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2930,12 +2926,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5bf2cb1e-d9be-4f09-8fc0-7e23f34c03ea
-            X-Total-Count:
-                - "0"
+                - 081059ff-74bb-4133-a0d0-d31cc9e14a99
         status: 200 OK
         code: 200
-        duration: 117.516917ms
+        duration: 93.615041ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -2952,7 +2946,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/89f83395-b4cf-4fee-9853-833f24fdd971
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf
         method: GET
       response:
         proto: HTTP/2.0
@@ -2960,20 +2954,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 445
+        content_length: 1836
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-02-12T15:18:30.774581+00:00","export_uri":null,"id":"89f83395-b4cf-4fee-9853-833f24fdd971","modification_date":"2025-02-12T15:18:34.957281+00:00","name":"tf-vol-cranky-blackwell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-12T15:53:16.407771+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-amazing-franklin","id":"0bf0d0f8-fccc-497f-a665-43f0d549eddf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"801","node_id":"145","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c6:8f","maintenances":[],"modification_date":"2025-02-12T15:53:22.468531+00:00","name":"tf-srv-amazing-franklin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "445"
+                - "1836"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:31 GMT
+                - Wed, 12 Feb 2025 15:54:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2981,10 +2975,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4bc49b2a-03a6-43ed-9518-7729820c6dc3
+                - cdfff91a-eaeb-4460-b52f-6236ce49ad96
         status: 200 OK
         code: 200
-        duration: 1.3647115s
+        duration: 202.031708ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -3001,7 +2995,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/1b0ce8dc-403d-4ab9-b326-d30ddee68e64
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/c96574f5-f857-475c-a9f7-41677887eb70
         method: GET
       response:
         proto: HTTP/2.0
@@ -3009,20 +3003,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 535
+        content_length: 694
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:18:56.896267+00:00","error_details":null,"id":"1b0ce8dc-403d-4ab9-b326-d30ddee68e64","modification_date":"2025-02-12T15:19:23.710368+00:00","name":"tf-snap-stupefied-hellman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"class":"sbs","created_at":"2025-02-12T15:53:21.153503Z","id":"c96574f5-f857-475c-a9f7-41677887eb70","name":"tf-snapshot-optimistic-noyce","parent_volume":{"id":"9716a7b8-b692-4c04-8a07-aa6e723ed33c","name":"tf-volume-reverent-almeida","status":"available","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T15:54:05.925300Z","id":"d2bf064c-9939-4f0e-8fcd-c728725b71a9","product_resource_id":"8995f9f0-67d5-43cd-9844-c11c3a5736e5","product_resource_type":"instance_image","status":"attached","type":"link"}],"size":21000000000,"status":"in_use","tags":[],"updated_at":"2025-02-12T15:54:05.925300Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "535"
+                - "694"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:31 GMT
+                - Wed, 12 Feb 2025 15:54:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3030,10 +3024,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d23d0635-76f4-4616-bacb-acf8dd065549
+                - a02168e6-bd6e-4279-b5e0-b0dc61312f93
         status: 200 OK
         code: 200
-        duration: 115.175708ms
+        duration: 106.457167ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -3050,7 +3044,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f97824b7-3276-4224-b71a-d450304ed14c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/5d0109bc-940e-4bc6-b082-d7fa906ccea4
         method: GET
       response:
         proto: HTTP/2.0
@@ -3058,20 +3052,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 536
+        content_length: 143
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"89f83395-b4cf-4fee-9853-833f24fdd971","name":"tf-vol-cranky-blackwell"},"creation_date":"2025-02-12T15:18:31.227612+00:00","error_details":null,"id":"f97824b7-3276-4224-b71a-d450304ed14c","modification_date":"2025-02-12T15:18:34.957281+00:00","name":"tf-snap-distracted-poincare","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","type":"not_found"}'
         headers:
             Content-Length:
-                - "536"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:31 GMT
+                - Wed, 12 Feb 2025 15:54:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3079,10 +3073,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 643cbd53-4c0f-4745-9e6b-7f12a2122048
-        status: 200 OK
-        code: 200
-        duration: 128.166875ms
+                - d7e342cf-8922-4f06-b3c7-a78502910af8
+        status: 404 Not Found
+        code: 404
+        duration: 48.549208ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -3099,7 +3093,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/4955169c-7666-48cb-9e27-7ee608b717d5
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/5d0109bc-940e-4bc6-b082-d7fa906ccea4
         method: GET
       response:
         proto: HTTP/2.0
@@ -3107,20 +3101,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 746
+        content_length: 701
         uncompressed: false
-        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T15:19:28.932980+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"f97824b7-3276-4224-b71a-d450304ed14c","name":"tf-snap-distracted-poincare","size":21000000000,"volume_type":"b_ssd"}},"from_server":"","id":"4955169c-7666-48cb-9e27-7ee608b717d5","modification_date":"2025-02-12T15:19:28.932980+00:00","name":"tf-image-vigilant-hertz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"1b0ce8dc-403d-4ab9-b326-d30ddee68e64","name":"tf-snap-stupefied-hellman","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-12T15:53:16.620555Z","id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T15:53:16.620555Z","id":"bbe07d04-0b0e-4c8c-8bbf-c9693b5d4fce","product_resource_id":"0bf0d0f8-fccc-497f-a665-43f0d549eddf","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T15:53:16.620555Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "746"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:31 GMT
+                - Wed, 12 Feb 2025 15:54:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3128,10 +3122,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2e41e835-7324-4415-ba87-f33b7ac52c43
+                - e9c72309-0742-427e-b754-41071288861b
         status: 200 OK
         code: 200
-        duration: 124.309833ms
+        duration: 80.109666ms
     - id: 63
       request:
         proto: HTTP/1.1
@@ -3148,7 +3142,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/89f83395-b4cf-4fee-9853-833f24fdd971
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -3156,20 +3150,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 445
+        content_length: 17
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-02-12T15:18:30.774581+00:00","export_uri":null,"id":"89f83395-b4cf-4fee-9853-833f24fdd971","modification_date":"2025-02-12T15:18:34.957281+00:00","name":"tf-vol-cranky-blackwell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "445"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:32 GMT
+                - Wed, 12 Feb 2025 15:54:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3177,10 +3171,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 88e45850-d700-45b1-ab1e-977463eedc52
+                - 7ca5c292-fb16-4cdd-a9b3-01562c214fbd
         status: 200 OK
         code: 200
-        duration: 246.723917ms
+        duration: 108.1335ms
     - id: 64
       request:
         proto: HTTP/1.1
@@ -3197,7 +3191,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -3205,20 +3199,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2269
+        content_length: 20
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.373972+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-cerf","id":"1780c24c-59ed-4db8-bb22-7191af979336","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"2002","node_id":"21","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:43","maintenances":[],"modification_date":"2025-02-12T15:18:48.907477+00:00","name":"tf-srv-reverent-cerf","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.373972+00:00","export_uri":null,"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","modification_date":"2025-02-12T15:19:23.710368+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1780c24c-59ed-4db8-bb22-7191af979336","name":"tf-srv-reverent-cerf"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "2269"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:32 GMT
+                - Wed, 12 Feb 2025 15:54:07 GMT
+            Link:
+                - </servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3226,10 +3222,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f4792745-a60e-4887-957a-b83be79d4005
+                - 7603b3fe-4146-4db1-922f-468aaa1d35b3
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 315.729167ms
+        duration: 104.181334ms
     - id: 65
       request:
         proto: HTTP/1.1
@@ -3246,7 +3244,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f97824b7-3276-4224-b71a-d450304ed14c
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/ddfdab48-0b8a-4048-8233-5f8bd4fd950b
         method: GET
       response:
         proto: HTTP/2.0
@@ -3254,20 +3252,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 536
+        content_length: 695
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"89f83395-b4cf-4fee-9853-833f24fdd971","name":"tf-vol-cranky-blackwell"},"creation_date":"2025-02-12T15:18:31.227612+00:00","error_details":null,"id":"f97824b7-3276-4224-b71a-d450304ed14c","modification_date":"2025-02-12T15:18:34.957281+00:00","name":"tf-snap-distracted-poincare","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"class":"sbs","created_at":"2025-02-12T15:53:29.101307Z","id":"ddfdab48-0b8a-4048-8233-5f8bd4fd950b","name":"tf-snapshot-keen-pike","parent_volume":{"id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","status":"in_use","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T15:54:05.790877Z","id":"0dd3486b-e0c7-44c5-8995-8a7c23b4cfca","product_resource_id":"8995f9f0-67d5-43cd-9844-c11c3a5736e5","product_resource_type":"instance_image","status":"attached","type":"link"}],"size":10000000000,"status":"in_use","tags":[],"updated_at":"2025-02-12T15:54:05.790877Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "536"
+                - "695"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:32 GMT
+                - Wed, 12 Feb 2025 15:54:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3275,10 +3273,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d411e1c1-dd07-457b-b310-e98ee762f021
+                - aaa6bdce-1eec-4145-90a0-07a3beae188a
         status: 200 OK
         code: 200
-        duration: 106.369458ms
+        duration: 103.235791ms
     - id: 66
       request:
         proto: HTTP/1.1
@@ -3295,7 +3293,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/55312258-0bc4-449f-b2a3-e95fcb3fa094
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8995f9f0-67d5-43cd-9844-c11c3a5736e5
         method: GET
       response:
         proto: HTTP/2.0
@@ -3303,20 +3301,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 520
+        content_length: 687
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-02-12T15:18:31.373972+00:00","export_uri":null,"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","modification_date":"2025-02-12T15:19:23.710368+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1780c24c-59ed-4db8-bb22-7191af979336","name":"tf-srv-reverent-cerf"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T15:54:05.720450+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"c96574f5-f857-475c-a9f7-41677887eb70","name":"","size":0,"volume_type":"sbs_snapshot"}},"from_server":"","id":"8995f9f0-67d5-43cd-9844-c11c3a5736e5","modification_date":"2025-02-12T15:54:05.720450+00:00","name":"tf-image-silly-wozniak","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"ddfdab48-0b8a-4048-8233-5f8bd4fd950b","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "520"
+                - "687"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:32 GMT
+                - Wed, 12 Feb 2025 15:54:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3324,10 +3322,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2de61aba-4392-468c-a138-79fa83cb6212
+                - d2b86049-61be-4446-bd29-d7513661d9d9
         status: 200 OK
         code: 200
-        duration: 156.966ms
+        duration: 174.560125ms
     - id: 67
       request:
         proto: HTTP/1.1
@@ -3344,7 +3342,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336/user_data
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/9716a7b8-b692-4c04-8a07-aa6e723ed33c
         method: GET
       response:
         proto: HTTP/2.0
@@ -3352,20 +3350,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 424
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"created_at":"2025-02-12T15:53:15.665265Z","id":"9716a7b8-b692-4c04-8a07-aa6e723ed33c","last_detached_at":null,"name":"tf-volume-reverent-almeida","parent_snapshot_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":21000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T15:53:15.665265Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "17"
+                - "424"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:32 GMT
+                - Wed, 12 Feb 2025 15:54:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3373,10 +3371,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3a9638db-a7c9-4161-9e4b-d261c43cc016
+                - c6dfce3e-bfd3-4bd6-9726-e62b7423266e
         status: 200 OK
         code: 200
-        duration: 125.750209ms
+        duration: 78.44925ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -3393,7 +3391,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336/private_nics
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf
         method: GET
       response:
         proto: HTTP/2.0
@@ -3401,22 +3399,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 1836
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-12T15:53:16.407771+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-amazing-franklin","id":"0bf0d0f8-fccc-497f-a665-43f0d549eddf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"801","node_id":"145","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c6:8f","maintenances":[],"modification_date":"2025-02-12T15:53:22.468531+00:00","name":"tf-srv-amazing-franklin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "20"
+                - "1836"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:32 GMT
-            Link:
-                - </servers/1780c24c-59ed-4db8-bb22-7191af979336/private_nics?page=0&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 15:54:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3424,12 +3420,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 25244db1-f4fd-4270-ab24-83e6e067748b
-            X-Total-Count:
-                - "0"
+                - dd95540f-372d-49d8-9f71-123ce5a35141
         status: 200 OK
         code: 200
-        duration: 118.440125ms
+        duration: 173.117625ms
     - id: 69
       request:
         proto: HTTP/1.1
@@ -3446,7 +3440,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/1b0ce8dc-403d-4ab9-b326-d30ddee68e64
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/c96574f5-f857-475c-a9f7-41677887eb70
         method: GET
       response:
         proto: HTTP/2.0
@@ -3454,20 +3448,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 535
+        content_length: 694
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:18:56.896267+00:00","error_details":null,"id":"1b0ce8dc-403d-4ab9-b326-d30ddee68e64","modification_date":"2025-02-12T15:19:23.710368+00:00","name":"tf-snap-stupefied-hellman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"class":"sbs","created_at":"2025-02-12T15:53:21.153503Z","id":"c96574f5-f857-475c-a9f7-41677887eb70","name":"tf-snapshot-optimistic-noyce","parent_volume":{"id":"9716a7b8-b692-4c04-8a07-aa6e723ed33c","name":"tf-volume-reverent-almeida","status":"available","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T15:54:05.925300Z","id":"d2bf064c-9939-4f0e-8fcd-c728725b71a9","product_resource_id":"8995f9f0-67d5-43cd-9844-c11c3a5736e5","product_resource_type":"instance_image","status":"attached","type":"link"}],"size":21000000000,"status":"in_use","tags":[],"updated_at":"2025-02-12T15:54:05.925300Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "535"
+                - "694"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:32 GMT
+                - Wed, 12 Feb 2025 15:54:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3475,10 +3469,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 31bd0413-aeba-4027-832a-fb28f9cebbe3
+                - ec35accd-caaa-4384-85ee-fc28f2a55c22
         status: 200 OK
         code: 200
-        duration: 113.740959ms
+        duration: 99.834667ms
     - id: 70
       request:
         proto: HTTP/1.1
@@ -3495,7 +3489,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/4955169c-7666-48cb-9e27-7ee608b717d5
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/5d0109bc-940e-4bc6-b082-d7fa906ccea4
         method: GET
       response:
         proto: HTTP/2.0
@@ -3503,20 +3497,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 746
+        content_length: 143
         uncompressed: false
-        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T15:19:28.932980+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"f97824b7-3276-4224-b71a-d450304ed14c","name":"tf-snap-distracted-poincare","size":21000000000,"volume_type":"b_ssd"}},"from_server":"","id":"4955169c-7666-48cb-9e27-7ee608b717d5","modification_date":"2025-02-12T15:19:28.932980+00:00","name":"tf-image-vigilant-hertz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"1b0ce8dc-403d-4ab9-b326-d30ddee68e64","name":"tf-snap-stupefied-hellman","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","type":"not_found"}'
         headers:
             Content-Length:
-                - "746"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:33 GMT
+                - Wed, 12 Feb 2025 15:54:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3524,52 +3518,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a2df5010-c38d-41cf-988d-1392b17e282f
-        status: 200 OK
-        code: 200
-        duration: 107.77525ms
+                - 96c2b30d-7be8-43f9-9c6d-5923f9db0573
+        status: 404 Not Found
+        code: 404
+        duration: 44.28525ms
     - id: 71
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 128
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-vol-hopeful-visvesvaraya","project":"105bdce1-64c0-48ab-899d-868455867ecf","volume_type":"b_ssd","size":22000000000}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes
-        method: POST
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/5d0109bc-940e-4bc6-b082-d7fa906ccea4
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 449
+        content_length: 701
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-02-12T15:19:33.645129+00:00","export_uri":null,"id":"9b2de5c3-e30b-447e-93e2-983fdba06000","modification_date":"2025-02-12T15:19:33.645129+00:00","name":"tf-vol-hopeful-visvesvaraya","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":22000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-12T15:53:16.620555Z","id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T15:53:16.620555Z","id":"bbe07d04-0b0e-4c8c-8bbf-c9693b5d4fce","product_resource_id":"0bf0d0f8-fccc-497f-a665-43f0d549eddf","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T15:53:16.620555Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "449"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:33 GMT
-            Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/9b2de5c3-e30b-447e-93e2-983fdba06000
+                - Wed, 12 Feb 2025 15:54:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3577,10 +3567,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 49178bc3-088a-465d-8f4d-4bd41fa85127
-        status: 201 Created
-        code: 201
-        duration: 349.203084ms
+                - 4068864b-5659-443a-9a1d-80c2a429f4a8
+        status: 200 OK
+        code: 200
+        duration: 88.374458ms
     - id: 72
       request:
         proto: HTTP/1.1
@@ -3597,1187 +3587,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/9b2de5c3-e30b-447e-93e2-983fdba06000
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 449
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-02-12T15:19:33.645129+00:00","export_uri":null,"id":"9b2de5c3-e30b-447e-93e2-983fdba06000","modification_date":"2025-02-12T15:19:33.645129+00:00","name":"tf-vol-hopeful-visvesvaraya","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":22000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "449"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:19:33 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 5c38ed87-afe7-4ee3-a646-d7cdf217e965
-        status: 200 OK
-        code: 200
-        duration: 607.614209ms
-    - id: 73
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/9b2de5c3-e30b-447e-93e2-983fdba06000
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 449
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-02-12T15:19:33.645129+00:00","export_uri":null,"id":"9b2de5c3-e30b-447e-93e2-983fdba06000","modification_date":"2025-02-12T15:19:33.645129+00:00","name":"tf-vol-hopeful-visvesvaraya","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":22000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "449"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:19:34 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 9308b081-6439-4923-8290-bf318de73b6d
-        status: 200 OK
-        code: 200
-        duration: 115.592333ms
-    - id: 74
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 129
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"name":"tf-snap-jolly-bose","volume_id":"9b2de5c3-e30b-447e-93e2-983fdba06000","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 845
-        uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"9b2de5c3-e30b-447e-93e2-983fdba06000","name":"tf-vol-hopeful-visvesvaraya"},"creation_date":"2025-02-12T15:19:34.736767+00:00","error_details":null,"id":"57129456-dcee-482c-b4f2-7ba6d81c6439","modification_date":"2025-02-12T15:19:34.736767+00:00","name":"tf-snap-jolly-bose","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":22000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"},"task":{"description":"volume_snapshot","href_from":"/snapshots","href_result":"snapshots/57129456-dcee-482c-b4f2-7ba6d81c6439","id":"d29b0c9a-1d12-4822-83b1-793fbc3bd06d","progress":0,"started_at":"2025-02-12T15:19:35.014149+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "845"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:19:35 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 38d06adb-03e3-4ff7-a073-a464387095de
-        status: 201 Created
-        code: 201
-        duration: 863.502042ms
-    - id: 75
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/57129456-dcee-482c-b4f2-7ba6d81c6439
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 534
-        uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"9b2de5c3-e30b-447e-93e2-983fdba06000","name":"tf-vol-hopeful-visvesvaraya"},"creation_date":"2025-02-12T15:19:34.736767+00:00","error_details":null,"id":"57129456-dcee-482c-b4f2-7ba6d81c6439","modification_date":"2025-02-12T15:19:34.736767+00:00","name":"tf-snap-jolly-bose","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":22000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "534"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:19:35 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 9680235e-1eb1-4dca-b7a9-c1948022114d
-        status: 200 OK
-        code: 200
-        duration: 116.928834ms
-    - id: 76
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/57129456-dcee-482c-b4f2-7ba6d81c6439
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 531
-        uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"9b2de5c3-e30b-447e-93e2-983fdba06000","name":"tf-vol-hopeful-visvesvaraya"},"creation_date":"2025-02-12T15:19:34.736767+00:00","error_details":null,"id":"57129456-dcee-482c-b4f2-7ba6d81c6439","modification_date":"2025-02-12T15:19:37.900348+00:00","name":"tf-snap-jolly-bose","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":22000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "531"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:19:40 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 1a5abb7d-aed3-44f2-b6d5-c3a9690d53dc
-        status: 200 OK
-        code: 200
-        duration: 108.176584ms
-    - id: 77
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/57129456-dcee-482c-b4f2-7ba6d81c6439
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 531
-        uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"9b2de5c3-e30b-447e-93e2-983fdba06000","name":"tf-vol-hopeful-visvesvaraya"},"creation_date":"2025-02-12T15:19:34.736767+00:00","error_details":null,"id":"57129456-dcee-482c-b4f2-7ba6d81c6439","modification_date":"2025-02-12T15:19:37.900348+00:00","name":"tf-snap-jolly-bose","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":22000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "531"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:19:40 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 8e26d625-a9bf-4a79-9d2a-d8744e3b1e72
-        status: 200 OK
-        code: 200
-        duration: 92.740708ms
-    - id: 78
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/4955169c-7666-48cb-9e27-7ee608b717d5
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 746
-        uncompressed: false
-        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T15:19:28.932980+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"f97824b7-3276-4224-b71a-d450304ed14c","name":"tf-snap-distracted-poincare","size":21000000000,"volume_type":"b_ssd"}},"from_server":"","id":"4955169c-7666-48cb-9e27-7ee608b717d5","modification_date":"2025-02-12T15:19:28.932980+00:00","name":"tf-image-vigilant-hertz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"1b0ce8dc-403d-4ab9-b326-d30ddee68e64","name":"tf-snap-stupefied-hellman","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "746"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:19:40 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 460ecf5b-78e8-44cc-ba6d-69a95024be74
-        status: 200 OK
-        code: 200
-        duration: 235.424ms
-    - id: 79
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/4955169c-7666-48cb-9e27-7ee608b717d5
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 746
-        uncompressed: false
-        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T15:19:28.932980+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"f97824b7-3276-4224-b71a-d450304ed14c","name":"tf-snap-distracted-poincare","size":21000000000,"volume_type":"b_ssd"}},"from_server":"","id":"4955169c-7666-48cb-9e27-7ee608b717d5","modification_date":"2025-02-12T15:19:28.932980+00:00","name":"tf-image-vigilant-hertz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"1b0ce8dc-403d-4ab9-b326-d30ddee68e64","name":"tf-snap-stupefied-hellman","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "746"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:19:40 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - f4b96c48-7a5c-4add-993a-4ab5c615a519
-        status: 200 OK
-        code: 200
-        duration: 136.5965ms
-    - id: 80
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 128
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"name":"tf-image-vigilant-hertz","arch":"x86_64","extra_volumes":{"1":{"id":"57129456-dcee-482c-b4f2-7ba6d81c6439"}},"tags":[]}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/4955169c-7666-48cb-9e27-7ee608b717d5
-        method: PATCH
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 737
-        uncompressed: false
-        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T15:19:28.932980+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"57129456-dcee-482c-b4f2-7ba6d81c6439","name":"tf-snap-jolly-bose","size":22000000000,"volume_type":"b_ssd"}},"from_server":"","id":"4955169c-7666-48cb-9e27-7ee608b717d5","modification_date":"2025-02-12T15:19:28.932980+00:00","name":"tf-image-vigilant-hertz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"1b0ce8dc-403d-4ab9-b326-d30ddee68e64","name":"tf-snap-stupefied-hellman","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "737"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:19:41 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - f6c455e6-aa3b-4db3-92ca-819f86f65c02
-        status: 200 OK
-        code: 200
-        duration: 263.780334ms
-    - id: 81
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/4955169c-7666-48cb-9e27-7ee608b717d5
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 737
-        uncompressed: false
-        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T15:19:28.932980+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"57129456-dcee-482c-b4f2-7ba6d81c6439","name":"tf-snap-jolly-bose","size":22000000000,"volume_type":"b_ssd"}},"from_server":"","id":"4955169c-7666-48cb-9e27-7ee608b717d5","modification_date":"2025-02-12T15:19:28.932980+00:00","name":"tf-image-vigilant-hertz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"1b0ce8dc-403d-4ab9-b326-d30ddee68e64","name":"tf-snap-stupefied-hellman","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "737"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:19:41 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - e93e807f-e7e6-42a5-9502-34ced54f7b3e
-        status: 200 OK
-        code: 200
-        duration: 117.056458ms
-    - id: 82
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/4955169c-7666-48cb-9e27-7ee608b717d5
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 737
-        uncompressed: false
-        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T15:19:28.932980+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"57129456-dcee-482c-b4f2-7ba6d81c6439","name":"tf-snap-jolly-bose","size":22000000000,"volume_type":"b_ssd"}},"from_server":"","id":"4955169c-7666-48cb-9e27-7ee608b717d5","modification_date":"2025-02-12T15:19:28.932980+00:00","name":"tf-image-vigilant-hertz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"1b0ce8dc-403d-4ab9-b326-d30ddee68e64","name":"tf-snap-stupefied-hellman","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "737"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:19:41 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - b883cf39-e72d-46b1-8497-3ce9ba6ebaf8
-        status: 200 OK
-        code: 200
-        duration: 135.313583ms
-    - id: 83
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/89f83395-b4cf-4fee-9853-833f24fdd971
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 445
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-02-12T15:18:30.774581+00:00","export_uri":null,"id":"89f83395-b4cf-4fee-9853-833f24fdd971","modification_date":"2025-02-12T15:18:34.957281+00:00","name":"tf-vol-cranky-blackwell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "445"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:19:41 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 133e10b0-f579-47c7-b9cf-52173be1a82a
-        status: 200 OK
-        code: 200
-        duration: 108.642375ms
-    - id: 84
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/9b2de5c3-e30b-447e-93e2-983fdba06000
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 449
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-02-12T15:19:33.645129+00:00","export_uri":null,"id":"9b2de5c3-e30b-447e-93e2-983fdba06000","modification_date":"2025-02-12T15:19:37.900348+00:00","name":"tf-vol-hopeful-visvesvaraya","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":22000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "449"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:19:41 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 721a606d-e7a8-45b4-8643-0f7784dd2b99
-        status: 200 OK
-        code: 200
-        duration: 96.4465ms
-    - id: 85
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2269
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.373972+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-cerf","id":"1780c24c-59ed-4db8-bb22-7191af979336","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"2002","node_id":"21","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:43","maintenances":[],"modification_date":"2025-02-12T15:18:48.907477+00:00","name":"tf-srv-reverent-cerf","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.373972+00:00","export_uri":null,"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","modification_date":"2025-02-12T15:19:23.710368+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1780c24c-59ed-4db8-bb22-7191af979336","name":"tf-srv-reverent-cerf"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2269"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:19:41 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - b5727184-5530-4962-ae7f-d6e782797765
-        status: 200 OK
-        code: 200
-        duration: 284.29025ms
-    - id: 86
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f97824b7-3276-4224-b71a-d450304ed14c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 536
-        uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"89f83395-b4cf-4fee-9853-833f24fdd971","name":"tf-vol-cranky-blackwell"},"creation_date":"2025-02-12T15:18:31.227612+00:00","error_details":null,"id":"f97824b7-3276-4224-b71a-d450304ed14c","modification_date":"2025-02-12T15:18:34.957281+00:00","name":"tf-snap-distracted-poincare","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "536"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:19:42 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - f7e9f83e-9032-4b3b-848b-65703685f5f0
-        status: 200 OK
-        code: 200
-        duration: 100.034084ms
-    - id: 87
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/57129456-dcee-482c-b4f2-7ba6d81c6439
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 531
-        uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"9b2de5c3-e30b-447e-93e2-983fdba06000","name":"tf-vol-hopeful-visvesvaraya"},"creation_date":"2025-02-12T15:19:34.736767+00:00","error_details":null,"id":"57129456-dcee-482c-b4f2-7ba6d81c6439","modification_date":"2025-02-12T15:19:37.900348+00:00","name":"tf-snap-jolly-bose","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":22000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "531"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:19:42 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 78f4ee51-f088-4ea9-8ab4-913d5a5acef4
-        status: 200 OK
-        code: 200
-        duration: 117.324125ms
-    - id: 88
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/1b0ce8dc-403d-4ab9-b326-d30ddee68e64
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 535
-        uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:18:56.896267+00:00","error_details":null,"id":"1b0ce8dc-403d-4ab9-b326-d30ddee68e64","modification_date":"2025-02-12T15:19:23.710368+00:00","name":"tf-snap-stupefied-hellman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "535"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:19:42 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - b5d97f76-fb1d-4b22-bf95-59b8545f7abe
-        status: 200 OK
-        code: 200
-        duration: 94.000875ms
-    - id: 89
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/4955169c-7666-48cb-9e27-7ee608b717d5
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 737
-        uncompressed: false
-        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T15:19:28.932980+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"57129456-dcee-482c-b4f2-7ba6d81c6439","name":"tf-snap-jolly-bose","size":22000000000,"volume_type":"b_ssd"}},"from_server":"","id":"4955169c-7666-48cb-9e27-7ee608b717d5","modification_date":"2025-02-12T15:19:28.932980+00:00","name":"tf-image-vigilant-hertz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"1b0ce8dc-403d-4ab9-b326-d30ddee68e64","name":"tf-snap-stupefied-hellman","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "737"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:19:42 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 93bd4a4b-8f38-46bd-aba8-37b95478e3fe
-        status: 200 OK
-        code: 200
-        duration: 120.669083ms
-    - id: 90
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/89f83395-b4cf-4fee-9853-833f24fdd971
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 445
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-02-12T15:18:30.774581+00:00","export_uri":null,"id":"89f83395-b4cf-4fee-9853-833f24fdd971","modification_date":"2025-02-12T15:18:34.957281+00:00","name":"tf-vol-cranky-blackwell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "445"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:19:42 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - a120892d-5f91-4731-9ebd-26054a27cebf
-        status: 200 OK
-        code: 200
-        duration: 99.915041ms
-    - id: 91
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/9b2de5c3-e30b-447e-93e2-983fdba06000
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 449
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-02-12T15:19:33.645129+00:00","export_uri":null,"id":"9b2de5c3-e30b-447e-93e2-983fdba06000","modification_date":"2025-02-12T15:19:37.900348+00:00","name":"tf-vol-hopeful-visvesvaraya","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":22000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "449"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:19:42 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 729dc1bb-2f66-42f1-946f-826d5642a5f5
-        status: 200 OK
-        code: 200
-        duration: 101.15675ms
-    - id: 92
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f97824b7-3276-4224-b71a-d450304ed14c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 536
-        uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"89f83395-b4cf-4fee-9853-833f24fdd971","name":"tf-vol-cranky-blackwell"},"creation_date":"2025-02-12T15:18:31.227612+00:00","error_details":null,"id":"f97824b7-3276-4224-b71a-d450304ed14c","modification_date":"2025-02-12T15:18:34.957281+00:00","name":"tf-snap-distracted-poincare","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "536"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:19:42 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 6a7c8294-c9d6-4c1d-b225-3eb38f4a13af
-        status: 200 OK
-        code: 200
-        duration: 100.346209ms
-    - id: 93
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/57129456-dcee-482c-b4f2-7ba6d81c6439
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 531
-        uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"9b2de5c3-e30b-447e-93e2-983fdba06000","name":"tf-vol-hopeful-visvesvaraya"},"creation_date":"2025-02-12T15:19:34.736767+00:00","error_details":null,"id":"57129456-dcee-482c-b4f2-7ba6d81c6439","modification_date":"2025-02-12T15:19:37.900348+00:00","name":"tf-snap-jolly-bose","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":22000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "531"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:19:42 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 6cbe1525-4c70-4bca-8812-88af235004f5
-        status: 200 OK
-        code: 200
-        duration: 103.031667ms
-    - id: 94
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2269
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.373972+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-cerf","id":"1780c24c-59ed-4db8-bb22-7191af979336","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"2002","node_id":"21","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:43","maintenances":[],"modification_date":"2025-02-12T15:18:48.907477+00:00","name":"tf-srv-reverent-cerf","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.373972+00:00","export_uri":null,"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","modification_date":"2025-02-12T15:19:23.710368+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1780c24c-59ed-4db8-bb22-7191af979336","name":"tf-srv-reverent-cerf"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2269"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:19:42 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 37b5c193-1415-4be7-bec1-37a3dae40b8f
-        status: 200 OK
-        code: 200
-        duration: 225.191625ms
-    - id: 95
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/55312258-0bc4-449f-b2a3-e95fcb3fa094
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 520
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-02-12T15:18:31.373972+00:00","export_uri":null,"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","modification_date":"2025-02-12T15:19:23.710368+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1780c24c-59ed-4db8-bb22-7191af979336","name":"tf-srv-reverent-cerf"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "520"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:19:43 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - b107605c-1ad8-42b1-a256-99fd1a1e8bab
-        status: 200 OK
-        code: 200
-        duration: 183.887375ms
-    - id: 96
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336/user_data
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -4796,9 +3606,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:43 GMT
+                - Wed, 12 Feb 2025 15:54:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4806,11 +3616,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 74faff76-6bd2-44ec-88d4-c09c0ef75dc3
+                - 70155391-c369-4990-84c9-b4e2972969ce
         status: 200 OK
         code: 200
-        duration: 122.216625ms
-    - id: 97
+        duration: 92.853917ms
+    - id: 73
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4826,7 +3636,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336/private_nics
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -4845,11 +3655,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:43 GMT
+                - Wed, 12 Feb 2025 15:54:08 GMT
             Link:
-                - </servers/1780c24c-59ed-4db8-bb22-7191af979336/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4857,12 +3667,1194 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c8e9a62e-3778-42a6-8e63-c54db9b7ef5b
+                - 77bbaec1-ed53-4c43-90c7-5c1e6d3d24d2
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 120.925042ms
+        duration: 107.824792ms
+    - id: 74
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/ddfdab48-0b8a-4048-8233-5f8bd4fd950b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 695
+        uncompressed: false
+        body: '{"class":"sbs","created_at":"2025-02-12T15:53:29.101307Z","id":"ddfdab48-0b8a-4048-8233-5f8bd4fd950b","name":"tf-snapshot-keen-pike","parent_volume":{"id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","status":"in_use","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T15:54:05.790877Z","id":"0dd3486b-e0c7-44c5-8995-8a7c23b4cfca","product_resource_id":"8995f9f0-67d5-43cd-9844-c11c3a5736e5","product_resource_type":"instance_image","status":"attached","type":"link"}],"size":10000000000,"status":"in_use","tags":[],"updated_at":"2025-02-12T15:54:05.790877Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "695"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:09 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7a93c0da-4fa8-4426-9018-5a8eab064326
+        status: 200 OK
+        code: 200
+        duration: 109.457541ms
+    - id: 75
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8995f9f0-67d5-43cd-9844-c11c3a5736e5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 687
+        uncompressed: false
+        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T15:54:05.720450+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"c96574f5-f857-475c-a9f7-41677887eb70","name":"","size":0,"volume_type":"sbs_snapshot"}},"from_server":"","id":"8995f9f0-67d5-43cd-9844-c11c3a5736e5","modification_date":"2025-02-12T15:54:05.720450+00:00","name":"tf-image-silly-wozniak","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"ddfdab48-0b8a-4048-8233-5f8bd4fd950b","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "687"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:09 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4d9f908b-7b1b-40f8-80b7-4932a456e55d
+        status: 200 OK
+        code: 200
+        duration: 157.513375ms
+    - id: 76
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 153
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf-volume-interesting-leakey","perf_iops":15000,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","from_empty":{"size":22000000000},"tags":[]}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 427
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T15:54:09.639279Z","id":"e9dda481-3566-43af-afe3-859e3cb3aa76","last_detached_at":null,"name":"tf-volume-interesting-leakey","parent_snapshot_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":22000000000,"specs":{"class":"sbs","perf_iops":15000},"status":"creating","tags":[],"type":"sbs_15k","updated_at":"2025-02-12T15:54:09.639279Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "427"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:09 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 968589a0-8cff-4fa2-920d-845be1fe050b
+        status: 200 OK
+        code: 200
+        duration: 259.198333ms
+    - id: 77
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/e9dda481-3566-43af-afe3-859e3cb3aa76
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 427
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T15:54:09.639279Z","id":"e9dda481-3566-43af-afe3-859e3cb3aa76","last_detached_at":null,"name":"tf-volume-interesting-leakey","parent_snapshot_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":22000000000,"specs":{"class":"sbs","perf_iops":15000},"status":"creating","tags":[],"type":"sbs_15k","updated_at":"2025-02-12T15:54:09.639279Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "427"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:09 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 76ccb776-9497-4a7d-bc61-40361dea6f53
+        status: 200 OK
+        code: 200
+        duration: 98.72325ms
+    - id: 78
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/e9dda481-3566-43af-afe3-859e3cb3aa76
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 428
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T15:54:09.639279Z","id":"e9dda481-3566-43af-afe3-859e3cb3aa76","last_detached_at":null,"name":"tf-volume-interesting-leakey","parent_snapshot_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":22000000000,"specs":{"class":"sbs","perf_iops":15000},"status":"available","tags":[],"type":"sbs_15k","updated_at":"2025-02-12T15:54:09.639279Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "428"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:14 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9e96324c-f2e0-4282-8629-edcd247b8dbd
+        status: 200 OK
+        code: 200
+        duration: 86.046541ms
+    - id: 79
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/e9dda481-3566-43af-afe3-859e3cb3aa76
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 428
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T15:54:09.639279Z","id":"e9dda481-3566-43af-afe3-859e3cb3aa76","last_detached_at":null,"name":"tf-volume-interesting-leakey","parent_snapshot_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":22000000000,"specs":{"class":"sbs","perf_iops":15000},"status":"available","tags":[],"type":"sbs_15k","updated_at":"2025-02-12T15:54:09.639279Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "428"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:14 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ced70a45-0723-49c7-90f7-b587697044cc
+        status: 200 OK
+        code: 200
+        duration: 103.211625ms
+    - id: 80
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 152
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"volume_id":"e9dda481-3566-43af-afe3-859e3cb3aa76","name":"tf-snapshot-musing-lederberg","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[]}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 470
+        uncompressed: false
+        body: '{"class":"sbs","created_at":"2025-02-12T15:54:15.171183Z","id":"d1c86ecb-5c28-44fe-81f6-fbed836f38e2","name":"tf-snapshot-musing-lederberg","parent_volume":{"id":"e9dda481-3566-43af-afe3-859e3cb3aa76","name":"tf-volume-interesting-leakey","status":"available","type":"sbs_15k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":22000000000,"status":"creating","tags":[],"updated_at":"2025-02-12T15:54:15.171183Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "470"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:15 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1c88860b-ae29-49b4-b8a0-09d788a98d38
+        status: 200 OK
+        code: 200
+        duration: 331.599625ms
+    - id: 81
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/d1c86ecb-5c28-44fe-81f6-fbed836f38e2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 470
+        uncompressed: false
+        body: '{"class":"sbs","created_at":"2025-02-12T15:54:15.171183Z","id":"d1c86ecb-5c28-44fe-81f6-fbed836f38e2","name":"tf-snapshot-musing-lederberg","parent_volume":{"id":"e9dda481-3566-43af-afe3-859e3cb3aa76","name":"tf-volume-interesting-leakey","status":"available","type":"sbs_15k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":22000000000,"status":"creating","tags":[],"updated_at":"2025-02-12T15:54:15.171183Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "470"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:15 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 71680029-5b23-4582-9198-4e3f761493b5
+        status: 200 OK
+        code: 200
+        duration: 119.343791ms
+    - id: 82
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/d1c86ecb-5c28-44fe-81f6-fbed836f38e2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 471
+        uncompressed: false
+        body: '{"class":"sbs","created_at":"2025-02-12T15:54:15.171183Z","id":"d1c86ecb-5c28-44fe-81f6-fbed836f38e2","name":"tf-snapshot-musing-lederberg","parent_volume":{"id":"e9dda481-3566-43af-afe3-859e3cb3aa76","name":"tf-volume-interesting-leakey","status":"available","type":"sbs_15k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":22000000000,"status":"available","tags":[],"updated_at":"2025-02-12T15:54:15.171183Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "471"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:20 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ec19cb9e-c484-4808-9a1c-2d3b66c14b4b
+        status: 200 OK
+        code: 200
+        duration: 173.400041ms
+    - id: 83
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/d1c86ecb-5c28-44fe-81f6-fbed836f38e2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 471
+        uncompressed: false
+        body: '{"class":"sbs","created_at":"2025-02-12T15:54:15.171183Z","id":"d1c86ecb-5c28-44fe-81f6-fbed836f38e2","name":"tf-snapshot-musing-lederberg","parent_volume":{"id":"e9dda481-3566-43af-afe3-859e3cb3aa76","name":"tf-volume-interesting-leakey","status":"available","type":"sbs_15k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":22000000000,"status":"available","tags":[],"updated_at":"2025-02-12T15:54:15.171183Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "471"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:20 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 281154a9-74ab-4b05-872e-391730d8588b
+        status: 200 OK
+        code: 200
+        duration: 126.376333ms
+    - id: 84
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8995f9f0-67d5-43cd-9844-c11c3a5736e5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 687
+        uncompressed: false
+        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T15:54:05.720450+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"c96574f5-f857-475c-a9f7-41677887eb70","name":"","size":0,"volume_type":"sbs_snapshot"}},"from_server":"","id":"8995f9f0-67d5-43cd-9844-c11c3a5736e5","modification_date":"2025-02-12T15:54:05.720450+00:00","name":"tf-image-silly-wozniak","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"ddfdab48-0b8a-4048-8233-5f8bd4fd950b","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "687"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:20 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3dce7da0-206e-4119-9a0f-64cda200ce6f
+        status: 200 OK
+        code: 200
+        duration: 147.50325ms
+    - id: 85
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8995f9f0-67d5-43cd-9844-c11c3a5736e5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 687
+        uncompressed: false
+        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T15:54:05.720450+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"c96574f5-f857-475c-a9f7-41677887eb70","name":"","size":0,"volume_type":"sbs_snapshot"}},"from_server":"","id":"8995f9f0-67d5-43cd-9844-c11c3a5736e5","modification_date":"2025-02-12T15:54:05.720450+00:00","name":"tf-image-silly-wozniak","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"ddfdab48-0b8a-4048-8233-5f8bd4fd950b","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "687"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:20 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ac8ef489-ca0b-4ad0-b7a3-db0591c1dce4
+        status: 200 OK
+        code: 200
+        duration: 166.62125ms
+    - id: 86
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 127
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf-image-silly-wozniak","arch":"x86_64","extra_volumes":{"1":{"id":"d1c86ecb-5c28-44fe-81f6-fbed836f38e2"}},"tags":[]}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8995f9f0-67d5-43cd-9844-c11c3a5736e5
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 687
+        uncompressed: false
+        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T15:54:05.720450+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"d1c86ecb-5c28-44fe-81f6-fbed836f38e2","name":"","size":0,"volume_type":"sbs_snapshot"}},"from_server":"","id":"8995f9f0-67d5-43cd-9844-c11c3a5736e5","modification_date":"2025-02-12T15:54:05.720450+00:00","name":"tf-image-silly-wozniak","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"ddfdab48-0b8a-4048-8233-5f8bd4fd950b","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "687"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:21 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 50f1d56a-22ed-4a3d-bfc7-bff8cbf68b06
+        status: 200 OK
+        code: 200
+        duration: 568.716167ms
+    - id: 87
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8995f9f0-67d5-43cd-9844-c11c3a5736e5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 687
+        uncompressed: false
+        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T15:54:05.720450+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"d1c86ecb-5c28-44fe-81f6-fbed836f38e2","name":"","size":0,"volume_type":"sbs_snapshot"}},"from_server":"","id":"8995f9f0-67d5-43cd-9844-c11c3a5736e5","modification_date":"2025-02-12T15:54:05.720450+00:00","name":"tf-image-silly-wozniak","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"ddfdab48-0b8a-4048-8233-5f8bd4fd950b","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "687"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:21 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e183b030-ae25-4962-97cf-44d4ae2378a8
+        status: 200 OK
+        code: 200
+        duration: 160.021334ms
+    - id: 88
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8995f9f0-67d5-43cd-9844-c11c3a5736e5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 687
+        uncompressed: false
+        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T15:54:05.720450+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"d1c86ecb-5c28-44fe-81f6-fbed836f38e2","name":"","size":0,"volume_type":"sbs_snapshot"}},"from_server":"","id":"8995f9f0-67d5-43cd-9844-c11c3a5736e5","modification_date":"2025-02-12T15:54:05.720450+00:00","name":"tf-image-silly-wozniak","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"ddfdab48-0b8a-4048-8233-5f8bd4fd950b","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "687"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:21 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c1a377cf-8d49-42cf-a1b9-a609d2573d49
+        status: 200 OK
+        code: 200
+        duration: 155.692917ms
+    - id: 89
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/9716a7b8-b692-4c04-8a07-aa6e723ed33c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 424
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T15:53:15.665265Z","id":"9716a7b8-b692-4c04-8a07-aa6e723ed33c","last_detached_at":null,"name":"tf-volume-reverent-almeida","parent_snapshot_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":21000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T15:53:15.665265Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "424"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f943ba9e-27e4-4332-80b2-ccb2a30a4b8d
+        status: 200 OK
+        code: 200
+        duration: 79.583584ms
+    - id: 90
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/e9dda481-3566-43af-afe3-859e3cb3aa76
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 428
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T15:54:09.639279Z","id":"e9dda481-3566-43af-afe3-859e3cb3aa76","last_detached_at":null,"name":"tf-volume-interesting-leakey","parent_snapshot_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":22000000000,"specs":{"class":"sbs","perf_iops":15000},"status":"available","tags":[],"type":"sbs_15k","updated_at":"2025-02-12T15:54:09.639279Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "428"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 97422d34-09e2-42b1-9ee3-72fc6f283c4c
+        status: 200 OK
+        code: 200
+        duration: 96.938583ms
+    - id: 91
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1836
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-12T15:53:16.407771+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-amazing-franklin","id":"0bf0d0f8-fccc-497f-a665-43f0d549eddf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"801","node_id":"145","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c6:8f","maintenances":[],"modification_date":"2025-02-12T15:53:22.468531+00:00","name":"tf-srv-amazing-franklin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1836"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5ae168b6-d926-42e8-b89f-29e8c6fd1d54
+        status: 200 OK
+        code: 200
+        duration: 215.934375ms
+    - id: 92
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/c96574f5-f857-475c-a9f7-41677887eb70
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 468
+        uncompressed: false
+        body: '{"class":"sbs","created_at":"2025-02-12T15:53:21.153503Z","id":"c96574f5-f857-475c-a9f7-41677887eb70","name":"tf-snapshot-optimistic-noyce","parent_volume":{"id":"9716a7b8-b692-4c04-8a07-aa6e723ed33c","name":"tf-volume-reverent-almeida","status":"available","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":21000000000,"status":"available","tags":[],"updated_at":"2025-02-12T15:54:21.666119Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "468"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8f91ceb2-ff51-4075-809f-538e2352b395
+        status: 200 OK
+        code: 200
+        duration: 111.314333ms
+    - id: 93
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/d1c86ecb-5c28-44fe-81f6-fbed836f38e2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 697
+        uncompressed: false
+        body: '{"class":"sbs","created_at":"2025-02-12T15:54:15.171183Z","id":"d1c86ecb-5c28-44fe-81f6-fbed836f38e2","name":"tf-snapshot-musing-lederberg","parent_volume":{"id":"e9dda481-3566-43af-afe3-859e3cb3aa76","name":"tf-volume-interesting-leakey","status":"available","type":"sbs_15k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T15:54:21.268412Z","id":"47dcfc86-877b-4611-b35a-0ea0ebc3fe5a","product_resource_id":"8995f9f0-67d5-43cd-9844-c11c3a5736e5","product_resource_type":"instance_image","status":"attached","type":"link"}],"size":22000000000,"status":"in_use","tags":[],"updated_at":"2025-02-12T15:54:21.268412Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "697"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b916779d-dfb1-45b4-9694-8f02cc3864a3
+        status: 200 OK
+        code: 200
+        duration: 103.504208ms
+    - id: 94
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/ddfdab48-0b8a-4048-8233-5f8bd4fd950b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 695
+        uncompressed: false
+        body: '{"class":"sbs","created_at":"2025-02-12T15:53:29.101307Z","id":"ddfdab48-0b8a-4048-8233-5f8bd4fd950b","name":"tf-snapshot-keen-pike","parent_volume":{"id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","status":"in_use","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T15:54:05.790877Z","id":"0dd3486b-e0c7-44c5-8995-8a7c23b4cfca","product_resource_id":"8995f9f0-67d5-43cd-9844-c11c3a5736e5","product_resource_type":"instance_image","status":"attached","type":"link"}],"size":10000000000,"status":"in_use","tags":[],"updated_at":"2025-02-12T15:54:05.790877Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "695"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 36e869c0-7053-4e34-94e5-111318ec7f44
+        status: 200 OK
+        code: 200
+        duration: 113.412125ms
+    - id: 95
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8995f9f0-67d5-43cd-9844-c11c3a5736e5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 687
+        uncompressed: false
+        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T15:54:05.720450+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"d1c86ecb-5c28-44fe-81f6-fbed836f38e2","name":"","size":0,"volume_type":"sbs_snapshot"}},"from_server":"","id":"8995f9f0-67d5-43cd-9844-c11c3a5736e5","modification_date":"2025-02-12T15:54:05.720450+00:00","name":"tf-image-silly-wozniak","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"ddfdab48-0b8a-4048-8233-5f8bd4fd950b","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "687"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e0733d39-a105-4ce3-bfb6-a188f11c8f2b
+        status: 200 OK
+        code: 200
+        duration: 162.65675ms
+    - id: 96
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/e9dda481-3566-43af-afe3-859e3cb3aa76
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 428
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T15:54:09.639279Z","id":"e9dda481-3566-43af-afe3-859e3cb3aa76","last_detached_at":null,"name":"tf-volume-interesting-leakey","parent_snapshot_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":22000000000,"specs":{"class":"sbs","perf_iops":15000},"status":"available","tags":[],"type":"sbs_15k","updated_at":"2025-02-12T15:54:09.639279Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "428"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6339cbfa-ea5c-4bd1-9386-960a1b91e0b9
+        status: 200 OK
+        code: 200
+        duration: 369.782291ms
+    - id: 97
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/9716a7b8-b692-4c04-8a07-aa6e723ed33c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 424
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T15:53:15.665265Z","id":"9716a7b8-b692-4c04-8a07-aa6e723ed33c","last_detached_at":null,"name":"tf-volume-reverent-almeida","parent_snapshot_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":21000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T15:53:15.665265Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "424"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d41ff237-0627-49bf-a6bb-4e164b756f06
+        status: 200 OK
+        code: 200
+        duration: 372.782667ms
     - id: 98
       request:
         proto: HTTP/1.1
@@ -4879,7 +4871,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/1b0ce8dc-403d-4ab9-b326-d30ddee68e64
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf
         method: GET
       response:
         proto: HTTP/2.0
@@ -4887,20 +4879,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 535
+        content_length: 1836
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:18:56.896267+00:00","error_details":null,"id":"1b0ce8dc-403d-4ab9-b326-d30ddee68e64","modification_date":"2025-02-12T15:19:23.710368+00:00","name":"tf-snap-stupefied-hellman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-12T15:53:16.407771+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-amazing-franklin","id":"0bf0d0f8-fccc-497f-a665-43f0d549eddf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"801","node_id":"145","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c6:8f","maintenances":[],"modification_date":"2025-02-12T15:53:22.468531+00:00","name":"tf-srv-amazing-franklin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "535"
+                - "1836"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:43 GMT
+                - Wed, 12 Feb 2025 15:54:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4908,10 +4900,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8f7c11e1-a45e-4e4c-a0aa-eb473c4cecb9
+                - 200bd348-3433-473d-8362-c8bad908ec48
         status: 200 OK
         code: 200
-        duration: 100.895917ms
+        duration: 482.85875ms
     - id: 99
       request:
         proto: HTTP/1.1
@@ -4928,7 +4920,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/4955169c-7666-48cb-9e27-7ee608b717d5
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/d1c86ecb-5c28-44fe-81f6-fbed836f38e2
         method: GET
       response:
         proto: HTTP/2.0
@@ -4936,20 +4928,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 737
+        content_length: 697
         uncompressed: false
-        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T15:19:28.932980+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"57129456-dcee-482c-b4f2-7ba6d81c6439","name":"tf-snap-jolly-bose","size":22000000000,"volume_type":"b_ssd"}},"from_server":"","id":"4955169c-7666-48cb-9e27-7ee608b717d5","modification_date":"2025-02-12T15:19:28.932980+00:00","name":"tf-image-vigilant-hertz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"1b0ce8dc-403d-4ab9-b326-d30ddee68e64","name":"tf-snap-stupefied-hellman","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"class":"sbs","created_at":"2025-02-12T15:54:15.171183Z","id":"d1c86ecb-5c28-44fe-81f6-fbed836f38e2","name":"tf-snapshot-musing-lederberg","parent_volume":{"id":"e9dda481-3566-43af-afe3-859e3cb3aa76","name":"tf-volume-interesting-leakey","status":"available","type":"sbs_15k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T15:54:21.268412Z","id":"47dcfc86-877b-4611-b35a-0ea0ebc3fe5a","product_resource_id":"8995f9f0-67d5-43cd-9844-c11c3a5736e5","product_resource_type":"instance_image","status":"attached","type":"link"}],"size":22000000000,"status":"in_use","tags":[],"updated_at":"2025-02-12T15:54:21.268412Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "737"
+                - "697"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:43 GMT
+                - Wed, 12 Feb 2025 15:54:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4957,10 +4949,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a2b2ba6a-a726-4982-b46d-0f255d4e7b08
+                - a4f8cd58-93dc-4def-ac0e-9b2858bddfa7
         status: 200 OK
         code: 200
-        duration: 135.875167ms
+        duration: 121.560666ms
     - id: 100
       request:
         proto: HTTP/1.1
@@ -4977,7 +4969,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/4955169c-7666-48cb-9e27-7ee608b717d5
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/c96574f5-f857-475c-a9f7-41677887eb70
         method: GET
       response:
         proto: HTTP/2.0
@@ -4985,20 +4977,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 737
+        content_length: 468
         uncompressed: false
-        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T15:19:28.932980+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"57129456-dcee-482c-b4f2-7ba6d81c6439","name":"tf-snap-jolly-bose","size":22000000000,"volume_type":"b_ssd"}},"from_server":"","id":"4955169c-7666-48cb-9e27-7ee608b717d5","modification_date":"2025-02-12T15:19:28.932980+00:00","name":"tf-image-vigilant-hertz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"1b0ce8dc-403d-4ab9-b326-d30ddee68e64","name":"tf-snap-stupefied-hellman","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"class":"sbs","created_at":"2025-02-12T15:53:21.153503Z","id":"c96574f5-f857-475c-a9f7-41677887eb70","name":"tf-snapshot-optimistic-noyce","parent_volume":{"id":"9716a7b8-b692-4c04-8a07-aa6e723ed33c","name":"tf-volume-reverent-almeida","status":"available","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":21000000000,"status":"available","tags":[],"updated_at":"2025-02-12T15:54:21.666119Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "737"
+                - "468"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:44 GMT
+                - Wed, 12 Feb 2025 15:54:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5006,10 +4998,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2237de39-70f6-497d-a646-c5616fe07e58
+                - 3527fe58-fb8c-48e0-aba5-977ff0ec5c22
         status: 200 OK
         code: 200
-        duration: 113.17575ms
+        duration: 122.737209ms
     - id: 101
       request:
         proto: HTTP/1.1
@@ -5026,7 +5018,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f97824b7-3276-4224-b71a-d450304ed14c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/5d0109bc-940e-4bc6-b082-d7fa906ccea4
         method: GET
       response:
         proto: HTTP/2.0
@@ -5034,20 +5026,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 536
+        content_length: 143
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"89f83395-b4cf-4fee-9853-833f24fdd971","name":"tf-vol-cranky-blackwell"},"creation_date":"2025-02-12T15:18:31.227612+00:00","error_details":null,"id":"f97824b7-3276-4224-b71a-d450304ed14c","modification_date":"2025-02-12T15:18:34.957281+00:00","name":"tf-snap-distracted-poincare","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","type":"not_found"}'
         headers:
             Content-Length:
-                - "536"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:44 GMT
+                - Wed, 12 Feb 2025 15:54:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5055,10 +5047,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 01f44002-d23e-4a17-b992-558525378f08
-        status: 200 OK
-        code: 200
-        duration: 134.513166ms
+                - 48d6a11f-be32-4e3d-ac72-a925b3496c09
+        status: 404 Not Found
+        code: 404
+        duration: 60.456083ms
     - id: 102
       request:
         proto: HTTP/1.1
@@ -5075,26 +5067,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f97824b7-3276-4224-b71a-d450304ed14c
-        method: DELETE
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/5d0109bc-940e-4bc6-b082-d7fa906ccea4
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 701
         uncompressed: false
-        body: ""
+        body: '{"created_at":"2025-02-12T15:53:16.620555Z","id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T15:53:16.620555Z","id":"bbe07d04-0b0e-4c8c-8bbf-c9693b5d4fce","product_resource_id":"0bf0d0f8-fccc-497f-a665-43f0d549eddf","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T15:53:16.620555Z","zone":"fr-par-1"}'
         headers:
+            Content-Length:
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:44 GMT
+                - Wed, 12 Feb 2025 15:54:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5102,10 +5096,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7b3a7126-7b91-4302-9a89-cf0abaed08f7
-        status: 204 No Content
-        code: 204
-        duration: 211.162ms
+                - a02a4355-cba6-4ad2-b744-7fcefd1673c6
+        status: 200 OK
+        code: 200
+        duration: 87.906334ms
     - id: 103
       request:
         proto: HTTP/1.1
@@ -5122,7 +5116,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f97824b7-3276-4224-b71a-d450304ed14c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -5130,20 +5124,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 145
+        content_length: 17
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"f97824b7-3276-4224-b71a-d450304ed14c","type":"not_found"}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "145"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:44 GMT
+                - Wed, 12 Feb 2025 15:54:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5151,10 +5145,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e016c0c7-8335-4d0f-bfe9-2946dbb02079
-        status: 404 Not Found
-        code: 404
-        duration: 53.814917ms
+                - fef3063d-30de-4d78-b8de-28dff3cf3c60
+        status: 200 OK
+        code: 200
+        duration: 112.497875ms
     - id: 104
       request:
         proto: HTTP/1.1
@@ -5171,26 +5165,30 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/4955169c-7666-48cb-9e27-7ee608b717d5
-        method: DELETE
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf/private_nics
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 20
         uncompressed: false
-        body: ""
+        body: '{"private_nics":[]}'
         headers:
+            Content-Length:
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:44 GMT
+                - Wed, 12 Feb 2025 15:54:23 GMT
+            Link:
+                - </servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5198,10 +5196,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4d8029e6-04b9-4251-aecc-8e47c66ac6e6
-        status: 204 No Content
-        code: 204
-        duration: 311.906167ms
+                - 2c3d451f-34c7-46c4-849b-fae94caaba48
+            X-Total-Count:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 98.714167ms
     - id: 105
       request:
         proto: HTTP/1.1
@@ -5218,7 +5218,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/4955169c-7666-48cb-9e27-7ee608b717d5
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/ddfdab48-0b8a-4048-8233-5f8bd4fd950b
         method: GET
       response:
         proto: HTTP/2.0
@@ -5226,20 +5226,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 142
+        content_length: 695
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_image","resource_id":"4955169c-7666-48cb-9e27-7ee608b717d5","type":"not_found"}'
+        body: '{"class":"sbs","created_at":"2025-02-12T15:53:29.101307Z","id":"ddfdab48-0b8a-4048-8233-5f8bd4fd950b","name":"tf-snapshot-keen-pike","parent_volume":{"id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","status":"in_use","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T15:54:05.790877Z","id":"0dd3486b-e0c7-44c5-8995-8a7c23b4cfca","product_resource_id":"8995f9f0-67d5-43cd-9844-c11c3a5736e5","product_resource_type":"instance_image","status":"attached","type":"link"}],"size":10000000000,"status":"in_use","tags":[],"updated_at":"2025-02-12T15:54:05.790877Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "142"
+                - "695"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:44 GMT
+                - Wed, 12 Feb 2025 15:54:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5247,10 +5247,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2e8f7fa4-bfda-481d-a3f8-cb184ed91193
-        status: 404 Not Found
-        code: 404
-        duration: 54.586709ms
+                - 1e9e1f91-db19-4ff3-a075-d5e05655440c
+        status: 200 OK
+        code: 200
+        duration: 107.757666ms
     - id: 106
       request:
         proto: HTTP/1.1
@@ -5267,7 +5267,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/89f83395-b4cf-4fee-9853-833f24fdd971
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8995f9f0-67d5-43cd-9844-c11c3a5736e5
         method: GET
       response:
         proto: HTTP/2.0
@@ -5275,20 +5275,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 445
+        content_length: 687
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-02-12T15:18:30.774581+00:00","export_uri":null,"id":"89f83395-b4cf-4fee-9853-833f24fdd971","modification_date":"2025-02-12T15:18:34.957281+00:00","name":"tf-vol-cranky-blackwell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T15:54:05.720450+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"d1c86ecb-5c28-44fe-81f6-fbed836f38e2","name":"","size":0,"volume_type":"sbs_snapshot"}},"from_server":"","id":"8995f9f0-67d5-43cd-9844-c11c3a5736e5","modification_date":"2025-02-12T15:54:05.720450+00:00","name":"tf-image-silly-wozniak","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"ddfdab48-0b8a-4048-8233-5f8bd4fd950b","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "445"
+                - "687"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:44 GMT
+                - Wed, 12 Feb 2025 15:54:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5296,10 +5296,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ffcf370d-8cdb-4be3-96b3-dc0b73814c44
+                - 285098a0-fa9a-43aa-ab67-ec4b7d6682c6
         status: 200 OK
         code: 200
-        duration: 117.469334ms
+        duration: 118.184667ms
     - id: 107
       request:
         proto: HTTP/1.1
@@ -5316,7 +5316,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/1b0ce8dc-403d-4ab9-b326-d30ddee68e64
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/c96574f5-f857-475c-a9f7-41677887eb70
         method: GET
       response:
         proto: HTTP/2.0
@@ -5324,20 +5324,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 535
+        content_length: 468
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:18:56.896267+00:00","error_details":null,"id":"1b0ce8dc-403d-4ab9-b326-d30ddee68e64","modification_date":"2025-02-12T15:19:23.710368+00:00","name":"tf-snap-stupefied-hellman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"class":"sbs","created_at":"2025-02-12T15:53:21.153503Z","id":"c96574f5-f857-475c-a9f7-41677887eb70","name":"tf-snapshot-optimistic-noyce","parent_volume":{"id":"9716a7b8-b692-4c04-8a07-aa6e723ed33c","name":"tf-volume-reverent-almeida","status":"available","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":21000000000,"status":"available","tags":[],"updated_at":"2025-02-12T15:54:21.666119Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "535"
+                - "468"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:44 GMT
+                - Wed, 12 Feb 2025 15:54:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5345,10 +5345,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d0e832e3-732a-4ccd-9c63-4c09be1f2917
+                - 84a15d6e-a11d-4c05-80f5-aaaf2bfef2d0
         status: 200 OK
         code: 200
-        duration: 100.954292ms
+        duration: 98.4805ms
     - id: 108
       request:
         proto: HTTP/1.1
@@ -5365,7 +5365,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/57129456-dcee-482c-b4f2-7ba6d81c6439
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8995f9f0-67d5-43cd-9844-c11c3a5736e5
         method: GET
       response:
         proto: HTTP/2.0
@@ -5373,20 +5373,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 531
+        content_length: 687
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"9b2de5c3-e30b-447e-93e2-983fdba06000","name":"tf-vol-hopeful-visvesvaraya"},"creation_date":"2025-02-12T15:19:34.736767+00:00","error_details":null,"id":"57129456-dcee-482c-b4f2-7ba6d81c6439","modification_date":"2025-02-12T15:19:37.900348+00:00","name":"tf-snap-jolly-bose","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":22000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T15:54:05.720450+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"d1c86ecb-5c28-44fe-81f6-fbed836f38e2","name":"","size":0,"volume_type":"sbs_snapshot"}},"from_server":"","id":"8995f9f0-67d5-43cd-9844-c11c3a5736e5","modification_date":"2025-02-12T15:54:05.720450+00:00","name":"tf-image-silly-wozniak","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"ddfdab48-0b8a-4048-8233-5f8bd4fd950b","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "531"
+                - "687"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:44 GMT
+                - Wed, 12 Feb 2025 15:54:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5394,10 +5394,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3c1a8a32-777f-4c44-aa5f-0abf193df7ed
+                - 8ec94539-7687-42ad-a922-601e0110c4d0
         status: 200 OK
         code: 200
-        duration: 124.626166ms
+        duration: 144.191334ms
     - id: 109
       request:
         proto: HTTP/1.1
@@ -5414,7 +5414,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/89f83395-b4cf-4fee-9853-833f24fdd971
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/c96574f5-f857-475c-a9f7-41677887eb70
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5431,9 +5431,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:44 GMT
+                - Wed, 12 Feb 2025 15:54:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5441,10 +5441,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d3f62259-f710-4255-8414-846960e89f96
+                - 126b8520-3642-4973-b23f-8a8ab0da5721
         status: 204 No Content
         code: 204
-        duration: 184.764625ms
+        duration: 173.456375ms
     - id: 110
       request:
         proto: HTTP/1.1
@@ -5461,26 +5461,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/57129456-dcee-482c-b4f2-7ba6d81c6439
-        method: DELETE
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/c96574f5-f857-475c-a9f7-41677887eb70
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 129
         uncompressed: false
-        body: ""
+        body: '{"message":"resource is not found","resource":"snapshot","resource_id":"c96574f5-f857-475c-a9f7-41677887eb70","type":"not_found"}'
         headers:
+            Content-Length:
+                - "129"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:44 GMT
+                - Wed, 12 Feb 2025 15:54:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5488,10 +5490,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3a727250-dac4-4e11-9f39-834ffe68b274
-        status: 204 No Content
-        code: 204
-        duration: 190.994292ms
+                - 19b8ee26-b38f-40b6-8e85-e188f6926a79
+        status: 404 Not Found
+        code: 404
+        duration: 82.510125ms
     - id: 111
       request:
         proto: HTTP/1.1
@@ -5508,26 +5510,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/1b0ce8dc-403d-4ab9-b326-d30ddee68e64
-        method: DELETE
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/9716a7b8-b692-4c04-8a07-aa6e723ed33c
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 424
         uncompressed: false
-        body: ""
+        body: '{"created_at":"2025-02-12T15:53:15.665265Z","id":"9716a7b8-b692-4c04-8a07-aa6e723ed33c","last_detached_at":null,"name":"tf-volume-reverent-almeida","parent_snapshot_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":21000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T15:53:15.665265Z","zone":"fr-par-1"}'
         headers:
+            Content-Length:
+                - "424"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:44 GMT
+                - Wed, 12 Feb 2025 15:54:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5535,10 +5539,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 01ab8b84-02b1-49c9-a5c7-db8d12bb2dc9
-        status: 204 No Content
-        code: 204
-        duration: 217.528625ms
+                - 7dd47cb1-16db-4a8f-8ed5-dd05ea6d9595
+        status: 200 OK
+        code: 200
+        duration: 83.064709ms
     - id: 112
       request:
         proto: HTTP/1.1
@@ -5555,203 +5559,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/57129456-dcee-482c-b4f2-7ba6d81c6439
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 145
-        uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"57129456-dcee-482c-b4f2-7ba6d81c6439","type":"not_found"}'
-        headers:
-            Content-Length:
-                - "145"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:19:44 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - c9693b61-0ba8-45a0-af20-9c5b524638c4
-        status: 404 Not Found
-        code: 404
-        duration: 55.780959ms
-    - id: 113
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/1b0ce8dc-403d-4ab9-b326-d30ddee68e64
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 145
-        uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"1b0ce8dc-403d-4ab9-b326-d30ddee68e64","type":"not_found"}'
-        headers:
-            Content-Length:
-                - "145"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:19:44 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - b4731225-b711-461e-90a0-8cec4ebf4e21
-        status: 404 Not Found
-        code: 404
-        duration: 52.388209ms
-    - id: 114
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/9b2de5c3-e30b-447e-93e2-983fdba06000
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 449
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-02-12T15:19:33.645129+00:00","export_uri":null,"id":"9b2de5c3-e30b-447e-93e2-983fdba06000","modification_date":"2025-02-12T15:19:37.900348+00:00","name":"tf-vol-hopeful-visvesvaraya","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":22000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "449"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:19:44 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 56eff888-c836-4720-a1fb-ef2f25d7a581
-        status: 200 OK
-        code: 200
-        duration: 107.120875ms
-    - id: 115
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2269
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.373972+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-cerf","id":"1780c24c-59ed-4db8-bb22-7191af979336","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"2002","node_id":"21","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:43","maintenances":[],"modification_date":"2025-02-12T15:18:48.907477+00:00","name":"tf-srv-reverent-cerf","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.373972+00:00","export_uri":null,"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","modification_date":"2025-02-12T15:19:23.710368+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1780c24c-59ed-4db8-bb22-7191af979336","name":"tf-srv-reverent-cerf"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2269"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:19:44 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 5d670b22-d2b8-4594-8c7e-11a7fae19838
-        status: 200 OK
-        code: 200
-        duration: 187.786667ms
-    - id: 116
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/9b2de5c3-e30b-447e-93e2-983fdba06000
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/9716a7b8-b692-4c04-8a07-aa6e723ed33c
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5768,9 +5576,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:45 GMT
+                - Wed, 12 Feb 2025 15:54:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5778,11 +5586,689 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 536cbbc0-4196-4bd0-b71b-94b59c06a272
+                - dd1a1c4f-2f3c-433f-80fb-f64e5aec3b50
         status: 204 No Content
         code: 204
-        duration: 196.287416ms
+        duration: 152.425333ms
+    - id: 113
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8995f9f0-67d5-43cd-9844-c11c3a5736e5
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:24 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 26e41bab-8f9f-4db4-bfd3-67109d16abcf
+        status: 204 No Content
+        code: 204
+        duration: 536.766292ms
+    - id: 114
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/9716a7b8-b692-4c04-8a07-aa6e723ed33c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 127
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"volume","resource_id":"9716a7b8-b692-4c04-8a07-aa6e723ed33c","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "127"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 90e3a26b-66a3-4fb2-8f3f-36f0607c16fb
+        status: 404 Not Found
+        code: 404
+        duration: 84.324291ms
+    - id: 115
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8995f9f0-67d5-43cd-9844-c11c3a5736e5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 142
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_image","resource_id":"8995f9f0-67d5-43cd-9844-c11c3a5736e5","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "142"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:24 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4db49808-84d3-41e4-ab44-8153b4c2a65a
+        status: 404 Not Found
+        code: 404
+        duration: 51.492334ms
+    - id: 116
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/ddfdab48-0b8a-4048-8233-5f8bd4fd950b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 469
+        uncompressed: false
+        body: '{"class":"sbs","created_at":"2025-02-12T15:53:29.101307Z","id":"ddfdab48-0b8a-4048-8233-5f8bd4fd950b","name":"tf-snapshot-keen-pike","parent_volume":{"id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","status":"in_use","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"status":"available","tags":[],"updated_at":"2025-02-12T15:54:25.221128Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "469"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 32ac102d-ec72-4dfa-8729-914987459c97
+        status: 200 OK
+        code: 200
+        duration: 111.055041ms
     - id: 117
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/d1c86ecb-5c28-44fe-81f6-fbed836f38e2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 471
+        uncompressed: false
+        body: '{"class":"sbs","created_at":"2025-02-12T15:54:15.171183Z","id":"d1c86ecb-5c28-44fe-81f6-fbed836f38e2","name":"tf-snapshot-musing-lederberg","parent_volume":{"id":"e9dda481-3566-43af-afe3-859e3cb3aa76","name":"tf-volume-interesting-leakey","status":"available","type":"sbs_15k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":22000000000,"status":"available","tags":[],"updated_at":"2025-02-12T15:54:25.189601Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "471"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 717f9fbf-6aa4-4915-8a7e-5aa869863504
+        status: 200 OK
+        code: 200
+        duration: 115.026959ms
+    - id: 118
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/ddfdab48-0b8a-4048-8233-5f8bd4fd950b
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3ae0c9ed-b532-4af2-9909-9c818f9b36df
+        status: 204 No Content
+        code: 204
+        duration: 154.034041ms
+    - id: 119
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/d1c86ecb-5c28-44fe-81f6-fbed836f38e2
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1a5bac68-0e02-4642-9d20-77e27fe26228
+        status: 204 No Content
+        code: 204
+        duration: 156.494292ms
+    - id: 120
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/ddfdab48-0b8a-4048-8233-5f8bd4fd950b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 129
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"snapshot","resource_id":"ddfdab48-0b8a-4048-8233-5f8bd4fd950b","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "129"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5c19d87d-5eaf-47ac-9cd6-3254ad6488d6
+        status: 404 Not Found
+        code: 404
+        duration: 80.070208ms
+    - id: 121
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/d1c86ecb-5c28-44fe-81f6-fbed836f38e2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 129
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"snapshot","resource_id":"d1c86ecb-5c28-44fe-81f6-fbed836f38e2","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "129"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d173bf21-5253-41ba-801e-1b70b94fb7df
+        status: 404 Not Found
+        code: 404
+        duration: 78.377792ms
+    - id: 122
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/e9dda481-3566-43af-afe3-859e3cb3aa76
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 428
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T15:54:09.639279Z","id":"e9dda481-3566-43af-afe3-859e3cb3aa76","last_detached_at":null,"name":"tf-volume-interesting-leakey","parent_snapshot_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":22000000000,"specs":{"class":"sbs","perf_iops":15000},"status":"available","tags":[],"type":"sbs_15k","updated_at":"2025-02-12T15:54:09.639279Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "428"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 236dad49-4f56-4a7f-9a61-ee51e3b4a844
+        status: 200 OK
+        code: 200
+        duration: 84.445084ms
+    - id: 123
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/e9dda481-3566-43af-afe3-859e3cb3aa76
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3176cd3f-5dc5-4996-82aa-03a68b7b9ed1
+        status: 204 No Content
+        code: 204
+        duration: 135.776083ms
+    - id: 124
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1836
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-12T15:53:16.407771+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-amazing-franklin","id":"0bf0d0f8-fccc-497f-a665-43f0d549eddf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"801","node_id":"145","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c6:8f","maintenances":[],"modification_date":"2025-02-12T15:53:22.468531+00:00","name":"tf-srv-amazing-franklin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1836"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - cbf8f098-6bbd-4a82-a9dc-395d4a7a9ec9
+        status: 200 OK
+        code: 200
+        duration: 237.9355ms
+    - id: 125
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/e9dda481-3566-43af-afe3-859e3cb3aa76
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 127
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"volume","resource_id":"e9dda481-3566-43af-afe3-859e3cb3aa76","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "127"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 12a0f82b-19fb-4006-8e8c-24135d522923
+        status: 404 Not Found
+        code: 404
+        duration: 74.542375ms
+    - id: 126
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/5d0109bc-940e-4bc6-b082-d7fa906ccea4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T15:53:16.620555Z","id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T15:53:16.620555Z","id":"bbe07d04-0b0e-4c8c-8bbf-c9693b5d4fce","product_resource_id":"0bf0d0f8-fccc-497f-a665-43f0d549eddf","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T15:53:16.620555Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 20f9cb6b-7b03-4ef4-9075-63f10db6aa70
+        status: 200 OK
+        code: 200
+        duration: 76.859625ms
+    - id: 127
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -5800,7 +6286,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336/action
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -5810,7 +6296,7 @@ interactions:
         trailer: {}
         content_length: 352
         uncompressed: false
-        body: '{"task":{"description":"server_poweroff","href_from":"/servers/1780c24c-59ed-4db8-bb22-7191af979336/action","href_result":"/servers/1780c24c-59ed-4db8-bb22-7191af979336","id":"06510ded-c1f5-454f-b6d1-73de437bff9b","progress":0,"started_at":"2025-02-12T15:19:45.582145+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_poweroff","href_from":"/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf/action","href_result":"/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf","id":"30f8f602-6e93-4cf5-8cd5-ada31dbae1e3","progress":0,"started_at":"2025-02-12T15:54:26.407082+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "352"
@@ -5819,11 +6305,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:19:45 GMT
+                - Wed, 12 Feb 2025 15:54:26 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/06510ded-c1f5-454f-b6d1-73de437bff9b
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/30f8f602-6e93-4cf5-8cd5-ada31dbae1e3
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5831,498 +6317,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 14fbe969-2198-465f-9055-dd038f6b3d58
+                - 3fd341ea-ba3c-415c-8fe2-308abd3072ec
         status: 202 Accepted
         code: 202
-        duration: 451.300833ms
-    - id: 118
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2229
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.373972+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-cerf","id":"1780c24c-59ed-4db8-bb22-7191af979336","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"2002","node_id":"21","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:43","maintenances":[],"modification_date":"2025-02-12T15:19:45.212098+00:00","name":"tf-srv-reverent-cerf","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.373972+00:00","export_uri":null,"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","modification_date":"2025-02-12T15:19:23.710368+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1780c24c-59ed-4db8-bb22-7191af979336","name":"tf-srv-reverent-cerf"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2229"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:19:45 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 54f75ad3-8520-4ecc-b7d4-bdf258d0e34d
-        status: 200 OK
-        code: 200
-        duration: 279.724166ms
-    - id: 119
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2229
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.373972+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-cerf","id":"1780c24c-59ed-4db8-bb22-7191af979336","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"2002","node_id":"21","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:43","maintenances":[],"modification_date":"2025-02-12T15:19:45.212098+00:00","name":"tf-srv-reverent-cerf","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.373972+00:00","export_uri":null,"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","modification_date":"2025-02-12T15:19:23.710368+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1780c24c-59ed-4db8-bb22-7191af979336","name":"tf-srv-reverent-cerf"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2229"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:19:50 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 72699f98-ba05-411c-b811-637455209f9a
-        status: 200 OK
-        code: 200
-        duration: 190.8525ms
-    - id: 120
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2229
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.373972+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-cerf","id":"1780c24c-59ed-4db8-bb22-7191af979336","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"2002","node_id":"21","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:43","maintenances":[],"modification_date":"2025-02-12T15:19:45.212098+00:00","name":"tf-srv-reverent-cerf","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.373972+00:00","export_uri":null,"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","modification_date":"2025-02-12T15:19:23.710368+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1780c24c-59ed-4db8-bb22-7191af979336","name":"tf-srv-reverent-cerf"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2229"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:19:56 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - be3f669e-f814-4485-87fe-3e052506474d
-        status: 200 OK
-        code: 200
-        duration: 177.60525ms
-    - id: 121
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2229
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.373972+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-cerf","id":"1780c24c-59ed-4db8-bb22-7191af979336","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"2002","node_id":"21","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:43","maintenances":[],"modification_date":"2025-02-12T15:19:45.212098+00:00","name":"tf-srv-reverent-cerf","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.373972+00:00","export_uri":null,"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","modification_date":"2025-02-12T15:19:23.710368+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1780c24c-59ed-4db8-bb22-7191af979336","name":"tf-srv-reverent-cerf"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2229"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:20:01 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 59c32937-f939-42db-8092-18e30d97857f
-        status: 200 OK
-        code: 200
-        duration: 206.172458ms
-    - id: 122
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2229
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.373972+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-cerf","id":"1780c24c-59ed-4db8-bb22-7191af979336","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"2002","node_id":"21","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c4:43","maintenances":[],"modification_date":"2025-02-12T15:19:45.212098+00:00","name":"tf-srv-reverent-cerf","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.373972+00:00","export_uri":null,"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","modification_date":"2025-02-12T15:19:23.710368+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1780c24c-59ed-4db8-bb22-7191af979336","name":"tf-srv-reverent-cerf"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2229"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:20:06 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 25b2b384-5f2f-4df5-9dbf-e30af387bdaa
-        status: 200 OK
-        code: 200
-        duration: 304.077875ms
-    - id: 123
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2112
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.373972+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-cerf","id":"1780c24c-59ed-4db8-bb22-7191af979336","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c4:43","maintenances":[],"modification_date":"2025-02-12T15:20:11.585790+00:00","name":"tf-srv-reverent-cerf","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.373972+00:00","export_uri":null,"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","modification_date":"2025-02-12T15:19:23.710368+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1780c24c-59ed-4db8-bb22-7191af979336","name":"tf-srv-reverent-cerf"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2112"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:20:11 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 047dafc4-e4e7-464b-9614-7566cefe85fe
-        status: 200 OK
-        code: 200
-        duration: 163.757125ms
-    - id: 124
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2112
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:18:31.373972+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-cerf","id":"1780c24c-59ed-4db8-bb22-7191af979336","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c4:43","maintenances":[],"modification_date":"2025-02-12T15:20:11.585790+00:00","name":"tf-srv-reverent-cerf","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:18:31.373972+00:00","export_uri":null,"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","modification_date":"2025-02-12T15:19:23.710368+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1780c24c-59ed-4db8-bb22-7191af979336","name":"tf-srv-reverent-cerf"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2112"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:20:11 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 24f55271-9dcd-4165-8cdc-cd574f6615be
-        status: 200 OK
-        code: 200
-        duration: 162.676458ms
-    - id: 125
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:20:11 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 4308d020-7635-4ffe-8278-2bcd3748e9e6
-        status: 204 No Content
-        code: 204
-        duration: 172.441125ms
-    - id: 126
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 143
-        uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"1780c24c-59ed-4db8-bb22-7191af979336","type":"not_found"}'
-        headers:
-            Content-Length:
-                - "143"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:20:12 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 329f635c-2356-4975-91cf-37f5a12dea36
-        status: 404 Not Found
-        code: 404
-        duration: 122.989583ms
-    - id: 127
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/55312258-0bc4-449f-b2a3-e95fcb3fa094
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 446
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-02-12T15:18:31.373972+00:00","export_uri":null,"id":"55312258-0bc4-449f-b2a3-e95fcb3fa094","modification_date":"2025-02-12T15:20:12.165474+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "446"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 15:20:12 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - cf4eb145-b786-4a0a-a190-ccb3ceea1a8a
-        status: 200 OK
-        code: 200
-        duration: 93.57925ms
+        duration: 535.510916ms
     - id: 128
       request:
         proto: HTTP/1.1
@@ -6339,26 +6337,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/55312258-0bc4-449f-b2a3-e95fcb3fa094
-        method: DELETE
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 1796
         uncompressed: false
-        body: ""
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-12T15:53:16.407771+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-amazing-franklin","id":"0bf0d0f8-fccc-497f-a665-43f0d549eddf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"801","node_id":"145","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c6:8f","maintenances":[],"modification_date":"2025-02-12T15:54:25.961202+00:00","name":"tf-srv-amazing-franklin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
+            Content-Length:
+                - "1796"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:20:12 GMT
+                - Wed, 12 Feb 2025 15:54:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6366,10 +6366,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d281482a-b909-4c97-b4c5-e39934fb34c2
-        status: 204 No Content
-        code: 204
-        duration: 156.732584ms
+                - abe4ea3c-f85a-42b2-8af5-69bc34aac5bf
+        status: 200 OK
+        code: 200
+        duration: 216.63375ms
     - id: 129
       request:
         proto: HTTP/1.1
@@ -6386,7 +6386,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/4955169c-7666-48cb-9e27-7ee608b717d5
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf
         method: GET
       response:
         proto: HTTP/2.0
@@ -6394,20 +6394,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 142
+        content_length: 1796
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_image","resource_id":"4955169c-7666-48cb-9e27-7ee608b717d5","type":"not_found"}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-12T15:53:16.407771+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-amazing-franklin","id":"0bf0d0f8-fccc-497f-a665-43f0d549eddf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"801","node_id":"145","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c6:8f","maintenances":[],"modification_date":"2025-02-12T15:54:25.961202+00:00","name":"tf-srv-amazing-franklin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "142"
+                - "1796"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:20:12 GMT
+                - Wed, 12 Feb 2025 15:54:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6415,10 +6415,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4802329e-c61f-4dba-bc59-4bca81fd0302
-        status: 404 Not Found
-        code: 404
-        duration: 65.869334ms
+                - 9397c2c6-12fa-4e59-a16c-e61cf50c5a2e
+        status: 200 OK
+        code: 200
+        duration: 263.561291ms
     - id: 130
       request:
         proto: HTTP/1.1
@@ -6435,7 +6435,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f97824b7-3276-4224-b71a-d450304ed14c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf
         method: GET
       response:
         proto: HTTP/2.0
@@ -6443,20 +6443,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 145
+        content_length: 1796
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"f97824b7-3276-4224-b71a-d450304ed14c","type":"not_found"}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-12T15:53:16.407771+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-amazing-franklin","id":"0bf0d0f8-fccc-497f-a665-43f0d549eddf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"801","node_id":"145","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c6:8f","maintenances":[],"modification_date":"2025-02-12T15:54:25.961202+00:00","name":"tf-srv-amazing-franklin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "145"
+                - "1796"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:20:12 GMT
+                - Wed, 12 Feb 2025 15:54:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6464,10 +6464,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5e90937c-787d-4e69-996d-25e0133937df
-        status: 404 Not Found
-        code: 404
-        duration: 62.367417ms
+                - a2d26814-5c0f-449f-9142-0763439f20a0
+        status: 200 OK
+        code: 200
+        duration: 223.601041ms
     - id: 131
       request:
         proto: HTTP/1.1
@@ -6484,7 +6484,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/57129456-dcee-482c-b4f2-7ba6d81c6439
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf
         method: GET
       response:
         proto: HTTP/2.0
@@ -6492,20 +6492,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 145
+        content_length: 1680
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"57129456-dcee-482c-b4f2-7ba6d81c6439","type":"not_found"}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-12T15:53:16.407771+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-amazing-franklin","id":"0bf0d0f8-fccc-497f-a665-43f0d549eddf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c6:8f","maintenances":[],"modification_date":"2025-02-12T15:54:41.623206+00:00","name":"tf-srv-amazing-franklin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "145"
+                - "1680"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:20:12 GMT
+                - Wed, 12 Feb 2025 15:54:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6513,10 +6513,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 59b67a71-4cb7-4d0a-8db2-b7c791ffbb93
-        status: 404 Not Found
-        code: 404
-        duration: 73.376917ms
+                - 0c546db1-c4e4-4113-8a06-a6a2eb1565d8
+        status: 200 OK
+        code: 200
+        duration: 166.336292ms
     - id: 132
       request:
         proto: HTTP/1.1
@@ -6533,7 +6533,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/1b0ce8dc-403d-4ab9-b326-d30ddee68e64
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf
         method: GET
       response:
         proto: HTTP/2.0
@@ -6541,20 +6541,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 145
+        content_length: 1680
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"1b0ce8dc-403d-4ab9-b326-d30ddee68e64","type":"not_found"}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-12T15:53:16.407771+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-amazing-franklin","id":"0bf0d0f8-fccc-497f-a665-43f0d549eddf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c6:8f","maintenances":[],"modification_date":"2025-02-12T15:54:41.623206+00:00","name":"tf-srv-amazing-franklin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "145"
+                - "1680"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:20:12 GMT
+                - Wed, 12 Feb 2025 15:54:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6562,10 +6562,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 02ccab5e-bd56-430a-a510-e4a1e578c6b4
-        status: 404 Not Found
-        code: 404
-        duration: 58.182541ms
+                - c6042921-f2e6-4c3a-b256-e6357b5df880
+        status: 200 OK
+        code: 200
+        duration: 160.269042ms
     - id: 133
       request:
         proto: HTTP/1.1
@@ -6582,28 +6582,26 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/89f83395-b4cf-4fee-9853-833f24fdd971
-        method: GET
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 143
+        content_length: 0
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"89f83395-b4cf-4fee-9853-833f24fdd971","type":"not_found"}'
+        body: ""
         headers:
-            Content-Length:
-                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:20:12 GMT
+                - Wed, 12 Feb 2025 15:54:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6611,10 +6609,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0cd05a60-2cfe-4342-a700-021af4ce2181
-        status: 404 Not Found
-        code: 404
-        duration: 68.170375ms
+                - 70ba0ba2-83f6-432f-8609-b0017d23682c
+        status: 204 No Content
+        code: 204
+        duration: 915.302834ms
     - id: 134
       request:
         proto: HTTP/1.1
@@ -6631,7 +6629,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/9b2de5c3-e30b-447e-93e2-983fdba06000
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf
         method: GET
       response:
         proto: HTTP/2.0
@@ -6641,7 +6639,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"9b2de5c3-e30b-447e-93e2-983fdba06000","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"0bf0d0f8-fccc-497f-a665-43f0d549eddf","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -6650,9 +6648,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:20:12 GMT
+                - Wed, 12 Feb 2025 15:54:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6660,10 +6658,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0db30cbc-d55f-40c0-8f5a-be8892fb70c8
+                - e1d64f78-c4da-428d-9db3-b739a5d5bf38
         status: 404 Not Found
         code: 404
-        duration: 72.595167ms
+        duration: 116.240417ms
     - id: 135
       request:
         proto: HTTP/1.1
@@ -6680,7 +6678,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1780c24c-59ed-4db8-bb22-7191af979336
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/5d0109bc-940e-4bc6-b082-d7fa906ccea4
         method: GET
       response:
         proto: HTTP/2.0
@@ -6690,7 +6688,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"1780c24c-59ed-4db8-bb22-7191af979336","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -6699,9 +6697,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 15:20:13 GMT
+                - Wed, 12 Feb 2025 15:54:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6709,7 +6707,446 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a0cf5275-b2dd-4f4e-ae51-afdd8ddff5d6
+                - 2350df9d-4aba-4287-add3-adcca0c370a6
         status: 404 Not Found
         code: 404
-        duration: 93.342542ms
+        duration: 478.288709ms
+    - id: 136
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/5d0109bc-940e-4bc6-b082-d7fa906ccea4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 494
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T15:53:16.620555Z","id":"5d0109bc-940e-4bc6-b082-d7fa906ccea4","last_detached_at":"2025-02-12T15:54:43.354087Z","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T15:54:43.354087Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "494"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c513d855-c391-4a86-a5e5-efbdbf63b3f7
+        status: 200 OK
+        code: 200
+        duration: 90.171167ms
+    - id: 137
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/5d0109bc-940e-4bc6-b082-d7fa906ccea4
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7630e7bf-1bc9-461d-8738-4691de395990
+        status: 204 No Content
+        code: 204
+        duration: 232.874541ms
+    - id: 138
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8995f9f0-67d5-43cd-9844-c11c3a5736e5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 142
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_image","resource_id":"8995f9f0-67d5-43cd-9844-c11c3a5736e5","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "142"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 255759ed-5d6f-4fe2-9e04-976fc37dfc1a
+        status: 404 Not Found
+        code: 404
+        duration: 61.127042ms
+    - id: 139
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/c96574f5-f857-475c-a9f7-41677887eb70
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 129
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"snapshot","resource_id":"c96574f5-f857-475c-a9f7-41677887eb70","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "129"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9d87bb52-cb4b-4931-bcc3-946ff8c17e5e
+        status: 404 Not Found
+        code: 404
+        duration: 121.669042ms
+    - id: 140
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/d1c86ecb-5c28-44fe-81f6-fbed836f38e2
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 129
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"snapshot","resource_id":"d1c86ecb-5c28-44fe-81f6-fbed836f38e2","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "129"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4e09c44a-d3f6-4434-b48e-00a69454819e
+        status: 404 Not Found
+        code: 404
+        duration: 122.774042ms
+    - id: 141
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/ddfdab48-0b8a-4048-8233-5f8bd4fd950b
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 129
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"snapshot","resource_id":"ddfdab48-0b8a-4048-8233-5f8bd4fd950b","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "129"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - af83b72a-fddb-4561-a974-d2b36f80341a
+        status: 404 Not Found
+        code: 404
+        duration: 116.922417ms
+    - id: 142
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/9716a7b8-b692-4c04-8a07-aa6e723ed33c
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 127
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"volume","resource_id":"9716a7b8-b692-4c04-8a07-aa6e723ed33c","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "127"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c38f3e77-9935-4e44-8367-814e85d18111
+        status: 404 Not Found
+        code: 404
+        duration: 134.187167ms
+    - id: 143
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/e9dda481-3566-43af-afe3-859e3cb3aa76
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 127
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"volume","resource_id":"e9dda481-3566-43af-afe3-859e3cb3aa76","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "127"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 10761b99-d28b-42d8-a1fd-ae101c3253bc
+        status: 404 Not Found
+        code: 404
+        duration: 143.573375ms
+    - id: 144
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf0d0f8-fccc-497f-a665-43f0d549eddf
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"0bf0d0f8-fccc-497f-a665-43f0d549eddf","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:54:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f9ab494f-444d-45d1-9ffb-c1b9fff8d386
+        status: 404 Not Found
+        code: 404
+        duration: 116.885833ms

--- a/internal/services/instance/testdata/image-server.cassette.yaml
+++ b/internal/services/instance/testdata/image-server.cassette.yaml
@@ -16,7 +16,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
         method: GET
       response:
@@ -25,22 +25,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 38539
+        content_length: 35639
         uncompressed: false
-        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
+        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
         headers:
             Content-Length:
-                - "38539"
+                - "35639"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:43 GMT
+                - Wed, 12 Feb 2025 16:01:31 GMT
             Link:
                 - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,12 +48,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9bc4c20d-f2f1-4c07-bcb4-fae485e432e7
+                - 29ede2d0-9af8-452c-b140-87b273ab7f13
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 60.493875ms
+        duration: 291.870875ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -69,7 +69,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
         method: GET
       response:
@@ -78,22 +78,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 14208
+        content_length: 13164
         uncompressed: false
-        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
         headers:
             Content-Length:
-                - "14208"
+                - "13164"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:43 GMT
+                - Wed, 12 Feb 2025 16:01:31 GMT
             Link:
                 - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -101,12 +101,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ae87620a-6c30-4aa4-ab07-a52b47dca055
+                - ed7d5645-dbf4-40e6-88a5-0ecc4a98f1cd
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 51.758834ms
+        duration: 73.086042ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -122,8 +122,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_local&zone=fr-par-1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_sbs&zone=fr-par-1
         method: GET
       response:
         proto: HTTP/2.0
@@ -131,20 +131,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1300
+        content_length: 1296
         uncompressed: false
-        body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"56d4019c-8305-467a-a3f2-70498ad799df","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
+        body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"57509e82-ac3b-49b7-9970-97b60f40ff72","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"9b647e1e-253a-41e7-8c15-911c622ee2dc","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"}],"total_count":2}'
         headers:
             Content-Length:
-                - "1300"
+                - "1296"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:43 GMT
+                - Wed, 12 Feb 2025 16:01:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -152,28 +152,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 86045bf5-5040-4492-ab8f-48849014ff2a
+                - 5259171f-d30a-46ef-b6ea-2de3e13ded92
         status: 200 OK
         code: 200
-        duration: 84.556334ms
+        duration: 101.9515ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 277
+        content_length: 234
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-srv-distracted-gould","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+        body: '{"name":"tf-srv-tender-lumiere","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"57509e82-ac3b-49b7-9970-97b60f40ff72","volumes":{"0":{"boot":false}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
         method: POST
       response:
@@ -182,22 +182,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2121
+        content_length: 1672
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:44.079396+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-distracted-gould","id":"eaca9908-d54e-4427-bcee-8d728569458c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:61","maintenances":[],"modification_date":"2025-01-27T13:53:44.079396+00:00","name":"tf-srv-distracted-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:44.079396+00:00","export_uri":null,"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","modification_date":"2025-01-27T13:53:44.079396+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"eaca9908-d54e-4427-bcee-8d728569458c","name":"tf-srv-distracted-gould"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:01:32.495034+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-lumiere","id":"de141f80-bcb9-4d1b-b91e-0c71769c128f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:23","maintenances":[],"modification_date":"2025-02-12T16:01:32.495034+00:00","name":"tf-srv-tender-lumiere","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"0aa2eadf-770f-41d8-84a6-e3929a361816","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2121"
+                - "1672"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:44 GMT
+                - Wed, 12 Feb 2025 16:01:32 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/eaca9908-d54e-4427-bcee-8d728569458c
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/de141f80-bcb9-4d1b-b91e-0c71769c128f
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -205,10 +205,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 621d14de-f598-437b-a133-2184084521a5
+                - c4877413-761c-4be1-b8ab-469bd8ad890d
         status: 201 Created
         code: 201
-        duration: 1.031979125s
+        duration: 853.383667ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -224,8 +224,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/eaca9908-d54e-4427-bcee-8d728569458c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/de141f80-bcb9-4d1b-b91e-0c71769c128f
         method: GET
       response:
         proto: HTTP/2.0
@@ -233,20 +233,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2121
+        content_length: 1672
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:44.079396+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-distracted-gould","id":"eaca9908-d54e-4427-bcee-8d728569458c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:61","maintenances":[],"modification_date":"2025-01-27T13:53:44.079396+00:00","name":"tf-srv-distracted-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:44.079396+00:00","export_uri":null,"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","modification_date":"2025-01-27T13:53:44.079396+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"eaca9908-d54e-4427-bcee-8d728569458c","name":"tf-srv-distracted-gould"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:01:32.495034+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-lumiere","id":"de141f80-bcb9-4d1b-b91e-0c71769c128f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:23","maintenances":[],"modification_date":"2025-02-12T16:01:32.495034+00:00","name":"tf-srv-tender-lumiere","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"0aa2eadf-770f-41d8-84a6-e3929a361816","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2121"
+                - "1672"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:44 GMT
+                - Wed, 12 Feb 2025 16:01:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -254,10 +254,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c9edd613-f27e-4b33-bef2-08b1d76608a6
+                - c85de0eb-2fd3-4323-a455-e4928180d47a
         status: 200 OK
         code: 200
-        duration: 141.053417ms
+        duration: 213.127958ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -273,8 +273,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/eaca9908-d54e-4427-bcee-8d728569458c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/de141f80-bcb9-4d1b-b91e-0c71769c128f
         method: GET
       response:
         proto: HTTP/2.0
@@ -282,20 +282,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2121
+        content_length: 1672
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:44.079396+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-distracted-gould","id":"eaca9908-d54e-4427-bcee-8d728569458c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:61","maintenances":[],"modification_date":"2025-01-27T13:53:44.079396+00:00","name":"tf-srv-distracted-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:44.079396+00:00","export_uri":null,"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","modification_date":"2025-01-27T13:53:44.079396+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"eaca9908-d54e-4427-bcee-8d728569458c","name":"tf-srv-distracted-gould"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:01:32.495034+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-lumiere","id":"de141f80-bcb9-4d1b-b91e-0c71769c128f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:23","maintenances":[],"modification_date":"2025-02-12T16:01:32.495034+00:00","name":"tf-srv-tender-lumiere","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"0aa2eadf-770f-41d8-84a6-e3929a361816","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2121"
+                - "1672"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:44 GMT
+                - Wed, 12 Feb 2025 16:01:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -303,11 +303,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 758f1832-33a0-4037-ba46-38c12c65b64e
+                - a275b74a-9bb0-4d65-bb0a-761eb0950220
         status: 200 OK
         code: 200
-        duration: 146.236459ms
+        duration: 174.736042ms
     - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/0aa2eadf-770f-41d8-84a6-e3929a361816
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:01:32.745747Z","id":"0aa2eadf-770f-41d8-84a6-e3929a361816","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:01:32.745747Z","id":"b8c235c0-4ff6-4222-bb46-f2d56ea57648","product_resource_id":"de141f80-bcb9-4d1b-b91e-0c71769c128f","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:01:32.745747Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:01:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4f6668c4-eade-4da5-af74-584d8782c49c
+        status: 200 OK
+        code: 200
+        duration: 83.739584ms
+    - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -324,8 +373,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/eaca9908-d54e-4427-bcee-8d728569458c/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/de141f80-bcb9-4d1b-b91e-0c71769c128f/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -335,7 +384,7 @@ interactions:
         trailer: {}
         content_length: 357
         uncompressed: false
-        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/eaca9908-d54e-4427-bcee-8d728569458c/action","href_result":"/servers/eaca9908-d54e-4427-bcee-8d728569458c","id":"0c5c7bb0-b429-4356-b8fa-a1ee2eeef57f","progress":0,"started_at":"2025-01-27T13:53:45.120993+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/de141f80-bcb9-4d1b-b91e-0c71769c128f/action","href_result":"/servers/de141f80-bcb9-4d1b-b91e-0c71769c128f","id":"2403f599-1fae-43ab-8ef9-41b277032f51","progress":0,"started_at":"2025-02-12T16:01:33.899545+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -344,11 +393,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:45 GMT
+                - Wed, 12 Feb 2025 16:01:33 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/0c5c7bb0-b429-4356-b8fa-a1ee2eeef57f
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/2403f599-1fae-43ab-8ef9-41b277032f51
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -356,59 +405,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c7763b6a-55c4-4f48-bed4-fc0bae4bf8f9
+                - 3ba33a58-3888-4d6d-9d90-25da2a500db0
         status: 202 Accepted
         code: 202
-        duration: 459.067416ms
-    - id: 7
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/eaca9908-d54e-4427-bcee-8d728569458c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2143
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:44.079396+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-distracted-gould","id":"eaca9908-d54e-4427-bcee-8d728569458c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:61","maintenances":[],"modification_date":"2025-01-27T13:53:44.778120+00:00","name":"tf-srv-distracted-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:44.079396+00:00","export_uri":null,"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","modification_date":"2025-01-27T13:53:44.079396+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"eaca9908-d54e-4427-bcee-8d728569458c","name":"tf-srv-distracted-gould"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2143"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:53:45 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - a00f929e-a6eb-40b0-aeab-1c5e7be6ebef
-        status: 200 OK
-        code: 200
-        duration: 212.939958ms
+        duration: 352.708292ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -424,8 +424,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/eaca9908-d54e-4427-bcee-8d728569458c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/de141f80-bcb9-4d1b-b91e-0c71769c128f
         method: GET
       response:
         proto: HTTP/2.0
@@ -433,20 +433,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2247
+        content_length: 1694
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:44.079396+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-distracted-gould","id":"eaca9908-d54e-4427-bcee-8d728569458c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1102","node_id":"27","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:61","maintenances":[],"modification_date":"2025-01-27T13:53:44.778120+00:00","name":"tf-srv-distracted-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:44.079396+00:00","export_uri":null,"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","modification_date":"2025-01-27T13:53:44.079396+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"eaca9908-d54e-4427-bcee-8d728569458c","name":"tf-srv-distracted-gould"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:01:32.495034+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-lumiere","id":"de141f80-bcb9-4d1b-b91e-0c71769c128f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:23","maintenances":[],"modification_date":"2025-02-12T16:01:33.624411+00:00","name":"tf-srv-tender-lumiere","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"id":"0aa2eadf-770f-41d8-84a6-e3929a361816","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2247"
+                - "1694"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:50 GMT
+                - Wed, 12 Feb 2025 16:01:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -454,10 +454,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5230d580-92c3-473e-bf16-b43ad1625d53
+                - f0316016-8a43-491d-b197-c2d64d6d46da
         status: 200 OK
         code: 200
-        duration: 162.158208ms
+        duration: 170.408209ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -473,8 +473,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/eaca9908-d54e-4427-bcee-8d728569458c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/de141f80-bcb9-4d1b-b91e-0c71769c128f
         method: GET
       response:
         proto: HTTP/2.0
@@ -482,20 +482,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2247
+        content_length: 1827
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:44.079396+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-distracted-gould","id":"eaca9908-d54e-4427-bcee-8d728569458c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1102","node_id":"27","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:61","maintenances":[],"modification_date":"2025-01-27T13:53:44.778120+00:00","name":"tf-srv-distracted-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:44.079396+00:00","export_uri":null,"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","modification_date":"2025-01-27T13:53:44.079396+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"eaca9908-d54e-4427-bcee-8d728569458c","name":"tf-srv-distracted-gould"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:01:32.495034+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-lumiere","id":"de141f80-bcb9-4d1b-b91e-0c71769c128f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"801","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:23","maintenances":[],"modification_date":"2025-02-12T16:01:38.899249+00:00","name":"tf-srv-tender-lumiere","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"0aa2eadf-770f-41d8-84a6-e3929a361816","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2247"
+                - "1827"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:55 GMT
+                - Wed, 12 Feb 2025 16:01:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -503,10 +503,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f0af0ddb-d7ce-4d29-bae4-4fb137ab1896
+                - ad3ead89-e72e-4aac-a6d5-ad310dae0e74
         status: 200 OK
         code: 200
-        duration: 160.671417ms
+        duration: 233.200583ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -522,8 +522,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/eaca9908-d54e-4427-bcee-8d728569458c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/de141f80-bcb9-4d1b-b91e-0c71769c128f
         method: GET
       response:
         proto: HTTP/2.0
@@ -531,20 +531,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2278
+        content_length: 1827
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:44.079396+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-distracted-gould","id":"eaca9908-d54e-4427-bcee-8d728569458c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1102","node_id":"27","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:61","maintenances":[],"modification_date":"2025-01-27T13:53:57.454534+00:00","name":"tf-srv-distracted-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:44.079396+00:00","export_uri":null,"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","modification_date":"2025-01-27T13:53:44.079396+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"eaca9908-d54e-4427-bcee-8d728569458c","name":"tf-srv-distracted-gould"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:01:32.495034+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-lumiere","id":"de141f80-bcb9-4d1b-b91e-0c71769c128f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"801","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:23","maintenances":[],"modification_date":"2025-02-12T16:01:38.899249+00:00","name":"tf-srv-tender-lumiere","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"0aa2eadf-770f-41d8-84a6-e3929a361816","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2278"
+                - "1827"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:00 GMT
+                - Wed, 12 Feb 2025 16:01:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -552,10 +552,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 97c101c0-19dc-4a7b-a914-d3507867ff2e
+                - 01ce8158-243d-44b7-97e3-b8df96684e32
         status: 200 OK
         code: 200
-        duration: 186.484167ms
+        duration: 226.656ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -571,8 +571,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/eaca9908-d54e-4427-bcee-8d728569458c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0aa2eadf-770f-41d8-84a6-e3929a361816
         method: GET
       response:
         proto: HTTP/2.0
@@ -580,20 +580,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2278
+        content_length: 143
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:44.079396+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-distracted-gould","id":"eaca9908-d54e-4427-bcee-8d728569458c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1102","node_id":"27","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:61","maintenances":[],"modification_date":"2025-01-27T13:53:57.454534+00:00","name":"tf-srv-distracted-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:44.079396+00:00","export_uri":null,"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","modification_date":"2025-01-27T13:53:44.079396+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"eaca9908-d54e-4427-bcee-8d728569458c","name":"tf-srv-distracted-gould"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"0aa2eadf-770f-41d8-84a6-e3929a361816","type":"not_found"}'
         headers:
             Content-Length:
-                - "2278"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:01 GMT
+                - Wed, 12 Feb 2025 16:01:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -601,10 +601,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 52efcd04-dc2e-4d3f-810d-d21634a590b3
-        status: 200 OK
-        code: 200
-        duration: 175.856791ms
+                - 195ff258-d500-41d8-a00a-9dba9f9b378f
+        status: 404 Not Found
+        code: 404
+        duration: 62.229167ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -620,8 +620,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/6c12a713-2b3c-495e-b095-c5a0a5c4d98e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/0aa2eadf-770f-41d8-84a6-e3929a361816
         method: GET
       response:
         proto: HTTP/2.0
@@ -629,20 +629,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 523
+        content_length: 701
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:53:44.079396+00:00","export_uri":null,"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","modification_date":"2025-01-27T13:53:44.079396+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"eaca9908-d54e-4427-bcee-8d728569458c","name":"tf-srv-distracted-gould"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-12T16:01:32.745747Z","id":"0aa2eadf-770f-41d8-84a6-e3929a361816","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:01:32.745747Z","id":"b8c235c0-4ff6-4222-bb46-f2d56ea57648","product_resource_id":"de141f80-bcb9-4d1b-b91e-0c71769c128f","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:01:32.745747Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "523"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:01 GMT
+                - Wed, 12 Feb 2025 16:01:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -650,10 +650,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8c7cfb9b-43d8-4d91-97d9-20cbf095409e
+                - 53fb6ce1-e673-49e6-8be3-985c62265d82
         status: 200 OK
         code: 200
-        duration: 91.658334ms
+        duration: 86.112208ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -669,8 +669,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/eaca9908-d54e-4427-bcee-8d728569458c/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/de141f80-bcb9-4d1b-b91e-0c71769c128f/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -689,9 +689,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:00 GMT
+                - Wed, 12 Feb 2025 16:01:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -699,10 +699,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ab98cb51-bf3a-4260-8f8b-8b290f10ba86
+                - 581ca698-3647-439a-8c8c-685fbd3ea858
         status: 200 OK
         code: 200
-        duration: 87.186292ms
+        duration: 130.9975ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -718,8 +718,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/eaca9908-d54e-4427-bcee-8d728569458c/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/de141f80-bcb9-4d1b-b91e-0c71769c128f/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -738,11 +738,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:01 GMT
+                - Wed, 12 Feb 2025 16:01:39 GMT
             Link:
-                - </servers/eaca9908-d54e-4427-bcee-8d728569458c/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/de141f80-bcb9-4d1b-b91e-0c71769c128f/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -750,31 +750,31 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1dd616c2-6cb7-42b0-b702-00e7f78dcd86
+                - bd26d665-53e0-4b2e-9b42-d8d55e2dca07
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 75.681334ms
+        duration: 114.752ms
     - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 131
+        content_length: 153
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-snap-hungry-payne","volume_id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+        body: '{"volume_id":"0aa2eadf-770f-41d8-84a6-e3929a361816","name":"tf-snapshot-confident-wescoff","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[]}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots
         method: POST
       response:
         proto: HTTP/2.0
@@ -782,20 +782,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 844
+        content_length: 476
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:54:01.525823+00:00","error_details":null,"id":"f6413266-6b5f-49bd-b984-64ea90d174da","modification_date":"2025-01-27T13:54:01.525823+00:00","name":"tf-snap-hungry-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"task":{"description":"volume_snapshot","href_from":"/snapshots","href_result":"snapshots/f6413266-6b5f-49bd-b984-64ea90d174da","id":"e50a3676-4571-4425-b1b3-def490ed4729","progress":0,"started_at":"2025-01-27T13:54:01.786880+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"class":"sbs","created_at":"2025-02-12T16:01:40.148231Z","id":"e8ceb46c-9003-4eb1-a5fc-53465a1574d5","name":"tf-snapshot-confident-wescoff","parent_volume":{"id":"0aa2eadf-770f-41d8-84a6-e3929a361816","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","status":"in_use","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"status":"creating","tags":[],"updated_at":"2025-02-12T16:01:40.148231Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "844"
+                - "476"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:01 GMT
+                - Wed, 12 Feb 2025 16:01:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -803,10 +803,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f2f566dc-f2df-49b6-83e2-6119dae29e53
-        status: 201 Created
-        code: 201
-        duration: 588.991791ms
+                - 1f0bb75d-ccf9-4039-a2a2-976f7ca2fd43
+        status: 200 OK
+        code: 200
+        duration: 405.391625ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -822,8 +822,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f6413266-6b5f-49bd-b984-64ea90d174da
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/e8ceb46c-9003-4eb1-a5fc-53465a1574d5
         method: GET
       response:
         proto: HTTP/2.0
@@ -831,20 +831,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 533
+        content_length: 707
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:54:01.525823+00:00","error_details":null,"id":"f6413266-6b5f-49bd-b984-64ea90d174da","modification_date":"2025-01-27T13:54:01.525823+00:00","name":"tf-snap-hungry-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"class":"sbs","created_at":"2025-02-12T16:01:40.148231Z","id":"e8ceb46c-9003-4eb1-a5fc-53465a1574d5","name":"tf-snapshot-confident-wescoff","parent_volume":{"id":"0aa2eadf-770f-41d8-84a6-e3929a361816","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","status":"in_use","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:01:40.178092Z","id":"00505db2-8b91-4c25-9b6e-006d87467341","product_resource_id":"00000000-0000-0000-0000-000000000000","product_resource_type":"internal","status":"attached","type":"unknown_type"}],"size":10000000000,"status":"creating","tags":[],"updated_at":"2025-02-12T16:01:40.148231Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "533"
+                - "707"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:01 GMT
+                - Wed, 12 Feb 2025 16:01:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -852,10 +852,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d3f58213-4b41-4f0b-b960-6dd6390d0c7a
+                - 33837354-8d4b-4b94-9ac3-5a61b818223d
         status: 200 OK
         code: 200
-        duration: 86.941041ms
+        duration: 142.530459ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -871,8 +871,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f6413266-6b5f-49bd-b984-64ea90d174da
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/e8ceb46c-9003-4eb1-a5fc-53465a1574d5
         method: GET
       response:
         proto: HTTP/2.0
@@ -880,20 +880,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 533
+        content_length: 707
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:54:01.525823+00:00","error_details":null,"id":"f6413266-6b5f-49bd-b984-64ea90d174da","modification_date":"2025-01-27T13:54:01.525823+00:00","name":"tf-snap-hungry-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"class":"sbs","created_at":"2025-02-12T16:01:40.148231Z","id":"e8ceb46c-9003-4eb1-a5fc-53465a1574d5","name":"tf-snapshot-confident-wescoff","parent_volume":{"id":"0aa2eadf-770f-41d8-84a6-e3929a361816","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","status":"in_use","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:01:40.178092Z","id":"00505db2-8b91-4c25-9b6e-006d87467341","product_resource_id":"00000000-0000-0000-0000-000000000000","product_resource_type":"internal","status":"attached","type":"unknown_type"}],"size":10000000000,"status":"creating","tags":[],"updated_at":"2025-02-12T16:01:40.148231Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "533"
+                - "707"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:07 GMT
+                - Wed, 12 Feb 2025 16:01:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -901,10 +901,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6bd15356-1493-4b0e-be03-c210e7da60e7
+                - b9ed95c0-c3fe-4902-ac72-49fbfd8b1139
         status: 200 OK
         code: 200
-        duration: 86.76575ms
+        duration: 123.693375ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -920,8 +920,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f6413266-6b5f-49bd-b984-64ea90d174da
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/e8ceb46c-9003-4eb1-a5fc-53465a1574d5
         method: GET
       response:
         proto: HTTP/2.0
@@ -929,20 +929,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 533
+        content_length: 707
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:54:01.525823+00:00","error_details":null,"id":"f6413266-6b5f-49bd-b984-64ea90d174da","modification_date":"2025-01-27T13:54:01.525823+00:00","name":"tf-snap-hungry-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"class":"sbs","created_at":"2025-02-12T16:01:40.148231Z","id":"e8ceb46c-9003-4eb1-a5fc-53465a1574d5","name":"tf-snapshot-confident-wescoff","parent_volume":{"id":"0aa2eadf-770f-41d8-84a6-e3929a361816","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","status":"in_use","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:01:40.178092Z","id":"00505db2-8b91-4c25-9b6e-006d87467341","product_resource_id":"00000000-0000-0000-0000-000000000000","product_resource_type":"internal","status":"attached","type":"unknown_type"}],"size":10000000000,"status":"creating","tags":[],"updated_at":"2025-02-12T16:01:40.148231Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "533"
+                - "707"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:12 GMT
+                - Wed, 12 Feb 2025 16:01:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -950,10 +950,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6cc8a21c-964b-4e68-9cdf-f113bad787bd
+                - 66ca1518-a270-49c9-90c9-ae42c26d6803
         status: 200 OK
         code: 200
-        duration: 77.083667ms
+        duration: 371.656709ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -969,8 +969,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f6413266-6b5f-49bd-b984-64ea90d174da
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/e8ceb46c-9003-4eb1-a5fc-53465a1574d5
         method: GET
       response:
         proto: HTTP/2.0
@@ -978,20 +978,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 533
+        content_length: 707
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:54:01.525823+00:00","error_details":null,"id":"f6413266-6b5f-49bd-b984-64ea90d174da","modification_date":"2025-01-27T13:54:01.525823+00:00","name":"tf-snap-hungry-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"class":"sbs","created_at":"2025-02-12T16:01:40.148231Z","id":"e8ceb46c-9003-4eb1-a5fc-53465a1574d5","name":"tf-snapshot-confident-wescoff","parent_volume":{"id":"0aa2eadf-770f-41d8-84a6-e3929a361816","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","status":"in_use","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:01:40.178092Z","id":"00505db2-8b91-4c25-9b6e-006d87467341","product_resource_id":"00000000-0000-0000-0000-000000000000","product_resource_type":"internal","status":"attached","type":"unknown_type"}],"size":10000000000,"status":"creating","tags":[],"updated_at":"2025-02-12T16:01:40.148231Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "533"
+                - "707"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:17 GMT
+                - Wed, 12 Feb 2025 16:01:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -999,10 +999,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b4df9457-860d-4d5a-b02a-2ba9c02c4eab
+                - 034d3029-3091-4671-8247-a4fda3a7a7e3
         status: 200 OK
         code: 200
-        duration: 79.345291ms
+        duration: 104.734291ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1018,8 +1018,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f6413266-6b5f-49bd-b984-64ea90d174da
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/e8ceb46c-9003-4eb1-a5fc-53465a1574d5
         method: GET
       response:
         proto: HTTP/2.0
@@ -1027,20 +1027,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 533
+        content_length: 707
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:54:01.525823+00:00","error_details":null,"id":"f6413266-6b5f-49bd-b984-64ea90d174da","modification_date":"2025-01-27T13:54:01.525823+00:00","name":"tf-snap-hungry-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"class":"sbs","created_at":"2025-02-12T16:01:40.148231Z","id":"e8ceb46c-9003-4eb1-a5fc-53465a1574d5","name":"tf-snapshot-confident-wescoff","parent_volume":{"id":"0aa2eadf-770f-41d8-84a6-e3929a361816","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","status":"in_use","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:01:40.178092Z","id":"00505db2-8b91-4c25-9b6e-006d87467341","product_resource_id":"00000000-0000-0000-0000-000000000000","product_resource_type":"internal","status":"attached","type":"unknown_type"}],"size":10000000000,"status":"creating","tags":[],"updated_at":"2025-02-12T16:01:40.148231Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "533"
+                - "707"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:22 GMT
+                - Wed, 12 Feb 2025 16:02:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1048,10 +1048,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 970d6668-bde0-45bf-8692-a1871b988e34
+                - 9c451da0-7a08-4eda-92c4-7fc0efc0a1f8
         status: 200 OK
         code: 200
-        duration: 108.088458ms
+        duration: 414.812875ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1067,8 +1067,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f6413266-6b5f-49bd-b984-64ea90d174da
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/e8ceb46c-9003-4eb1-a5fc-53465a1574d5
         method: GET
       response:
         proto: HTTP/2.0
@@ -1076,20 +1076,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 533
+        content_length: 707
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:54:01.525823+00:00","error_details":null,"id":"f6413266-6b5f-49bd-b984-64ea90d174da","modification_date":"2025-01-27T13:54:01.525823+00:00","name":"tf-snap-hungry-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"class":"sbs","created_at":"2025-02-12T16:01:40.148231Z","id":"e8ceb46c-9003-4eb1-a5fc-53465a1574d5","name":"tf-snapshot-confident-wescoff","parent_volume":{"id":"0aa2eadf-770f-41d8-84a6-e3929a361816","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","status":"in_use","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:01:40.178092Z","id":"00505db2-8b91-4c25-9b6e-006d87467341","product_resource_id":"00000000-0000-0000-0000-000000000000","product_resource_type":"internal","status":"attached","type":"unknown_type"}],"size":10000000000,"status":"creating","tags":[],"updated_at":"2025-02-12T16:01:40.148231Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "533"
+                - "707"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:27 GMT
+                - Wed, 12 Feb 2025 16:02:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1097,10 +1097,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7c145484-fd61-4e7d-9604-3d0646fccd35
+                - 964ba839-6490-4cf3-b78d-33a6d35290e8
         status: 200 OK
         code: 200
-        duration: 76.032875ms
+        duration: 113.655125ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1116,8 +1116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f6413266-6b5f-49bd-b984-64ea90d174da
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/e8ceb46c-9003-4eb1-a5fc-53465a1574d5
         method: GET
       response:
         proto: HTTP/2.0
@@ -1125,20 +1125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 533
+        content_length: 707
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:54:01.525823+00:00","error_details":null,"id":"f6413266-6b5f-49bd-b984-64ea90d174da","modification_date":"2025-01-27T13:54:01.525823+00:00","name":"tf-snap-hungry-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"class":"sbs","created_at":"2025-02-12T16:01:40.148231Z","id":"e8ceb46c-9003-4eb1-a5fc-53465a1574d5","name":"tf-snapshot-confident-wescoff","parent_volume":{"id":"0aa2eadf-770f-41d8-84a6-e3929a361816","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","status":"in_use","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:01:40.178092Z","id":"00505db2-8b91-4c25-9b6e-006d87467341","product_resource_id":"00000000-0000-0000-0000-000000000000","product_resource_type":"internal","status":"attached","type":"unknown_type"}],"size":10000000000,"status":"creating","tags":[],"updated_at":"2025-02-12T16:01:40.148231Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "533"
+                - "707"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:32 GMT
+                - Wed, 12 Feb 2025 16:02:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1146,10 +1146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4362ac12-a7c3-4f8a-9b78-25d2ee2ae100
+                - 9c372e8e-450e-4f89-883a-875182252713
         status: 200 OK
         code: 200
-        duration: 84.54375ms
+        duration: 104.922875ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1165,8 +1165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f6413266-6b5f-49bd-b984-64ea90d174da
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/e8ceb46c-9003-4eb1-a5fc-53465a1574d5
         method: GET
       response:
         proto: HTTP/2.0
@@ -1174,20 +1174,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 530
+        content_length: 477
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:54:01.525823+00:00","error_details":null,"id":"f6413266-6b5f-49bd-b984-64ea90d174da","modification_date":"2025-01-27T13:54:36.396179+00:00","name":"tf-snap-hungry-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"class":"sbs","created_at":"2025-02-12T16:01:40.148231Z","id":"e8ceb46c-9003-4eb1-a5fc-53465a1574d5","name":"tf-snapshot-confident-wescoff","parent_volume":{"id":"0aa2eadf-770f-41d8-84a6-e3929a361816","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","status":"in_use","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"status":"available","tags":[],"updated_at":"2025-02-12T16:01:40.148231Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "530"
+                - "477"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:37 GMT
+                - Wed, 12 Feb 2025 16:02:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1195,10 +1195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 67f84d1d-ec9e-4253-ac97-863b3baf4735
+                - 539b35b1-d51b-4712-804f-300efe79bbf5
         status: 200 OK
         code: 200
-        duration: 80.49175ms
+        duration: 114.017ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1214,8 +1214,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f6413266-6b5f-49bd-b984-64ea90d174da
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/e8ceb46c-9003-4eb1-a5fc-53465a1574d5
         method: GET
       response:
         proto: HTTP/2.0
@@ -1223,20 +1223,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 530
+        content_length: 477
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:54:01.525823+00:00","error_details":null,"id":"f6413266-6b5f-49bd-b984-64ea90d174da","modification_date":"2025-01-27T13:54:36.396179+00:00","name":"tf-snap-hungry-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"class":"sbs","created_at":"2025-02-12T16:01:40.148231Z","id":"e8ceb46c-9003-4eb1-a5fc-53465a1574d5","name":"tf-snapshot-confident-wescoff","parent_volume":{"id":"0aa2eadf-770f-41d8-84a6-e3929a361816","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","status":"in_use","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"status":"available","tags":[],"updated_at":"2025-02-12T16:01:40.148231Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "530"
+                - "477"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:37 GMT
+                - Wed, 12 Feb 2025 16:02:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1244,28 +1244,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5abaf109-54af-4556-a03a-973555ac01cc
+                - 10aa8011-4b16-48fd-bc0b-77040982f382
         status: 200 OK
         code: 200
-        duration: 87.042083ms
+        duration: 127.865667ms
     - id: 25
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 195
+        content_length: 192
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-image-reverent-euler","root_volume":"f6413266-6b5f-49bd-b984-64ea90d174da","arch":"x86_64","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":["test_remove_tags"],"public":false}'
+        body: '{"name":"tf-image-cranky-boyd","root_volume":"e8ceb46c-9003-4eb1-a5fc-53465a1574d5","arch":"x86_64","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":["test_remove_tags"],"public":false}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images
         method: POST
       response:
@@ -1274,22 +1274,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 624
+        content_length: 598
         uncompressed: false
-        body: '{"image":{"arch":"x86_64","creation_date":"2025-01-27T13:54:37.883974+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"6cecef1a-ddd1-4e77-953c-8b809986f0ff","modification_date":"2025-01-27T13:54:37.883974+00:00","name":"tf-image-reverent-euler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"f6413266-6b5f-49bd-b984-64ea90d174da","name":"tf-snap-hungry-payne","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":["test_remove_tags"],"zone":"fr-par-1"}}'
+        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T16:02:17.190841+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"775987a3-b39a-414c-b482-9b098f631d1e","modification_date":"2025-02-12T16:02:17.190841+00:00","name":"tf-image-cranky-boyd","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"e8ceb46c-9003-4eb1-a5fc-53465a1574d5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":["test_remove_tags"],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "624"
+                - "598"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:37 GMT
+                - Wed, 12 Feb 2025 16:02:17 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/images/6cecef1a-ddd1-4e77-953c-8b809986f0ff
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/images/775987a3-b39a-414c-b482-9b098f631d1e
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1297,10 +1297,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2d9cedd4-ef2c-4c06-9204-c7a103c1a3fe
+                - 88e5046d-c6b5-426f-9d50-80e4d9ad5306
         status: 201 Created
         code: 201
-        duration: 253.681583ms
+        duration: 517.448125ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1316,8 +1316,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/6cecef1a-ddd1-4e77-953c-8b809986f0ff
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/775987a3-b39a-414c-b482-9b098f631d1e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1325,20 +1325,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 624
+        content_length: 598
         uncompressed: false
-        body: '{"image":{"arch":"x86_64","creation_date":"2025-01-27T13:54:37.883974+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"6cecef1a-ddd1-4e77-953c-8b809986f0ff","modification_date":"2025-01-27T13:54:37.883974+00:00","name":"tf-image-reverent-euler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"f6413266-6b5f-49bd-b984-64ea90d174da","name":"tf-snap-hungry-payne","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":["test_remove_tags"],"zone":"fr-par-1"}}'
+        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T16:02:17.190841+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"775987a3-b39a-414c-b482-9b098f631d1e","modification_date":"2025-02-12T16:02:17.190841+00:00","name":"tf-image-cranky-boyd","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"e8ceb46c-9003-4eb1-a5fc-53465a1574d5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":["test_remove_tags"],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "624"
+                - "598"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:37 GMT
+                - Wed, 12 Feb 2025 16:02:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1346,10 +1346,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d3168d60-741e-49e9-918f-d416d3153d6a
+                - 9157514c-c220-4cd4-9503-6417f0700be0
         status: 200 OK
         code: 200
-        duration: 103.942583ms
+        duration: 124.698333ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1365,8 +1365,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/6cecef1a-ddd1-4e77-953c-8b809986f0ff
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/775987a3-b39a-414c-b482-9b098f631d1e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1374,20 +1374,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 624
+        content_length: 598
         uncompressed: false
-        body: '{"image":{"arch":"x86_64","creation_date":"2025-01-27T13:54:37.883974+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"6cecef1a-ddd1-4e77-953c-8b809986f0ff","modification_date":"2025-01-27T13:54:37.883974+00:00","name":"tf-image-reverent-euler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"f6413266-6b5f-49bd-b984-64ea90d174da","name":"tf-snap-hungry-payne","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":["test_remove_tags"],"zone":"fr-par-1"}}'
+        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T16:02:17.190841+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"775987a3-b39a-414c-b482-9b098f631d1e","modification_date":"2025-02-12T16:02:17.190841+00:00","name":"tf-image-cranky-boyd","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"e8ceb46c-9003-4eb1-a5fc-53465a1574d5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":["test_remove_tags"],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "624"
+                - "598"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:37 GMT
+                - Wed, 12 Feb 2025 16:02:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1395,10 +1395,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1c031adc-3046-4ed2-a2d6-69570f782c86
+                - 931f9a0d-1396-41ac-aa7a-bf3264c563e2
         status: 200 OK
         code: 200
-        duration: 109.432625ms
+        duration: 686.262041ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1414,8 +1414,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/eaca9908-d54e-4427-bcee-8d728569458c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/de141f80-bcb9-4d1b-b91e-0c71769c128f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1423,20 +1423,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2278
+        content_length: 1827
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:44.079396+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-distracted-gould","id":"eaca9908-d54e-4427-bcee-8d728569458c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1102","node_id":"27","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:61","maintenances":[],"modification_date":"2025-01-27T13:53:57.454534+00:00","name":"tf-srv-distracted-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:44.079396+00:00","export_uri":null,"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","modification_date":"2025-01-27T13:54:36.396179+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"eaca9908-d54e-4427-bcee-8d728569458c","name":"tf-srv-distracted-gould"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:01:32.495034+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-lumiere","id":"de141f80-bcb9-4d1b-b91e-0c71769c128f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"801","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:23","maintenances":[],"modification_date":"2025-02-12T16:01:38.899249+00:00","name":"tf-srv-tender-lumiere","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"0aa2eadf-770f-41d8-84a6-e3929a361816","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2278"
+                - "1827"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:38 GMT
+                - Wed, 12 Feb 2025 16:02:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1444,10 +1444,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e698b6b2-6d92-4e3a-9253-4ae821b7db7d
+                - f369b86a-ca14-44e2-9e94-7c631f996eb1
         status: 200 OK
         code: 200
-        duration: 151.126167ms
+        duration: 244.213958ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1463,8 +1463,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f6413266-6b5f-49bd-b984-64ea90d174da
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/e8ceb46c-9003-4eb1-a5fc-53465a1574d5
         method: GET
       response:
         proto: HTTP/2.0
@@ -1472,20 +1472,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 530
+        content_length: 703
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:54:01.525823+00:00","error_details":null,"id":"f6413266-6b5f-49bd-b984-64ea90d174da","modification_date":"2025-01-27T13:54:36.396179+00:00","name":"tf-snap-hungry-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"class":"sbs","created_at":"2025-02-12T16:01:40.148231Z","id":"e8ceb46c-9003-4eb1-a5fc-53465a1574d5","name":"tf-snapshot-confident-wescoff","parent_volume":{"id":"0aa2eadf-770f-41d8-84a6-e3929a361816","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","status":"in_use","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:02:17.250835Z","id":"b11f2295-91a3-4560-b2c6-e4a98774a0da","product_resource_id":"775987a3-b39a-414c-b482-9b098f631d1e","product_resource_type":"instance_image","status":"attached","type":"link"}],"size":10000000000,"status":"in_use","tags":[],"updated_at":"2025-02-12T16:02:17.250835Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "530"
+                - "703"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:38 GMT
+                - Wed, 12 Feb 2025 16:02:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1493,10 +1493,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - da0fc5d7-bd6c-4384-bb74-616b5ad8a6ab
+                - 9916cebd-cc5f-481b-9180-82e3faa8a320
         status: 200 OK
         code: 200
-        duration: 94.936083ms
+        duration: 100.348625ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1512,8 +1512,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/6cecef1a-ddd1-4e77-953c-8b809986f0ff
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/775987a3-b39a-414c-b482-9b098f631d1e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1521,20 +1521,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 624
+        content_length: 598
         uncompressed: false
-        body: '{"image":{"arch":"x86_64","creation_date":"2025-01-27T13:54:37.883974+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"6cecef1a-ddd1-4e77-953c-8b809986f0ff","modification_date":"2025-01-27T13:54:37.883974+00:00","name":"tf-image-reverent-euler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"f6413266-6b5f-49bd-b984-64ea90d174da","name":"tf-snap-hungry-payne","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":["test_remove_tags"],"zone":"fr-par-1"}}'
+        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T16:02:17.190841+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"775987a3-b39a-414c-b482-9b098f631d1e","modification_date":"2025-02-12T16:02:17.190841+00:00","name":"tf-image-cranky-boyd","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"e8ceb46c-9003-4eb1-a5fc-53465a1574d5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":["test_remove_tags"],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "624"
+                - "598"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:38 GMT
+                - Wed, 12 Feb 2025 16:02:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1542,10 +1542,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8cc1f993-12dc-4b22-89df-87e757d0c898
+                - bbb47297-3a38-4eda-ac34-4e43c658836f
         status: 200 OK
         code: 200
-        duration: 76.069292ms
+        duration: 121.21025ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1561,8 +1561,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/eaca9908-d54e-4427-bcee-8d728569458c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/de141f80-bcb9-4d1b-b91e-0c71769c128f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1570,20 +1570,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2278
+        content_length: 1827
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:44.079396+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-distracted-gould","id":"eaca9908-d54e-4427-bcee-8d728569458c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1102","node_id":"27","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:61","maintenances":[],"modification_date":"2025-01-27T13:53:57.454534+00:00","name":"tf-srv-distracted-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:44.079396+00:00","export_uri":null,"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","modification_date":"2025-01-27T13:54:36.396179+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"eaca9908-d54e-4427-bcee-8d728569458c","name":"tf-srv-distracted-gould"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:01:32.495034+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-lumiere","id":"de141f80-bcb9-4d1b-b91e-0c71769c128f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"801","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:23","maintenances":[],"modification_date":"2025-02-12T16:01:38.899249+00:00","name":"tf-srv-tender-lumiere","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"0aa2eadf-770f-41d8-84a6-e3929a361816","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2278"
+                - "1827"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:38 GMT
+                - Wed, 12 Feb 2025 16:02:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1591,10 +1591,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 42df1fb1-079a-4c86-9312-d4bf284ca757
+                - 189a5cf5-1e6c-4ab9-aa30-c5f56031b770
         status: 200 OK
         code: 200
-        duration: 156.146ms
+        duration: 243.96375ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1610,8 +1610,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/6c12a713-2b3c-495e-b095-c5a0a5c4d98e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0aa2eadf-770f-41d8-84a6-e3929a361816
         method: GET
       response:
         proto: HTTP/2.0
@@ -1619,20 +1619,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 523
+        content_length: 143
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:53:44.079396+00:00","export_uri":null,"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","modification_date":"2025-01-27T13:54:36.396179+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"eaca9908-d54e-4427-bcee-8d728569458c","name":"tf-srv-distracted-gould"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"0aa2eadf-770f-41d8-84a6-e3929a361816","type":"not_found"}'
         headers:
             Content-Length:
-                - "523"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:39 GMT
+                - Wed, 12 Feb 2025 16:02:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1640,10 +1640,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fac48f5f-a712-4c96-ad45-008a74ab5f3e
-        status: 200 OK
-        code: 200
-        duration: 104.779958ms
+                - 8ea4901b-820d-462a-9543-dab5caced5ff
+        status: 404 Not Found
+        code: 404
+        duration: 52.6935ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1659,8 +1659,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/eaca9908-d54e-4427-bcee-8d728569458c/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/0aa2eadf-770f-41d8-84a6-e3929a361816
         method: GET
       response:
         proto: HTTP/2.0
@@ -1668,20 +1668,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 701
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"created_at":"2025-02-12T16:01:32.745747Z","id":"0aa2eadf-770f-41d8-84a6-e3929a361816","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:01:32.745747Z","id":"b8c235c0-4ff6-4222-bb46-f2d56ea57648","product_resource_id":"de141f80-bcb9-4d1b-b91e-0c71769c128f","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:01:32.745747Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "17"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:39 GMT
+                - Wed, 12 Feb 2025 16:02:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1689,10 +1689,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d4825819-88f4-4369-a8c8-50966825aa00
+                - df1ca0fd-0ac0-42fa-bcc7-b45c0adc51ba
         status: 200 OK
         code: 200
-        duration: 88.201166ms
+        duration: 100.91475ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1708,8 +1708,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/eaca9908-d54e-4427-bcee-8d728569458c/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/de141f80-bcb9-4d1b-b91e-0c71769c128f/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1717,22 +1717,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 17
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "20"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:39 GMT
-            Link:
-                - </servers/eaca9908-d54e-4427-bcee-8d728569458c/private_nics?page=0&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 16:02:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1740,12 +1738,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a586752b-3575-4763-b3fa-627892edef41
-            X-Total-Count:
-                - "0"
+                - 240db443-eadd-48c0-b2f3-fb1e9e3fd4df
         status: 200 OK
         code: 200
-        duration: 78.201333ms
+        duration: 113.848542ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1761,8 +1757,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f6413266-6b5f-49bd-b984-64ea90d174da
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/de141f80-bcb9-4d1b-b91e-0c71769c128f/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1770,20 +1766,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 530
+        content_length: 20
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:54:01.525823+00:00","error_details":null,"id":"f6413266-6b5f-49bd-b984-64ea90d174da","modification_date":"2025-01-27T13:54:36.396179+00:00","name":"tf-snap-hungry-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "530"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:38 GMT
+                - Wed, 12 Feb 2025 16:02:19 GMT
+            Link:
+                - </servers/de141f80-bcb9-4d1b-b91e-0c71769c128f/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1791,10 +1789,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d132d3a0-a322-470a-b50f-fb8105657dc7
+                - 2ebcdc8e-101b-4bc4-9999-5f353d66bb64
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 84.966708ms
+        duration: 107.743167ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1810,8 +1810,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/6cecef1a-ddd1-4e77-953c-8b809986f0ff
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/e8ceb46c-9003-4eb1-a5fc-53465a1574d5
         method: GET
       response:
         proto: HTTP/2.0
@@ -1819,20 +1819,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 624
+        content_length: 703
         uncompressed: false
-        body: '{"image":{"arch":"x86_64","creation_date":"2025-01-27T13:54:37.883974+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"6cecef1a-ddd1-4e77-953c-8b809986f0ff","modification_date":"2025-01-27T13:54:37.883974+00:00","name":"tf-image-reverent-euler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"f6413266-6b5f-49bd-b984-64ea90d174da","name":"tf-snap-hungry-payne","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":["test_remove_tags"],"zone":"fr-par-1"}}'
+        body: '{"class":"sbs","created_at":"2025-02-12T16:01:40.148231Z","id":"e8ceb46c-9003-4eb1-a5fc-53465a1574d5","name":"tf-snapshot-confident-wescoff","parent_volume":{"id":"0aa2eadf-770f-41d8-84a6-e3929a361816","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","status":"in_use","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:02:17.250835Z","id":"b11f2295-91a3-4560-b2c6-e4a98774a0da","product_resource_id":"775987a3-b39a-414c-b482-9b098f631d1e","product_resource_type":"instance_image","status":"attached","type":"link"}],"size":10000000000,"status":"in_use","tags":[],"updated_at":"2025-02-12T16:02:17.250835Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "624"
+                - "703"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:38 GMT
+                - Wed, 12 Feb 2025 16:02:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1840,10 +1840,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f45e7743-bd52-473e-a113-3a75cc681a17
+                - 14987768-34a4-492c-bec2-4f265a9b397a
         status: 200 OK
         code: 200
-        duration: 100.185208ms
+        duration: 186.423042ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1859,8 +1859,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/eaca9908-d54e-4427-bcee-8d728569458c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/775987a3-b39a-414c-b482-9b098f631d1e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1868,20 +1868,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2278
+        content_length: 598
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:44.079396+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-distracted-gould","id":"eaca9908-d54e-4427-bcee-8d728569458c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1102","node_id":"27","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:61","maintenances":[],"modification_date":"2025-01-27T13:53:57.454534+00:00","name":"tf-srv-distracted-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:44.079396+00:00","export_uri":null,"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","modification_date":"2025-01-27T13:54:36.396179+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"eaca9908-d54e-4427-bcee-8d728569458c","name":"tf-srv-distracted-gould"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T16:02:17.190841+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"775987a3-b39a-414c-b482-9b098f631d1e","modification_date":"2025-02-12T16:02:17.190841+00:00","name":"tf-image-cranky-boyd","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"e8ceb46c-9003-4eb1-a5fc-53465a1574d5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":["test_remove_tags"],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2278"
+                - "598"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:39 GMT
+                - Wed, 12 Feb 2025 16:02:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1889,10 +1889,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 63004be3-fa1c-4d9f-99e6-abd5f333efc1
+                - 6a2fbba9-867a-454b-96c6-8105efee927e
         status: 200 OK
         code: 200
-        duration: 144.719583ms
+        duration: 116.736834ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1908,8 +1908,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/6c12a713-2b3c-495e-b095-c5a0a5c4d98e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/de141f80-bcb9-4d1b-b91e-0c71769c128f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1917,20 +1917,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 523
+        content_length: 1827
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:53:44.079396+00:00","export_uri":null,"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","modification_date":"2025-01-27T13:54:36.396179+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"eaca9908-d54e-4427-bcee-8d728569458c","name":"tf-srv-distracted-gould"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:01:32.495034+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-lumiere","id":"de141f80-bcb9-4d1b-b91e-0c71769c128f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"801","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:23","maintenances":[],"modification_date":"2025-02-12T16:01:38.899249+00:00","name":"tf-srv-tender-lumiere","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"0aa2eadf-770f-41d8-84a6-e3929a361816","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "523"
+                - "1827"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:39 GMT
+                - Wed, 12 Feb 2025 16:02:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1938,10 +1938,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0a005556-f70d-4fcc-81ca-783c36e3c019
+                - 227e12e3-babd-4e85-91d0-6690c90b82ac
         status: 200 OK
         code: 200
-        duration: 94.975459ms
+        duration: 202.679583ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1957,8 +1957,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/eaca9908-d54e-4427-bcee-8d728569458c/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0aa2eadf-770f-41d8-84a6-e3929a361816
         method: GET
       response:
         proto: HTTP/2.0
@@ -1966,20 +1966,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 143
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"0aa2eadf-770f-41d8-84a6-e3929a361816","type":"not_found"}'
         headers:
             Content-Length:
-                - "17"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:39 GMT
+                - Wed, 12 Feb 2025 16:02:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1987,10 +1987,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 77b3291f-febf-4db9-9b01-43cf739fff6c
-        status: 200 OK
-        code: 200
-        duration: 105.191458ms
+                - 5db3ddae-8c65-41c4-94e5-f0e85f190dbf
+        status: 404 Not Found
+        code: 404
+        duration: 59.327583ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2006,8 +2006,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/eaca9908-d54e-4427-bcee-8d728569458c/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/0aa2eadf-770f-41d8-84a6-e3929a361816
         method: GET
       response:
         proto: HTTP/2.0
@@ -2015,22 +2015,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 701
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"created_at":"2025-02-12T16:01:32.745747Z","id":"0aa2eadf-770f-41d8-84a6-e3929a361816","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:01:32.745747Z","id":"b8c235c0-4ff6-4222-bb46-f2d56ea57648","product_resource_id":"de141f80-bcb9-4d1b-b91e-0c71769c128f","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:01:32.745747Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "20"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:39 GMT
-            Link:
-                - </servers/eaca9908-d54e-4427-bcee-8d728569458c/private_nics?page=0&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 16:02:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2038,12 +2036,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 729cc15e-95a2-49b3-956e-91103f99f089
-            X-Total-Count:
-                - "0"
+                - 043ce154-ef5a-418d-88b4-2c3e4f12b8b3
         status: 200 OK
         code: 200
-        duration: 84.035792ms
+        duration: 82.08475ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2059,598 +2055,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f6413266-6b5f-49bd-b984-64ea90d174da
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 530
-        uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:54:01.525823+00:00","error_details":null,"id":"f6413266-6b5f-49bd-b984-64ea90d174da","modification_date":"2025-01-27T13:54:36.396179+00:00","name":"tf-snap-hungry-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "530"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:54:40 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - e649a606-5f3c-4989-91c7-dc0abf78f865
-        status: 200 OK
-        code: 200
-        duration: 76.675208ms
-    - id: 42
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/6cecef1a-ddd1-4e77-953c-8b809986f0ff
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 624
-        uncompressed: false
-        body: '{"image":{"arch":"x86_64","creation_date":"2025-01-27T13:54:37.883974+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"6cecef1a-ddd1-4e77-953c-8b809986f0ff","modification_date":"2025-01-27T13:54:37.883974+00:00","name":"tf-image-reverent-euler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"f6413266-6b5f-49bd-b984-64ea90d174da","name":"tf-snap-hungry-payne","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":["test_remove_tags"],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "624"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:54:40 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - c687407a-5f87-46fa-b564-23aba11570d6
-        status: 200 OK
-        code: 200
-        duration: 96.381875ms
-    - id: 43
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/6cecef1a-ddd1-4e77-953c-8b809986f0ff
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 624
-        uncompressed: false
-        body: '{"image":{"arch":"x86_64","creation_date":"2025-01-27T13:54:37.883974+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"6cecef1a-ddd1-4e77-953c-8b809986f0ff","modification_date":"2025-01-27T13:54:37.883974+00:00","name":"tf-image-reverent-euler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"f6413266-6b5f-49bd-b984-64ea90d174da","name":"tf-snap-hungry-payne","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":["test_remove_tags"],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "624"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:54:40 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 84fb8e4d-8c15-4573-8ebc-838a3f2c9e98
-        status: 200 OK
-        code: 200
-        duration: 108.395708ms
-    - id: 44
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/6cecef1a-ddd1-4e77-953c-8b809986f0ff
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 624
-        uncompressed: false
-        body: '{"image":{"arch":"x86_64","creation_date":"2025-01-27T13:54:37.883974+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"6cecef1a-ddd1-4e77-953c-8b809986f0ff","modification_date":"2025-01-27T13:54:37.883974+00:00","name":"tf-image-reverent-euler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"f6413266-6b5f-49bd-b984-64ea90d174da","name":"tf-snap-hungry-payne","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":["test_remove_tags"],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "624"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:54:40 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - ef6d44be-3f24-48f1-a750-92cf4a76e806
-        status: 200 OK
-        code: 200
-        duration: 80.765167ms
-    - id: 45
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 60
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"name":"tf-image-reverent-euler","arch":"x86_64","tags":[]}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/6cecef1a-ddd1-4e77-953c-8b809986f0ff
-        method: PATCH
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 606
-        uncompressed: false
-        body: '{"image":{"arch":"x86_64","creation_date":"2025-01-27T13:54:37.883974+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"6cecef1a-ddd1-4e77-953c-8b809986f0ff","modification_date":"2025-01-27T13:54:40.731587+00:00","name":"tf-image-reverent-euler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"f6413266-6b5f-49bd-b984-64ea90d174da","name":"tf-snap-hungry-payne","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "606"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:54:40 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - e145511e-72a7-4a22-961f-241827b018e9
-        status: 200 OK
-        code: 200
-        duration: 132.656792ms
-    - id: 46
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/6cecef1a-ddd1-4e77-953c-8b809986f0ff
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 606
-        uncompressed: false
-        body: '{"image":{"arch":"x86_64","creation_date":"2025-01-27T13:54:37.883974+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"6cecef1a-ddd1-4e77-953c-8b809986f0ff","modification_date":"2025-01-27T13:54:40.731587+00:00","name":"tf-image-reverent-euler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"f6413266-6b5f-49bd-b984-64ea90d174da","name":"tf-snap-hungry-payne","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "606"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:54:40 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 0b3f5338-be36-467e-b06b-f573b00b14bd
-        status: 200 OK
-        code: 200
-        duration: 109.999792ms
-    - id: 47
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/6cecef1a-ddd1-4e77-953c-8b809986f0ff
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 606
-        uncompressed: false
-        body: '{"image":{"arch":"x86_64","creation_date":"2025-01-27T13:54:37.883974+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"6cecef1a-ddd1-4e77-953c-8b809986f0ff","modification_date":"2025-01-27T13:54:40.731587+00:00","name":"tf-image-reverent-euler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"f6413266-6b5f-49bd-b984-64ea90d174da","name":"tf-snap-hungry-payne","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "606"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:54:40 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - d494c6f0-bcfa-4aab-96ac-f3fe6c2a5075
-        status: 200 OK
-        code: 200
-        duration: 98.456333ms
-    - id: 48
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/eaca9908-d54e-4427-bcee-8d728569458c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2278
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:44.079396+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-distracted-gould","id":"eaca9908-d54e-4427-bcee-8d728569458c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1102","node_id":"27","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:61","maintenances":[],"modification_date":"2025-01-27T13:53:57.454534+00:00","name":"tf-srv-distracted-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:44.079396+00:00","export_uri":null,"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","modification_date":"2025-01-27T13:54:36.396179+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"eaca9908-d54e-4427-bcee-8d728569458c","name":"tf-srv-distracted-gould"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2278"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:54:40 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 1f5c6f5c-cda7-4661-aefd-7f9884daa5d5
-        status: 200 OK
-        code: 200
-        duration: 145.59875ms
-    - id: 49
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f6413266-6b5f-49bd-b984-64ea90d174da
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 530
-        uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:54:01.525823+00:00","error_details":null,"id":"f6413266-6b5f-49bd-b984-64ea90d174da","modification_date":"2025-01-27T13:54:36.396179+00:00","name":"tf-snap-hungry-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "530"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:54:41 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - e9d9b58d-ef85-4af4-9aa3-9937e79e50a4
-        status: 200 OK
-        code: 200
-        duration: 110.024459ms
-    - id: 50
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/6cecef1a-ddd1-4e77-953c-8b809986f0ff
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 606
-        uncompressed: false
-        body: '{"image":{"arch":"x86_64","creation_date":"2025-01-27T13:54:37.883974+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"6cecef1a-ddd1-4e77-953c-8b809986f0ff","modification_date":"2025-01-27T13:54:40.731587+00:00","name":"tf-image-reverent-euler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"f6413266-6b5f-49bd-b984-64ea90d174da","name":"tf-snap-hungry-payne","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "606"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:54:41 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 32c2000d-8918-4130-a14a-9f3720590c9d
-        status: 200 OK
-        code: 200
-        duration: 102.259667ms
-    - id: 51
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/eaca9908-d54e-4427-bcee-8d728569458c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2278
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:44.079396+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-distracted-gould","id":"eaca9908-d54e-4427-bcee-8d728569458c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1102","node_id":"27","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:61","maintenances":[],"modification_date":"2025-01-27T13:53:57.454534+00:00","name":"tf-srv-distracted-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:44.079396+00:00","export_uri":null,"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","modification_date":"2025-01-27T13:54:36.396179+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"eaca9908-d54e-4427-bcee-8d728569458c","name":"tf-srv-distracted-gould"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2278"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:54:41 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 8b48e5eb-4fa7-4129-af8e-bcf0c46a9b2c
-        status: 200 OK
-        code: 200
-        duration: 179.043583ms
-    - id: 52
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/6c12a713-2b3c-495e-b095-c5a0a5c4d98e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 523
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:53:44.079396+00:00","export_uri":null,"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","modification_date":"2025-01-27T13:54:36.396179+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"eaca9908-d54e-4427-bcee-8d728569458c","name":"tf-srv-distracted-gould"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "523"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:54:41 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - d49335a7-b037-409c-82ca-15e02a537cd0
-        status: 200 OK
-        code: 200
-        duration: 91.361584ms
-    - id: 53
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/eaca9908-d54e-4427-bcee-8d728569458c/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/de141f80-bcb9-4d1b-b91e-0c71769c128f/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -2669,9 +2075,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:41 GMT
+                - Wed, 12 Feb 2025 16:02:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2679,11 +2085,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 878cfd38-bea6-4cd1-9638-c42bfce922b2
+                - 46325f4d-4f21-49e2-b36a-ee86723cd3d1
         status: 200 OK
         code: 200
-        duration: 82.441875ms
-    - id: 54
+        duration: 117.872417ms
+    - id: 42
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2698,8 +2104,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/eaca9908-d54e-4427-bcee-8d728569458c/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/de141f80-bcb9-4d1b-b91e-0c71769c128f/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -2718,11 +2124,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:42 GMT
+                - Wed, 12 Feb 2025 16:02:20 GMT
             Link:
-                - </servers/eaca9908-d54e-4427-bcee-8d728569458c/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/de141f80-bcb9-4d1b-b91e-0c71769c128f/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2730,12 +2136,602 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 29c8f4f0-a754-4f4a-ac09-590c32265220
+                - 5e196f9e-786b-4155-9bd4-9cb1f9cef12d
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 112.429708ms
+        duration: 140.823459ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/e8ceb46c-9003-4eb1-a5fc-53465a1574d5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 703
+        uncompressed: false
+        body: '{"class":"sbs","created_at":"2025-02-12T16:01:40.148231Z","id":"e8ceb46c-9003-4eb1-a5fc-53465a1574d5","name":"tf-snapshot-confident-wescoff","parent_volume":{"id":"0aa2eadf-770f-41d8-84a6-e3929a361816","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","status":"in_use","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:02:17.250835Z","id":"b11f2295-91a3-4560-b2c6-e4a98774a0da","product_resource_id":"775987a3-b39a-414c-b482-9b098f631d1e","product_resource_type":"instance_image","status":"attached","type":"link"}],"size":10000000000,"status":"in_use","tags":[],"updated_at":"2025-02-12T16:02:17.250835Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "703"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:02:21 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6b50020d-8987-454e-a0ac-3d79121be091
+        status: 200 OK
+        code: 200
+        duration: 408.781917ms
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/775987a3-b39a-414c-b482-9b098f631d1e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 598
+        uncompressed: false
+        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T16:02:17.190841+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"775987a3-b39a-414c-b482-9b098f631d1e","modification_date":"2025-02-12T16:02:17.190841+00:00","name":"tf-image-cranky-boyd","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"e8ceb46c-9003-4eb1-a5fc-53465a1574d5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":["test_remove_tags"],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "598"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:02:20 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 56b8c08d-db7a-42db-93eb-3dbd54af0956
+        status: 200 OK
+        code: 200
+        duration: 133.497292ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/775987a3-b39a-414c-b482-9b098f631d1e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 598
+        uncompressed: false
+        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T16:02:17.190841+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"775987a3-b39a-414c-b482-9b098f631d1e","modification_date":"2025-02-12T16:02:17.190841+00:00","name":"tf-image-cranky-boyd","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"e8ceb46c-9003-4eb1-a5fc-53465a1574d5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":["test_remove_tags"],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "598"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:02:21 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4bfc46d1-6215-4a09-8ea7-20c600019453
+        status: 200 OK
+        code: 200
+        duration: 137.010292ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/775987a3-b39a-414c-b482-9b098f631d1e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 598
+        uncompressed: false
+        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T16:02:17.190841+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"775987a3-b39a-414c-b482-9b098f631d1e","modification_date":"2025-02-12T16:02:17.190841+00:00","name":"tf-image-cranky-boyd","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"e8ceb46c-9003-4eb1-a5fc-53465a1574d5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":["test_remove_tags"],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "598"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:02:21 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1d4d84ec-7a9a-490b-867f-a7b0b54e2135
+        status: 200 OK
+        code: 200
+        duration: 100.122958ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 57
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf-image-cranky-boyd","arch":"x86_64","tags":[]}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/775987a3-b39a-414c-b482-9b098f631d1e
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 580
+        uncompressed: false
+        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T16:02:17.190841+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"775987a3-b39a-414c-b482-9b098f631d1e","modification_date":"2025-02-12T16:02:22.049102+00:00","name":"tf-image-cranky-boyd","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"e8ceb46c-9003-4eb1-a5fc-53465a1574d5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "580"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:02:21 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3e5c6bd6-e1be-4304-a08f-bf4e107b3905
+        status: 200 OK
+        code: 200
+        duration: 262.077417ms
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/775987a3-b39a-414c-b482-9b098f631d1e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 580
+        uncompressed: false
+        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T16:02:17.190841+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"775987a3-b39a-414c-b482-9b098f631d1e","modification_date":"2025-02-12T16:02:22.049102+00:00","name":"tf-image-cranky-boyd","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"e8ceb46c-9003-4eb1-a5fc-53465a1574d5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "580"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:02:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e52882b0-914d-4df7-b163-4ed7a4175a8e
+        status: 200 OK
+        code: 200
+        duration: 135.630292ms
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/775987a3-b39a-414c-b482-9b098f631d1e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 580
+        uncompressed: false
+        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T16:02:17.190841+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"775987a3-b39a-414c-b482-9b098f631d1e","modification_date":"2025-02-12T16:02:22.049102+00:00","name":"tf-image-cranky-boyd","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"e8ceb46c-9003-4eb1-a5fc-53465a1574d5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "580"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:02:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 17fde406-442f-41d6-a1bc-1ab02bae7746
+        status: 200 OK
+        code: 200
+        duration: 131.192625ms
+    - id: 50
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/de141f80-bcb9-4d1b-b91e-0c71769c128f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1827
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:01:32.495034+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-lumiere","id":"de141f80-bcb9-4d1b-b91e-0c71769c128f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"801","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:23","maintenances":[],"modification_date":"2025-02-12T16:01:38.899249+00:00","name":"tf-srv-tender-lumiere","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"0aa2eadf-770f-41d8-84a6-e3929a361816","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1827"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:02:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 931f0df9-a0d7-4f68-9db5-82a1bcc75f08
+        status: 200 OK
+        code: 200
+        duration: 221.013291ms
+    - id: 51
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/e8ceb46c-9003-4eb1-a5fc-53465a1574d5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 703
+        uncompressed: false
+        body: '{"class":"sbs","created_at":"2025-02-12T16:01:40.148231Z","id":"e8ceb46c-9003-4eb1-a5fc-53465a1574d5","name":"tf-snapshot-confident-wescoff","parent_volume":{"id":"0aa2eadf-770f-41d8-84a6-e3929a361816","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","status":"in_use","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:02:17.250835Z","id":"b11f2295-91a3-4560-b2c6-e4a98774a0da","product_resource_id":"775987a3-b39a-414c-b482-9b098f631d1e","product_resource_type":"instance_image","status":"attached","type":"link"}],"size":10000000000,"status":"in_use","tags":[],"updated_at":"2025-02-12T16:02:17.250835Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "703"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:02:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 05bdf3d3-e335-48a2-a5b1-b5c6aed64911
+        status: 200 OK
+        code: 200
+        duration: 112.494042ms
+    - id: 52
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/775987a3-b39a-414c-b482-9b098f631d1e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 580
+        uncompressed: false
+        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T16:02:17.190841+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"775987a3-b39a-414c-b482-9b098f631d1e","modification_date":"2025-02-12T16:02:22.049102+00:00","name":"tf-image-cranky-boyd","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"e8ceb46c-9003-4eb1-a5fc-53465a1574d5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "580"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:02:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 18342d89-72d1-4d4c-b52c-9803a62e0647
+        status: 200 OK
+        code: 200
+        duration: 141.582334ms
+    - id: 53
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/de141f80-bcb9-4d1b-b91e-0c71769c128f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1827
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:01:32.495034+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-lumiere","id":"de141f80-bcb9-4d1b-b91e-0c71769c128f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"801","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:23","maintenances":[],"modification_date":"2025-02-12T16:01:38.899249+00:00","name":"tf-srv-tender-lumiere","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"0aa2eadf-770f-41d8-84a6-e3929a361816","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1827"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:02:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 48b8b05a-32d9-43f1-b018-ea5922340f76
+        status: 200 OK
+        code: 200
+        duration: 184.492375ms
+    - id: 54
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0aa2eadf-770f-41d8-84a6-e3929a361816
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"0aa2eadf-770f-41d8-84a6-e3929a361816","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:02:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - cc98985c-4734-41d2-a8f5-5b8c24602912
+        status: 404 Not Found
+        code: 404
+        duration: 51.188042ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -2751,8 +2747,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f6413266-6b5f-49bd-b984-64ea90d174da
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/0aa2eadf-770f-41d8-84a6-e3929a361816
         method: GET
       response:
         proto: HTTP/2.0
@@ -2760,20 +2756,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 530
+        content_length: 701
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:54:01.525823+00:00","error_details":null,"id":"f6413266-6b5f-49bd-b984-64ea90d174da","modification_date":"2025-01-27T13:54:36.396179+00:00","name":"tf-snap-hungry-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-12T16:01:32.745747Z","id":"0aa2eadf-770f-41d8-84a6-e3929a361816","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:01:32.745747Z","id":"b8c235c0-4ff6-4222-bb46-f2d56ea57648","product_resource_id":"de141f80-bcb9-4d1b-b91e-0c71769c128f","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:01:32.745747Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "530"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:42 GMT
+                - Wed, 12 Feb 2025 16:02:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2781,10 +2777,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4a21c60f-1cc2-44bb-8f12-0792ed942c56
+                - f0335943-3a87-4334-b59e-46732bd4cc74
         status: 200 OK
         code: 200
-        duration: 116.786834ms
+        duration: 112.796417ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2800,8 +2796,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/6cecef1a-ddd1-4e77-953c-8b809986f0ff
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/de141f80-bcb9-4d1b-b91e-0c71769c128f/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -2809,20 +2805,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 606
+        content_length: 17
         uncompressed: false
-        body: '{"image":{"arch":"x86_64","creation_date":"2025-01-27T13:54:37.883974+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"6cecef1a-ddd1-4e77-953c-8b809986f0ff","modification_date":"2025-01-27T13:54:40.731587+00:00","name":"tf-image-reverent-euler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"f6413266-6b5f-49bd-b984-64ea90d174da","name":"tf-snap-hungry-payne","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "606"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:42 GMT
+                - Wed, 12 Feb 2025 16:02:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2830,10 +2826,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 03fba94f-0c67-498c-8437-bca07c7658d6
+                - 1004ed99-a2b9-4124-bcc0-a8c6e060f58c
         status: 200 OK
         code: 200
-        duration: 99.949625ms
+        duration: 199.990209ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2849,8 +2845,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/6cecef1a-ddd1-4e77-953c-8b809986f0ff
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/de141f80-bcb9-4d1b-b91e-0c71769c128f/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -2858,20 +2854,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 606
+        content_length: 20
         uncompressed: false
-        body: '{"image":{"arch":"x86_64","creation_date":"2025-01-27T13:54:37.883974+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"6cecef1a-ddd1-4e77-953c-8b809986f0ff","modification_date":"2025-01-27T13:54:40.731587+00:00","name":"tf-image-reverent-euler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"f6413266-6b5f-49bd-b984-64ea90d174da","name":"tf-snap-hungry-payne","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "606"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:42 GMT
+                - Wed, 12 Feb 2025 16:02:23 GMT
+            Link:
+                - </servers/de141f80-bcb9-4d1b-b91e-0c71769c128f/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2879,10 +2877,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ace5dfd1-93e4-4096-8738-c7eab6601cec
+                - 83349e03-74de-4241-bd36-eee718a50de1
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 113.020459ms
+        duration: 121.835666ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -2898,27 +2898,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/6cecef1a-ddd1-4e77-953c-8b809986f0ff
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/e8ceb46c-9003-4eb1-a5fc-53465a1574d5
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 703
         uncompressed: false
-        body: ""
+        body: '{"class":"sbs","created_at":"2025-02-12T16:01:40.148231Z","id":"e8ceb46c-9003-4eb1-a5fc-53465a1574d5","name":"tf-snapshot-confident-wescoff","parent_volume":{"id":"0aa2eadf-770f-41d8-84a6-e3929a361816","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","status":"in_use","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:02:17.250835Z","id":"b11f2295-91a3-4560-b2c6-e4a98774a0da","product_resource_id":"775987a3-b39a-414c-b482-9b098f631d1e","product_resource_type":"instance_image","status":"attached","type":"link"}],"size":10000000000,"status":"in_use","tags":[],"updated_at":"2025-02-12T16:02:17.250835Z","zone":"fr-par-1"}'
         headers:
+            Content-Length:
+                - "703"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:42 GMT
+                - Wed, 12 Feb 2025 16:02:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2926,10 +2928,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5e6b53d1-400c-4716-acf9-9c241b7ffd2d
-        status: 204 No Content
-        code: 204
-        duration: 239.148875ms
+                - cc9d1931-11e0-4367-9531-696705b70c28
+        status: 200 OK
+        code: 200
+        duration: 123.158042ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -2945,8 +2947,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/6cecef1a-ddd1-4e77-953c-8b809986f0ff
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/775987a3-b39a-414c-b482-9b098f631d1e
         method: GET
       response:
         proto: HTTP/2.0
@@ -2954,20 +2956,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 142
+        content_length: 580
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_image","resource_id":"6cecef1a-ddd1-4e77-953c-8b809986f0ff","type":"not_found"}'
+        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T16:02:17.190841+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"775987a3-b39a-414c-b482-9b098f631d1e","modification_date":"2025-02-12T16:02:22.049102+00:00","name":"tf-image-cranky-boyd","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"e8ceb46c-9003-4eb1-a5fc-53465a1574d5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "142"
+                - "580"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:42 GMT
+                - Wed, 12 Feb 2025 16:02:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2975,10 +2977,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c9cf923e-a424-4926-a28a-e3de153fd451
-        status: 404 Not Found
-        code: 404
-        duration: 39.091208ms
+                - b96d85b8-4265-4044-9044-cc7aa90e5e29
+        status: 200 OK
+        code: 200
+        duration: 122.394833ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -2994,8 +2996,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f6413266-6b5f-49bd-b984-64ea90d174da
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/775987a3-b39a-414c-b482-9b098f631d1e
         method: GET
       response:
         proto: HTTP/2.0
@@ -3003,20 +3005,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 530
+        content_length: 580
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:54:01.525823+00:00","error_details":null,"id":"f6413266-6b5f-49bd-b984-64ea90d174da","modification_date":"2025-01-27T13:54:36.396179+00:00","name":"tf-snap-hungry-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"image":{"arch":"x86_64","creation_date":"2025-02-12T16:02:17.190841+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"775987a3-b39a-414c-b482-9b098f631d1e","modification_date":"2025-02-12T16:02:22.049102+00:00","name":"tf-image-cranky-boyd","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"e8ceb46c-9003-4eb1-a5fc-53465a1574d5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "530"
+                - "580"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:42 GMT
+                - Wed, 12 Feb 2025 16:02:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3024,10 +3026,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f9cf8d10-3392-4c1d-a638-3dfc82b8fd9e
+                - e5b2f769-725f-4776-bfc5-8c123fc9ffe5
         status: 200 OK
         code: 200
-        duration: 90.785042ms
+        duration: 122.954375ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -3043,8 +3045,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f6413266-6b5f-49bd-b984-64ea90d174da
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/775987a3-b39a-414c-b482-9b098f631d1e
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3061,9 +3063,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:42 GMT
+                - Wed, 12 Feb 2025 16:02:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3071,10 +3073,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b4953bdb-8af6-4f55-9dba-5e8550603fe2
+                - afcc129f-6a16-4199-8c90-747a974420f9
         status: 204 No Content
         code: 204
-        duration: 180.592625ms
+        duration: 477.879458ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -3090,8 +3092,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f6413266-6b5f-49bd-b984-64ea90d174da
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/775987a3-b39a-414c-b482-9b098f631d1e
         method: GET
       response:
         proto: HTTP/2.0
@@ -3099,20 +3101,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 145
+        content_length: 142
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"f6413266-6b5f-49bd-b984-64ea90d174da","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_image","resource_id":"775987a3-b39a-414c-b482-9b098f631d1e","type":"not_found"}'
         headers:
             Content-Length:
-                - "145"
+                - "142"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:43 GMT
+                - Wed, 12 Feb 2025 16:02:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3120,10 +3122,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9dbdc039-68e0-49ec-8ac6-8350f8a5e3fd
+                - 041af980-ecfa-454a-98b8-a2ce355cf68d
         status: 404 Not Found
         code: 404
-        duration: 32.6255ms
+        duration: 48.912416ms
     - id: 63
       request:
         proto: HTTP/1.1
@@ -3139,8 +3141,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/eaca9908-d54e-4427-bcee-8d728569458c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/e8ceb46c-9003-4eb1-a5fc-53465a1574d5
         method: GET
       response:
         proto: HTTP/2.0
@@ -3148,20 +3150,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2278
+        content_length: 477
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:44.079396+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-distracted-gould","id":"eaca9908-d54e-4427-bcee-8d728569458c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1102","node_id":"27","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:61","maintenances":[],"modification_date":"2025-01-27T13:53:57.454534+00:00","name":"tf-srv-distracted-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:44.079396+00:00","export_uri":null,"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","modification_date":"2025-01-27T13:54:36.396179+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"eaca9908-d54e-4427-bcee-8d728569458c","name":"tf-srv-distracted-gould"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"class":"sbs","created_at":"2025-02-12T16:01:40.148231Z","id":"e8ceb46c-9003-4eb1-a5fc-53465a1574d5","name":"tf-snapshot-confident-wescoff","parent_volume":{"id":"0aa2eadf-770f-41d8-84a6-e3929a361816","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","status":"in_use","type":"sbs_5k"},"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"status":"available","tags":[],"updated_at":"2025-02-12T16:02:25.127657Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2278"
+                - "477"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:43 GMT
+                - Wed, 12 Feb 2025 16:02:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3169,11 +3171,205 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - deaad624-a7b4-4c8c-843b-7ab9e18f7ad7
+                - 765cb742-dab2-4232-8e3e-43bec02bb8fb
         status: 200 OK
         code: 200
-        duration: 177.027958ms
+        duration: 111.073792ms
     - id: 64
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/e8ceb46c-9003-4eb1-a5fc-53465a1574d5
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:02:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 480b9e91-6a42-467e-a83c-655168c8a6fb
+        status: 204 No Content
+        code: 204
+        duration: 274.193ms
+    - id: 65
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/e8ceb46c-9003-4eb1-a5fc-53465a1574d5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 129
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"snapshot","resource_id":"e8ceb46c-9003-4eb1-a5fc-53465a1574d5","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "129"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:02:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7e2dfa91-9dbc-45db-9b20-8eb08921cadd
+        status: 404 Not Found
+        code: 404
+        duration: 99.163584ms
+    - id: 66
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/de141f80-bcb9-4d1b-b91e-0c71769c128f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1827
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:01:32.495034+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-lumiere","id":"de141f80-bcb9-4d1b-b91e-0c71769c128f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"801","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:23","maintenances":[],"modification_date":"2025-02-12T16:01:38.899249+00:00","name":"tf-srv-tender-lumiere","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"0aa2eadf-770f-41d8-84a6-e3929a361816","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1827"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:02:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 466e1fc0-c3e6-4479-aef3-729a9f05424b
+        status: 200 OK
+        code: 200
+        duration: 297.435833ms
+    - id: 67
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/0aa2eadf-770f-41d8-84a6-e3929a361816
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:01:32.745747Z","id":"0aa2eadf-770f-41d8-84a6-e3929a361816","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:01:32.745747Z","id":"b8c235c0-4ff6-4222-bb46-f2d56ea57648","product_resource_id":"de141f80-bcb9-4d1b-b91e-0c71769c128f","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:01:32.745747Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:02:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 90941b06-a18d-45b3-a3a5-01c2c3065a3b
+        status: 200 OK
+        code: 200
+        duration: 105.614375ms
+    - id: 68
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3190,8 +3386,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/eaca9908-d54e-4427-bcee-8d728569458c/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/de141f80-bcb9-4d1b-b91e-0c71769c128f/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -3201,7 +3397,7 @@ interactions:
         trailer: {}
         content_length: 352
         uncompressed: false
-        body: '{"task":{"description":"server_poweroff","href_from":"/servers/eaca9908-d54e-4427-bcee-8d728569458c/action","href_result":"/servers/eaca9908-d54e-4427-bcee-8d728569458c","id":"2cc92dd8-9867-480c-81ef-a029536b0803","progress":0,"started_at":"2025-01-27T13:54:43.754231+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_poweroff","href_from":"/servers/de141f80-bcb9-4d1b-b91e-0c71769c128f/action","href_result":"/servers/de141f80-bcb9-4d1b-b91e-0c71769c128f","id":"92c359f9-8802-4949-8b3a-58f50af9da24","progress":0,"started_at":"2025-02-12T16:02:26.256568+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "352"
@@ -3210,11 +3406,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:43 GMT
+                - Wed, 12 Feb 2025 16:02:26 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/2cc92dd8-9867-480c-81ef-a029536b0803
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/92c359f9-8802-4949-8b3a-58f50af9da24
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3222,206 +3418,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 38267197-7a04-4907-874c-a41801875273
+                - 8bcc3c22-3bf4-4866-8f1c-5c28f51facb4
         status: 202 Accepted
         code: 202
-        duration: 255.964792ms
-    - id: 65
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/eaca9908-d54e-4427-bcee-8d728569458c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2238
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:44.079396+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-distracted-gould","id":"eaca9908-d54e-4427-bcee-8d728569458c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1102","node_id":"27","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:61","maintenances":[],"modification_date":"2025-01-27T13:54:43.551556+00:00","name":"tf-srv-distracted-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:44.079396+00:00","export_uri":null,"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","modification_date":"2025-01-27T13:54:36.396179+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"eaca9908-d54e-4427-bcee-8d728569458c","name":"tf-srv-distracted-gould"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2238"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:54:43 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - b0d930fc-893b-4436-a6af-452052f93b95
-        status: 200 OK
-        code: 200
-        duration: 170.497ms
-    - id: 66
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/eaca9908-d54e-4427-bcee-8d728569458c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2238
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:44.079396+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-distracted-gould","id":"eaca9908-d54e-4427-bcee-8d728569458c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1102","node_id":"27","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:61","maintenances":[],"modification_date":"2025-01-27T13:54:43.551556+00:00","name":"tf-srv-distracted-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:44.079396+00:00","export_uri":null,"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","modification_date":"2025-01-27T13:54:36.396179+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"eaca9908-d54e-4427-bcee-8d728569458c","name":"tf-srv-distracted-gould"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2238"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:54:49 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - cf20c99b-a958-4439-bcdd-fb00ebf8e58a
-        status: 200 OK
-        code: 200
-        duration: 247.742416ms
-    - id: 67
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/eaca9908-d54e-4427-bcee-8d728569458c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2238
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:44.079396+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-distracted-gould","id":"eaca9908-d54e-4427-bcee-8d728569458c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1102","node_id":"27","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:61","maintenances":[],"modification_date":"2025-01-27T13:54:43.551556+00:00","name":"tf-srv-distracted-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:44.079396+00:00","export_uri":null,"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","modification_date":"2025-01-27T13:54:36.396179+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"eaca9908-d54e-4427-bcee-8d728569458c","name":"tf-srv-distracted-gould"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2238"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:54:54 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - e0371a66-b04a-438d-b4e5-a6f452b3989c
-        status: 200 OK
-        code: 200
-        duration: 160.105833ms
-    - id: 68
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/eaca9908-d54e-4427-bcee-8d728569458c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2238
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:44.079396+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-distracted-gould","id":"eaca9908-d54e-4427-bcee-8d728569458c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1102","node_id":"27","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:61","maintenances":[],"modification_date":"2025-01-27T13:54:43.551556+00:00","name":"tf-srv-distracted-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:44.079396+00:00","export_uri":null,"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","modification_date":"2025-01-27T13:54:36.396179+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"eaca9908-d54e-4427-bcee-8d728569458c","name":"tf-srv-distracted-gould"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2238"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:54:59 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 696f5965-826d-4a2c-aa1a-16d1b1eabb09
-        status: 200 OK
-        code: 200
-        duration: 177.03175ms
+        duration: 301.542542ms
     - id: 69
       request:
         proto: HTTP/1.1
@@ -3437,8 +3437,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/eaca9908-d54e-4427-bcee-8d728569458c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/de141f80-bcb9-4d1b-b91e-0c71769c128f
         method: GET
       response:
         proto: HTTP/2.0
@@ -3446,20 +3446,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2238
+        content_length: 1787
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:44.079396+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-distracted-gould","id":"eaca9908-d54e-4427-bcee-8d728569458c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1102","node_id":"27","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:61","maintenances":[],"modification_date":"2025-01-27T13:54:43.551556+00:00","name":"tf-srv-distracted-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:44.079396+00:00","export_uri":null,"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","modification_date":"2025-01-27T13:54:36.396179+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"eaca9908-d54e-4427-bcee-8d728569458c","name":"tf-srv-distracted-gould"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:01:32.495034+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-lumiere","id":"de141f80-bcb9-4d1b-b91e-0c71769c128f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"801","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:23","maintenances":[],"modification_date":"2025-02-12T16:02:26.092361+00:00","name":"tf-srv-tender-lumiere","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"0aa2eadf-770f-41d8-84a6-e3929a361816","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2238"
+                - "1787"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:04 GMT
+                - Wed, 12 Feb 2025 16:02:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3467,10 +3467,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 35b19b9b-4ef9-4c97-9135-fa7512aa7e07
+                - eddfcbe7-1585-4270-b4a8-6eb297a7aaee
         status: 200 OK
         code: 200
-        duration: 138.001958ms
+        duration: 820.844ms
     - id: 70
       request:
         proto: HTTP/1.1
@@ -3486,8 +3486,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/eaca9908-d54e-4427-bcee-8d728569458c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/de141f80-bcb9-4d1b-b91e-0c71769c128f
         method: GET
       response:
         proto: HTTP/2.0
@@ -3495,20 +3495,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2238
+        content_length: 1787
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:44.079396+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-distracted-gould","id":"eaca9908-d54e-4427-bcee-8d728569458c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1102","node_id":"27","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:61","maintenances":[],"modification_date":"2025-01-27T13:54:43.551556+00:00","name":"tf-srv-distracted-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:44.079396+00:00","export_uri":null,"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","modification_date":"2025-01-27T13:54:36.396179+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"eaca9908-d54e-4427-bcee-8d728569458c","name":"tf-srv-distracted-gould"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:01:32.495034+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-lumiere","id":"de141f80-bcb9-4d1b-b91e-0c71769c128f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"801","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:23","maintenances":[],"modification_date":"2025-02-12T16:02:26.092361+00:00","name":"tf-srv-tender-lumiere","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"0aa2eadf-770f-41d8-84a6-e3929a361816","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2238"
+                - "1787"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:09 GMT
+                - Wed, 12 Feb 2025 16:02:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3516,10 +3516,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 639c89ce-1004-4208-95c3-3e99b2f1fba7
+                - cb42d391-53e9-403d-b3d4-cf8bff9a3d8c
         status: 200 OK
         code: 200
-        duration: 156.563416ms
+        duration: 320.004834ms
     - id: 71
       request:
         proto: HTTP/1.1
@@ -3535,8 +3535,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/eaca9908-d54e-4427-bcee-8d728569458c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/de141f80-bcb9-4d1b-b91e-0c71769c128f
         method: GET
       response:
         proto: HTTP/2.0
@@ -3544,20 +3544,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2238
+        content_length: 1787
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:44.079396+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-distracted-gould","id":"eaca9908-d54e-4427-bcee-8d728569458c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1102","node_id":"27","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:61","maintenances":[],"modification_date":"2025-01-27T13:54:43.551556+00:00","name":"tf-srv-distracted-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:44.079396+00:00","export_uri":null,"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","modification_date":"2025-01-27T13:54:36.396179+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"eaca9908-d54e-4427-bcee-8d728569458c","name":"tf-srv-distracted-gould"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:01:32.495034+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-lumiere","id":"de141f80-bcb9-4d1b-b91e-0c71769c128f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"801","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:23","maintenances":[],"modification_date":"2025-02-12T16:02:26.092361+00:00","name":"tf-srv-tender-lumiere","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"0aa2eadf-770f-41d8-84a6-e3929a361816","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2238"
+                - "1787"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:14 GMT
+                - Wed, 12 Feb 2025 16:02:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3565,10 +3565,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3a155b0d-970b-43d9-b3e6-fc1e8b1621a0
+                - a3fe0010-07d0-4129-a7ef-5a63ce66be3e
         status: 200 OK
         code: 200
-        duration: 316.946875ms
+        duration: 859.707917ms
     - id: 72
       request:
         proto: HTTP/1.1
@@ -3584,8 +3584,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/eaca9908-d54e-4427-bcee-8d728569458c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/de141f80-bcb9-4d1b-b91e-0c71769c128f
         method: GET
       response:
         proto: HTTP/2.0
@@ -3593,20 +3593,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2121
+        content_length: 1787
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:44.079396+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-distracted-gould","id":"eaca9908-d54e-4427-bcee-8d728569458c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:61","maintenances":[],"modification_date":"2025-01-27T13:55:19.443401+00:00","name":"tf-srv-distracted-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:44.079396+00:00","export_uri":null,"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","modification_date":"2025-01-27T13:54:36.396179+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"eaca9908-d54e-4427-bcee-8d728569458c","name":"tf-srv-distracted-gould"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:01:32.495034+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-lumiere","id":"de141f80-bcb9-4d1b-b91e-0c71769c128f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"801","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:23","maintenances":[],"modification_date":"2025-02-12T16:02:26.092361+00:00","name":"tf-srv-tender-lumiere","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"0aa2eadf-770f-41d8-84a6-e3929a361816","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2121"
+                - "1787"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:20 GMT
+                - Wed, 12 Feb 2025 16:02:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3614,10 +3614,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 41ecf00d-898e-4799-8c72-d18e1b7990af
+                - afd12ba9-159b-4d1f-8713-caae0ec50a0a
         status: 200 OK
         code: 200
-        duration: 179.401625ms
+        duration: 222.29475ms
     - id: 73
       request:
         proto: HTTP/1.1
@@ -3633,8 +3633,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/eaca9908-d54e-4427-bcee-8d728569458c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/de141f80-bcb9-4d1b-b91e-0c71769c128f
         method: GET
       response:
         proto: HTTP/2.0
@@ -3642,20 +3642,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2121
+        content_length: 1672
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:44.079396+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-distracted-gould","id":"eaca9908-d54e-4427-bcee-8d728569458c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:61","maintenances":[],"modification_date":"2025-01-27T13:55:19.443401+00:00","name":"tf-srv-distracted-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:44.079396+00:00","export_uri":null,"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","modification_date":"2025-01-27T13:54:36.396179+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"eaca9908-d54e-4427-bcee-8d728569458c","name":"tf-srv-distracted-gould"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:01:32.495034+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-lumiere","id":"de141f80-bcb9-4d1b-b91e-0c71769c128f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:23","maintenances":[],"modification_date":"2025-02-12T16:02:46.747614+00:00","name":"tf-srv-tender-lumiere","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"0aa2eadf-770f-41d8-84a6-e3929a361816","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2121"
+                - "1672"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:20 GMT
+                - Wed, 12 Feb 2025 16:02:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3663,10 +3663,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6980cb5f-0f79-4dbe-a746-e8d9dfa827bc
+                - 4fa459c2-2c2e-4dd1-a693-c1801c5a3d33
         status: 200 OK
         code: 200
-        duration: 155.449542ms
+        duration: 185.481208ms
     - id: 74
       request:
         proto: HTTP/1.1
@@ -3682,27 +3682,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/eaca9908-d54e-4427-bcee-8d728569458c
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/de141f80-bcb9-4d1b-b91e-0c71769c128f
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 1672
         uncompressed: false
-        body: ""
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:01:32.495034+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-lumiere","id":"de141f80-bcb9-4d1b-b91e-0c71769c128f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:23","maintenances":[],"modification_date":"2025-02-12T16:02:46.747614+00:00","name":"tf-srv-tender-lumiere","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"0aa2eadf-770f-41d8-84a6-e3929a361816","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
+            Content-Length:
+                - "1672"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:20 GMT
+                - Wed, 12 Feb 2025 16:02:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3710,10 +3712,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4e07cfdd-f1c7-4a98-a138-fd068c33468d
-        status: 204 No Content
-        code: 204
-        duration: 177.858625ms
+                - 29d62de9-c221-4c6e-9b72-cf365b874490
+        status: 200 OK
+        code: 200
+        duration: 753.070708ms
     - id: 75
       request:
         proto: HTTP/1.1
@@ -3729,106 +3731,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/eaca9908-d54e-4427-bcee-8d728569458c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 143
-        uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"eaca9908-d54e-4427-bcee-8d728569458c","type":"not_found"}'
-        headers:
-            Content-Length:
-                - "143"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:55:20 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - f2d01c84-aa60-4f5c-bf3f-38796effa57f
-        status: 404 Not Found
-        code: 404
-        duration: 106.844375ms
-    - id: 76
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/6c12a713-2b3c-495e-b095-c5a0a5c4d98e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 446
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:53:44.079396+00:00","export_uri":null,"id":"6c12a713-2b3c-495e-b095-c5a0a5c4d98e","modification_date":"2025-01-27T13:55:20.528483+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "446"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:55:20 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - b9f2b99a-f1a5-4acd-afab-d870c6c0051f
-        status: 200 OK
-        code: 200
-        duration: 96.14825ms
-    - id: 77
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/6c12a713-2b3c-495e-b095-c5a0a5c4d98e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/de141f80-bcb9-4d1b-b91e-0c71769c128f
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3845,9 +3749,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:20 GMT
+                - Wed, 12 Feb 2025 16:02:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3855,10 +3759,108 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 132a4012-a5c8-4a94-921e-c3286f5667c5
+                - f1c4fdc9-7356-40a9-9f9c-df3f4321f5f0
         status: 204 No Content
         code: 204
-        duration: 193.161208ms
+        duration: 380.327708ms
+    - id: 76
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/de141f80-bcb9-4d1b-b91e-0c71769c128f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"de141f80-bcb9-4d1b-b91e-0c71769c128f","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:02:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d9a0b2d3-9dd8-4931-bbf9-213dc6227b8b
+        status: 404 Not Found
+        code: 404
+        duration: 128.149375ms
+    - id: 77
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0aa2eadf-770f-41d8-84a6-e3929a361816
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"0aa2eadf-770f-41d8-84a6-e3929a361816","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:02:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ba87640a-d283-49bc-883b-ac9bfe2ba85e
+        status: 404 Not Found
+        code: 404
+        duration: 47.052625ms
     - id: 78
       request:
         proto: HTTP/1.1
@@ -3874,8 +3876,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/6cecef1a-ddd1-4e77-953c-8b809986f0ff
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/0aa2eadf-770f-41d8-84a6-e3929a361816
         method: GET
       response:
         proto: HTTP/2.0
@@ -3883,20 +3885,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 142
+        content_length: 494
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_image","resource_id":"6cecef1a-ddd1-4e77-953c-8b809986f0ff","type":"not_found"}'
+        body: '{"created_at":"2025-02-12T16:01:32.745747Z","id":"0aa2eadf-770f-41d8-84a6-e3929a361816","last_detached_at":"2025-02-12T16:02:49.875110Z","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:02:49.875110Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "142"
+                - "494"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:20 GMT
+                - Wed, 12 Feb 2025 16:02:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3904,10 +3906,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0cf6cdbe-e4cc-4852-9582-3e6bdd29aeb9
-        status: 404 Not Found
-        code: 404
-        duration: 33.788542ms
+                - bde1e0f8-946b-4b59-9071-0c3f4924988d
+        status: 200 OK
+        code: 200
+        duration: 86.268417ms
     - id: 79
       request:
         proto: HTTP/1.1
@@ -3923,29 +3925,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f6413266-6b5f-49bd-b984-64ea90d174da
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/0aa2eadf-770f-41d8-84a6-e3929a361816
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 145
+        content_length: 0
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"f6413266-6b5f-49bd-b984-64ea90d174da","type":"not_found"}'
+        body: ""
         headers:
-            Content-Length:
-                - "145"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:20 GMT
+                - Wed, 12 Feb 2025 16:02:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3953,10 +3953,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 535cf720-3cec-4708-ad22-daf048334168
-        status: 404 Not Found
-        code: 404
-        duration: 37.9805ms
+                - 55fdf877-8e4d-4ce7-b8a3-6124f4d0891f
+        status: 204 No Content
+        code: 204
+        duration: 143.240875ms
     - id: 80
       request:
         proto: HTTP/1.1
@@ -3972,8 +3972,57 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/eaca9908-d54e-4427-bcee-8d728569458c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/775987a3-b39a-414c-b482-9b098f631d1e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 142
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_image","resource_id":"775987a3-b39a-414c-b482-9b098f631d1e","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "142"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:02:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 28e9679f-1c0b-4a3c-bcb4-28c78c91cf83
+        status: 404 Not Found
+        code: 404
+        duration: 66.894459ms
+    - id: 81
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/de141f80-bcb9-4d1b-b91e-0c71769c128f
         method: GET
       response:
         proto: HTTP/2.0
@@ -3983,7 +4032,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"eaca9908-d54e-4427-bcee-8d728569458c","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"de141f80-bcb9-4d1b-b91e-0c71769c128f","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -3992,9 +4041,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:21 GMT
+                - Wed, 12 Feb 2025 16:02:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4002,7 +4051,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - afee95b0-d91a-4318-8e0a-ace35d3b8e7d
+                - aafb0eac-c864-4db4-8998-ca985e937516
         status: 404 Not Found
         code: 404
-        duration: 86.617542ms
+        duration: 109.109ms

--- a/internal/services/instance/testdata/ip-reverse-dns-basic.cassette.yaml
+++ b/internal/services/instance/testdata/ip-reverse-dns-basic.cassette.yaml
@@ -29,7 +29,7 @@ interactions:
         trailer: {}
         content_length: 365
         uncompressed: false
-        body: '{"ip":{"address":"51.15.219.146","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"1a9cbbdc-cbd6-4c37-abd6-60f88530b254","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        body: '{"ip":{"address":"51.15.250.217","id":"2136a5a4-5f73-43b1-b390-9cfeac46050f","ipam_id":"1d125bc2-e709-49b8-b560-4c408b9580ba","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "365"
@@ -38,11 +38,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 11 Feb 2025 14:23:44 GMT
+                - Wed, 12 Feb 2025 16:28:47 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/090b718f-a41b-45ad-9bdb-0514effd355c
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/2136a5a4-5f73-43b1-b390-9cfeac46050f
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -50,10 +50,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fd45d6a0-ebcb-40f2-8125-e9e546ecd24b
+                - 79b35aa1-5e72-4ef9-9f70-64e911ab83cd
         status: 201 Created
         code: 201
-        duration: 551.839167ms
+        duration: 824.338208ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -70,7 +70,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/090b718f-a41b-45ad-9bdb-0514effd355c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/2136a5a4-5f73-43b1-b390-9cfeac46050f
         method: GET
       response:
         proto: HTTP/2.0
@@ -80,7 +80,7 @@ interactions:
         trailer: {}
         content_length: 365
         uncompressed: false
-        body: '{"ip":{"address":"51.15.219.146","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"1a9cbbdc-cbd6-4c37-abd6-60f88530b254","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        body: '{"ip":{"address":"51.15.250.217","id":"2136a5a4-5f73-43b1-b390-9cfeac46050f","ipam_id":"1d125bc2-e709-49b8-b560-4c408b9580ba","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "365"
@@ -89,9 +89,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 11 Feb 2025 14:23:45 GMT
+                - Wed, 12 Feb 2025 16:28:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -99,10 +99,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c69a3dca-0d3d-4b8e-a5db-42c177742329
+                - a7b0119a-ab3e-4c63-9bda-30825cec9494
         status: 200 OK
         code: 200
-        duration: 97.940375ms
+        duration: 142.726333ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -114,7 +114,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"changes":[{"add":{"records":[{"data":"51.15.219.146","name":"","priority":1,"ttl":3600,"type":"A","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
+        body: '{"changes":[{"add":{"records":[{"data":"51.15.250.217","name":"","priority":1,"ttl":3600,"type":"A","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
         form: {}
         headers:
             Content-Type:
@@ -131,7 +131,7 @@ interactions:
         trailer: {}
         content_length: 148
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"51.15.219.146","id":"354ed232-1a8e-4c92-88fa-7390a736922a","name":"","priority":1,"ttl":3600,"type":"A"}]}'
+        body: '{"records":[{"comment":null,"data":"51.15.250.217","id":"decd3535-bf1e-4e37-b30b-9936e865cae8","name":"","priority":1,"ttl":3600,"type":"A"}]}'
         headers:
             Content-Length:
                 - "148"
@@ -140,9 +140,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 11 Feb 2025 14:23:45 GMT
+                - Wed, 12 Feb 2025 16:28:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -150,10 +150,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 34b5c1e0-ea6a-4fde-9f95-181f619006fb
+                - d712536d-52a8-499c-8f84-9b71675e8e22
         status: 200 OK
         code: 200
-        duration: 439.692959ms
+        duration: 462.615417ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -180,7 +180,7 @@ interactions:
         trailer: {}
         content_length: 165
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"51.15.219.146","id":"354ed232-1a8e-4c92-88fa-7390a736922a","name":"","priority":1,"ttl":3600,"type":"A"}],"total_count":1}'
+        body: '{"records":[{"comment":null,"data":"51.15.250.217","id":"decd3535-bf1e-4e37-b30b-9936e865cae8","name":"","priority":1,"ttl":3600,"type":"A"}],"total_count":1}'
         headers:
             Content-Length:
                 - "165"
@@ -189,9 +189,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 11 Feb 2025 14:23:45 GMT
+                - Wed, 12 Feb 2025 16:28:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -199,10 +199,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 61beee3b-b284-40cf-bed7-58108e27ded0
+                - d17b6966-8913-415f-b9e6-b5cfbf33b83c
         status: 200 OK
         code: 200
-        duration: 83.839167ms
+        duration: 88.6835ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -229,7 +229,7 @@ interactions:
         trailer: {}
         content_length: 165
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"51.15.219.146","id":"354ed232-1a8e-4c92-88fa-7390a736922a","name":"","priority":1,"ttl":3600,"type":"A"}],"total_count":1}'
+        body: '{"records":[{"comment":null,"data":"51.15.250.217","id":"decd3535-bf1e-4e37-b30b-9936e865cae8","name":"","priority":1,"ttl":3600,"type":"A"}],"total_count":1}'
         headers:
             Content-Length:
                 - "165"
@@ -238,9 +238,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 11 Feb 2025 14:23:45 GMT
+                - Wed, 12 Feb 2025 16:28:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -248,10 +248,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - afb10c4a-55f6-49cc-9711-0a849d8170d1
+                - dfc0da12-8b9f-4222-9c4e-8339ef4b24f6
         status: 200 OK
         code: 200
-        duration: 73.588417ms
+        duration: 89.075583ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -268,7 +268,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones/tf-reverse-instance.scaleway-terraform.com/records?id=354ed232-1a8e-4c92-88fa-7390a736922a&name=&order_by=name_asc&page=1&type=unknown
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones/tf-reverse-instance.scaleway-terraform.com/records?id=decd3535-bf1e-4e37-b30b-9936e865cae8&name=&order_by=name_asc&page=1&type=unknown
         method: GET
       response:
         proto: HTTP/2.0
@@ -278,7 +278,7 @@ interactions:
         trailer: {}
         content_length: 165
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"51.15.219.146","id":"354ed232-1a8e-4c92-88fa-7390a736922a","name":"","priority":1,"ttl":3600,"type":"A"}],"total_count":1}'
+        body: '{"records":[{"comment":null,"data":"51.15.250.217","id":"decd3535-bf1e-4e37-b30b-9936e865cae8","name":"","priority":1,"ttl":3600,"type":"A"}],"total_count":1}'
         headers:
             Content-Length:
                 - "165"
@@ -287,9 +287,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 11 Feb 2025 14:23:45 GMT
+                - Wed, 12 Feb 2025 16:28:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -297,10 +297,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1181ddee-dd4b-40d8-9d14-d0344eceea9b
+                - d9a9bde2-3ebe-405f-9f80-8e27bdcf768b
         status: 200 OK
         code: 200
-        duration: 109.353333ms
+        duration: 92.089459ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -327,7 +327,7 @@ interactions:
         trailer: {}
         content_length: 373
         uncompressed: false
-        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"tf-reverse-instance","updated_at":"2025-02-11T14:23:45Z"}],"total_count":1}'
+        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"tf-reverse-instance","updated_at":"2025-02-12T16:28:48Z"}],"total_count":1}'
         headers:
             Content-Length:
                 - "373"
@@ -336,9 +336,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 11 Feb 2025 14:23:45 GMT
+                - Wed, 12 Feb 2025 16:28:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -346,10 +346,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 43807290-a022-41e0-a895-35daf8b5f1ca
+                - 7c4f7858-3cc5-4424-9493-0c328c265a1c
         status: 200 OK
         code: 200
-        duration: 71.210583ms
+        duration: 98.488416ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -366,7 +366,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/090b718f-a41b-45ad-9bdb-0514effd355c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/2136a5a4-5f73-43b1-b390-9cfeac46050f
         method: GET
       response:
         proto: HTTP/2.0
@@ -376,7 +376,7 @@ interactions:
         trailer: {}
         content_length: 365
         uncompressed: false
-        body: '{"ip":{"address":"51.15.219.146","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"1a9cbbdc-cbd6-4c37-abd6-60f88530b254","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        body: '{"ip":{"address":"51.15.250.217","id":"2136a5a4-5f73-43b1-b390-9cfeac46050f","ipam_id":"1d125bc2-e709-49b8-b560-4c408b9580ba","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "365"
@@ -385,9 +385,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 11 Feb 2025 14:23:46 GMT
+                - Wed, 12 Feb 2025 16:28:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -395,10 +395,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fb6c42f5-fd12-4548-b22e-d3f95d286378
+                - 3c453237-68b8-4470-b07d-676abb583dcf
         status: 200 OK
         code: 200
-        duration: 94.530917ms
+        duration: 94.693542ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -415,7 +415,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones/tf-reverse-instance.scaleway-terraform.com/records?id=354ed232-1a8e-4c92-88fa-7390a736922a&name=&order_by=name_asc&page=1&type=A
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones/tf-reverse-instance.scaleway-terraform.com/records?id=decd3535-bf1e-4e37-b30b-9936e865cae8&name=&order_by=name_asc&page=1&type=A
         method: GET
       response:
         proto: HTTP/2.0
@@ -425,7 +425,7 @@ interactions:
         trailer: {}
         content_length: 165
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"51.15.219.146","id":"354ed232-1a8e-4c92-88fa-7390a736922a","name":"","priority":1,"ttl":3600,"type":"A"}],"total_count":1}'
+        body: '{"records":[{"comment":null,"data":"51.15.250.217","id":"decd3535-bf1e-4e37-b30b-9936e865cae8","name":"","priority":1,"ttl":3600,"type":"A"}],"total_count":1}'
         headers:
             Content-Length:
                 - "165"
@@ -434,9 +434,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 11 Feb 2025 14:23:46 GMT
+                - Wed, 12 Feb 2025 16:28:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -444,10 +444,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 195b122e-db12-4966-ace6-53dd5035148f
+                - 2301eea0-e479-4cc8-bb08-4c3445472d67
         status: 200 OK
         code: 200
-        duration: 71.755416ms
+        duration: 106.350375ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -474,7 +474,7 @@ interactions:
         trailer: {}
         content_length: 373
         uncompressed: false
-        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"tf-reverse-instance","updated_at":"2025-02-11T14:23:45Z"}],"total_count":1}'
+        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"tf-reverse-instance","updated_at":"2025-02-12T16:28:48Z"}],"total_count":1}'
         headers:
             Content-Length:
                 - "373"
@@ -483,9 +483,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 11 Feb 2025 14:23:46 GMT
+                - Wed, 12 Feb 2025 16:28:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -493,10 +493,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 437ed819-3495-44d4-b204-248372c7cebd
+                - 29328e83-d8ab-4e7c-8b87-a41f83338d7b
         status: 200 OK
         code: 200
-        duration: 85.226375ms
+        duration: 96.764625ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -513,7 +513,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/090b718f-a41b-45ad-9bdb-0514effd355c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/2136a5a4-5f73-43b1-b390-9cfeac46050f
         method: GET
       response:
         proto: HTTP/2.0
@@ -523,7 +523,7 @@ interactions:
         trailer: {}
         content_length: 365
         uncompressed: false
-        body: '{"ip":{"address":"51.15.219.146","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"1a9cbbdc-cbd6-4c37-abd6-60f88530b254","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        body: '{"ip":{"address":"51.15.250.217","id":"2136a5a4-5f73-43b1-b390-9cfeac46050f","ipam_id":"1d125bc2-e709-49b8-b560-4c408b9580ba","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "365"
@@ -532,9 +532,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 11 Feb 2025 14:23:46 GMT
+                - Wed, 12 Feb 2025 16:28:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -542,10 +542,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a9d642d3-d077-4968-b24c-fc29a941b01d
+                - d512fd16-3f66-4fa9-a971-4cd79b202f32
         status: 200 OK
         code: 200
-        duration: 94.416083ms
+        duration: 110.035541ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -562,7 +562,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones/tf-reverse-instance.scaleway-terraform.com/records?id=354ed232-1a8e-4c92-88fa-7390a736922a&name=&order_by=name_asc&page=1&type=A
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones/tf-reverse-instance.scaleway-terraform.com/records?id=decd3535-bf1e-4e37-b30b-9936e865cae8&name=&order_by=name_asc&page=1&type=A
         method: GET
       response:
         proto: HTTP/2.0
@@ -572,7 +572,7 @@ interactions:
         trailer: {}
         content_length: 165
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"51.15.219.146","id":"354ed232-1a8e-4c92-88fa-7390a736922a","name":"","priority":1,"ttl":3600,"type":"A"}],"total_count":1}'
+        body: '{"records":[{"comment":null,"data":"51.15.250.217","id":"decd3535-bf1e-4e37-b30b-9936e865cae8","name":"","priority":1,"ttl":3600,"type":"A"}],"total_count":1}'
         headers:
             Content-Length:
                 - "165"
@@ -581,9 +581,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 11 Feb 2025 14:23:47 GMT
+                - Wed, 12 Feb 2025 16:28:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -591,10 +591,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 73843a71-6302-4c99-8cb9-4dd727860928
+                - b1f92216-98be-46d0-af80-f61b02327ab0
         status: 200 OK
         code: 200
-        duration: 122.569084ms
+        duration: 89.473667ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -621,7 +621,7 @@ interactions:
         trailer: {}
         content_length: 373
         uncompressed: false
-        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"tf-reverse-instance","updated_at":"2025-02-11T14:23:45Z"}],"total_count":1}'
+        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"tf-reverse-instance","updated_at":"2025-02-12T16:28:48Z"}],"total_count":1}'
         headers:
             Content-Length:
                 - "373"
@@ -630,9 +630,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 11 Feb 2025 14:23:47 GMT
+                - Wed, 12 Feb 2025 16:28:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -640,10 +640,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 88dd4e1b-e364-4e75-9c47-f2ce03e881e1
+                - 8e08210a-8c69-40e9-8718-f2f57870c415
         status: 200 OK
         code: 200
-        duration: 67.9505ms
+        duration: 87.626958ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -660,7 +660,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/090b718f-a41b-45ad-9bdb-0514effd355c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/2136a5a4-5f73-43b1-b390-9cfeac46050f
         method: GET
       response:
         proto: HTTP/2.0
@@ -670,7 +670,7 @@ interactions:
         trailer: {}
         content_length: 365
         uncompressed: false
-        body: '{"ip":{"address":"51.15.219.146","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"1a9cbbdc-cbd6-4c37-abd6-60f88530b254","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        body: '{"ip":{"address":"51.15.250.217","id":"2136a5a4-5f73-43b1-b390-9cfeac46050f","ipam_id":"1d125bc2-e709-49b8-b560-4c408b9580ba","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "365"
@@ -679,9 +679,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 11 Feb 2025 14:23:47 GMT
+                - Wed, 12 Feb 2025 16:28:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -689,61 +689,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d110d8ca-8c99-4d0a-b3b2-b9c9fffbe2e8
+                - b9ed2f68-7626-4be4-8082-3a7b6b0f4147
         status: 200 OK
         code: 200
-        duration: 83.714958ms
-    - id: 14
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 56
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"reverse":"tf-reverse-instance.scaleway-terraform.com"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/090b718f-a41b-45ad-9bdb-0514effd355c
-        method: PATCH
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 329
-        uncompressed: false
-        body: '{"details":[{"argument_name":"reverse","help_message":"Your reverse must resolve. Ensure the command ''dig +short tf-reverse-instance.scaleway-terraform.com'' matches your IP address ''51.15.219.146''. If it does, please contact our support.","reason":"constraint"}],"message":"Validation Error","type":"invalid_arguments"}'
-        headers:
-            Content-Length:
-                - "329"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 11 Feb 2025 14:23:52 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - c6604d2c-6e17-4ba0-8435-17645b20380a
-        status: 400 Bad Request
-        code: 400
-        duration: 210.146292ms
+        duration: 105.717166ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -762,160 +711,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/090b718f-a41b-45ad-9bdb-0514effd355c
-        method: PATCH
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 329
-        uncompressed: false
-        body: '{"details":[{"argument_name":"reverse","help_message":"Your reverse must resolve. Ensure the command ''dig +short tf-reverse-instance.scaleway-terraform.com'' matches your IP address ''51.15.219.146''. If it does, please contact our support.","reason":"constraint"}],"message":"Validation Error","type":"invalid_arguments"}'
-        headers:
-            Content-Length:
-                - "329"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 11 Feb 2025 14:23:57 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 2ac649e7-05c2-4604-8d81-ac99b3465c6b
-        status: 400 Bad Request
-        code: 400
-        duration: 118.917167ms
-    - id: 16
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 56
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"reverse":"tf-reverse-instance.scaleway-terraform.com"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/090b718f-a41b-45ad-9bdb-0514effd355c
-        method: PATCH
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 329
-        uncompressed: false
-        body: '{"details":[{"argument_name":"reverse","help_message":"Your reverse must resolve. Ensure the command ''dig +short tf-reverse-instance.scaleway-terraform.com'' matches your IP address ''51.15.219.146''. If it does, please contact our support.","reason":"constraint"}],"message":"Validation Error","type":"invalid_arguments"}'
-        headers:
-            Content-Length:
-                - "329"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 11 Feb 2025 14:24:02 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 71fb6116-8b6c-461c-a287-f9a5211e38ab
-        status: 400 Bad Request
-        code: 400
-        duration: 125.570666ms
-    - id: 17
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 56
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"reverse":"tf-reverse-instance.scaleway-terraform.com"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/090b718f-a41b-45ad-9bdb-0514effd355c
-        method: PATCH
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 329
-        uncompressed: false
-        body: '{"details":[{"argument_name":"reverse","help_message":"Your reverse must resolve. Ensure the command ''dig +short tf-reverse-instance.scaleway-terraform.com'' matches your IP address ''51.15.219.146''. If it does, please contact our support.","reason":"constraint"}],"message":"Validation Error","type":"invalid_arguments"}'
-        headers:
-            Content-Length:
-                - "329"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 11 Feb 2025 14:24:08 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 5226fc07-fb78-4eff-ae88-d4f38efe17e1
-        status: 400 Bad Request
-        code: 400
-        duration: 102.3645ms
-    - id: 18
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 56
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"reverse":"tf-reverse-instance.scaleway-terraform.com"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/090b718f-a41b-45ad-9bdb-0514effd355c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/2136a5a4-5f73-43b1-b390-9cfeac46050f
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -925,7 +721,7 @@ interactions:
         trailer: {}
         content_length: 405
         uncompressed: false
-        body: '{"ip":{"address":"51.15.219.146","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"1a9cbbdc-cbd6-4c37-abd6-60f88530b254","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"tf-reverse-instance.scaleway-terraform.com","server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        body: '{"ip":{"address":"51.15.250.217","id":"2136a5a4-5f73-43b1-b390-9cfeac46050f","ipam_id":"1d125bc2-e709-49b8-b560-4c408b9580ba","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"tf-reverse-instance.scaleway-terraform.com","server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "405"
@@ -934,9 +730,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 11 Feb 2025 14:24:13 GMT
+                - Wed, 12 Feb 2025 16:29:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -944,10 +740,157 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - eab485b3-2dcc-4128-aeb8-e3a04fa553f3
+                - d799c985-52ea-4f29-a69e-f2f8e08c578f
         status: 200 OK
         code: 200
-        duration: 168.707333ms
+        duration: 481.091459ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/2136a5a4-5f73-43b1-b390-9cfeac46050f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 405
+        uncompressed: false
+        body: '{"ip":{"address":"51.15.250.217","id":"2136a5a4-5f73-43b1-b390-9cfeac46050f","ipam_id":"1d125bc2-e709-49b8-b560-4c408b9580ba","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"tf-reverse-instance.scaleway-terraform.com","server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "405"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:29:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6005ab92-c0fd-4bca-8378-9928d268ae3e
+        status: 200 OK
+        code: 200
+        duration: 107.520583ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/2136a5a4-5f73-43b1-b390-9cfeac46050f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 405
+        uncompressed: false
+        body: '{"ip":{"address":"51.15.250.217","id":"2136a5a4-5f73-43b1-b390-9cfeac46050f","ipam_id":"1d125bc2-e709-49b8-b560-4c408b9580ba","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"tf-reverse-instance.scaleway-terraform.com","server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "405"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:29:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7cad4cc7-0aca-41e6-94d4-ae0519c7c67d
+        status: 200 OK
+        code: 200
+        duration: 106.116291ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones/tf-reverse-instance.scaleway-terraform.com/records?id=decd3535-bf1e-4e37-b30b-9936e865cae8&name=&order_by=name_asc&page=1&type=A
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 165
+        uncompressed: false
+        body: '{"records":[{"comment":null,"data":"51.15.250.217","id":"decd3535-bf1e-4e37-b30b-9936e865cae8","name":"","priority":1,"ttl":3600,"type":"A"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "165"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:29:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 23d15358-79d1-4f91-bc0a-f17390200fe5
+        status: 200 OK
+        code: 200
+        duration: 95.035584ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -964,7 +907,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/090b718f-a41b-45ad-9bdb-0514effd355c
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zones=tf-reverse-instance.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -972,20 +915,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 405
+        content_length: 372
         uncompressed: false
-        body: '{"ip":{"address":"51.15.219.146","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"1a9cbbdc-cbd6-4c37-abd6-60f88530b254","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"tf-reverse-instance.scaleway-terraform.com","server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"tf-reverse-instance","updated_at":"2025-02-12T16:28:58Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "405"
+                - "372"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 11 Feb 2025 14:24:13 GMT
+                - Wed, 12 Feb 2025 16:29:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -993,10 +936,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d1d53254-f027-4170-a0e7-b4d97799a66f
+                - d9ee5dc7-e2d2-42d0-8be2-8f962d040026
         status: 200 OK
         code: 200
-        duration: 76.24825ms
+        duration: 98.058875ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1013,7 +956,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/090b718f-a41b-45ad-9bdb-0514effd355c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/2136a5a4-5f73-43b1-b390-9cfeac46050f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1023,7 +966,7 @@ interactions:
         trailer: {}
         content_length: 405
         uncompressed: false
-        body: '{"ip":{"address":"51.15.219.146","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"1a9cbbdc-cbd6-4c37-abd6-60f88530b254","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"tf-reverse-instance.scaleway-terraform.com","server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        body: '{"ip":{"address":"51.15.250.217","id":"2136a5a4-5f73-43b1-b390-9cfeac46050f","ipam_id":"1d125bc2-e709-49b8-b560-4c408b9580ba","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"tf-reverse-instance.scaleway-terraform.com","server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "405"
@@ -1032,9 +975,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 11 Feb 2025 14:24:13 GMT
+                - Wed, 12 Feb 2025 16:29:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1042,10 +985,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6451df8e-c5a8-4b4e-b46e-ba3c30ddd351
+                - 5d78f40e-a896-4338-87af-017fdb3fac0e
         status: 200 OK
         code: 200
-        duration: 80.982166ms
+        duration: 105.162208ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1062,7 +1005,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones/tf-reverse-instance.scaleway-terraform.com/records?id=354ed232-1a8e-4c92-88fa-7390a736922a&name=&order_by=name_asc&page=1&type=A
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones/tf-reverse-instance.scaleway-terraform.com/records?id=decd3535-bf1e-4e37-b30b-9936e865cae8&name=&order_by=name_asc&page=1&type=A
         method: GET
       response:
         proto: HTTP/2.0
@@ -1072,7 +1015,7 @@ interactions:
         trailer: {}
         content_length: 165
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"51.15.219.146","id":"354ed232-1a8e-4c92-88fa-7390a736922a","name":"","priority":1,"ttl":3600,"type":"A"}],"total_count":1}'
+        body: '{"records":[{"comment":null,"data":"51.15.250.217","id":"decd3535-bf1e-4e37-b30b-9936e865cae8","name":"","priority":1,"ttl":3600,"type":"A"}],"total_count":1}'
         headers:
             Content-Length:
                 - "165"
@@ -1081,9 +1024,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 11 Feb 2025 14:24:13 GMT
+                - Wed, 12 Feb 2025 16:29:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1091,10 +1034,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d3e9350e-2acd-4b89-a3b9-4bb8d3abc1df
+                - 6974272c-779c-4750-a62b-0373073d9f7f
         status: 200 OK
         code: 200
-        duration: 63.36125ms
+        duration: 92.350541ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1111,7 +1054,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zones=tf-reverse-instance.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/2136a5a4-5f73-43b1-b390-9cfeac46050f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1119,20 +1062,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 372
+        content_length: 405
         uncompressed: false
-        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"tf-reverse-instance","updated_at":"2025-02-11T14:23:54Z"}],"total_count":1}'
+        body: '{"ip":{"address":"51.15.250.217","id":"2136a5a4-5f73-43b1-b390-9cfeac46050f","ipam_id":"1d125bc2-e709-49b8-b560-4c408b9580ba","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"tf-reverse-instance.scaleway-terraform.com","server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "372"
+                - "405"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 11 Feb 2025 14:24:14 GMT
+                - Wed, 12 Feb 2025 16:29:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1140,10 +1083,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 40b5472a-c1ed-4fb3-8750-372be6175840
+                - 1290ec6a-0384-4e7f-9305-8cc44d506126
         status: 200 OK
         code: 200
-        duration: 70.885333ms
+        duration: 103.975166ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1160,7 +1103,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/090b718f-a41b-45ad-9bdb-0514effd355c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/2136a5a4-5f73-43b1-b390-9cfeac46050f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1170,7 +1113,7 @@ interactions:
         trailer: {}
         content_length: 405
         uncompressed: false
-        body: '{"ip":{"address":"51.15.219.146","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"1a9cbbdc-cbd6-4c37-abd6-60f88530b254","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"tf-reverse-instance.scaleway-terraform.com","server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        body: '{"ip":{"address":"51.15.250.217","id":"2136a5a4-5f73-43b1-b390-9cfeac46050f","ipam_id":"1d125bc2-e709-49b8-b560-4c408b9580ba","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"tf-reverse-instance.scaleway-terraform.com","server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "405"
@@ -1179,9 +1122,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 11 Feb 2025 14:24:13 GMT
+                - Wed, 12 Feb 2025 16:29:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1189,158 +1132,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7d95fb19-4e65-44af-868f-d81a1410a206
+                - 3133ac41-fb6b-429d-90e2-04b078a48a08
         status: 200 OK
         code: 200
-        duration: 189.197916ms
+        duration: 180.110042ms
     - id: 24
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/090b718f-a41b-45ad-9bdb-0514effd355c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 405
-        uncompressed: false
-        body: '{"ip":{"address":"51.15.219.146","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"1a9cbbdc-cbd6-4c37-abd6-60f88530b254","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"tf-reverse-instance.scaleway-terraform.com","server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "405"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 11 Feb 2025 14:24:14 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 71636ac2-1d5c-4cc8-bfac-38862947d0c0
-        status: 200 OK
-        code: 200
-        duration: 65.0775ms
-    - id: 25
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/090b718f-a41b-45ad-9bdb-0514effd355c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 405
-        uncompressed: false
-        body: '{"ip":{"address":"51.15.219.146","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"1a9cbbdc-cbd6-4c37-abd6-60f88530b254","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"tf-reverse-instance.scaleway-terraform.com","server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "405"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 11 Feb 2025 14:24:14 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - d4f4d9a2-e82c-4959-9e85-c8bfe87d93a0
-        status: 200 OK
-        code: 200
-        duration: 73.883416ms
-    - id: 26
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones/tf-reverse-instance.scaleway-terraform.com/records?id=354ed232-1a8e-4c92-88fa-7390a736922a&name=&order_by=name_asc&page=1&type=A
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 165
-        uncompressed: false
-        body: '{"records":[{"comment":null,"data":"51.15.219.146","id":"354ed232-1a8e-4c92-88fa-7390a736922a","name":"","priority":1,"ttl":3600,"type":"A"}],"total_count":1}'
-        headers:
-            Content-Length:
-                - "165"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 11 Feb 2025 14:24:14 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 9902a9df-ded2-4c4e-9fbc-7320c37d11b4
-        status: 200 OK
-        code: 200
-        duration: 73.222666ms
-    - id: 27
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1366,7 +1162,7 @@ interactions:
         trailer: {}
         content_length: 372
         uncompressed: false
-        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"tf-reverse-instance","updated_at":"2025-02-11T14:23:54Z"}],"total_count":1}'
+        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"tf-reverse-instance","updated_at":"2025-02-12T16:28:58Z"}],"total_count":1}'
         headers:
             Content-Length:
                 - "372"
@@ -1375,9 +1171,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 11 Feb 2025 14:24:14 GMT
+                - Wed, 12 Feb 2025 16:29:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1385,11 +1181,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a55ab26e-69aa-43e3-9a86-f019a76b5b01
+                - 095ece52-28b2-48f9-a964-07b3e9e24906
         status: 200 OK
         code: 200
-        duration: 90.004292ms
-    - id: 28
+        duration: 91.379916ms
+    - id: 25
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1407,7 +1203,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/090b718f-a41b-45ad-9bdb-0514effd355c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/2136a5a4-5f73-43b1-b390-9cfeac46050f
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -1417,7 +1213,7 @@ interactions:
         trailer: {}
         content_length: 365
         uncompressed: false
-        body: '{"ip":{"address":"51.15.219.146","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"1a9cbbdc-cbd6-4c37-abd6-60f88530b254","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        body: '{"ip":{"address":"51.15.250.217","id":"2136a5a4-5f73-43b1-b390-9cfeac46050f","ipam_id":"1d125bc2-e709-49b8-b560-4c408b9580ba","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "365"
@@ -1426,9 +1222,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 11 Feb 2025 14:24:14 GMT
+                - Wed, 12 Feb 2025 16:29:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1436,11 +1232,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - faa8b109-4cdb-428b-bda4-e866cbb069e6
+                - d41d3e53-15da-4558-90f0-6fb54f33471b
         status: 200 OK
         code: 200
-        duration: 132.984834ms
-    - id: 29
+        duration: 199.415708ms
+    - id: 26
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1451,7 +1247,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"changes":[{"delete":{"id":"354ed232-1a8e-4c92-88fa-7390a736922a"}}],"return_all_records":false,"disallow_new_zone_creation":false}'
+        body: '{"changes":[{"delete":{"id":"decd3535-bf1e-4e37-b30b-9936e865cae8"}}],"return_all_records":false,"disallow_new_zone_creation":false}'
         form: {}
         headers:
             Content-Type:
@@ -1477,9 +1273,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 11 Feb 2025 14:24:15 GMT
+                - Wed, 12 Feb 2025 16:29:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1487,11 +1283,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c6129fe2-37b6-45c9-ba91-d63fcf60c6e2
+                - dd13ab76-6f0c-4219-8f7e-f7508dddb759
         status: 200 OK
         code: 200
-        duration: 115.096708ms
-    - id: 30
+        duration: 127.260792ms
+    - id: 27
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1517,7 +1313,7 @@ interactions:
         trailer: {}
         content_length: 313
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"aac22f13-1937-4c21-a02a-29ecb8f6f877","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"a4a071c8-9d6d-43c2-a33f-90708ca798fe","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
+        body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"870d5486-ed8e-4104-b355-2d8e8512aa83","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"e8f56bbc-19d2-41f4-a8fa-acef473dd5c9","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
         headers:
             Content-Length:
                 - "313"
@@ -1526,9 +1322,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 11 Feb 2025 14:24:15 GMT
+                - Wed, 12 Feb 2025 16:29:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1536,60 +1332,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e66cf191-d47c-4e7e-b085-fb4e42b5464b
+                - 08e3426a-9c0a-4ca2-a66d-d41b44fed240
         status: 200 OK
         code: 200
-        duration: 73.588042ms
-    - id: 31
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=tf-reverse-instance.scaleway-terraform.com&domain=&order_by=domain_asc
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 373
-        uncompressed: false
-        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"tf-reverse-instance","updated_at":"2025-02-11T14:24:15Z"}],"total_count":1}'
-        headers:
-            Content-Length:
-                - "373"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 11 Feb 2025 14:24:15 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 1a220659-34a3-48f4-9417-07a2e66d3849
-        status: 200 OK
-        code: 200
-        duration: 72.882291ms
-    - id: 32
+        duration: 95.133334ms
+    - id: 28
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1617,7 +1364,7 @@ interactions:
         trailer: {}
         content_length: 365
         uncompressed: false
-        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"0a5206cb-66fb-41e1-bdc5-9fad8ab4e4a7","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"da609bec-185d-4756-8f95-763b4abd107b","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "365"
@@ -1626,11 +1373,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 11 Feb 2025 14:24:15 GMT
+                - Wed, 12 Feb 2025 16:29:02 GMT
             Location:
                 - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1638,60 +1385,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cccb2c9a-cb5d-4a8c-b71e-632ca50ba0d7
+                - 12871423-b353-496b-ae77-fb3de720d018
         status: 201 Created
         code: 201
-        duration: 521.425916ms
-    - id: 33
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 365
-        uncompressed: false
-        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"0a5206cb-66fb-41e1-bdc5-9fad8ab4e4a7","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "365"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 11 Feb 2025 14:24:15 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - ec0799c9-ced8-4b4b-9930-12fff6afa505
-        status: 200 OK
-        code: 200
-        duration: 87.215334ms
-    - id: 34
+        duration: 462.001042ms
+    - id: 29
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1717,7 +1415,7 @@ interactions:
         trailer: {}
         content_length: 373
         uncompressed: false
-        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"tf-reverse-instance","updated_at":"2025-02-11T14:24:15Z"}],"total_count":1}'
+        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"tf-reverse-instance","updated_at":"2025-02-12T16:29:02Z"}],"total_count":1}'
         headers:
             Content-Length:
                 - "373"
@@ -1726,9 +1424,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 11 Feb 2025 14:24:20 GMT
+                - Wed, 12 Feb 2025 16:29:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1736,11 +1434,109 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b78119dd-5dbb-4fca-8113-becb7266082f
+                - 751f8a45-db2f-4845-8b74-a9751ba0fb64
         status: 200 OK
         code: 200
-        duration: 105.285708ms
-    - id: 35
+        duration: 98.881625ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 365
+        uncompressed: false
+        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"da609bec-185d-4756-8f95-763b4abd107b","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "365"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:29:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8b89adf3-0bdc-4c67-ba24-18b42ddb9913
+        status: 200 OK
+        code: 200
+        duration: 110.882167ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=tf-reverse-instance.scaleway-terraform.com&domain=&order_by=domain_asc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 373
+        uncompressed: false
+        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"tf-reverse-instance","updated_at":"2025-02-12T16:29:02Z"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "373"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:29:08 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7758f2f5-15d3-4304-acfe-074118e634f7
+        status: 200 OK
+        code: 200
+        duration: 103.703208ms
+    - id: 32
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1766,7 +1562,7 @@ interactions:
         trailer: {}
         content_length: 372
         uncompressed: false
-        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"tf-reverse-instance","updated_at":"2025-02-11T14:24:25Z"}],"total_count":1}'
+        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"tf-reverse-instance","updated_at":"2025-02-12T16:29:09Z"}],"total_count":1}'
         headers:
             Content-Length:
                 - "372"
@@ -1775,9 +1571,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 11 Feb 2025 14:24:25 GMT
+                - Wed, 12 Feb 2025 16:29:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1785,11 +1581,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 663955f7-6fcb-4656-a211-7746edca26bc
+                - 4f35f7c6-ef53-4a01-99ed-bbbe523b5904
         status: 200 OK
         code: 200
-        duration: 71.081708ms
-    - id: 36
+        duration: 101.151792ms
+    - id: 33
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1824,9 +1620,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 11 Feb 2025 14:24:25 GMT
+                - Wed, 12 Feb 2025 16:29:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1834,11 +1630,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6b3f846a-eb61-4c5b-91cc-a562ea04f8fd
+                - 80ac6f8a-cdad-46f9-b1ba-743151abc472
         status: 200 OK
         code: 200
-        duration: 213.725041ms
-    - id: 37
+        duration: 204.84425ms
+    - id: 34
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1854,7 +1650,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/090b718f-a41b-45ad-9bdb-0514effd355c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/2136a5a4-5f73-43b1-b390-9cfeac46050f
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1871,9 +1667,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 11 Feb 2025 14:24:25 GMT
+                - Wed, 12 Feb 2025 16:29:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1881,11 +1677,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f5b39ad7-ee6b-4861-89ef-0aa775f8073b
+                - 31cd3aeb-4299-4d28-8813-8975af5ac5f3
         status: 204 No Content
         code: 204
-        duration: 439.288042ms
-    - id: 38
+        duration: 485.199542ms
+    - id: 35
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1911,7 +1707,7 @@ interactions:
         trailer: {}
         content_length: 365
         uncompressed: false
-        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"0a5206cb-66fb-41e1-bdc5-9fad8ab4e4a7","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"da609bec-185d-4756-8f95-763b4abd107b","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "365"
@@ -1920,9 +1716,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 11 Feb 2025 14:24:26 GMT
+                - Wed, 12 Feb 2025 16:29:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1930,11 +1726,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 519609bc-ccdd-4607-ad43-0e855a434e19
+                - 2d9397ea-0338-418d-beac-1afb4b75c925
         status: 200 OK
         code: 200
-        duration: 148.695375ms
-    - id: 39
+        duration: 101.496875ms
+    - id: 36
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1967,9 +1763,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 11 Feb 2025 14:24:26 GMT
+                - Wed, 12 Feb 2025 16:29:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1977,11 +1773,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e95a70d8-4c85-4261-9f58-aff48e86f56a
+                - 3d4193ce-dcd4-4f71-87f0-44296002f925
         status: 204 No Content
         code: 204
-        duration: 534.135542ms
-    - id: 40
+        duration: 626.661208ms
+    - id: 37
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2016,9 +1812,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 11 Feb 2025 14:24:27 GMT
+                - Wed, 12 Feb 2025 16:29:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2026,7 +1822,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4deaebe4-dde0-46e4-92de-f3340303d471
+                - be60bff0-4be9-43aa-8847-3ae93454c2d5
         status: 403 Forbidden
         code: 403
-        duration: 98.266083ms
+        duration: 110.6985ms

--- a/internal/services/instance/testdata/ip-reverse-dns-basic.cassette.yaml
+++ b/internal/services/instance/testdata/ip-reverse-dns-basic.cassette.yaml
@@ -18,7 +18,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips
         method: POST
       response:
@@ -29,7 +29,7 @@ interactions:
         trailer: {}
         content_length: 365
         uncompressed: false
-        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"68c5abc0-1c09-4094-b0b9-35ba0e951c93","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        body: '{"ip":{"address":"51.15.219.146","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"1a9cbbdc-cbd6-4c37-abd6-60f88530b254","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "365"
@@ -38,11 +38,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:04:35 GMT
+                - Tue, 11 Feb 2025 14:23:44 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/090b718f-a41b-45ad-9bdb-0514effd355c
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -50,10 +50,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a3ecd572-1447-4af2-ba4d-5b002724ead1
+                - fd45d6a0-ebcb-40f2-8125-e9e546ecd24b
         status: 201 Created
         code: 201
-        duration: 817.180458ms
+        duration: 551.839167ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -69,8 +69,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/090b718f-a41b-45ad-9bdb-0514effd355c
         method: GET
       response:
         proto: HTTP/2.0
@@ -80,7 +80,7 @@ interactions:
         trailer: {}
         content_length: 365
         uncompressed: false
-        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"68c5abc0-1c09-4094-b0b9-35ba0e951c93","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        body: '{"ip":{"address":"51.15.219.146","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"1a9cbbdc-cbd6-4c37-abd6-60f88530b254","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "365"
@@ -89,9 +89,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:04:36 GMT
+                - Tue, 11 Feb 2025 14:23:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -99,10 +99,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9b6075fb-5beb-44f9-92e1-a1cf398aa268
+                - c69a3dca-0d3d-4b8e-a5db-42c177742329
         status: 200 OK
         code: 200
-        duration: 88.843083ms
+        duration: 97.940375ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -114,13 +114,13 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"changes":[{"add":{"records":[{"data":"51.15.236.240","name":"","priority":1,"ttl":3600,"type":"A","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
+        body: '{"changes":[{"add":{"records":[{"data":"51.15.219.146","name":"","priority":1,"ttl":3600,"type":"A","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/domain/v2beta1/dns-zones/tf-reverse-instance.scaleway-terraform.com/records
         method: PATCH
       response:
@@ -131,7 +131,7 @@ interactions:
         trailer: {}
         content_length: 148
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"51.15.236.240","id":"967b4ebf-8eea-4e03-9329-cc3056b77112","name":"","priority":1,"ttl":3600,"type":"A"}]}'
+        body: '{"records":[{"comment":null,"data":"51.15.219.146","id":"354ed232-1a8e-4c92-88fa-7390a736922a","name":"","priority":1,"ttl":3600,"type":"A"}]}'
         headers:
             Content-Length:
                 - "148"
@@ -140,9 +140,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:04:36 GMT
+                - Tue, 11 Feb 2025 14:23:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -150,10 +150,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c84c872a-9e65-4987-b14a-4bbb357ebc73
+                - 34b5c1e0-ea6a-4fde-9f95-181f619006fb
         status: 200 OK
         code: 200
-        duration: 604.720083ms
+        duration: 439.692959ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -169,7 +169,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/domain/v2beta1/dns-zones/tf-reverse-instance.scaleway-terraform.com/records?name=&order_by=name_asc&type=A
         method: GET
       response:
@@ -180,7 +180,7 @@ interactions:
         trailer: {}
         content_length: 165
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"51.15.236.240","id":"967b4ebf-8eea-4e03-9329-cc3056b77112","name":"","priority":1,"ttl":3600,"type":"A"}],"total_count":1}'
+        body: '{"records":[{"comment":null,"data":"51.15.219.146","id":"354ed232-1a8e-4c92-88fa-7390a736922a","name":"","priority":1,"ttl":3600,"type":"A"}],"total_count":1}'
         headers:
             Content-Length:
                 - "165"
@@ -189,9 +189,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:04:36 GMT
+                - Tue, 11 Feb 2025 14:23:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -199,10 +199,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - eaf2aede-1892-44f8-bc8f-ea02ac84c73c
+                - 61beee3b-b284-40cf-bed7-58108e27ded0
         status: 200 OK
         code: 200
-        duration: 66.728916ms
+        duration: 83.839167ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -218,7 +218,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/domain/v2beta1/dns-zones/tf-reverse-instance.scaleway-terraform.com/records?name=&order_by=name_asc&page=1&type=A
         method: GET
       response:
@@ -229,7 +229,7 @@ interactions:
         trailer: {}
         content_length: 165
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"51.15.236.240","id":"967b4ebf-8eea-4e03-9329-cc3056b77112","name":"","priority":1,"ttl":3600,"type":"A"}],"total_count":1}'
+        body: '{"records":[{"comment":null,"data":"51.15.219.146","id":"354ed232-1a8e-4c92-88fa-7390a736922a","name":"","priority":1,"ttl":3600,"type":"A"}],"total_count":1}'
         headers:
             Content-Length:
                 - "165"
@@ -238,9 +238,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:04:36 GMT
+                - Tue, 11 Feb 2025 14:23:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -248,10 +248,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 236a80da-bae2-4521-8418-74b0ffb3bc52
+                - afb10c4a-55f6-49cc-9711-0a849d8170d1
         status: 200 OK
         code: 200
-        duration: 69.784709ms
+        duration: 73.588417ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -267,8 +267,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones/tf-reverse-instance.scaleway-terraform.com/records?id=967b4ebf-8eea-4e03-9329-cc3056b77112&name=&order_by=name_asc&page=1&type=unknown
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones/tf-reverse-instance.scaleway-terraform.com/records?id=354ed232-1a8e-4c92-88fa-7390a736922a&name=&order_by=name_asc&page=1&type=unknown
         method: GET
       response:
         proto: HTTP/2.0
@@ -278,7 +278,7 @@ interactions:
         trailer: {}
         content_length: 165
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"51.15.236.240","id":"967b4ebf-8eea-4e03-9329-cc3056b77112","name":"","priority":1,"ttl":3600,"type":"A"}],"total_count":1}'
+        body: '{"records":[{"comment":null,"data":"51.15.219.146","id":"354ed232-1a8e-4c92-88fa-7390a736922a","name":"","priority":1,"ttl":3600,"type":"A"}],"total_count":1}'
         headers:
             Content-Length:
                 - "165"
@@ -287,9 +287,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:04:36 GMT
+                - Tue, 11 Feb 2025 14:23:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -297,10 +297,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b717a23f-c37b-4380-9fb1-b2d7a3d07776
+                - 1181ddee-dd4b-40d8-9d14-d0344eceea9b
         status: 200 OK
         code: 200
-        duration: 87.532792ms
+        duration: 109.353333ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -316,7 +316,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zones=tf-reverse-instance.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
         method: GET
       response:
@@ -327,7 +327,7 @@ interactions:
         trailer: {}
         content_length: 373
         uncompressed: false
-        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"tf-reverse-instance","updated_at":"2025-01-27T14:04:36Z"}],"total_count":1}'
+        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"tf-reverse-instance","updated_at":"2025-02-11T14:23:45Z"}],"total_count":1}'
         headers:
             Content-Length:
                 - "373"
@@ -336,9 +336,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:04:37 GMT
+                - Tue, 11 Feb 2025 14:23:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -346,10 +346,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 21fba5fe-68bb-4f4c-acd9-cf6a10115f4a
+                - 43807290-a022-41e0-a895-35daf8b5f1ca
         status: 200 OK
         code: 200
-        duration: 76.170584ms
+        duration: 71.210583ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -365,8 +365,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/090b718f-a41b-45ad-9bdb-0514effd355c
         method: GET
       response:
         proto: HTTP/2.0
@@ -376,7 +376,7 @@ interactions:
         trailer: {}
         content_length: 365
         uncompressed: false
-        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"68c5abc0-1c09-4094-b0b9-35ba0e951c93","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        body: '{"ip":{"address":"51.15.219.146","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"1a9cbbdc-cbd6-4c37-abd6-60f88530b254","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "365"
@@ -385,9 +385,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:04:37 GMT
+                - Tue, 11 Feb 2025 14:23:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -395,10 +395,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6f9c1f5f-a4fb-4d2e-afcb-7a55e1e8b4db
+                - fb6c42f5-fd12-4548-b22e-d3f95d286378
         status: 200 OK
         code: 200
-        duration: 88.735375ms
+        duration: 94.530917ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -414,8 +414,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones/tf-reverse-instance.scaleway-terraform.com/records?id=967b4ebf-8eea-4e03-9329-cc3056b77112&name=&order_by=name_asc&page=1&type=A
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones/tf-reverse-instance.scaleway-terraform.com/records?id=354ed232-1a8e-4c92-88fa-7390a736922a&name=&order_by=name_asc&page=1&type=A
         method: GET
       response:
         proto: HTTP/2.0
@@ -425,7 +425,7 @@ interactions:
         trailer: {}
         content_length: 165
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"51.15.236.240","id":"967b4ebf-8eea-4e03-9329-cc3056b77112","name":"","priority":1,"ttl":3600,"type":"A"}],"total_count":1}'
+        body: '{"records":[{"comment":null,"data":"51.15.219.146","id":"354ed232-1a8e-4c92-88fa-7390a736922a","name":"","priority":1,"ttl":3600,"type":"A"}],"total_count":1}'
         headers:
             Content-Length:
                 - "165"
@@ -434,9 +434,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:04:37 GMT
+                - Tue, 11 Feb 2025 14:23:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -444,10 +444,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a898fb27-39a5-4340-9409-23cd896fe839
+                - 195b122e-db12-4966-ace6-53dd5035148f
         status: 200 OK
         code: 200
-        duration: 71.193792ms
+        duration: 71.755416ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -463,7 +463,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zones=tf-reverse-instance.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
         method: GET
       response:
@@ -474,7 +474,7 @@ interactions:
         trailer: {}
         content_length: 373
         uncompressed: false
-        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"tf-reverse-instance","updated_at":"2025-01-27T14:04:36Z"}],"total_count":1}'
+        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"tf-reverse-instance","updated_at":"2025-02-11T14:23:45Z"}],"total_count":1}'
         headers:
             Content-Length:
                 - "373"
@@ -483,9 +483,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:04:37 GMT
+                - Tue, 11 Feb 2025 14:23:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -493,10 +493,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 68c63a51-3bf4-4241-9eef-e71a11b1c022
+                - 437ed819-3495-44d4-b204-248372c7cebd
         status: 200 OK
         code: 200
-        duration: 72.25025ms
+        duration: 85.226375ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -512,8 +512,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/090b718f-a41b-45ad-9bdb-0514effd355c
         method: GET
       response:
         proto: HTTP/2.0
@@ -523,7 +523,7 @@ interactions:
         trailer: {}
         content_length: 365
         uncompressed: false
-        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"68c5abc0-1c09-4094-b0b9-35ba0e951c93","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        body: '{"ip":{"address":"51.15.219.146","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"1a9cbbdc-cbd6-4c37-abd6-60f88530b254","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "365"
@@ -532,9 +532,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:04:37 GMT
+                - Tue, 11 Feb 2025 14:23:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -542,10 +542,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 108361ef-5ef8-496a-8e3c-13288466e334
+                - a9d642d3-d077-4968-b24c-fc29a941b01d
         status: 200 OK
         code: 200
-        duration: 90.990375ms
+        duration: 94.416083ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -561,8 +561,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones/tf-reverse-instance.scaleway-terraform.com/records?id=967b4ebf-8eea-4e03-9329-cc3056b77112&name=&order_by=name_asc&page=1&type=A
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones/tf-reverse-instance.scaleway-terraform.com/records?id=354ed232-1a8e-4c92-88fa-7390a736922a&name=&order_by=name_asc&page=1&type=A
         method: GET
       response:
         proto: HTTP/2.0
@@ -572,7 +572,7 @@ interactions:
         trailer: {}
         content_length: 165
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"51.15.236.240","id":"967b4ebf-8eea-4e03-9329-cc3056b77112","name":"","priority":1,"ttl":3600,"type":"A"}],"total_count":1}'
+        body: '{"records":[{"comment":null,"data":"51.15.219.146","id":"354ed232-1a8e-4c92-88fa-7390a736922a","name":"","priority":1,"ttl":3600,"type":"A"}],"total_count":1}'
         headers:
             Content-Length:
                 - "165"
@@ -581,9 +581,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:04:37 GMT
+                - Tue, 11 Feb 2025 14:23:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -591,10 +591,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f3e6c73e-91fb-472e-8522-fc5c6c61f90a
+                - 73843a71-6302-4c99-8cb9-4dd727860928
         status: 200 OK
         code: 200
-        duration: 75.879417ms
+        duration: 122.569084ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -610,7 +610,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zones=tf-reverse-instance.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
         method: GET
       response:
@@ -621,7 +621,7 @@ interactions:
         trailer: {}
         content_length: 373
         uncompressed: false
-        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"tf-reverse-instance","updated_at":"2025-01-27T14:04:36Z"}],"total_count":1}'
+        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"tf-reverse-instance","updated_at":"2025-02-11T14:23:45Z"}],"total_count":1}'
         headers:
             Content-Length:
                 - "373"
@@ -630,9 +630,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:04:37 GMT
+                - Tue, 11 Feb 2025 14:23:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -640,10 +640,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - eb2e3839-2616-41fd-819a-2b521274f8bd
+                - 88dd4e1b-e364-4e75-9c47-f2ce03e881e1
         status: 200 OK
         code: 200
-        duration: 69.082292ms
+        duration: 67.9505ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -659,8 +659,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/090b718f-a41b-45ad-9bdb-0514effd355c
         method: GET
       response:
         proto: HTTP/2.0
@@ -670,7 +670,7 @@ interactions:
         trailer: {}
         content_length: 365
         uncompressed: false
-        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"68c5abc0-1c09-4094-b0b9-35ba0e951c93","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        body: '{"ip":{"address":"51.15.219.146","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"1a9cbbdc-cbd6-4c37-abd6-60f88530b254","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "365"
@@ -679,9 +679,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:04:38 GMT
+                - Tue, 11 Feb 2025 14:23:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -689,10 +689,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d650ad47-8933-45a2-ab0c-34307f542099
+                - d110d8ca-8c99-4d0a-b3b2-b9c9fffbe2e8
         status: 200 OK
         code: 200
-        duration: 99.97025ms
+        duration: 83.714958ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -710,8 +710,212 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/090b718f-a41b-45ad-9bdb-0514effd355c
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 329
+        uncompressed: false
+        body: '{"details":[{"argument_name":"reverse","help_message":"Your reverse must resolve. Ensure the command ''dig +short tf-reverse-instance.scaleway-terraform.com'' matches your IP address ''51.15.219.146''. If it does, please contact our support.","reason":"constraint"}],"message":"Validation Error","type":"invalid_arguments"}'
+        headers:
+            Content-Length:
+                - "329"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c6604d2c-6e17-4ba0-8435-17645b20380a
+        status: 400 Bad Request
+        code: 400
+        duration: 210.146292ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 56
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"reverse":"tf-reverse-instance.scaleway-terraform.com"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/090b718f-a41b-45ad-9bdb-0514effd355c
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 329
+        uncompressed: false
+        body: '{"details":[{"argument_name":"reverse","help_message":"Your reverse must resolve. Ensure the command ''dig +short tf-reverse-instance.scaleway-terraform.com'' matches your IP address ''51.15.219.146''. If it does, please contact our support.","reason":"constraint"}],"message":"Validation Error","type":"invalid_arguments"}'
+        headers:
+            Content-Length:
+                - "329"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2ac649e7-05c2-4604-8d81-ac99b3465c6b
+        status: 400 Bad Request
+        code: 400
+        duration: 118.917167ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 56
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"reverse":"tf-reverse-instance.scaleway-terraform.com"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/090b718f-a41b-45ad-9bdb-0514effd355c
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 329
+        uncompressed: false
+        body: '{"details":[{"argument_name":"reverse","help_message":"Your reverse must resolve. Ensure the command ''dig +short tf-reverse-instance.scaleway-terraform.com'' matches your IP address ''51.15.219.146''. If it does, please contact our support.","reason":"constraint"}],"message":"Validation Error","type":"invalid_arguments"}'
+        headers:
+            Content-Length:
+                - "329"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 71fb6116-8b6c-461c-a287-f9a5211e38ab
+        status: 400 Bad Request
+        code: 400
+        duration: 125.570666ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 56
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"reverse":"tf-reverse-instance.scaleway-terraform.com"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/090b718f-a41b-45ad-9bdb-0514effd355c
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 329
+        uncompressed: false
+        body: '{"details":[{"argument_name":"reverse","help_message":"Your reverse must resolve. Ensure the command ''dig +short tf-reverse-instance.scaleway-terraform.com'' matches your IP address ''51.15.219.146''. If it does, please contact our support.","reason":"constraint"}],"message":"Validation Error","type":"invalid_arguments"}'
+        headers:
+            Content-Length:
+                - "329"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:08 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5226fc07-fb78-4eff-ae88-d4f38efe17e1
+        status: 400 Bad Request
+        code: 400
+        duration: 102.3645ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 56
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"reverse":"tf-reverse-instance.scaleway-terraform.com"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/090b718f-a41b-45ad-9bdb-0514effd355c
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -721,7 +925,7 @@ interactions:
         trailer: {}
         content_length: 405
         uncompressed: false
-        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"68c5abc0-1c09-4094-b0b9-35ba0e951c93","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"tf-reverse-instance.scaleway-terraform.com","server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        body: '{"ip":{"address":"51.15.219.146","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"1a9cbbdc-cbd6-4c37-abd6-60f88530b254","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"tf-reverse-instance.scaleway-terraform.com","server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "405"
@@ -730,9 +934,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:04:43 GMT
+                - Tue, 11 Feb 2025 14:24:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -740,206 +944,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 91f5fd62-2678-4612-83c0-8dd68bad382b
+                - eab485b3-2dcc-4128-aeb8-e3a04fa553f3
         status: 200 OK
         code: 200
-        duration: 159.027583ms
-    - id: 15
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 405
-        uncompressed: false
-        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"68c5abc0-1c09-4094-b0b9-35ba0e951c93","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"tf-reverse-instance.scaleway-terraform.com","server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "405"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 14:04:43 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 74cd1615-40c8-4e21-b99b-5252b53153cf
-        status: 200 OK
-        code: 200
-        duration: 98.766916ms
-    - id: 16
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 405
-        uncompressed: false
-        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"68c5abc0-1c09-4094-b0b9-35ba0e951c93","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"tf-reverse-instance.scaleway-terraform.com","server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "405"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 14:04:43 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - dc112f8c-097e-418b-bf1a-d4fe77ae71a8
-        status: 200 OK
-        code: 200
-        duration: 125.474042ms
-    - id: 17
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones/tf-reverse-instance.scaleway-terraform.com/records?id=967b4ebf-8eea-4e03-9329-cc3056b77112&name=&order_by=name_asc&page=1&type=A
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 165
-        uncompressed: false
-        body: '{"records":[{"comment":null,"data":"51.15.236.240","id":"967b4ebf-8eea-4e03-9329-cc3056b77112","name":"","priority":1,"ttl":3600,"type":"A"}],"total_count":1}'
-        headers:
-            Content-Length:
-                - "165"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 14:04:44 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 6c175253-a0d2-4195-b915-02bbc556c3df
-        status: 200 OK
-        code: 200
-        duration: 74.241542ms
-    - id: 18
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zones=tf-reverse-instance.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 372
-        uncompressed: false
-        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"tf-reverse-instance","updated_at":"2025-01-27T14:04:39Z"}],"total_count":1}'
-        headers:
-            Content-Length:
-                - "372"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 14:04:44 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 7706d201-c25f-4968-a7c8-137233d38305
-        status: 200 OK
-        code: 200
-        duration: 87.746ms
+        duration: 168.707333ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -955,8 +963,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/090b718f-a41b-45ad-9bdb-0514effd355c
         method: GET
       response:
         proto: HTTP/2.0
@@ -966,7 +974,7 @@ interactions:
         trailer: {}
         content_length: 405
         uncompressed: false
-        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"68c5abc0-1c09-4094-b0b9-35ba0e951c93","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"tf-reverse-instance.scaleway-terraform.com","server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        body: '{"ip":{"address":"51.15.219.146","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"1a9cbbdc-cbd6-4c37-abd6-60f88530b254","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"tf-reverse-instance.scaleway-terraform.com","server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "405"
@@ -975,9 +983,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:04:44 GMT
+                - Tue, 11 Feb 2025 14:24:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -985,10 +993,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4983919c-8160-4c3a-b0a5-593f2ec45e7b
+                - d1d53254-f027-4170-a0e7-b4d97799a66f
         status: 200 OK
         code: 200
-        duration: 75.939791ms
+        duration: 76.24825ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1004,8 +1012,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/domain/v2beta1/dns-zones/tf-reverse-instance.scaleway-terraform.com/records?id=967b4ebf-8eea-4e03-9329-cc3056b77112&name=&order_by=name_asc&page=1&type=A
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/090b718f-a41b-45ad-9bdb-0514effd355c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1013,20 +1021,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 165
+        content_length: 405
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"51.15.236.240","id":"967b4ebf-8eea-4e03-9329-cc3056b77112","name":"","priority":1,"ttl":3600,"type":"A"}],"total_count":1}'
+        body: '{"ip":{"address":"51.15.219.146","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"1a9cbbdc-cbd6-4c37-abd6-60f88530b254","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"tf-reverse-instance.scaleway-terraform.com","server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "165"
+                - "405"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:04:44 GMT
+                - Tue, 11 Feb 2025 14:24:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1034,10 +1042,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6f5b3747-bb5f-44f4-b354-405eb8cb1d34
+                - 6451df8e-c5a8-4b4e-b46e-ba3c30ddd351
         status: 200 OK
         code: 200
-        duration: 63.243584ms
+        duration: 80.982166ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1053,8 +1061,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones/tf-reverse-instance.scaleway-terraform.com/records?id=354ed232-1a8e-4c92-88fa-7390a736922a&name=&order_by=name_asc&page=1&type=A
         method: GET
       response:
         proto: HTTP/2.0
@@ -1062,20 +1070,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 405
+        content_length: 165
         uncompressed: false
-        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"68c5abc0-1c09-4094-b0b9-35ba0e951c93","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"tf-reverse-instance.scaleway-terraform.com","server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        body: '{"records":[{"comment":null,"data":"51.15.219.146","id":"354ed232-1a8e-4c92-88fa-7390a736922a","name":"","priority":1,"ttl":3600,"type":"A"}],"total_count":1}'
         headers:
             Content-Length:
-                - "405"
+                - "165"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:04:44 GMT
+                - Tue, 11 Feb 2025 14:24:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1083,10 +1091,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e0922053-8847-4d7c-a4ce-f663e2e6d155
+                - d3e9350e-2acd-4b89-a3b9-4bb8d3abc1df
         status: 200 OK
         code: 200
-        duration: 76.132834ms
+        duration: 63.36125ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1102,7 +1110,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zones=tf-reverse-instance.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
         method: GET
       response:
@@ -1113,7 +1121,7 @@ interactions:
         trailer: {}
         content_length: 372
         uncompressed: false
-        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"tf-reverse-instance","updated_at":"2025-01-27T14:04:39Z"}],"total_count":1}'
+        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"tf-reverse-instance","updated_at":"2025-02-11T14:23:54Z"}],"total_count":1}'
         headers:
             Content-Length:
                 - "372"
@@ -1122,9 +1130,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:04:44 GMT
+                - Tue, 11 Feb 2025 14:24:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1132,10 +1140,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5db5935b-0e58-48dd-8a1f-7d171b016d99
+                - 40b5472a-c1ed-4fb3-8750-372be6175840
         status: 200 OK
         code: 200
-        duration: 66.811625ms
+        duration: 70.885333ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1151,8 +1159,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/090b718f-a41b-45ad-9bdb-0514effd355c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1162,7 +1170,7 @@ interactions:
         trailer: {}
         content_length: 405
         uncompressed: false
-        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"68c5abc0-1c09-4094-b0b9-35ba0e951c93","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"tf-reverse-instance.scaleway-terraform.com","server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        body: '{"ip":{"address":"51.15.219.146","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"1a9cbbdc-cbd6-4c37-abd6-60f88530b254","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"tf-reverse-instance.scaleway-terraform.com","server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "405"
@@ -1171,9 +1179,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:04:44 GMT
+                - Tue, 11 Feb 2025 14:24:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1181,11 +1189,207 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e3756ef6-9b79-4247-8a5e-27ad6086c6e0
+                - 7d95fb19-4e65-44af-868f-d81a1410a206
         status: 200 OK
         code: 200
-        duration: 210.293958ms
+        duration: 189.197916ms
     - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/090b718f-a41b-45ad-9bdb-0514effd355c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 405
+        uncompressed: false
+        body: '{"ip":{"address":"51.15.219.146","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"1a9cbbdc-cbd6-4c37-abd6-60f88530b254","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"tf-reverse-instance.scaleway-terraform.com","server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "405"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:14 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 71636ac2-1d5c-4cc8-bfac-38862947d0c0
+        status: 200 OK
+        code: 200
+        duration: 65.0775ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/090b718f-a41b-45ad-9bdb-0514effd355c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 405
+        uncompressed: false
+        body: '{"ip":{"address":"51.15.219.146","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"1a9cbbdc-cbd6-4c37-abd6-60f88530b254","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"tf-reverse-instance.scaleway-terraform.com","server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "405"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:14 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d4f4d9a2-e82c-4959-9e85-c8bfe87d93a0
+        status: 200 OK
+        code: 200
+        duration: 73.883416ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones/tf-reverse-instance.scaleway-terraform.com/records?id=354ed232-1a8e-4c92-88fa-7390a736922a&name=&order_by=name_asc&page=1&type=A
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 165
+        uncompressed: false
+        body: '{"records":[{"comment":null,"data":"51.15.219.146","id":"354ed232-1a8e-4c92-88fa-7390a736922a","name":"","priority":1,"ttl":3600,"type":"A"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "165"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:14 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9902a9df-ded2-4c4e-9fbc-7320c37d11b4
+        status: 200 OK
+        code: 200
+        duration: 73.222666ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zones=tf-reverse-instance.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 372
+        uncompressed: false
+        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"tf-reverse-instance","updated_at":"2025-02-11T14:23:54Z"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "372"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:14 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a55ab26e-69aa-43e3-9a86-f019a76b5b01
+        status: 200 OK
+        code: 200
+        duration: 90.004292ms
+    - id: 28
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1202,8 +1406,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/090b718f-a41b-45ad-9bdb-0514effd355c
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -1213,7 +1417,7 @@ interactions:
         trailer: {}
         content_length: 365
         uncompressed: false
-        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"68c5abc0-1c09-4094-b0b9-35ba0e951c93","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        body: '{"ip":{"address":"51.15.219.146","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"1a9cbbdc-cbd6-4c37-abd6-60f88530b254","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "365"
@@ -1222,9 +1426,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:04:44 GMT
+                - Tue, 11 Feb 2025 14:24:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1232,11 +1436,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7502ea8d-a7b1-435a-8c7b-dac6fb850249
+                - faa8b109-4cdb-428b-bda4-e866cbb069e6
         status: 200 OK
         code: 200
-        duration: 155.119084ms
-    - id: 25
+        duration: 132.984834ms
+    - id: 29
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1247,13 +1451,13 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"changes":[{"delete":{"id":"967b4ebf-8eea-4e03-9329-cc3056b77112"}}],"return_all_records":false,"disallow_new_zone_creation":false}'
+        body: '{"changes":[{"delete":{"id":"354ed232-1a8e-4c92-88fa-7390a736922a"}}],"return_all_records":false,"disallow_new_zone_creation":false}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/domain/v2beta1/dns-zones/tf-reverse-instance.scaleway-terraform.com/records
         method: PATCH
       response:
@@ -1273,9 +1477,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:04:45 GMT
+                - Tue, 11 Feb 2025 14:24:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1283,11 +1487,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 22d529a3-f2d1-43ca-bcb3-d6dbaba575da
+                - c6129fe2-37b6-45c9-ba91-d63fcf60c6e2
         status: 200 OK
         code: 200
-        duration: 106.142083ms
-    - id: 26
+        duration: 115.096708ms
+    - id: 30
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1302,7 +1506,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/domain/v2beta1/dns-zones/tf-reverse-instance.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
         method: GET
       response:
@@ -1313,7 +1517,7 @@ interactions:
         trailer: {}
         content_length: 313
         uncompressed: false
-        body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"1bdc190f-2a2f-4ea3-9183-cde88aaed568","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"e22703e1-d2a1-4d12-beb3-71a1a7f42c48","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
+        body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"aac22f13-1937-4c21-a02a-29ecb8f6f877","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"a4a071c8-9d6d-43c2-a33f-90708ca798fe","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
         headers:
             Content-Length:
                 - "313"
@@ -1322,9 +1526,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:04:45 GMT
+                - Tue, 11 Feb 2025 14:24:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1332,11 +1536,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 849c8707-191a-415e-aecc-3f8a95645521
+                - e66cf191-d47c-4e7e-b085-fb4e42b5464b
         status: 200 OK
         code: 200
-        duration: 71.073709ms
-    - id: 27
+        duration: 73.588042ms
+    - id: 31
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1351,7 +1555,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=tf-reverse-instance.scaleway-terraform.com&domain=&order_by=domain_asc
         method: GET
       response:
@@ -1362,7 +1566,7 @@ interactions:
         trailer: {}
         content_length: 373
         uncompressed: false
-        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"tf-reverse-instance","updated_at":"2025-01-27T14:04:45Z"}],"total_count":1}'
+        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"tf-reverse-instance","updated_at":"2025-02-11T14:24:15Z"}],"total_count":1}'
         headers:
             Content-Length:
                 - "373"
@@ -1371,9 +1575,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:04:45 GMT
+                - Tue, 11 Feb 2025 14:24:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1381,11 +1585,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dd5dd3d1-f5ce-47f4-84a1-b842a595c7b3
+                - 1a220659-34a3-48f4-9417-07a2e66d3849
         status: 200 OK
         code: 200
-        duration: 70.084208ms
-    - id: 28
+        duration: 72.882291ms
+    - id: 32
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1402,7 +1606,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips
         method: POST
       response:
@@ -1411,22 +1615,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 367
+        content_length: 365
         uncompressed: false
-        body: '{"ip":{"address":"163.172.145.106","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"e546692e-e2f1-464b-b1eb-91fd789bb5be","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"0a5206cb-66fb-41e1-bdc5-9fad8ab4e4a7","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "367"
+                - "365"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:04:45 GMT
+                - Tue, 11 Feb 2025 14:24:15 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/780585ed-d10d-45e0-a5a4-9cce36efefd9
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1434,11 +1638,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6c190ea8-9b07-4042-bf58-3fffcbef7524
+                - cccb2c9a-cb5d-4a8c-b71e-632ca50ba0d7
         status: 201 Created
         code: 201
-        duration: 476.895625ms
-    - id: 29
+        duration: 521.425916ms
+    - id: 33
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1453,8 +1657,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/780585ed-d10d-45e0-a5a4-9cce36efefd9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
         method: GET
       response:
         proto: HTTP/2.0
@@ -1462,20 +1666,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 367
+        content_length: 365
         uncompressed: false
-        body: '{"ip":{"address":"163.172.145.106","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"e546692e-e2f1-464b-b1eb-91fd789bb5be","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"0a5206cb-66fb-41e1-bdc5-9fad8ab4e4a7","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "367"
+                - "365"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:04:45 GMT
+                - Tue, 11 Feb 2025 14:24:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1483,11 +1687,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cda4e648-2df1-416f-b88b-0fa0e7c457fe
+                - ec0799c9-ced8-4b4b-9930-12fff6afa505
         status: 200 OK
         code: 200
-        duration: 101.865709ms
-    - id: 30
+        duration: 87.215334ms
+    - id: 34
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1502,7 +1706,56 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=tf-reverse-instance.scaleway-terraform.com&domain=&order_by=domain_asc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 373
+        uncompressed: false
+        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"tf-reverse-instance","updated_at":"2025-02-11T14:24:15Z"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "373"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:20 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b78119dd-5dbb-4fca-8113-becb7266082f
+        status: 200 OK
+        code: 200
+        duration: 105.285708ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=tf-reverse-instance.scaleway-terraform.com&domain=&order_by=domain_asc
         method: GET
       response:
@@ -1513,7 +1766,7 @@ interactions:
         trailer: {}
         content_length: 372
         uncompressed: false
-        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"tf-reverse-instance","updated_at":"2025-01-27T14:04:49Z"}],"total_count":1}'
+        body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"tf-reverse-instance","updated_at":"2025-02-11T14:24:25Z"}],"total_count":1}'
         headers:
             Content-Length:
                 - "372"
@@ -1522,9 +1775,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:04:50 GMT
+                - Tue, 11 Feb 2025 14:24:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1532,11 +1785,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2af09494-fb46-4755-a4e7-3137c1cd7d51
+                - 663955f7-6fcb-4656-a211-7746edca26bc
         status: 200 OK
         code: 200
-        duration: 88.098792ms
-    - id: 31
+        duration: 71.081708ms
+    - id: 36
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1551,7 +1804,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/domain/v2beta1/dns-zones/tf-reverse-instance.scaleway-terraform.com?project_id=105bdce1-64c0-48ab-899d-868455867ecf
         method: DELETE
       response:
@@ -1571,9 +1824,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:04:50 GMT
+                - Tue, 11 Feb 2025 14:24:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1581,11 +1834,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3749e52f-8353-4892-b603-2e35b87bd625
+                - 6b3f846a-eb61-4c5b-91cc-a562ea04f8fd
         status: 200 OK
         code: 200
-        duration: 169.575083ms
-    - id: 32
+        duration: 213.725041ms
+    - id: 37
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1600,7 +1853,103 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/090b718f-a41b-45ad-9bdb-0514effd355c
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f5b39ad7-ee6b-4861-89ef-0aa775f8073b
+        status: 204 No Content
+        code: 204
+        duration: 439.288042ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 365
+        uncompressed: false
+        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"0a5206cb-66fb-41e1-bdc5-9fad8ab4e4a7","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "365"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 519609bc-ccdd-4607-ad43-0e855a434e19
+        status: 200 OK
+        code: 200
+        duration: 148.695375ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
         method: DELETE
       response:
@@ -1618,9 +1967,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:04:50 GMT
+                - Tue, 11 Feb 2025 14:24:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1628,11 +1977,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2f8d2340-d0e0-4a2d-8802-7a9760d72087
+                - e95a70d8-4c85-4261-9f58-aff48e86f56a
         status: 204 No Content
         code: 204
-        duration: 427.827416ms
-    - id: 33
+        duration: 534.135542ms
+    - id: 40
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1647,104 +1996,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/780585ed-d10d-45e0-a5a4-9cce36efefd9
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 367
-        uncompressed: false
-        body: '{"ip":{"address":"163.172.145.106","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"e546692e-e2f1-464b-b1eb-91fd789bb5be","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "367"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 14:04:51 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 23c710ea-f24b-4fe3-8d7b-961ea1fbb681
-        status: 200 OK
-        code: 200
-        duration: 85.614167ms
-    - id: 34
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/780585ed-d10d-45e0-a5a4-9cce36efefd9
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 14:04:51 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 97052d59-15ad-4967-8baa-f791088f20c3
-        status: 204 No Content
-        code: 204
-        duration: 429.704708ms
-    - id: 35
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/780585ed-d10d-45e0-a5a4-9cce36efefd9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
         method: GET
       response:
         proto: HTTP/2.0
@@ -1763,9 +2016,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 14:04:51 GMT
+                - Tue, 11 Feb 2025 14:24:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1773,7 +2026,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 469e26d9-9a7f-43ef-b568-34b9e06768dc
+                - 4deaebe4-dde0-46e4-92de-f3340303d471
         status: 403 Forbidden
         code: 403
-        duration: 108.114333ms
+        duration: 98.266083ms

--- a/internal/services/instance/testdata/placement-group-rename.cassette.yaml
+++ b/internal/services/instance/testdata/placement-group-rename.cassette.yaml
@@ -18,7 +18,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups
         method: POST
       response:
@@ -29,7 +29,7 @@ interactions:
         trailer: {}
         content_length: 304
         uncompressed: false
-        body: '{"placement_group":{"id":"e101b370-f711-4d9c-9eba-ae275c495f0c","name":"foo","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"enforced","policy_respected":true,"policy_type":"low_latency","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"}}'
+        body: '{"placement_group":{"id":"8ae01bd6-3f7e-4e5a-9e2e-d5b801165913","name":"foo","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"enforced","policy_respected":true,"policy_type":"low_latency","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "304"
@@ -38,11 +38,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:56 GMT
+                - Tue, 11 Feb 2025 14:24:13 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/e101b370-f711-4d9c-9eba-ae275c495f0c
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/8ae01bd6-3f7e-4e5a-9e2e-d5b801165913
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -50,10 +50,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 737b8707-41f2-4d34-8809-517a696a156c
+                - f0c0fa7a-4e34-42b6-a66f-446ba834e0e7
         status: 201 Created
         code: 201
-        duration: 200.484833ms
+        duration: 250.460292ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -69,8 +69,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/e101b370-f711-4d9c-9eba-ae275c495f0c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/8ae01bd6-3f7e-4e5a-9e2e-d5b801165913
         method: GET
       response:
         proto: HTTP/2.0
@@ -80,7 +80,7 @@ interactions:
         trailer: {}
         content_length: 304
         uncompressed: false
-        body: '{"placement_group":{"id":"e101b370-f711-4d9c-9eba-ae275c495f0c","name":"foo","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"enforced","policy_respected":true,"policy_type":"low_latency","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"}}'
+        body: '{"placement_group":{"id":"8ae01bd6-3f7e-4e5a-9e2e-d5b801165913","name":"foo","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"enforced","policy_respected":true,"policy_type":"low_latency","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "304"
@@ -89,9 +89,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:57 GMT
+                - Tue, 11 Feb 2025 14:24:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -99,10 +99,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 79bddf17-a71d-4094-8629-2056c8461497
+                - 665f2407-4b5f-4bb1-a616-6f7338c4890e
         status: 200 OK
         code: 200
-        duration: 79.504375ms
+        duration: 87.7565ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -118,7 +118,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
         method: GET
       response:
@@ -127,22 +127,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 38539
+        content_length: 35639
         uncompressed: false
-        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
+        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
         headers:
             Content-Length:
-                - "38539"
+                - "35639"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:57 GMT
+                - Tue, 11 Feb 2025 14:24:13 GMT
             Link:
                 - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -150,12 +150,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0ff9006e-b852-4610-82ae-65c4d45f80dd
+                - c335d866-ddbd-4e2a-99c9-c5ef9ad3b9cb
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 57.288792ms
+        duration: 36.118583ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -171,7 +171,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
         method: GET
       response:
@@ -180,22 +180,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 14208
+        content_length: 13164
         uncompressed: false
-        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
         headers:
             Content-Length:
-                - "14208"
+                - "13164"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:57 GMT
+                - Tue, 11 Feb 2025 14:24:13 GMT
             Link:
                 - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -203,12 +203,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cfa46ea0-8ecf-498b-9a7b-dee8646228a8
+                - 9f2c45f6-7ad2-42c9-b08d-6fe3e59953ea
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 56.298917ms
+        duration: 66.691334ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -224,8 +224,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_local&zone=fr-par-1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_sbs&zone=fr-par-1
         method: GET
       response:
         proto: HTTP/2.0
@@ -233,20 +233,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1300
+        content_length: 1296
         uncompressed: false
-        body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"56d4019c-8305-467a-a3f2-70498ad799df","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
+        body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"57509e82-ac3b-49b7-9970-97b60f40ff72","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"9b647e1e-253a-41e7-8c15-911c622ee2dc","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"}],"total_count":2}'
         headers:
             Content-Length:
-                - "1300"
+                - "1296"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:57 GMT
+                - Tue, 11 Feb 2025 14:24:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -254,28 +254,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 69098966-3e08-4ebf-8178-51d5d0a0274b
+                - ef84e2f3-5511-4a5e-a5ab-c44aa81e621d
         status: 200 OK
         code: 200
-        duration: 86.937583ms
+        duration: 72.1335ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 333
+        content_length: 294
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-srv-upbeat-chatelet","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":"e101b370-f711-4d9c-9eba-ae275c495f0c"}'
+        body: '{"name":"tf-srv-beautiful-feistel","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"57509e82-ac3b-49b7-9970-97b60f40ff72","volumes":{"0":{"boot":false}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":"8ae01bd6-3f7e-4e5a-9e2e-d5b801165913"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
         method: POST
       response:
@@ -284,22 +284,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2397
+        content_length: 1958
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:57.976523+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-upbeat-chatelet","id":"02afa339-465b-473e-b62c-f5d149d616e9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:51","maintenances":[],"modification_date":"2025-01-27T13:49:57.976523+00:00","name":"tf-srv-upbeat-chatelet","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":{"id":"e101b370-f711-4d9c-9eba-ae275c495f0c","name":"foo","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"enforced","policy_respected":true,"policy_type":"low_latency","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"},"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:57.976523+00:00","export_uri":null,"id":"940d2639-e2d1-4e37-803f-ae946a4b06df","modification_date":"2025-01-27T13:49:57.976523+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"02afa339-465b-473e-b62c-f5d149d616e9","name":"tf-srv-upbeat-chatelet"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:14.327166+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-beautiful-feistel","id":"b376a98d-094a-4b45-af7e-6429d4991738","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:03","maintenances":[],"modification_date":"2025-02-11T14:24:14.327166+00:00","name":"tf-srv-beautiful-feistel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":{"id":"8ae01bd6-3f7e-4e5a-9e2e-d5b801165913","name":"foo","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"enforced","policy_respected":false,"policy_type":"low_latency","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"},"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"298c30a1-db94-481d-9ad2-ab1b4d0253df","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2397"
+                - "1958"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:58 GMT
+                - Tue, 11 Feb 2025 14:24:14 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/02afa339-465b-473e-b62c-f5d149d616e9
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b376a98d-094a-4b45-af7e-6429d4991738
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -307,10 +307,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4c3fb281-2b2a-4be5-949b-5fce48c3ccb0
+                - 13b80737-3bd3-4a36-83f9-f3a7b1cd2d6c
         status: 201 Created
         code: 201
-        duration: 951.769458ms
+        duration: 1.269068375s
     - id: 6
       request:
         proto: HTTP/1.1
@@ -326,8 +326,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/02afa339-465b-473e-b62c-f5d149d616e9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b376a98d-094a-4b45-af7e-6429d4991738
         method: GET
       response:
         proto: HTTP/2.0
@@ -335,20 +335,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2397
+        content_length: 1958
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:57.976523+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-upbeat-chatelet","id":"02afa339-465b-473e-b62c-f5d149d616e9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:51","maintenances":[],"modification_date":"2025-01-27T13:49:57.976523+00:00","name":"tf-srv-upbeat-chatelet","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":{"id":"e101b370-f711-4d9c-9eba-ae275c495f0c","name":"foo","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"enforced","policy_respected":true,"policy_type":"low_latency","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"},"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:57.976523+00:00","export_uri":null,"id":"940d2639-e2d1-4e37-803f-ae946a4b06df","modification_date":"2025-01-27T13:49:57.976523+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"02afa339-465b-473e-b62c-f5d149d616e9","name":"tf-srv-upbeat-chatelet"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:14.327166+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-beautiful-feistel","id":"b376a98d-094a-4b45-af7e-6429d4991738","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:03","maintenances":[],"modification_date":"2025-02-11T14:24:14.327166+00:00","name":"tf-srv-beautiful-feistel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":{"id":"8ae01bd6-3f7e-4e5a-9e2e-d5b801165913","name":"foo","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"enforced","policy_respected":false,"policy_type":"low_latency","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"},"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"298c30a1-db94-481d-9ad2-ab1b4d0253df","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2397"
+                - "1958"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:58 GMT
+                - Tue, 11 Feb 2025 14:24:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -356,10 +356,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fb8f5e60-39fd-4cc0-a541-f950af57a6f5
+                - 193485e6-d41d-4cc6-adc3-ee6f6bc08275
         status: 200 OK
         code: 200
-        duration: 188.252584ms
+        duration: 166.531417ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -375,8 +375,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/02afa339-465b-473e-b62c-f5d149d616e9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b376a98d-094a-4b45-af7e-6429d4991738
         method: GET
       response:
         proto: HTTP/2.0
@@ -384,20 +384,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2397
+        content_length: 1958
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:57.976523+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-upbeat-chatelet","id":"02afa339-465b-473e-b62c-f5d149d616e9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:51","maintenances":[],"modification_date":"2025-01-27T13:49:57.976523+00:00","name":"tf-srv-upbeat-chatelet","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":{"id":"e101b370-f711-4d9c-9eba-ae275c495f0c","name":"foo","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"enforced","policy_respected":true,"policy_type":"low_latency","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"},"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:57.976523+00:00","export_uri":null,"id":"940d2639-e2d1-4e37-803f-ae946a4b06df","modification_date":"2025-01-27T13:49:57.976523+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"02afa339-465b-473e-b62c-f5d149d616e9","name":"tf-srv-upbeat-chatelet"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:14.327166+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-beautiful-feistel","id":"b376a98d-094a-4b45-af7e-6429d4991738","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:03","maintenances":[],"modification_date":"2025-02-11T14:24:14.327166+00:00","name":"tf-srv-beautiful-feistel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":{"id":"8ae01bd6-3f7e-4e5a-9e2e-d5b801165913","name":"foo","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"enforced","policy_respected":false,"policy_type":"low_latency","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"},"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"298c30a1-db94-481d-9ad2-ab1b4d0253df","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2397"
+                - "1958"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:58 GMT
+                - Tue, 11 Feb 2025 14:24:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -405,11 +405,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0421ac0c-e78c-4fab-b53d-f4a3b3b25075
+                - 524bc493-baff-41e8-ba93-6fab5781748d
         status: 200 OK
         code: 200
-        duration: 160.574625ms
+        duration: 153.153625ms
     - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/298c30a1-db94-481d-9ad2-ab1b4d0253df
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:24:14.567498Z","id":"298c30a1-db94-481d-9ad2-ab1b4d0253df","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:24:14.567498Z","id":"1d4b5c15-0745-4b93-a84d-53fcc34e85d2","product_resource_id":"b376a98d-094a-4b45-af7e-6429d4991738","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:24:14.567498Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:15 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9d9d948e-44e0-49b1-8dba-e7cc19cd74a8
+        status: 200 OK
+        code: 200
+        duration: 69.133625ms
+    - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -426,8 +475,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/02afa339-465b-473e-b62c-f5d149d616e9/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b376a98d-094a-4b45-af7e-6429d4991738/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -437,7 +486,7 @@ interactions:
         trailer: {}
         content_length: 357
         uncompressed: false
-        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/02afa339-465b-473e-b62c-f5d149d616e9/action","href_result":"/servers/02afa339-465b-473e-b62c-f5d149d616e9","id":"39e0baa0-5e20-4826-a1c6-87ae9d3f998b","progress":0,"started_at":"2025-01-27T13:49:59.785949+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/b376a98d-094a-4b45-af7e-6429d4991738/action","href_result":"/servers/b376a98d-094a-4b45-af7e-6429d4991738","id":"64e9e834-60d7-44ac-b570-cb2a9dc61b3f","progress":0,"started_at":"2025-02-11T14:24:15.703062+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -446,11 +495,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:59 GMT
+                - Tue, 11 Feb 2025 14:24:15 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/39e0baa0-5e20-4826-a1c6-87ae9d3f998b
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/64e9e834-60d7-44ac-b570-cb2a9dc61b3f
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -458,59 +507,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 64eb5dac-bdef-4e91-bd83-6383c30c4fe5
+                - 3cf1a1ab-f4a7-416c-bca5-b35cd70e755e
         status: 202 Accepted
         code: 202
-        duration: 787.199625ms
-    - id: 9
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/02afa339-465b-473e-b62c-f5d149d616e9
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2419
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:57.976523+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-upbeat-chatelet","id":"02afa339-465b-473e-b62c-f5d149d616e9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:51","maintenances":[],"modification_date":"2025-01-27T13:49:59.059651+00:00","name":"tf-srv-upbeat-chatelet","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":{"id":"e101b370-f711-4d9c-9eba-ae275c495f0c","name":"foo","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"enforced","policy_respected":true,"policy_type":"low_latency","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"},"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:57.976523+00:00","export_uri":null,"id":"940d2639-e2d1-4e37-803f-ae946a4b06df","modification_date":"2025-01-27T13:49:57.976523+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"02afa339-465b-473e-b62c-f5d149d616e9","name":"tf-srv-upbeat-chatelet"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2419"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:49:59 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 316c1a2e-79ed-4682-be05-78a627e1f311
-        status: 200 OK
-        code: 200
-        duration: 165.3685ms
+        duration: 246.408709ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -526,8 +526,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/02afa339-465b-473e-b62c-f5d149d616e9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b376a98d-094a-4b45-af7e-6429d4991738
         method: GET
       response:
         proto: HTTP/2.0
@@ -535,20 +535,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2523
+        content_length: 1980
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:57.976523+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-upbeat-chatelet","id":"02afa339-465b-473e-b62c-f5d149d616e9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1601","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:51","maintenances":[],"modification_date":"2025-01-27T13:49:59.059651+00:00","name":"tf-srv-upbeat-chatelet","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":{"id":"e101b370-f711-4d9c-9eba-ae275c495f0c","name":"foo","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"enforced","policy_respected":true,"policy_type":"low_latency","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"},"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:57.976523+00:00","export_uri":null,"id":"940d2639-e2d1-4e37-803f-ae946a4b06df","modification_date":"2025-01-27T13:49:57.976523+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"02afa339-465b-473e-b62c-f5d149d616e9","name":"tf-srv-upbeat-chatelet"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:14.327166+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-beautiful-feistel","id":"b376a98d-094a-4b45-af7e-6429d4991738","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:03","maintenances":[],"modification_date":"2025-02-11T14:24:15.508209+00:00","name":"tf-srv-beautiful-feistel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":{"id":"8ae01bd6-3f7e-4e5a-9e2e-d5b801165913","name":"foo","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"enforced","policy_respected":false,"policy_type":"low_latency","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"},"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"id":"298c30a1-db94-481d-9ad2-ab1b4d0253df","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2523"
+                - "1980"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:04 GMT
+                - Tue, 11 Feb 2025 14:24:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -556,10 +556,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6493cc8b-74eb-47de-a5bd-942c6d200c9b
+                - b66581b3-a517-444d-9a70-cd0e7f76d1c1
         status: 200 OK
         code: 200
-        duration: 172.195458ms
+        duration: 160.690166ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -575,8 +575,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/02afa339-465b-473e-b62c-f5d149d616e9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b376a98d-094a-4b45-af7e-6429d4991738
         method: GET
       response:
         proto: HTTP/2.0
@@ -584,20 +584,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2523
+        content_length: 2115
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:57.976523+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-upbeat-chatelet","id":"02afa339-465b-473e-b62c-f5d149d616e9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1601","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:51","maintenances":[],"modification_date":"2025-01-27T13:49:59.059651+00:00","name":"tf-srv-upbeat-chatelet","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":{"id":"e101b370-f711-4d9c-9eba-ae275c495f0c","name":"foo","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"enforced","policy_respected":true,"policy_type":"low_latency","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"},"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:57.976523+00:00","export_uri":null,"id":"940d2639-e2d1-4e37-803f-ae946a4b06df","modification_date":"2025-01-27T13:49:57.976523+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"02afa339-465b-473e-b62c-f5d149d616e9","name":"tf-srv-upbeat-chatelet"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:14.327166+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-beautiful-feistel","id":"b376a98d-094a-4b45-af7e-6429d4991738","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"2001","node_id":"25","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:03","maintenances":[],"modification_date":"2025-02-11T14:24:20.214923+00:00","name":"tf-srv-beautiful-feistel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":{"id":"8ae01bd6-3f7e-4e5a-9e2e-d5b801165913","name":"foo","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"enforced","policy_respected":false,"policy_type":"low_latency","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"},"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"298c30a1-db94-481d-9ad2-ab1b4d0253df","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2523"
+                - "2115"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:10 GMT
+                - Tue, 11 Feb 2025 14:24:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -605,10 +605,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f5854c1f-a9cf-4a5d-a6f4-c73a28d94231
+                - 5b32d9ef-19f9-425a-a59f-fce310db4af9
         status: 200 OK
         code: 200
-        duration: 273.112791ms
+        duration: 188.038792ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -624,8 +624,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/02afa339-465b-473e-b62c-f5d149d616e9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b376a98d-094a-4b45-af7e-6429d4991738
         method: GET
       response:
         proto: HTTP/2.0
@@ -633,20 +633,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2554
+        content_length: 2115
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:57.976523+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-upbeat-chatelet","id":"02afa339-465b-473e-b62c-f5d149d616e9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1601","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:51","maintenances":[],"modification_date":"2025-01-27T13:50:12.305364+00:00","name":"tf-srv-upbeat-chatelet","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":{"id":"e101b370-f711-4d9c-9eba-ae275c495f0c","name":"foo","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"enforced","policy_respected":true,"policy_type":"low_latency","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"},"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:57.976523+00:00","export_uri":null,"id":"940d2639-e2d1-4e37-803f-ae946a4b06df","modification_date":"2025-01-27T13:49:57.976523+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"02afa339-465b-473e-b62c-f5d149d616e9","name":"tf-srv-upbeat-chatelet"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:14.327166+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-beautiful-feistel","id":"b376a98d-094a-4b45-af7e-6429d4991738","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"2001","node_id":"25","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:03","maintenances":[],"modification_date":"2025-02-11T14:24:20.214923+00:00","name":"tf-srv-beautiful-feistel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":{"id":"8ae01bd6-3f7e-4e5a-9e2e-d5b801165913","name":"foo","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"enforced","policy_respected":false,"policy_type":"low_latency","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"},"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"298c30a1-db94-481d-9ad2-ab1b4d0253df","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2554"
+                - "2115"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:15 GMT
+                - Tue, 11 Feb 2025 14:24:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -654,10 +654,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3fab4279-cc07-41a0-b6dc-d7564afaba56
+                - b465ea61-f30a-402e-bf72-5ee3531161c2
         status: 200 OK
         code: 200
-        duration: 201.051041ms
+        duration: 267.133542ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -673,8 +673,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/02afa339-465b-473e-b62c-f5d149d616e9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/298c30a1-db94-481d-9ad2-ab1b4d0253df
         method: GET
       response:
         proto: HTTP/2.0
@@ -682,20 +682,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2554
+        content_length: 143
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:57.976523+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-upbeat-chatelet","id":"02afa339-465b-473e-b62c-f5d149d616e9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1601","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:51","maintenances":[],"modification_date":"2025-01-27T13:50:12.305364+00:00","name":"tf-srv-upbeat-chatelet","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":{"id":"e101b370-f711-4d9c-9eba-ae275c495f0c","name":"foo","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"enforced","policy_respected":true,"policy_type":"low_latency","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"},"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:57.976523+00:00","export_uri":null,"id":"940d2639-e2d1-4e37-803f-ae946a4b06df","modification_date":"2025-01-27T13:49:57.976523+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"02afa339-465b-473e-b62c-f5d149d616e9","name":"tf-srv-upbeat-chatelet"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"298c30a1-db94-481d-9ad2-ab1b4d0253df","type":"not_found"}'
         headers:
             Content-Length:
-                - "2554"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:15 GMT
+                - Tue, 11 Feb 2025 14:24:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -703,10 +703,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4bb8f987-ed12-4ecb-805b-a76771c1fd50
-        status: 200 OK
-        code: 200
-        duration: 173.353458ms
+                - 3f4eee78-e996-44db-9f22-c7ac99a542a4
+        status: 404 Not Found
+        code: 404
+        duration: 66.060166ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -722,8 +722,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/940d2639-e2d1-4e37-803f-ae946a4b06df
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/298c30a1-db94-481d-9ad2-ab1b4d0253df
         method: GET
       response:
         proto: HTTP/2.0
@@ -731,20 +731,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 522
+        content_length: 701
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:49:57.976523+00:00","export_uri":null,"id":"940d2639-e2d1-4e37-803f-ae946a4b06df","modification_date":"2025-01-27T13:49:57.976523+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"02afa339-465b-473e-b62c-f5d149d616e9","name":"tf-srv-upbeat-chatelet"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T14:24:14.567498Z","id":"298c30a1-db94-481d-9ad2-ab1b4d0253df","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:24:14.567498Z","id":"1d4b5c15-0745-4b93-a84d-53fcc34e85d2","product_resource_id":"b376a98d-094a-4b45-af7e-6429d4991738","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:24:14.567498Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "522"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:15 GMT
+                - Tue, 11 Feb 2025 14:24:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -752,10 +752,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 232b6fcd-8028-4196-aabb-14f3e0be2cd9
+                - bcfcc6fb-0ec2-401f-8e96-34efde9ce2a5
         status: 200 OK
         code: 200
-        duration: 92.798834ms
+        duration: 80.901875ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -771,8 +771,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/02afa339-465b-473e-b62c-f5d149d616e9/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b376a98d-094a-4b45-af7e-6429d4991738/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -791,9 +791,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:15 GMT
+                - Tue, 11 Feb 2025 14:24:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -801,10 +801,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f14b4cda-e738-4f90-8750-58edc3318298
+                - 214e7ce1-fd97-441b-ac97-398cff21adfc
         status: 200 OK
         code: 200
-        duration: 88.201375ms
+        duration: 96.875208ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -820,8 +820,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/02afa339-465b-473e-b62c-f5d149d616e9/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b376a98d-094a-4b45-af7e-6429d4991738/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -840,11 +840,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:15 GMT
+                - Tue, 11 Feb 2025 14:24:21 GMT
             Link:
-                - </servers/02afa339-465b-473e-b62c-f5d149d616e9/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/b376a98d-094a-4b45-af7e-6429d4991738/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -852,12 +852,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3638525d-902a-4847-8ebc-da6100dfd6ea
+                - a5870214-1f36-45ff-9399-68c99b38a019
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 89.81925ms
+        duration: 72.70775ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -873,8 +873,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/e101b370-f711-4d9c-9eba-ae275c495f0c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/8ae01bd6-3f7e-4e5a-9e2e-d5b801165913
         method: GET
       response:
         proto: HTTP/2.0
@@ -884,7 +884,7 @@ interactions:
         trailer: {}
         content_length: 304
         uncompressed: false
-        body: '{"placement_group":{"id":"e101b370-f711-4d9c-9eba-ae275c495f0c","name":"foo","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"enforced","policy_respected":true,"policy_type":"low_latency","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"}}'
+        body: '{"placement_group":{"id":"8ae01bd6-3f7e-4e5a-9e2e-d5b801165913","name":"foo","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"enforced","policy_respected":true,"policy_type":"low_latency","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "304"
@@ -893,9 +893,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:16 GMT
+                - Tue, 11 Feb 2025 14:24:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -903,10 +903,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c6f0cb31-65e1-4a03-bbc9-e730f6a315d2
+                - f239ed65-eb9b-4b33-a8bc-351b58dcb08d
         status: 200 OK
         code: 200
-        duration: 107.025667ms
+        duration: 213.548292ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -922,8 +922,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/e101b370-f711-4d9c-9eba-ae275c495f0c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/8ae01bd6-3f7e-4e5a-9e2e-d5b801165913
         method: GET
       response:
         proto: HTTP/2.0
@@ -933,7 +933,7 @@ interactions:
         trailer: {}
         content_length: 304
         uncompressed: false
-        body: '{"placement_group":{"id":"e101b370-f711-4d9c-9eba-ae275c495f0c","name":"foo","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"enforced","policy_respected":true,"policy_type":"low_latency","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"}}'
+        body: '{"placement_group":{"id":"8ae01bd6-3f7e-4e5a-9e2e-d5b801165913","name":"foo","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"enforced","policy_respected":true,"policy_type":"low_latency","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "304"
@@ -942,9 +942,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:16 GMT
+                - Tue, 11 Feb 2025 14:24:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -952,10 +952,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4f220c7d-52ac-4862-9e8f-11fdd79f8e37
+                - 993861b5-7e97-40d8-ac67-0b4f454aca62
         status: 200 OK
         code: 200
-        duration: 72.097083ms
+        duration: 149.228208ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -971,8 +971,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/02afa339-465b-473e-b62c-f5d149d616e9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b376a98d-094a-4b45-af7e-6429d4991738
         method: GET
       response:
         proto: HTTP/2.0
@@ -980,20 +980,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2554
+        content_length: 2115
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:57.976523+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-upbeat-chatelet","id":"02afa339-465b-473e-b62c-f5d149d616e9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1601","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:51","maintenances":[],"modification_date":"2025-01-27T13:50:12.305364+00:00","name":"tf-srv-upbeat-chatelet","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":{"id":"e101b370-f711-4d9c-9eba-ae275c495f0c","name":"foo","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"enforced","policy_respected":true,"policy_type":"low_latency","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"},"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:57.976523+00:00","export_uri":null,"id":"940d2639-e2d1-4e37-803f-ae946a4b06df","modification_date":"2025-01-27T13:49:57.976523+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"02afa339-465b-473e-b62c-f5d149d616e9","name":"tf-srv-upbeat-chatelet"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:14.327166+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-beautiful-feistel","id":"b376a98d-094a-4b45-af7e-6429d4991738","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"2001","node_id":"25","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:03","maintenances":[],"modification_date":"2025-02-11T14:24:20.214923+00:00","name":"tf-srv-beautiful-feistel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":{"id":"8ae01bd6-3f7e-4e5a-9e2e-d5b801165913","name":"foo","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"enforced","policy_respected":false,"policy_type":"low_latency","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"},"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"298c30a1-db94-481d-9ad2-ab1b4d0253df","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2554"
+                - "2115"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:16 GMT
+                - Tue, 11 Feb 2025 14:24:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1001,10 +1001,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0b9d5ac0-b183-441b-8f85-a7896debd8c8
+                - cf0b82db-5726-4a04-83b5-9083edf8248b
         status: 200 OK
         code: 200
-        duration: 219.976917ms
+        duration: 206.431166ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1020,8 +1020,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/940d2639-e2d1-4e37-803f-ae946a4b06df
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/298c30a1-db94-481d-9ad2-ab1b4d0253df
         method: GET
       response:
         proto: HTTP/2.0
@@ -1029,20 +1029,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 522
+        content_length: 143
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:49:57.976523+00:00","export_uri":null,"id":"940d2639-e2d1-4e37-803f-ae946a4b06df","modification_date":"2025-01-27T13:49:57.976523+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"02afa339-465b-473e-b62c-f5d149d616e9","name":"tf-srv-upbeat-chatelet"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"298c30a1-db94-481d-9ad2-ab1b4d0253df","type":"not_found"}'
         headers:
             Content-Length:
-                - "522"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:16 GMT
+                - Tue, 11 Feb 2025 14:24:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1050,10 +1050,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2508786e-acad-4884-89b2-eac96d32d59f
-        status: 200 OK
-        code: 200
-        duration: 91.302ms
+                - 5b94b566-a27d-44b3-aa39-b3e2e4bf1f29
+        status: 404 Not Found
+        code: 404
+        duration: 47.52925ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1069,8 +1069,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/02afa339-465b-473e-b62c-f5d149d616e9/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/298c30a1-db94-481d-9ad2-ab1b4d0253df
         method: GET
       response:
         proto: HTTP/2.0
@@ -1078,20 +1078,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 701
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"created_at":"2025-02-11T14:24:14.567498Z","id":"298c30a1-db94-481d-9ad2-ab1b4d0253df","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:24:14.567498Z","id":"1d4b5c15-0745-4b93-a84d-53fcc34e85d2","product_resource_id":"b376a98d-094a-4b45-af7e-6429d4991738","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:24:14.567498Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "17"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:16 GMT
+                - Tue, 11 Feb 2025 14:24:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1099,10 +1099,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ff76315f-54d5-46ed-9350-de6610564db6
+                - 21f51053-d9f0-4e7c-b016-ec8701e0108e
         status: 200 OK
         code: 200
-        duration: 100.653458ms
+        duration: 67.96625ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1118,208 +1118,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/02afa339-465b-473e-b62c-f5d149d616e9/private_nics
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 20
-        uncompressed: false
-        body: '{"private_nics":[]}'
-        headers:
-            Content-Length:
-                - "20"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:16 GMT
-            Link:
-                - </servers/02afa339-465b-473e-b62c-f5d149d616e9/private_nics?page=0&per_page=50&>; rel="last"
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - ccbbcd86-8817-45f4-bb19-ae8f7dd135d3
-            X-Total-Count:
-                - "0"
-        status: 200 OK
-        code: 200
-        duration: 96.682292ms
-    - id: 23
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/e101b370-f711-4d9c-9eba-ae275c495f0c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 304
-        uncompressed: false
-        body: '{"placement_group":{"id":"e101b370-f711-4d9c-9eba-ae275c495f0c","name":"foo","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"enforced","policy_respected":true,"policy_type":"low_latency","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "304"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:17 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 3fc7de2d-c383-42e0-ad70-70590bd68e1a
-        status: 200 OK
-        code: 200
-        duration: 120.878833ms
-    - id: 24
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/02afa339-465b-473e-b62c-f5d149d616e9
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2554
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:57.976523+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-upbeat-chatelet","id":"02afa339-465b-473e-b62c-f5d149d616e9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1601","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:51","maintenances":[],"modification_date":"2025-01-27T13:50:12.305364+00:00","name":"tf-srv-upbeat-chatelet","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":{"id":"e101b370-f711-4d9c-9eba-ae275c495f0c","name":"foo","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"enforced","policy_respected":true,"policy_type":"low_latency","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"},"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:57.976523+00:00","export_uri":null,"id":"940d2639-e2d1-4e37-803f-ae946a4b06df","modification_date":"2025-01-27T13:49:57.976523+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"02afa339-465b-473e-b62c-f5d149d616e9","name":"tf-srv-upbeat-chatelet"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2554"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:17 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - fe8c0adb-32c9-41d0-b924-383d5ddec3bd
-        status: 200 OK
-        code: 200
-        duration: 197.011417ms
-    - id: 25
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/940d2639-e2d1-4e37-803f-ae946a4b06df
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 522
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:49:57.976523+00:00","export_uri":null,"id":"940d2639-e2d1-4e37-803f-ae946a4b06df","modification_date":"2025-01-27T13:49:57.976523+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"02afa339-465b-473e-b62c-f5d149d616e9","name":"tf-srv-upbeat-chatelet"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "522"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:17 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - d65a7e8f-4ed3-43af-bb92-2e64d56fe0dd
-        status: 200 OK
-        code: 200
-        duration: 91.88375ms
-    - id: 26
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/02afa339-465b-473e-b62c-f5d149d616e9/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b376a98d-094a-4b45-af7e-6429d4991738/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1338,9 +1138,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:17 GMT
+                - Tue, 11 Feb 2025 14:24:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1348,11 +1148,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 77acda43-2fb4-4be8-8698-6d76e10fd0c0
+                - 0ae4e7d5-8cee-4960-ae50-4cd79e87ad20
         status: 200 OK
         code: 200
-        duration: 83.73425ms
-    - id: 27
+        duration: 79.729167ms
+    - id: 23
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1367,8 +1167,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/02afa339-465b-473e-b62c-f5d149d616e9/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b376a98d-094a-4b45-af7e-6429d4991738/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1387,11 +1187,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:17 GMT
+                - Tue, 11 Feb 2025 14:24:22 GMT
             Link:
-                - </servers/02afa339-465b-473e-b62c-f5d149d616e9/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/b376a98d-094a-4b45-af7e-6429d4991738/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1399,13 +1199,311 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cba70a14-8680-48b1-9683-05b07026490d
+                - 41bdeaa7-c89f-4223-8517-141bea3178ab
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 98.475958ms
+        duration: 73.08825ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/8ae01bd6-3f7e-4e5a-9e2e-d5b801165913
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 304
+        uncompressed: false
+        body: '{"placement_group":{"id":"8ae01bd6-3f7e-4e5a-9e2e-d5b801165913","name":"foo","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"enforced","policy_respected":true,"policy_type":"low_latency","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "304"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - cbda8707-5d73-4ba2-a84f-0e42ff8592e4
+        status: 200 OK
+        code: 200
+        duration: 92.131917ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b376a98d-094a-4b45-af7e-6429d4991738
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2115
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:14.327166+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-beautiful-feistel","id":"b376a98d-094a-4b45-af7e-6429d4991738","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"2001","node_id":"25","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:03","maintenances":[],"modification_date":"2025-02-11T14:24:20.214923+00:00","name":"tf-srv-beautiful-feistel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":{"id":"8ae01bd6-3f7e-4e5a-9e2e-d5b801165913","name":"foo","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"enforced","policy_respected":false,"policy_type":"low_latency","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"},"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"298c30a1-db94-481d-9ad2-ab1b4d0253df","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2115"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 05e34479-e82c-43a7-b301-ca8be29e494d
+        status: 200 OK
+        code: 200
+        duration: 169.911625ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/298c30a1-db94-481d-9ad2-ab1b4d0253df
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"298c30a1-db94-481d-9ad2-ab1b4d0253df","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 63e3b889-cc02-438a-a211-94a144ed95ca
+        status: 404 Not Found
+        code: 404
+        duration: 35.609583ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/298c30a1-db94-481d-9ad2-ab1b4d0253df
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:24:14.567498Z","id":"298c30a1-db94-481d-9ad2-ab1b4d0253df","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:24:14.567498Z","id":"1d4b5c15-0745-4b93-a84d-53fcc34e85d2","product_resource_id":"b376a98d-094a-4b45-af7e-6429d4991738","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:24:14.567498Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - eb275f93-ede1-4e20-9f4d-8fa7abb83895
+        status: 200 OK
+        code: 200
+        duration: 58.947041ms
     - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b376a98d-094a-4b45-af7e-6429d4991738/user_data
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 17
+        uncompressed: false
+        body: '{"user_data":[]}'
+        headers:
+            Content-Length:
+                - "17"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 712294be-9c6c-49b0-9679-450dc27e3c7d
+        status: 200 OK
+        code: 200
+        duration: 88.398167ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b376a98d-094a-4b45-af7e-6429d4991738/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 20
+        uncompressed: false
+        body: '{"private_nics":[]}'
+        headers:
+            Content-Length:
+                - "20"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:23 GMT
+            Link:
+                - </servers/b376a98d-094a-4b45-af7e-6429d4991738/private_nics?page=0&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - dad54bb4-45e7-4292-be70-3055919d12cb
+            X-Total-Count:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 80.579958ms
+    - id: 30
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1422,8 +1520,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/02afa339-465b-473e-b62c-f5d149d616e9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b376a98d-094a-4b45-af7e-6429d4991738
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -1431,20 +1529,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2275
+        content_length: 1835
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:57.976523+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-upbeat-chatelet","id":"02afa339-465b-473e-b62c-f5d149d616e9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1601","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:51","maintenances":[],"modification_date":"2025-01-27T13:50:18.049319+00:00","name":"tf-srv-upbeat-chatelet","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:57.976523+00:00","export_uri":null,"id":"940d2639-e2d1-4e37-803f-ae946a4b06df","modification_date":"2025-01-27T13:49:57.976523+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"02afa339-465b-473e-b62c-f5d149d616e9","name":"tf-srv-upbeat-chatelet"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:14.327166+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-beautiful-feistel","id":"b376a98d-094a-4b45-af7e-6429d4991738","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"2001","node_id":"25","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:03","maintenances":[],"modification_date":"2025-02-11T14:24:24.535893+00:00","name":"tf-srv-beautiful-feistel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"298c30a1-db94-481d-9ad2-ab1b4d0253df","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2275"
+                - "1835"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:18 GMT
+                - Tue, 11 Feb 2025 14:24:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1452,11 +1550,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - af7acbcf-88ba-4706-a254-148a732a3d5d
+                - 37dc590c-6bae-45b1-9c26-419dd111420c
         status: 200 OK
         code: 200
-        duration: 300.679708ms
-    - id: 29
+        duration: 993.777875ms
+    - id: 31
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1471,8 +1569,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/02afa339-465b-473e-b62c-f5d149d616e9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b376a98d-094a-4b45-af7e-6429d4991738
         method: GET
       response:
         proto: HTTP/2.0
@@ -1480,20 +1578,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2275
+        content_length: 1835
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:57.976523+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-upbeat-chatelet","id":"02afa339-465b-473e-b62c-f5d149d616e9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1601","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:51","maintenances":[],"modification_date":"2025-01-27T13:50:18.049319+00:00","name":"tf-srv-upbeat-chatelet","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:57.976523+00:00","export_uri":null,"id":"940d2639-e2d1-4e37-803f-ae946a4b06df","modification_date":"2025-01-27T13:49:57.976523+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"02afa339-465b-473e-b62c-f5d149d616e9","name":"tf-srv-upbeat-chatelet"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:14.327166+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-beautiful-feistel","id":"b376a98d-094a-4b45-af7e-6429d4991738","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"2001","node_id":"25","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:03","maintenances":[],"modification_date":"2025-02-11T14:24:24.535893+00:00","name":"tf-srv-beautiful-feistel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"298c30a1-db94-481d-9ad2-ab1b4d0253df","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2275"
+                - "1835"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:18 GMT
+                - Tue, 11 Feb 2025 14:24:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1501,11 +1599,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 165d1b97-dfef-4349-bc91-e596cb2a6556
+                - 22660503-d5b9-46d6-9d2e-fc0eb8988129
         status: 200 OK
         code: 200
-        duration: 198.694875ms
-    - id: 30
+        duration: 147.10875ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/298c30a1-db94-481d-9ad2-ab1b4d0253df
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:24:14.567498Z","id":"298c30a1-db94-481d-9ad2-ab1b4d0253df","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:24:14.567498Z","id":"1d4b5c15-0745-4b93-a84d-53fcc34e85d2","product_resource_id":"b376a98d-094a-4b45-af7e-6429d4991738","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:24:14.567498Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:24 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0c951cea-1631-43f2-81b1-66cf224f2f2d
+        status: 200 OK
+        code: 200
+        duration: 68.195292ms
+    - id: 33
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1522,8 +1669,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/02afa339-465b-473e-b62c-f5d149d616e9/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b376a98d-094a-4b45-af7e-6429d4991738/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -1533,7 +1680,7 @@ interactions:
         trailer: {}
         content_length: 352
         uncompressed: false
-        body: '{"task":{"description":"server_poweroff","href_from":"/servers/02afa339-465b-473e-b62c-f5d149d616e9/action","href_result":"/servers/02afa339-465b-473e-b62c-f5d149d616e9","id":"8c8d7347-1d06-41e4-ae80-0e050a12b220","progress":0,"started_at":"2025-01-27T13:50:18.666132+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_poweroff","href_from":"/servers/b376a98d-094a-4b45-af7e-6429d4991738/action","href_result":"/servers/b376a98d-094a-4b45-af7e-6429d4991738","id":"6dda473d-357b-47a9-8de9-be4507623697","progress":0,"started_at":"2025-02-11T14:24:25.149509+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "352"
@@ -1542,11 +1689,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:18 GMT
+                - Tue, 11 Feb 2025 14:24:24 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/8c8d7347-1d06-41e4-ae80-0e050a12b220
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/6dda473d-357b-47a9-8de9-be4507623697
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1554,157 +1701,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a71a4717-da4e-4873-8cf6-ff814be399cb
+                - 5e476ade-3820-4a28-86a0-011d2973ebff
         status: 202 Accepted
         code: 202
-        duration: 270.921584ms
-    - id: 31
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/02afa339-465b-473e-b62c-f5d149d616e9
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2235
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:57.976523+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-upbeat-chatelet","id":"02afa339-465b-473e-b62c-f5d149d616e9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1601","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:51","maintenances":[],"modification_date":"2025-01-27T13:50:18.459932+00:00","name":"tf-srv-upbeat-chatelet","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:57.976523+00:00","export_uri":null,"id":"940d2639-e2d1-4e37-803f-ae946a4b06df","modification_date":"2025-01-27T13:49:57.976523+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"02afa339-465b-473e-b62c-f5d149d616e9","name":"tf-srv-upbeat-chatelet"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2235"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:18 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - ec6f0393-428e-4848-b4b5-43481691402e
-        status: 200 OK
-        code: 200
-        duration: 186.353167ms
-    - id: 32
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/02afa339-465b-473e-b62c-f5d149d616e9
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2235
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:57.976523+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-upbeat-chatelet","id":"02afa339-465b-473e-b62c-f5d149d616e9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1601","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:51","maintenances":[],"modification_date":"2025-01-27T13:50:18.459932+00:00","name":"tf-srv-upbeat-chatelet","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:57.976523+00:00","export_uri":null,"id":"940d2639-e2d1-4e37-803f-ae946a4b06df","modification_date":"2025-01-27T13:49:57.976523+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"02afa339-465b-473e-b62c-f5d149d616e9","name":"tf-srv-upbeat-chatelet"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2235"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:23 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 78bc1c3e-3d80-477b-82a2-034848393733
-        status: 200 OK
-        code: 200
-        duration: 170.5155ms
-    - id: 33
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/02afa339-465b-473e-b62c-f5d149d616e9
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2235
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:57.976523+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-upbeat-chatelet","id":"02afa339-465b-473e-b62c-f5d149d616e9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1601","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:51","maintenances":[],"modification_date":"2025-01-27T13:50:18.459932+00:00","name":"tf-srv-upbeat-chatelet","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:57.976523+00:00","export_uri":null,"id":"940d2639-e2d1-4e37-803f-ae946a4b06df","modification_date":"2025-01-27T13:49:57.976523+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"02afa339-465b-473e-b62c-f5d149d616e9","name":"tf-srv-upbeat-chatelet"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2235"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:29 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - e82b9be1-eaec-430a-be75-50f677d5e73a
-        status: 200 OK
-        code: 200
-        duration: 164.25525ms
+        duration: 199.7555ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1720,8 +1720,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/02afa339-465b-473e-b62c-f5d149d616e9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b376a98d-094a-4b45-af7e-6429d4991738
         method: GET
       response:
         proto: HTTP/2.0
@@ -1729,20 +1729,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2235
+        content_length: 1795
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:57.976523+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-upbeat-chatelet","id":"02afa339-465b-473e-b62c-f5d149d616e9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1601","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:51","maintenances":[],"modification_date":"2025-01-27T13:50:18.459932+00:00","name":"tf-srv-upbeat-chatelet","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:57.976523+00:00","export_uri":null,"id":"940d2639-e2d1-4e37-803f-ae946a4b06df","modification_date":"2025-01-27T13:49:57.976523+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"02afa339-465b-473e-b62c-f5d149d616e9","name":"tf-srv-upbeat-chatelet"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:14.327166+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-beautiful-feistel","id":"b376a98d-094a-4b45-af7e-6429d4991738","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"2001","node_id":"25","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:03","maintenances":[],"modification_date":"2025-02-11T14:24:24.992035+00:00","name":"tf-srv-beautiful-feistel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"298c30a1-db94-481d-9ad2-ab1b4d0253df","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2235"
+                - "1795"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:34 GMT
+                - Tue, 11 Feb 2025 14:24:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1750,10 +1750,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - acadc82a-dd62-4e99-8d6b-634dd7e3c7d5
+                - 2a7554f3-1f8e-4775-828f-78f5ac826dc0
         status: 200 OK
         code: 200
-        duration: 664.119834ms
+        duration: 173.458958ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1769,8 +1769,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/02afa339-465b-473e-b62c-f5d149d616e9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b376a98d-094a-4b45-af7e-6429d4991738
         method: GET
       response:
         proto: HTTP/2.0
@@ -1778,20 +1778,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2235
+        content_length: 1795
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:57.976523+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-upbeat-chatelet","id":"02afa339-465b-473e-b62c-f5d149d616e9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1601","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:51","maintenances":[],"modification_date":"2025-01-27T13:50:18.459932+00:00","name":"tf-srv-upbeat-chatelet","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:57.976523+00:00","export_uri":null,"id":"940d2639-e2d1-4e37-803f-ae946a4b06df","modification_date":"2025-01-27T13:49:57.976523+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"02afa339-465b-473e-b62c-f5d149d616e9","name":"tf-srv-upbeat-chatelet"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:14.327166+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-beautiful-feistel","id":"b376a98d-094a-4b45-af7e-6429d4991738","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"2001","node_id":"25","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:03","maintenances":[],"modification_date":"2025-02-11T14:24:24.992035+00:00","name":"tf-srv-beautiful-feistel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"298c30a1-db94-481d-9ad2-ab1b4d0253df","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2235"
+                - "1795"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:39 GMT
+                - Tue, 11 Feb 2025 14:24:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1799,10 +1799,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a7678a18-a11a-4def-96b5-812ce9ad0a1f
+                - e8674c9b-25b0-41d6-82d6-0815fcc2c743
         status: 200 OK
         code: 200
-        duration: 149.421542ms
+        duration: 182.131542ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1818,8 +1818,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/02afa339-465b-473e-b62c-f5d149d616e9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b376a98d-094a-4b45-af7e-6429d4991738
         method: GET
       response:
         proto: HTTP/2.0
@@ -1827,20 +1827,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2235
+        content_length: 1795
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:57.976523+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-upbeat-chatelet","id":"02afa339-465b-473e-b62c-f5d149d616e9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1601","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:51","maintenances":[],"modification_date":"2025-01-27T13:50:18.459932+00:00","name":"tf-srv-upbeat-chatelet","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:57.976523+00:00","export_uri":null,"id":"940d2639-e2d1-4e37-803f-ae946a4b06df","modification_date":"2025-01-27T13:49:57.976523+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"02afa339-465b-473e-b62c-f5d149d616e9","name":"tf-srv-upbeat-chatelet"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:14.327166+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-beautiful-feistel","id":"b376a98d-094a-4b45-af7e-6429d4991738","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"2001","node_id":"25","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:03","maintenances":[],"modification_date":"2025-02-11T14:24:24.992035+00:00","name":"tf-srv-beautiful-feistel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"298c30a1-db94-481d-9ad2-ab1b4d0253df","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2235"
+                - "1795"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:45 GMT
+                - Tue, 11 Feb 2025 14:24:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1848,10 +1848,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5d01b2f0-a878-4b52-be0d-447c984fd5da
+                - 148b7d5e-210d-4c78-a5d0-7846aacd64bc
         status: 200 OK
         code: 200
-        duration: 161.128458ms
+        duration: 173.371125ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1867,8 +1867,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/02afa339-465b-473e-b62c-f5d149d616e9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b376a98d-094a-4b45-af7e-6429d4991738
         method: GET
       response:
         proto: HTTP/2.0
@@ -1876,20 +1876,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2235
+        content_length: 1795
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:57.976523+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-upbeat-chatelet","id":"02afa339-465b-473e-b62c-f5d149d616e9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1601","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:51","maintenances":[],"modification_date":"2025-01-27T13:50:18.459932+00:00","name":"tf-srv-upbeat-chatelet","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:57.976523+00:00","export_uri":null,"id":"940d2639-e2d1-4e37-803f-ae946a4b06df","modification_date":"2025-01-27T13:49:57.976523+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"02afa339-465b-473e-b62c-f5d149d616e9","name":"tf-srv-upbeat-chatelet"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:14.327166+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-beautiful-feistel","id":"b376a98d-094a-4b45-af7e-6429d4991738","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"2001","node_id":"25","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:03","maintenances":[],"modification_date":"2025-02-11T14:24:24.992035+00:00","name":"tf-srv-beautiful-feistel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"298c30a1-db94-481d-9ad2-ab1b4d0253df","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2235"
+                - "1795"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:50 GMT
+                - Tue, 11 Feb 2025 14:24:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1897,10 +1897,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - afc07c3f-155a-49b2-a779-57dda3220b5f
+                - f71e5544-e281-417f-b478-44ddee12a574
         status: 200 OK
         code: 200
-        duration: 167.423875ms
+        duration: 198.906417ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1916,8 +1916,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/02afa339-465b-473e-b62c-f5d149d616e9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b376a98d-094a-4b45-af7e-6429d4991738
         method: GET
       response:
         proto: HTTP/2.0
@@ -1925,20 +1925,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2235
+        content_length: 1795
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:57.976523+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-upbeat-chatelet","id":"02afa339-465b-473e-b62c-f5d149d616e9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1601","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:51","maintenances":[],"modification_date":"2025-01-27T13:50:18.459932+00:00","name":"tf-srv-upbeat-chatelet","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:57.976523+00:00","export_uri":null,"id":"940d2639-e2d1-4e37-803f-ae946a4b06df","modification_date":"2025-01-27T13:49:57.976523+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"02afa339-465b-473e-b62c-f5d149d616e9","name":"tf-srv-upbeat-chatelet"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:14.327166+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-beautiful-feistel","id":"b376a98d-094a-4b45-af7e-6429d4991738","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"2001","node_id":"25","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:03","maintenances":[],"modification_date":"2025-02-11T14:24:24.992035+00:00","name":"tf-srv-beautiful-feistel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"298c30a1-db94-481d-9ad2-ab1b4d0253df","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2235"
+                - "1795"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:55 GMT
+                - Tue, 11 Feb 2025 14:24:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1946,10 +1946,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ad43da4a-b8fb-478b-811c-e341052054e7
+                - 7e44dbe8-f71a-4e5c-9641-7028aaa05ded
         status: 200 OK
         code: 200
-        duration: 162.21475ms
+        duration: 150.004666ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1965,8 +1965,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/02afa339-465b-473e-b62c-f5d149d616e9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b376a98d-094a-4b45-af7e-6429d4991738
         method: GET
       response:
         proto: HTTP/2.0
@@ -1974,20 +1974,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2235
+        content_length: 1795
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:57.976523+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-upbeat-chatelet","id":"02afa339-465b-473e-b62c-f5d149d616e9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1601","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:51","maintenances":[],"modification_date":"2025-01-27T13:50:18.459932+00:00","name":"tf-srv-upbeat-chatelet","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:57.976523+00:00","export_uri":null,"id":"940d2639-e2d1-4e37-803f-ae946a4b06df","modification_date":"2025-01-27T13:49:57.976523+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"02afa339-465b-473e-b62c-f5d149d616e9","name":"tf-srv-upbeat-chatelet"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:14.327166+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-beautiful-feistel","id":"b376a98d-094a-4b45-af7e-6429d4991738","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"2001","node_id":"25","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:03","maintenances":[],"modification_date":"2025-02-11T14:24:24.992035+00:00","name":"tf-srv-beautiful-feistel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"298c30a1-db94-481d-9ad2-ab1b4d0253df","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2235"
+                - "1795"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:00 GMT
+                - Tue, 11 Feb 2025 14:24:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1995,10 +1995,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 04f82d85-8d00-4f4e-8cc1-f392f1927a40
+                - ea14fee5-1807-42fb-b094-bf696b5b18ca
         status: 200 OK
         code: 200
-        duration: 141.828917ms
+        duration: 296.329542ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2014,8 +2014,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/02afa339-465b-473e-b62c-f5d149d616e9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b376a98d-094a-4b45-af7e-6429d4991738
         method: GET
       response:
         proto: HTTP/2.0
@@ -2023,20 +2023,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2118
+        content_length: 1795
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:57.976523+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-upbeat-chatelet","id":"02afa339-465b-473e-b62c-f5d149d616e9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:51","maintenances":[],"modification_date":"2025-01-27T13:51:01.292596+00:00","name":"tf-srv-upbeat-chatelet","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:57.976523+00:00","export_uri":null,"id":"940d2639-e2d1-4e37-803f-ae946a4b06df","modification_date":"2025-01-27T13:49:57.976523+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"02afa339-465b-473e-b62c-f5d149d616e9","name":"tf-srv-upbeat-chatelet"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:14.327166+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-beautiful-feistel","id":"b376a98d-094a-4b45-af7e-6429d4991738","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"2001","node_id":"25","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:03","maintenances":[],"modification_date":"2025-02-11T14:24:24.992035+00:00","name":"tf-srv-beautiful-feistel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"298c30a1-db94-481d-9ad2-ab1b4d0253df","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2118"
+                - "1795"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:05 GMT
+                - Tue, 11 Feb 2025 14:24:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2044,10 +2044,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a90d0c4f-f6a1-47b5-bddf-da64d6d01b16
+                - a84097df-da6f-4f62-b816-d5f76f18ea87
         status: 200 OK
         code: 200
-        duration: 141.410792ms
+        duration: 182.942458ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2063,8 +2063,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/02afa339-465b-473e-b62c-f5d149d616e9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b376a98d-094a-4b45-af7e-6429d4991738
         method: GET
       response:
         proto: HTTP/2.0
@@ -2072,20 +2072,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2118
+        content_length: 1678
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:57.976523+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-upbeat-chatelet","id":"02afa339-465b-473e-b62c-f5d149d616e9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:51","maintenances":[],"modification_date":"2025-01-27T13:51:01.292596+00:00","name":"tf-srv-upbeat-chatelet","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:57.976523+00:00","export_uri":null,"id":"940d2639-e2d1-4e37-803f-ae946a4b06df","modification_date":"2025-01-27T13:49:57.976523+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"02afa339-465b-473e-b62c-f5d149d616e9","name":"tf-srv-upbeat-chatelet"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:14.327166+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-beautiful-feistel","id":"b376a98d-094a-4b45-af7e-6429d4991738","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:03","maintenances":[],"modification_date":"2025-02-11T14:24:58.380472+00:00","name":"tf-srv-beautiful-feistel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"298c30a1-db94-481d-9ad2-ab1b4d0253df","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2118"
+                - "1678"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:05 GMT
+                - Tue, 11 Feb 2025 14:25:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2093,10 +2093,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ad579d80-04c4-4074-a943-a0438fb223c2
+                - 714e0332-e4c6-4e29-8552-eb32e3e25c04
         status: 200 OK
         code: 200
-        duration: 148.108375ms
+        duration: 178.725083ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2112,27 +2112,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/02afa339-465b-473e-b62c-f5d149d616e9
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b376a98d-094a-4b45-af7e-6429d4991738
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 1678
         uncompressed: false
-        body: ""
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:14.327166+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-beautiful-feistel","id":"b376a98d-094a-4b45-af7e-6429d4991738","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:03","maintenances":[],"modification_date":"2025-02-11T14:24:58.380472+00:00","name":"tf-srv-beautiful-feistel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"298c30a1-db94-481d-9ad2-ab1b4d0253df","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
+            Content-Length:
+                - "1678"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:05 GMT
+                - Tue, 11 Feb 2025 14:25:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2140,10 +2142,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9036902e-84d9-4bd0-9e17-c1713f58fb4e
-        status: 204 No Content
-        code: 204
-        duration: 157.471375ms
+                - d39ea8e7-1b9a-4dcf-9949-7ae69047b096
+        status: 200 OK
+        code: 200
+        duration: 130.484792ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2159,106 +2161,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/02afa339-465b-473e-b62c-f5d149d616e9
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 143
-        uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"02afa339-465b-473e-b62c-f5d149d616e9","type":"not_found"}'
-        headers:
-            Content-Length:
-                - "143"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:06 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 1979ab95-a937-4a6d-8e07-d7b4c20b16cd
-        status: 404 Not Found
-        code: 404
-        duration: 99.058375ms
-    - id: 44
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/940d2639-e2d1-4e37-803f-ae946a4b06df
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 446
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:49:57.976523+00:00","export_uri":null,"id":"940d2639-e2d1-4e37-803f-ae946a4b06df","modification_date":"2025-01-27T13:51:05.991927+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "446"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:06 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 637752ff-76d7-4845-bd20-b0be4d6a9026
-        status: 200 OK
-        code: 200
-        duration: 104.493458ms
-    - id: 45
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/940d2639-e2d1-4e37-803f-ae946a4b06df
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b376a98d-094a-4b45-af7e-6429d4991738
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2275,9 +2179,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:06 GMT
+                - Tue, 11 Feb 2025 14:25:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2285,11 +2189,205 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 56f95105-4158-4cc9-8936-d6796d729f09
+                - 26ef90d3-a9dd-489c-b2a3-350c0fda58db
         status: 204 No Content
         code: 204
-        duration: 168.854375ms
+        duration: 331.794833ms
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b376a98d-094a-4b45-af7e-6429d4991738
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"b376a98d-094a-4b45-af7e-6429d4991738","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 72c9c445-a099-44cd-b21e-0b9d0aa5b08c
+        status: 404 Not Found
+        code: 404
+        duration: 126.14725ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/298c30a1-db94-481d-9ad2-ab1b4d0253df
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"298c30a1-db94-481d-9ad2-ab1b4d0253df","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - dc62f740-992a-4bd9-8e66-0183796cf53d
+        status: 404 Not Found
+        code: 404
+        duration: 30.412375ms
     - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/298c30a1-db94-481d-9ad2-ab1b4d0253df
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 494
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:24:14.567498Z","id":"298c30a1-db94-481d-9ad2-ab1b4d0253df","last_detached_at":"2025-02-11T14:25:02.200602Z","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:25:02.200602Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "494"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ccdef5e3-4867-4bdf-b23e-846f158a17fb
+        status: 200 OK
+        code: 200
+        duration: 87.128125ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/298c30a1-db94-481d-9ad2-ab1b4d0253df
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d8746596-336a-4e24-a72d-ce519fc2da0d
+        status: 204 No Content
+        code: 204
+        duration: 158.308167ms
+    - id: 48
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2306,8 +2404,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/e101b370-f711-4d9c-9eba-ae275c495f0c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/8ae01bd6-3f7e-4e5a-9e2e-d5b801165913
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -2317,7 +2415,7 @@ interactions:
         trailer: {}
         content_length: 304
         uncompressed: false
-        body: '{"placement_group":{"id":"e101b370-f711-4d9c-9eba-ae275c495f0c","name":"bar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"enforced","policy_respected":true,"policy_type":"low_latency","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"}}'
+        body: '{"placement_group":{"id":"8ae01bd6-3f7e-4e5a-9e2e-d5b801165913","name":"bar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"enforced","policy_respected":true,"policy_type":"low_latency","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "304"
@@ -2326,9 +2424,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:06 GMT
+                - Tue, 11 Feb 2025 14:25:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2336,108 +2434,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6e8b2a7f-dd38-4847-b7a9-47369382febd
+                - 1f158441-4215-4c7a-9937-eab2452b791f
         status: 200 OK
         code: 200
-        duration: 147.658708ms
-    - id: 47
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/e101b370-f711-4d9c-9eba-ae275c495f0c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 304
-        uncompressed: false
-        body: '{"placement_group":{"id":"e101b370-f711-4d9c-9eba-ae275c495f0c","name":"bar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"enforced","policy_respected":true,"policy_type":"low_latency","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "304"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:06 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - c6b24e9c-ac26-4026-9e39-4272a51f99b5
-        status: 200 OK
-        code: 200
-        duration: 96.43875ms
-    - id: 48
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/e101b370-f711-4d9c-9eba-ae275c495f0c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 304
-        uncompressed: false
-        body: '{"placement_group":{"id":"e101b370-f711-4d9c-9eba-ae275c495f0c","name":"bar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"enforced","policy_respected":true,"policy_type":"low_latency","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "304"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:06 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 4da92ede-e5b5-4d59-a5f3-97165f5955a8
-        status: 200 OK
-        code: 200
-        duration: 101.510708ms
+        duration: 161.171208ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2453,8 +2453,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/e101b370-f711-4d9c-9eba-ae275c495f0c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/8ae01bd6-3f7e-4e5a-9e2e-d5b801165913
         method: GET
       response:
         proto: HTTP/2.0
@@ -2464,7 +2464,7 @@ interactions:
         trailer: {}
         content_length: 304
         uncompressed: false
-        body: '{"placement_group":{"id":"e101b370-f711-4d9c-9eba-ae275c495f0c","name":"bar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"enforced","policy_respected":true,"policy_type":"low_latency","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"}}'
+        body: '{"placement_group":{"id":"8ae01bd6-3f7e-4e5a-9e2e-d5b801165913","name":"bar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"enforced","policy_respected":true,"policy_type":"low_latency","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "304"
@@ -2473,9 +2473,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:06 GMT
+                - Tue, 11 Feb 2025 14:25:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2483,10 +2483,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 03fecbf4-a134-4550-8ff7-af14922a69cb
+                - c7cc6aa8-da0e-4317-8527-867bd4196fbc
         status: 200 OK
         code: 200
-        duration: 112.845542ms
+        duration: 120.305666ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -2502,8 +2502,106 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/e101b370-f711-4d9c-9eba-ae275c495f0c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/8ae01bd6-3f7e-4e5a-9e2e-d5b801165913
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 304
+        uncompressed: false
+        body: '{"placement_group":{"id":"8ae01bd6-3f7e-4e5a-9e2e-d5b801165913","name":"bar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"enforced","policy_respected":true,"policy_type":"low_latency","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "304"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b584fc91-1fdd-4c25-87b5-cde14f1013c7
+        status: 200 OK
+        code: 200
+        duration: 113.224375ms
+    - id: 51
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/8ae01bd6-3f7e-4e5a-9e2e-d5b801165913
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 304
+        uncompressed: false
+        body: '{"placement_group":{"id":"8ae01bd6-3f7e-4e5a-9e2e-d5b801165913","name":"bar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"enforced","policy_respected":true,"policy_type":"low_latency","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "304"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4c80f9bb-83e0-4007-8989-de87cd820ffd
+        status: 200 OK
+        code: 200
+        duration: 95.008041ms
+    - id: 52
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/8ae01bd6-3f7e-4e5a-9e2e-d5b801165913
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2520,9 +2618,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:07 GMT
+                - Tue, 11 Feb 2025 14:25:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2530,11 +2628,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e074385c-cf29-4f69-b151-072cfc391ee7
+                - 5473a7d2-9cd8-4781-b42f-9671585513d0
         status: 204 No Content
         code: 204
-        duration: 153.797959ms
-    - id: 51
+        duration: 140.565875ms
+    - id: 53
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2549,8 +2647,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/e101b370-f711-4d9c-9eba-ae275c495f0c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/8ae01bd6-3f7e-4e5a-9e2e-d5b801165913
         method: GET
       response:
         proto: HTTP/2.0
@@ -2560,7 +2658,7 @@ interactions:
         trailer: {}
         content_length: 152
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_placement_group","resource_id":"e101b370-f711-4d9c-9eba-ae275c495f0c","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_placement_group","resource_id":"8ae01bd6-3f7e-4e5a-9e2e-d5b801165913","type":"not_found"}'
         headers:
             Content-Length:
                 - "152"
@@ -2569,9 +2667,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:07 GMT
+                - Tue, 11 Feb 2025 14:25:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2579,7 +2677,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 54c844f8-0f62-40d9-b2d8-663077ae8ae8
+                - fe49d85d-db69-4078-8c36-fed324614569
         status: 404 Not Found
         code: 404
-        duration: 75.162083ms
+        duration: 74.03825ms

--- a/internal/services/instance/testdata/private-nic-basic.cassette.yaml
+++ b/internal/services/instance/testdata/private-nic-basic.cassette.yaml
@@ -16,7 +16,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
         method: GET
       response:
@@ -25,22 +25,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 38539
+        content_length: 35639
         uncompressed: false
-        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
+        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
         headers:
             Content-Length:
-                - "38539"
+                - "35639"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:52 GMT
+                - Tue, 11 Feb 2025 14:23:54 GMT
             Link:
                 - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,12 +48,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3d6a8150-f6cb-44d4-8bcf-e531e520ad10
+                - 09a83cf6-8c1a-410a-95d0-566e2d417ca1
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 76.920667ms
+        duration: 45.625ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -69,7 +69,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
         method: GET
       response:
@@ -78,22 +78,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 14208
+        content_length: 13164
         uncompressed: false
-        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
         headers:
             Content-Length:
-                - "14208"
+                - "13164"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:53 GMT
+                - Tue, 11 Feb 2025 14:23:54 GMT
             Link:
                 - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -101,12 +101,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4786c42f-64dd-409e-8152-8ffbb856973a
+                - e17298f1-8262-47c5-9226-66390346e718
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 54.180125ms
+        duration: 81.355833ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -122,8 +122,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_local&zone=fr-par-1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_sbs&zone=fr-par-1
         method: GET
       response:
         proto: HTTP/2.0
@@ -131,20 +131,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1300
+        content_length: 1296
         uncompressed: false
-        body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"56d4019c-8305-467a-a3f2-70498ad799df","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
+        body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"57509e82-ac3b-49b7-9970-97b60f40ff72","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"9b647e1e-253a-41e7-8c15-911c622ee2dc","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"}],"total_count":2}'
         headers:
             Content-Length:
-                - "1300"
+                - "1296"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:53 GMT
+                - Tue, 11 Feb 2025 14:23:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -152,10 +152,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 43e981f5-ce9e-4e49-a77e-f0cc0d085ee8
+                - fbcdb8b6-3b84-415b-87c4-4fc275e86fe6
         status: 200 OK
         code: 200
-        duration: 98.823167ms
+        duration: 68.090708ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -173,7 +173,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
         method: POST
       response:
@@ -182,20 +182,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1066
+        content_length: 1065
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:49:53.222154Z","dhcp_enabled":true,"id":"08148f79-a166-49ea-adb5-177cf226c6cb","name":"TestAccScalewayInstancePrivateNIC_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:49:53.222154Z","id":"4082cb17-6063-4815-9e7f-82b2ed080b78","private_network_id":"08148f79-a166-49ea-adb5-177cf226c6cb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.24.0/22","updated_at":"2025-01-27T13:49:53.222154Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:49:53.222154Z","id":"8b3f71b3-2e20-45e7-87a7-d1fe2419f4c6","private_network_id":"08148f79-a166-49ea-adb5-177cf226c6cb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:b09c::/64","updated_at":"2025-01-27T13:49:53.222154Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:49:53.222154Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"created_at":"2025-02-11T14:23:54.814541Z","dhcp_enabled":true,"id":"fb66d58e-9e88-426c-9dc8-70cf1124701e","name":"TestAccScalewayInstancePrivateNIC_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-11T14:23:54.814541Z","id":"a43e1f99-05a1-43b0-974b-c1ef730d5efd","private_network_id":"fb66d58e-9e88-426c-9dc8-70cf1124701e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.8.0/22","updated_at":"2025-02-11T14:23:54.814541Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-11T14:23:54.814541Z","id":"1b94e4aa-2241-4f86-925f-e65ec0e2455c","private_network_id":"fb66d58e-9e88-426c-9dc8-70cf1124701e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:b607::/64","updated_at":"2025-02-11T14:23:54.814541Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-11T14:23:54.814541Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "1066"
+                - "1065"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:53 GMT
+                - Tue, 11 Feb 2025 14:23:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -203,10 +203,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 913987ee-d6d2-44e0-bd4a-7b5365885d43
+                - 9562cb9b-7f1e-4ba7-a201-8b548a30f7a6
         status: 200 OK
         code: 200
-        duration: 567.749084ms
+        duration: 550.099417ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -222,8 +222,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/08148f79-a166-49ea-adb5-177cf226c6cb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/fb66d58e-9e88-426c-9dc8-70cf1124701e
         method: GET
       response:
         proto: HTTP/2.0
@@ -231,20 +231,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1066
+        content_length: 1065
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:49:53.222154Z","dhcp_enabled":true,"id":"08148f79-a166-49ea-adb5-177cf226c6cb","name":"TestAccScalewayInstancePrivateNIC_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:49:53.222154Z","id":"4082cb17-6063-4815-9e7f-82b2ed080b78","private_network_id":"08148f79-a166-49ea-adb5-177cf226c6cb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.24.0/22","updated_at":"2025-01-27T13:49:53.222154Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:49:53.222154Z","id":"8b3f71b3-2e20-45e7-87a7-d1fe2419f4c6","private_network_id":"08148f79-a166-49ea-adb5-177cf226c6cb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:b09c::/64","updated_at":"2025-01-27T13:49:53.222154Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:49:53.222154Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"created_at":"2025-02-11T14:23:54.814541Z","dhcp_enabled":true,"id":"fb66d58e-9e88-426c-9dc8-70cf1124701e","name":"TestAccScalewayInstancePrivateNIC_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-11T14:23:54.814541Z","id":"a43e1f99-05a1-43b0-974b-c1ef730d5efd","private_network_id":"fb66d58e-9e88-426c-9dc8-70cf1124701e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.8.0/22","updated_at":"2025-02-11T14:23:54.814541Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-11T14:23:54.814541Z","id":"1b94e4aa-2241-4f86-925f-e65ec0e2455c","private_network_id":"fb66d58e-9e88-426c-9dc8-70cf1124701e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:b607::/64","updated_at":"2025-02-11T14:23:54.814541Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-11T14:23:54.814541Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "1066"
+                - "1065"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:53 GMT
+                - Tue, 11 Feb 2025 14:23:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -252,28 +252,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1b9ce0c7-2c4d-4ef8-920c-f5307fe8b2eb
+                - 172460d1-de5e-42f6-9e77-e43363c5728b
         status: 200 OK
         code: 200
-        duration: 37.026584ms
+        duration: 31.471584ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 282
+        content_length: 233
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-srv-condescending-ritchie","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+        body: '{"name":"tf-srv-nervous-bassi","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"57509e82-ac3b-49b7-9970-97b60f40ff72","volumes":{"0":{"boot":false}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
         method: POST
       response:
@@ -282,22 +282,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 1670
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:54.026950+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-condescending-ritchie","id":"3cca217c-aff0-4541-a55f-e1e7a765132f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:49","maintenances":[],"modification_date":"2025-01-27T13:49:54.026950+00:00","name":"tf-srv-condescending-ritchie","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:54.026950+00:00","export_uri":null,"id":"6d3751c6-6e80-4d35-ba02-8575652e491c","modification_date":"2025-01-27T13:49:54.026950+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3cca217c-aff0-4541-a55f-e1e7a765132f","name":"tf-srv-condescending-ritchie"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:55.442736+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-bassi","id":"0545e66f-0214-4827-9aee-577b41b0ac91","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:fb","maintenances":[],"modification_date":"2025-02-11T14:23:55.442736+00:00","name":"tf-srv-nervous-bassi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"589485f8-15b2-410e-85d4-3d74f9296dd6","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "1670"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:54 GMT
+                - Tue, 11 Feb 2025 14:23:55 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -305,10 +305,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2ad47d7c-f168-4575-a937-8e40b8e6a5c4
+                - d3645d75-6403-49ee-bb03-31de7619c9ec
         status: 201 Created
         code: 201
-        duration: 924.28325ms
+        duration: 1.370822458s
     - id: 6
       request:
         proto: HTTP/1.1
@@ -324,8 +324,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91
         method: GET
       response:
         proto: HTTP/2.0
@@ -333,20 +333,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 1670
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:54.026950+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-condescending-ritchie","id":"3cca217c-aff0-4541-a55f-e1e7a765132f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:49","maintenances":[],"modification_date":"2025-01-27T13:49:54.026950+00:00","name":"tf-srv-condescending-ritchie","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:54.026950+00:00","export_uri":null,"id":"6d3751c6-6e80-4d35-ba02-8575652e491c","modification_date":"2025-01-27T13:49:54.026950+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3cca217c-aff0-4541-a55f-e1e7a765132f","name":"tf-srv-condescending-ritchie"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:55.442736+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-bassi","id":"0545e66f-0214-4827-9aee-577b41b0ac91","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:fb","maintenances":[],"modification_date":"2025-02-11T14:23:55.442736+00:00","name":"tf-srv-nervous-bassi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"589485f8-15b2-410e-85d4-3d74f9296dd6","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "1670"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:54 GMT
+                - Tue, 11 Feb 2025 14:23:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -354,10 +354,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6b5f3f70-9c79-40cb-810e-2bf13f0c469e
+                - 272fecc9-3337-4125-ae9a-0d6de743148a
         status: 200 OK
         code: 200
-        duration: 142.109459ms
+        duration: 155.144167ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -373,8 +373,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91
         method: GET
       response:
         proto: HTTP/2.0
@@ -382,20 +382,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 1670
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:54.026950+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-condescending-ritchie","id":"3cca217c-aff0-4541-a55f-e1e7a765132f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:49","maintenances":[],"modification_date":"2025-01-27T13:49:54.026950+00:00","name":"tf-srv-condescending-ritchie","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:54.026950+00:00","export_uri":null,"id":"6d3751c6-6e80-4d35-ba02-8575652e491c","modification_date":"2025-01-27T13:49:54.026950+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3cca217c-aff0-4541-a55f-e1e7a765132f","name":"tf-srv-condescending-ritchie"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:55.442736+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-bassi","id":"0545e66f-0214-4827-9aee-577b41b0ac91","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:fb","maintenances":[],"modification_date":"2025-02-11T14:23:55.442736+00:00","name":"tf-srv-nervous-bassi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"589485f8-15b2-410e-85d4-3d74f9296dd6","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "1670"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:54 GMT
+                - Tue, 11 Feb 2025 14:23:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -403,11 +403,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2783cb24-bf0b-4d27-b5b3-d56a2706c9ff
+                - d6cf43e3-cea1-4b95-9e94-31dadcda949a
         status: 200 OK
         code: 200
-        duration: 133.093708ms
+        duration: 151.669708ms
     - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/589485f8-15b2-410e-85d4-3d74f9296dd6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:23:55.640162Z","id":"589485f8-15b2-410e-85d4-3d74f9296dd6","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:55.640162Z","id":"95219529-f98a-4b98-8da4-20cc832a881f","product_resource_id":"0545e66f-0214-4827-9aee-577b41b0ac91","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:55.640162Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - cd1ce1ab-8796-466c-a772-8fff9bcaf90f
+        status: 200 OK
+        code: 200
+        duration: 73.018625ms
+    - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -424,8 +473,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -435,7 +484,7 @@ interactions:
         trailer: {}
         content_length: 357
         uncompressed: false
-        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/3cca217c-aff0-4541-a55f-e1e7a765132f/action","href_result":"/servers/3cca217c-aff0-4541-a55f-e1e7a765132f","id":"73962cc2-3bd8-46e3-bf01-994992475adc","progress":0,"started_at":"2025-01-27T13:49:55.335085+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/0545e66f-0214-4827-9aee-577b41b0ac91/action","href_result":"/servers/0545e66f-0214-4827-9aee-577b41b0ac91","id":"0fc16e5f-4ae2-4c55-8047-87bef4f65dee","progress":0,"started_at":"2025-02-11T14:23:56.941340+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -444,11 +493,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:55 GMT
+                - Tue, 11 Feb 2025 14:23:56 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/73962cc2-3bd8-46e3-bf01-994992475adc
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/0fc16e5f-4ae2-4c55-8047-87bef4f65dee
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -456,59 +505,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ea789035-718e-4f12-a02f-074391c02fdc
+                - bc805403-ad37-4317-8342-f8da9c3ac7c0
         status: 202 Accepted
         code: 202
-        duration: 816.052625ms
-    - id: 9
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2158
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:54.026950+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-condescending-ritchie","id":"3cca217c-aff0-4541-a55f-e1e7a765132f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:49","maintenances":[],"modification_date":"2025-01-27T13:49:54.599350+00:00","name":"tf-srv-condescending-ritchie","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:54.026950+00:00","export_uri":null,"id":"6d3751c6-6e80-4d35-ba02-8575652e491c","modification_date":"2025-01-27T13:49:54.026950+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3cca217c-aff0-4541-a55f-e1e7a765132f","name":"tf-srv-condescending-ritchie"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2158"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:49:55 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 761c86a1-2482-437e-8a9c-01f0e06df7a0
-        status: 200 OK
-        code: 200
-        duration: 158.831958ms
+        duration: 335.274334ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -524,8 +524,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91
         method: GET
       response:
         proto: HTTP/2.0
@@ -533,20 +533,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2261
+        content_length: 1692
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:54.026950+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-condescending-ritchie","id":"3cca217c-aff0-4541-a55f-e1e7a765132f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"49","hypervisor_id":"302","node_id":"33","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:49","maintenances":[],"modification_date":"2025-01-27T13:49:54.599350+00:00","name":"tf-srv-condescending-ritchie","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:54.026950+00:00","export_uri":null,"id":"6d3751c6-6e80-4d35-ba02-8575652e491c","modification_date":"2025-01-27T13:49:54.026950+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3cca217c-aff0-4541-a55f-e1e7a765132f","name":"tf-srv-condescending-ritchie"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:55.442736+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-bassi","id":"0545e66f-0214-4827-9aee-577b41b0ac91","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:fb","maintenances":[],"modification_date":"2025-02-11T14:23:56.750063+00:00","name":"tf-srv-nervous-bassi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"id":"589485f8-15b2-410e-85d4-3d74f9296dd6","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2261"
+                - "1692"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:00 GMT
+                - Tue, 11 Feb 2025 14:23:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -554,10 +554,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3b311ef3-9aa9-46ee-9f46-7433ec28d43e
+                - a3b95dc8-377a-49f0-8fde-56b01667143a
         status: 200 OK
         code: 200
-        duration: 196.21825ms
+        duration: 178.748042ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -573,8 +573,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91
         method: GET
       response:
         proto: HTTP/2.0
@@ -582,20 +582,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2261
+        content_length: 1825
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:54.026950+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-condescending-ritchie","id":"3cca217c-aff0-4541-a55f-e1e7a765132f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"49","hypervisor_id":"302","node_id":"33","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:49","maintenances":[],"modification_date":"2025-01-27T13:49:54.599350+00:00","name":"tf-srv-condescending-ritchie","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:54.026950+00:00","export_uri":null,"id":"6d3751c6-6e80-4d35-ba02-8575652e491c","modification_date":"2025-01-27T13:49:54.026950+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3cca217c-aff0-4541-a55f-e1e7a765132f","name":"tf-srv-condescending-ritchie"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:55.442736+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-bassi","id":"0545e66f-0214-4827-9aee-577b41b0ac91","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"604","node_id":"7","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:fb","maintenances":[],"modification_date":"2025-02-11T14:24:01.281072+00:00","name":"tf-srv-nervous-bassi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"589485f8-15b2-410e-85d4-3d74f9296dd6","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2261"
+                - "1825"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:05 GMT
+                - Tue, 11 Feb 2025 14:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -603,10 +603,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 37ff957e-bccd-4655-abe9-4819e71675ff
+                - dcefa0d6-34af-4fcc-ac29-7ec7d271928a
         status: 200 OK
         code: 200
-        duration: 172.290125ms
+        duration: 166.159416ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -622,8 +622,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91
         method: GET
       response:
         proto: HTTP/2.0
@@ -631,20 +631,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2292
+        content_length: 1825
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:54.026950+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-condescending-ritchie","id":"3cca217c-aff0-4541-a55f-e1e7a765132f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"49","hypervisor_id":"302","node_id":"33","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:49","maintenances":[],"modification_date":"2025-01-27T13:50:08.747474+00:00","name":"tf-srv-condescending-ritchie","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:54.026950+00:00","export_uri":null,"id":"6d3751c6-6e80-4d35-ba02-8575652e491c","modification_date":"2025-01-27T13:49:54.026950+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3cca217c-aff0-4541-a55f-e1e7a765132f","name":"tf-srv-condescending-ritchie"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:55.442736+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-bassi","id":"0545e66f-0214-4827-9aee-577b41b0ac91","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"604","node_id":"7","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:fb","maintenances":[],"modification_date":"2025-02-11T14:24:01.281072+00:00","name":"tf-srv-nervous-bassi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"589485f8-15b2-410e-85d4-3d74f9296dd6","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2292"
+                - "1825"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:10 GMT
+                - Tue, 11 Feb 2025 14:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -652,10 +652,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 87ea2d08-51a9-4447-8e42-e9b7d0bdbc18
+                - 155086b3-aac0-40cf-a20a-5b182e8721b4
         status: 200 OK
         code: 200
-        duration: 163.454959ms
+        duration: 167.171084ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -671,8 +671,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/589485f8-15b2-410e-85d4-3d74f9296dd6
         method: GET
       response:
         proto: HTTP/2.0
@@ -680,20 +680,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2292
+        content_length: 143
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:54.026950+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-condescending-ritchie","id":"3cca217c-aff0-4541-a55f-e1e7a765132f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"49","hypervisor_id":"302","node_id":"33","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:49","maintenances":[],"modification_date":"2025-01-27T13:50:08.747474+00:00","name":"tf-srv-condescending-ritchie","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:54.026950+00:00","export_uri":null,"id":"6d3751c6-6e80-4d35-ba02-8575652e491c","modification_date":"2025-01-27T13:49:54.026950+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3cca217c-aff0-4541-a55f-e1e7a765132f","name":"tf-srv-condescending-ritchie"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"589485f8-15b2-410e-85d4-3d74f9296dd6","type":"not_found"}'
         headers:
             Content-Length:
-                - "2292"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:11 GMT
+                - Tue, 11 Feb 2025 14:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -701,10 +701,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cf8ec60d-abc7-47e0-aa9a-997d5bc63bf7
-        status: 200 OK
-        code: 200
-        duration: 190.001ms
+                - 4380cf3a-2248-4719-a100-27504a283051
+        status: 404 Not Found
+        code: 404
+        duration: 37.737042ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -720,8 +720,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/6d3751c6-6e80-4d35-ba02-8575652e491c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/589485f8-15b2-410e-85d4-3d74f9296dd6
         method: GET
       response:
         proto: HTTP/2.0
@@ -729,20 +729,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 528
+        content_length: 701
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:49:54.026950+00:00","export_uri":null,"id":"6d3751c6-6e80-4d35-ba02-8575652e491c","modification_date":"2025-01-27T13:49:54.026950+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3cca217c-aff0-4541-a55f-e1e7a765132f","name":"tf-srv-condescending-ritchie"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T14:23:55.640162Z","id":"589485f8-15b2-410e-85d4-3d74f9296dd6","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:55.640162Z","id":"95219529-f98a-4b98-8da4-20cc832a881f","product_resource_id":"0545e66f-0214-4827-9aee-577b41b0ac91","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:55.640162Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "528"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:11 GMT
+                - Tue, 11 Feb 2025 14:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -750,10 +750,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a70322e3-267c-4989-b57e-428fbdf7d04b
+                - 1d0699aa-0871-4293-9b02-10b973af9e76
         status: 200 OK
         code: 200
-        duration: 106.263583ms
+        duration: 58.033625ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -769,8 +769,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -789,9 +789,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:11 GMT
+                - Tue, 11 Feb 2025 14:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -799,10 +799,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3da45e68-814c-4120-ab4c-3e94a3c3875b
+                - 817bdda5-6d60-4c4c-9810-140d6592863d
         status: 200 OK
         code: 200
-        duration: 96.214459ms
+        duration: 89.41825ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -818,8 +818,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -838,11 +838,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:11 GMT
+                - Tue, 11 Feb 2025 14:24:02 GMT
             Link:
-                - </servers/3cca217c-aff0-4541-a55f-e1e7a765132f/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/0545e66f-0214-4827-9aee-577b41b0ac91/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -850,12 +850,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7c6171c7-30bd-404b-b9f2-fe7dcac05caa
+                - 2badbb71-f481-4067-9911-907fcf9cbc0e
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 110.873125ms
+        duration: 72.276208ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -871,8 +871,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91
         method: GET
       response:
         proto: HTTP/2.0
@@ -880,20 +880,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2292
+        content_length: 1825
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:54.026950+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-condescending-ritchie","id":"3cca217c-aff0-4541-a55f-e1e7a765132f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"49","hypervisor_id":"302","node_id":"33","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:49","maintenances":[],"modification_date":"2025-01-27T13:50:08.747474+00:00","name":"tf-srv-condescending-ritchie","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:54.026950+00:00","export_uri":null,"id":"6d3751c6-6e80-4d35-ba02-8575652e491c","modification_date":"2025-01-27T13:49:54.026950+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3cca217c-aff0-4541-a55f-e1e7a765132f","name":"tf-srv-condescending-ritchie"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:55.442736+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-bassi","id":"0545e66f-0214-4827-9aee-577b41b0ac91","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"604","node_id":"7","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:fb","maintenances":[],"modification_date":"2025-02-11T14:24:01.281072+00:00","name":"tf-srv-nervous-bassi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"589485f8-15b2-410e-85d4-3d74f9296dd6","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2292"
+                - "1825"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:11 GMT
+                - Tue, 11 Feb 2025 14:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -901,10 +901,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7b957d1b-ae91-4ef7-a719-122e51251be0
+                - cb5eabb7-5f85-44fb-afe1-17d0a33345e5
         status: 200 OK
         code: 200
-        duration: 340.696917ms
+        duration: 139.715833ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -916,14 +916,14 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"private_network_id":"08148f79-a166-49ea-adb5-177cf226c6cb"}'
+        body: '{"private_network_id":"fb66d58e-9e88-426c-9dc8-70cf1124701e"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91/private_nics
         method: POST
       response:
         proto: HTTP/2.0
@@ -933,7 +933,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:50:11.953252+00:00","id":"e79a2b17-16b1-472d-95f2-68877a95f3dc","ipam_ip_ids":["49278731-c376-4e7b-b61a-7674a53d8127","55d590ad-f716-444a-ba2c-2162e1a4162c"],"mac_address":"02:00:00:1d:4b:ce","modification_date":"2025-01-27T13:50:12.201361+00:00","private_network_id":"08148f79-a166-49ea-adb5-177cf226c6cb","server_id":"3cca217c-aff0-4541-a55f-e1e7a765132f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:24:03.025113+00:00","id":"b4868c6d-2d73-4884-bcbf-7c8d6b48b198","ipam_ip_ids":["6e60e3d3-f2b2-40a6-953c-07a1b9f9616f","08f4bb9e-4daa-44e2-a012-9cfd957ea156"],"mac_address":"02:00:00:13:f0:22","modification_date":"2025-02-11T14:24:03.226289+00:00","private_network_id":"fb66d58e-9e88-426c-9dc8-70cf1124701e","server_id":"0545e66f-0214-4827-9aee-577b41b0ac91","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -942,9 +942,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:12 GMT
+                - Tue, 11 Feb 2025 14:24:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -952,10 +952,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a23e0677-50e2-4d37-9677-62149547773d
+                - 86b78575-69d8-4af0-824e-be3733b2537f
         status: 201 Created
         code: 201
-        duration: 1.137440042s
+        duration: 1.100152417s
     - id: 19
       request:
         proto: HTTP/1.1
@@ -971,8 +971,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f/private_nics/e79a2b17-16b1-472d-95f2-68877a95f3dc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91/private_nics/b4868c6d-2d73-4884-bcbf-7c8d6b48b198
         method: GET
       response:
         proto: HTTP/2.0
@@ -982,7 +982,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:50:11.953252+00:00","id":"e79a2b17-16b1-472d-95f2-68877a95f3dc","ipam_ip_ids":["49278731-c376-4e7b-b61a-7674a53d8127","55d590ad-f716-444a-ba2c-2162e1a4162c"],"mac_address":"02:00:00:1d:4b:ce","modification_date":"2025-01-27T13:50:12.201361+00:00","private_network_id":"08148f79-a166-49ea-adb5-177cf226c6cb","server_id":"3cca217c-aff0-4541-a55f-e1e7a765132f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:24:03.025113+00:00","id":"b4868c6d-2d73-4884-bcbf-7c8d6b48b198","ipam_ip_ids":["6e60e3d3-f2b2-40a6-953c-07a1b9f9616f","08f4bb9e-4daa-44e2-a012-9cfd957ea156"],"mac_address":"02:00:00:13:f0:22","modification_date":"2025-02-11T14:24:03.226289+00:00","private_network_id":"fb66d58e-9e88-426c-9dc8-70cf1124701e","server_id":"0545e66f-0214-4827-9aee-577b41b0ac91","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -991,9 +991,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:12 GMT
+                - Tue, 11 Feb 2025 14:24:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1001,10 +1001,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a684847b-a939-425c-a2db-9b132fe1951f
+                - bcd04fe5-e128-4337-b878-f74440c318f6
         status: 200 OK
         code: 200
-        duration: 91.714375ms
+        duration: 99.958ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1020,8 +1020,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f/private_nics/e79a2b17-16b1-472d-95f2-68877a95f3dc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91/private_nics/b4868c6d-2d73-4884-bcbf-7c8d6b48b198
         method: GET
       response:
         proto: HTTP/2.0
@@ -1031,7 +1031,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:50:11.953252+00:00","id":"e79a2b17-16b1-472d-95f2-68877a95f3dc","ipam_ip_ids":["49278731-c376-4e7b-b61a-7674a53d8127","55d590ad-f716-444a-ba2c-2162e1a4162c"],"mac_address":"02:00:00:1d:4b:ce","modification_date":"2025-01-27T13:50:12.201361+00:00","private_network_id":"08148f79-a166-49ea-adb5-177cf226c6cb","server_id":"3cca217c-aff0-4541-a55f-e1e7a765132f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:24:03.025113+00:00","id":"b4868c6d-2d73-4884-bcbf-7c8d6b48b198","ipam_ip_ids":["6e60e3d3-f2b2-40a6-953c-07a1b9f9616f","08f4bb9e-4daa-44e2-a012-9cfd957ea156"],"mac_address":"02:00:00:13:f0:22","modification_date":"2025-02-11T14:24:03.226289+00:00","private_network_id":"fb66d58e-9e88-426c-9dc8-70cf1124701e","server_id":"0545e66f-0214-4827-9aee-577b41b0ac91","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -1040,9 +1040,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:18 GMT
+                - Tue, 11 Feb 2025 14:24:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1050,10 +1050,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b26dc09b-3f04-4664-b2fa-090a48e1d670
+                - 4c43c833-6685-4769-a121-1ccdb49bf841
         status: 200 OK
         code: 200
-        duration: 92.69125ms
+        duration: 91.50425ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1069,8 +1069,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f/private_nics/e79a2b17-16b1-472d-95f2-68877a95f3dc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91/private_nics/b4868c6d-2d73-4884-bcbf-7c8d6b48b198
         method: GET
       response:
         proto: HTTP/2.0
@@ -1080,7 +1080,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:50:11.953252+00:00","id":"e79a2b17-16b1-472d-95f2-68877a95f3dc","ipam_ip_ids":["49278731-c376-4e7b-b61a-7674a53d8127","55d590ad-f716-444a-ba2c-2162e1a4162c"],"mac_address":"02:00:00:1d:4b:ce","modification_date":"2025-01-27T13:50:12.201361+00:00","private_network_id":"08148f79-a166-49ea-adb5-177cf226c6cb","server_id":"3cca217c-aff0-4541-a55f-e1e7a765132f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:24:03.025113+00:00","id":"b4868c6d-2d73-4884-bcbf-7c8d6b48b198","ipam_ip_ids":["6e60e3d3-f2b2-40a6-953c-07a1b9f9616f","08f4bb9e-4daa-44e2-a012-9cfd957ea156"],"mac_address":"02:00:00:13:f0:22","modification_date":"2025-02-11T14:24:03.226289+00:00","private_network_id":"fb66d58e-9e88-426c-9dc8-70cf1124701e","server_id":"0545e66f-0214-4827-9aee-577b41b0ac91","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -1089,9 +1089,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:23 GMT
+                - Tue, 11 Feb 2025 14:24:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1099,10 +1099,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d29c1a68-86e4-45eb-9610-5cf86303b77f
+                - 0f8fe0fb-70f0-42ea-8ff2-58fde3d0b944
         status: 200 OK
         code: 200
-        duration: 97.835542ms
+        duration: 94.042625ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1118,8 +1118,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f/private_nics/e79a2b17-16b1-472d-95f2-68877a95f3dc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91/private_nics/b4868c6d-2d73-4884-bcbf-7c8d6b48b198
         method: GET
       response:
         proto: HTTP/2.0
@@ -1129,7 +1129,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:50:11.953252+00:00","id":"e79a2b17-16b1-472d-95f2-68877a95f3dc","ipam_ip_ids":["49278731-c376-4e7b-b61a-7674a53d8127","55d590ad-f716-444a-ba2c-2162e1a4162c"],"mac_address":"02:00:00:1d:4b:ce","modification_date":"2025-01-27T13:50:12.201361+00:00","private_network_id":"08148f79-a166-49ea-adb5-177cf226c6cb","server_id":"3cca217c-aff0-4541-a55f-e1e7a765132f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:24:03.025113+00:00","id":"b4868c6d-2d73-4884-bcbf-7c8d6b48b198","ipam_ip_ids":["6e60e3d3-f2b2-40a6-953c-07a1b9f9616f","08f4bb9e-4daa-44e2-a012-9cfd957ea156"],"mac_address":"02:00:00:13:f0:22","modification_date":"2025-02-11T14:24:03.226289+00:00","private_network_id":"fb66d58e-9e88-426c-9dc8-70cf1124701e","server_id":"0545e66f-0214-4827-9aee-577b41b0ac91","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -1138,9 +1138,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:28 GMT
+                - Tue, 11 Feb 2025 14:24:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1148,10 +1148,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 21a408a2-8cca-4c67-b36b-9e8eab282176
+                - 389b0049-8288-4ab5-8369-93959f6e226f
         status: 200 OK
         code: 200
-        duration: 76.840416ms
+        duration: 113.849375ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1167,8 +1167,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f/private_nics/e79a2b17-16b1-472d-95f2-68877a95f3dc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91/private_nics/b4868c6d-2d73-4884-bcbf-7c8d6b48b198
         method: GET
       response:
         proto: HTTP/2.0
@@ -1178,7 +1178,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:50:11.953252+00:00","id":"e79a2b17-16b1-472d-95f2-68877a95f3dc","ipam_ip_ids":["49278731-c376-4e7b-b61a-7674a53d8127","55d590ad-f716-444a-ba2c-2162e1a4162c"],"mac_address":"02:00:00:1d:4b:ce","modification_date":"2025-01-27T13:50:12.201361+00:00","private_network_id":"08148f79-a166-49ea-adb5-177cf226c6cb","server_id":"3cca217c-aff0-4541-a55f-e1e7a765132f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:24:03.025113+00:00","id":"b4868c6d-2d73-4884-bcbf-7c8d6b48b198","ipam_ip_ids":["6e60e3d3-f2b2-40a6-953c-07a1b9f9616f","08f4bb9e-4daa-44e2-a012-9cfd957ea156"],"mac_address":"02:00:00:13:f0:22","modification_date":"2025-02-11T14:24:03.226289+00:00","private_network_id":"fb66d58e-9e88-426c-9dc8-70cf1124701e","server_id":"0545e66f-0214-4827-9aee-577b41b0ac91","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -1187,9 +1187,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:33 GMT
+                - Tue, 11 Feb 2025 14:24:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1197,10 +1197,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1e5a2f8d-8a36-45d8-a98e-619e00a91d7c
+                - 3a60b6fc-4a6a-4abc-9979-c292d0f9afc9
         status: 200 OK
         code: 200
-        duration: 89.619709ms
+        duration: 90.375ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1216,8 +1216,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f/private_nics/e79a2b17-16b1-472d-95f2-68877a95f3dc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91/private_nics/b4868c6d-2d73-4884-bcbf-7c8d6b48b198
         method: GET
       response:
         proto: HTTP/2.0
@@ -1227,7 +1227,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:50:11.953252+00:00","id":"e79a2b17-16b1-472d-95f2-68877a95f3dc","ipam_ip_ids":["49278731-c376-4e7b-b61a-7674a53d8127","55d590ad-f716-444a-ba2c-2162e1a4162c"],"mac_address":"02:00:00:1d:4b:ce","modification_date":"2025-01-27T13:50:12.201361+00:00","private_network_id":"08148f79-a166-49ea-adb5-177cf226c6cb","server_id":"3cca217c-aff0-4541-a55f-e1e7a765132f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:24:03.025113+00:00","id":"b4868c6d-2d73-4884-bcbf-7c8d6b48b198","ipam_ip_ids":["6e60e3d3-f2b2-40a6-953c-07a1b9f9616f","08f4bb9e-4daa-44e2-a012-9cfd957ea156"],"mac_address":"02:00:00:13:f0:22","modification_date":"2025-02-11T14:24:03.226289+00:00","private_network_id":"fb66d58e-9e88-426c-9dc8-70cf1124701e","server_id":"0545e66f-0214-4827-9aee-577b41b0ac91","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -1236,9 +1236,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:37 GMT
+                - Tue, 11 Feb 2025 14:24:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1246,10 +1246,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9a0c0e45-0041-4080-ad40-0af9c09d3876
+                - 0b9ee34c-984e-441e-884d-84522e3c19a9
         status: 200 OK
         code: 200
-        duration: 101.60775ms
+        duration: 87.370833ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1265,8 +1265,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f/private_nics/e79a2b17-16b1-472d-95f2-68877a95f3dc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91/private_nics/b4868c6d-2d73-4884-bcbf-7c8d6b48b198
         method: GET
       response:
         proto: HTTP/2.0
@@ -1276,7 +1276,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:50:11.953252+00:00","id":"e79a2b17-16b1-472d-95f2-68877a95f3dc","ipam_ip_ids":["49278731-c376-4e7b-b61a-7674a53d8127","55d590ad-f716-444a-ba2c-2162e1a4162c"],"mac_address":"02:00:00:1d:4b:ce","modification_date":"2025-01-27T13:50:12.201361+00:00","private_network_id":"08148f79-a166-49ea-adb5-177cf226c6cb","server_id":"3cca217c-aff0-4541-a55f-e1e7a765132f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:24:03.025113+00:00","id":"b4868c6d-2d73-4884-bcbf-7c8d6b48b198","ipam_ip_ids":["6e60e3d3-f2b2-40a6-953c-07a1b9f9616f","08f4bb9e-4daa-44e2-a012-9cfd957ea156"],"mac_address":"02:00:00:13:f0:22","modification_date":"2025-02-11T14:24:03.226289+00:00","private_network_id":"fb66d58e-9e88-426c-9dc8-70cf1124701e","server_id":"0545e66f-0214-4827-9aee-577b41b0ac91","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -1285,9 +1285,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:43 GMT
+                - Tue, 11 Feb 2025 14:24:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1295,10 +1295,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f5540f1d-8776-45fd-b4ae-ca14f592dab5
+                - 021a6308-215d-4980-8018-4ad3cb3df3cf
         status: 200 OK
         code: 200
-        duration: 100.701875ms
+        duration: 94.640875ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1314,8 +1314,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f/private_nics/e79a2b17-16b1-472d-95f2-68877a95f3dc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91/private_nics/b4868c6d-2d73-4884-bcbf-7c8d6b48b198
         method: GET
       response:
         proto: HTTP/2.0
@@ -1325,7 +1325,7 @@ interactions:
         trailer: {}
         content_length: 475
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:50:11.953252+00:00","id":"e79a2b17-16b1-472d-95f2-68877a95f3dc","ipam_ip_ids":["49278731-c376-4e7b-b61a-7674a53d8127","55d590ad-f716-444a-ba2c-2162e1a4162c"],"mac_address":"02:00:00:1d:4b:ce","modification_date":"2025-01-27T13:50:43.859337+00:00","private_network_id":"08148f79-a166-49ea-adb5-177cf226c6cb","server_id":"3cca217c-aff0-4541-a55f-e1e7a765132f","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:24:03.025113+00:00","id":"b4868c6d-2d73-4884-bcbf-7c8d6b48b198","ipam_ip_ids":["6e60e3d3-f2b2-40a6-953c-07a1b9f9616f","08f4bb9e-4daa-44e2-a012-9cfd957ea156"],"mac_address":"02:00:00:13:f0:22","modification_date":"2025-02-11T14:24:34.859513+00:00","private_network_id":"fb66d58e-9e88-426c-9dc8-70cf1124701e","server_id":"0545e66f-0214-4827-9aee-577b41b0ac91","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "475"
@@ -1334,9 +1334,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:48 GMT
+                - Tue, 11 Feb 2025 14:24:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1344,10 +1344,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 19a944a6-d8c0-463a-913f-f96b7b2f8799
+                - 85c42553-374b-4d01-bfb9-319b3651c84d
         status: 200 OK
         code: 200
-        duration: 95.730542ms
+        duration: 99.559042ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1363,8 +1363,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f/private_nics/e79a2b17-16b1-472d-95f2-68877a95f3dc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91/private_nics/b4868c6d-2d73-4884-bcbf-7c8d6b48b198
         method: GET
       response:
         proto: HTTP/2.0
@@ -1374,7 +1374,7 @@ interactions:
         trailer: {}
         content_length: 475
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:50:11.953252+00:00","id":"e79a2b17-16b1-472d-95f2-68877a95f3dc","ipam_ip_ids":["49278731-c376-4e7b-b61a-7674a53d8127","55d590ad-f716-444a-ba2c-2162e1a4162c"],"mac_address":"02:00:00:1d:4b:ce","modification_date":"2025-01-27T13:50:43.859337+00:00","private_network_id":"08148f79-a166-49ea-adb5-177cf226c6cb","server_id":"3cca217c-aff0-4541-a55f-e1e7a765132f","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:24:03.025113+00:00","id":"b4868c6d-2d73-4884-bcbf-7c8d6b48b198","ipam_ip_ids":["6e60e3d3-f2b2-40a6-953c-07a1b9f9616f","08f4bb9e-4daa-44e2-a012-9cfd957ea156"],"mac_address":"02:00:00:13:f0:22","modification_date":"2025-02-11T14:24:34.859513+00:00","private_network_id":"fb66d58e-9e88-426c-9dc8-70cf1124701e","server_id":"0545e66f-0214-4827-9aee-577b41b0ac91","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "475"
@@ -1383,9 +1383,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:48 GMT
+                - Tue, 11 Feb 2025 14:24:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1393,10 +1393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 261ab108-69ff-4eff-8f9e-4b980532a4cf
+                - 0f1bbc00-190e-48a1-8765-acc34ad39011
         status: 200 OK
         code: 200
-        duration: 91.513542ms
+        duration: 76.35025ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1412,8 +1412,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f/private_nics/e79a2b17-16b1-472d-95f2-68877a95f3dc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91/private_nics/b4868c6d-2d73-4884-bcbf-7c8d6b48b198
         method: GET
       response:
         proto: HTTP/2.0
@@ -1423,7 +1423,7 @@ interactions:
         trailer: {}
         content_length: 475
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:50:11.953252+00:00","id":"e79a2b17-16b1-472d-95f2-68877a95f3dc","ipam_ip_ids":["49278731-c376-4e7b-b61a-7674a53d8127","55d590ad-f716-444a-ba2c-2162e1a4162c"],"mac_address":"02:00:00:1d:4b:ce","modification_date":"2025-01-27T13:50:43.859337+00:00","private_network_id":"08148f79-a166-49ea-adb5-177cf226c6cb","server_id":"3cca217c-aff0-4541-a55f-e1e7a765132f","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:24:03.025113+00:00","id":"b4868c6d-2d73-4884-bcbf-7c8d6b48b198","ipam_ip_ids":["6e60e3d3-f2b2-40a6-953c-07a1b9f9616f","08f4bb9e-4daa-44e2-a012-9cfd957ea156"],"mac_address":"02:00:00:13:f0:22","modification_date":"2025-02-11T14:24:34.859513+00:00","private_network_id":"fb66d58e-9e88-426c-9dc8-70cf1124701e","server_id":"0545e66f-0214-4827-9aee-577b41b0ac91","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "475"
@@ -1432,9 +1432,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:48 GMT
+                - Tue, 11 Feb 2025 14:24:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1442,10 +1442,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - da8d30ce-9d29-492e-9f08-bc9b27bfad2b
+                - 7f53e31d-3322-4020-803d-7a36c8b46739
         status: 200 OK
         code: 200
-        duration: 82.57475ms
+        duration: 86.702375ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1461,8 +1461,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/08148f79-a166-49ea-adb5-177cf226c6cb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/fb66d58e-9e88-426c-9dc8-70cf1124701e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1470,20 +1470,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1066
+        content_length: 1065
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:49:53.222154Z","dhcp_enabled":true,"id":"08148f79-a166-49ea-adb5-177cf226c6cb","name":"TestAccScalewayInstancePrivateNIC_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:49:53.222154Z","id":"4082cb17-6063-4815-9e7f-82b2ed080b78","private_network_id":"08148f79-a166-49ea-adb5-177cf226c6cb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.24.0/22","updated_at":"2025-01-27T13:49:53.222154Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:49:53.222154Z","id":"8b3f71b3-2e20-45e7-87a7-d1fe2419f4c6","private_network_id":"08148f79-a166-49ea-adb5-177cf226c6cb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:b09c::/64","updated_at":"2025-01-27T13:49:53.222154Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:49:53.222154Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"created_at":"2025-02-11T14:23:54.814541Z","dhcp_enabled":true,"id":"fb66d58e-9e88-426c-9dc8-70cf1124701e","name":"TestAccScalewayInstancePrivateNIC_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-11T14:23:54.814541Z","id":"a43e1f99-05a1-43b0-974b-c1ef730d5efd","private_network_id":"fb66d58e-9e88-426c-9dc8-70cf1124701e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.8.0/22","updated_at":"2025-02-11T14:23:54.814541Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-11T14:23:54.814541Z","id":"1b94e4aa-2241-4f86-925f-e65ec0e2455c","private_network_id":"fb66d58e-9e88-426c-9dc8-70cf1124701e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:b607::/64","updated_at":"2025-02-11T14:23:54.814541Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-11T14:23:54.814541Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "1066"
+                - "1065"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:49 GMT
+                - Tue, 11 Feb 2025 14:24:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1491,10 +1491,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2eec5853-6816-4aa1-aac7-46070fc39ed5
+                - ef4c8314-4efa-4309-8a46-eb5dc722d719
         status: 200 OK
         code: 200
-        duration: 39.460375ms
+        duration: 30.634792ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1510,8 +1510,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91
         method: GET
       response:
         proto: HTTP/2.0
@@ -1519,20 +1519,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2750
+        content_length: 2283
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:54.026950+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-condescending-ritchie","id":"3cca217c-aff0-4541-a55f-e1e7a765132f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"49","hypervisor_id":"302","node_id":"33","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:49","maintenances":[],"modification_date":"2025-01-27T13:50:08.747474+00:00","name":"tf-srv-condescending-ritchie","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:50:11.953252+00:00","id":"e79a2b17-16b1-472d-95f2-68877a95f3dc","ipam_ip_ids":["49278731-c376-4e7b-b61a-7674a53d8127","55d590ad-f716-444a-ba2c-2162e1a4162c"],"mac_address":"02:00:00:1d:4b:ce","modification_date":"2025-01-27T13:50:43.859337+00:00","private_network_id":"08148f79-a166-49ea-adb5-177cf226c6cb","server_id":"3cca217c-aff0-4541-a55f-e1e7a765132f","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:54.026950+00:00","export_uri":null,"id":"6d3751c6-6e80-4d35-ba02-8575652e491c","modification_date":"2025-01-27T13:49:54.026950+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3cca217c-aff0-4541-a55f-e1e7a765132f","name":"tf-srv-condescending-ritchie"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:55.442736+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-bassi","id":"0545e66f-0214-4827-9aee-577b41b0ac91","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"604","node_id":"7","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:fb","maintenances":[],"modification_date":"2025-02-11T14:24:01.281072+00:00","name":"tf-srv-nervous-bassi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:24:03.025113+00:00","id":"b4868c6d-2d73-4884-bcbf-7c8d6b48b198","ipam_ip_ids":["6e60e3d3-f2b2-40a6-953c-07a1b9f9616f","08f4bb9e-4daa-44e2-a012-9cfd957ea156"],"mac_address":"02:00:00:13:f0:22","modification_date":"2025-02-11T14:24:34.859513+00:00","private_network_id":"fb66d58e-9e88-426c-9dc8-70cf1124701e","server_id":"0545e66f-0214-4827-9aee-577b41b0ac91","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"589485f8-15b2-410e-85d4-3d74f9296dd6","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2750"
+                - "2283"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:49 GMT
+                - Tue, 11 Feb 2025 14:24:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1540,10 +1540,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cf6d1f0a-8830-4fb9-8413-5bc735cc22b0
+                - 11acba3b-3ef4-4309-bb3c-21bbed711566
         status: 200 OK
         code: 200
-        duration: 174.536292ms
+        duration: 152.963291ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1559,8 +1559,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/6d3751c6-6e80-4d35-ba02-8575652e491c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/589485f8-15b2-410e-85d4-3d74f9296dd6
         method: GET
       response:
         proto: HTTP/2.0
@@ -1568,20 +1568,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 528
+        content_length: 143
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:49:54.026950+00:00","export_uri":null,"id":"6d3751c6-6e80-4d35-ba02-8575652e491c","modification_date":"2025-01-27T13:49:54.026950+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3cca217c-aff0-4541-a55f-e1e7a765132f","name":"tf-srv-condescending-ritchie"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"589485f8-15b2-410e-85d4-3d74f9296dd6","type":"not_found"}'
         headers:
             Content-Length:
-                - "528"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:49 GMT
+                - Tue, 11 Feb 2025 14:24:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1589,10 +1589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 03c81cbc-8f6a-4061-99a7-64ea577d4f3f
-        status: 200 OK
-        code: 200
-        duration: 89.574625ms
+                - 8374bc4b-a2f2-4864-aff1-ced987c6f576
+        status: 404 Not Found
+        code: 404
+        duration: 36.872334ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1608,8 +1608,57 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/589485f8-15b2-410e-85d4-3d74f9296dd6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:23:55.640162Z","id":"589485f8-15b2-410e-85d4-3d74f9296dd6","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:55.640162Z","id":"95219529-f98a-4b98-8da4-20cc832a881f","product_resource_id":"0545e66f-0214-4827-9aee-577b41b0ac91","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:55.640162Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4da31dc7-0d13-4c45-a454-2b931ba92bfb
+        status: 200 OK
+        code: 200
+        duration: 56.612959ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1628,9 +1677,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:49 GMT
+                - Tue, 11 Feb 2025 14:24:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1638,63 +1687,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c6cbe249-fe27-4fc9-8d3e-154096765bfa
+                - 333b7126-ade1-4b21-a0be-8ca6a533f4ba
         status: 200 OK
         code: 200
-        duration: 96.236708ms
-    - id: 33
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f/private_nics
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 478
-        uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:50:11.953252+00:00","id":"e79a2b17-16b1-472d-95f2-68877a95f3dc","ipam_ip_ids":["49278731-c376-4e7b-b61a-7674a53d8127","55d590ad-f716-444a-ba2c-2162e1a4162c"],"mac_address":"02:00:00:1d:4b:ce","modification_date":"2025-01-27T13:50:43.859337+00:00","private_network_id":"08148f79-a166-49ea-adb5-177cf226c6cb","server_id":"3cca217c-aff0-4541-a55f-e1e7a765132f","state":"available","tags":[],"zone":"fr-par-1"}]}'
-        headers:
-            Content-Length:
-                - "478"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:49 GMT
-            Link:
-                - </servers/3cca217c-aff0-4541-a55f-e1e7a765132f/private_nics?page=1&per_page=50&>; rel="last"
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 44b93e4e-a0cb-4743-9df5-1d5125827bcd
-            X-Total-Count:
-                - "1"
-        status: 200 OK
-        code: 200
-        duration: 104.471667ms
+        duration: 75.553916ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1710,8 +1706,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f/private_nics/e79a2b17-16b1-472d-95f2-68877a95f3dc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1719,20 +1715,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 475
+        content_length: 478
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:50:11.953252+00:00","id":"e79a2b17-16b1-472d-95f2-68877a95f3dc","ipam_ip_ids":["49278731-c376-4e7b-b61a-7674a53d8127","55d590ad-f716-444a-ba2c-2162e1a4162c"],"mac_address":"02:00:00:1d:4b:ce","modification_date":"2025-01-27T13:50:43.859337+00:00","private_network_id":"08148f79-a166-49ea-adb5-177cf226c6cb","server_id":"3cca217c-aff0-4541-a55f-e1e7a765132f","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nics":[{"creation_date":"2025-02-11T14:24:03.025113+00:00","id":"b4868c6d-2d73-4884-bcbf-7c8d6b48b198","ipam_ip_ids":["6e60e3d3-f2b2-40a6-953c-07a1b9f9616f","08f4bb9e-4daa-44e2-a012-9cfd957ea156"],"mac_address":"02:00:00:13:f0:22","modification_date":"2025-02-11T14:24:34.859513+00:00","private_network_id":"fb66d58e-9e88-426c-9dc8-70cf1124701e","server_id":"0545e66f-0214-4827-9aee-577b41b0ac91","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "475"
+                - "478"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:49 GMT
+                - Tue, 11 Feb 2025 14:24:40 GMT
+            Link:
+                - </servers/0545e66f-0214-4827-9aee-577b41b0ac91/private_nics?page=1&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1740,10 +1738,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 49031f1b-f26e-445f-b1dc-f6a0a93b07ff
+                - 86e08a6e-2177-459c-bf84-70e9d76c5e4b
+            X-Total-Count:
+                - "1"
         status: 200 OK
         code: 200
-        duration: 76.569417ms
+        duration: 80.309792ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1759,8 +1759,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f/private_nics/e79a2b17-16b1-472d-95f2-68877a95f3dc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91/private_nics/b4868c6d-2d73-4884-bcbf-7c8d6b48b198
         method: GET
       response:
         proto: HTTP/2.0
@@ -1770,7 +1770,7 @@ interactions:
         trailer: {}
         content_length: 475
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:50:11.953252+00:00","id":"e79a2b17-16b1-472d-95f2-68877a95f3dc","ipam_ip_ids":["49278731-c376-4e7b-b61a-7674a53d8127","55d590ad-f716-444a-ba2c-2162e1a4162c"],"mac_address":"02:00:00:1d:4b:ce","modification_date":"2025-01-27T13:50:43.859337+00:00","private_network_id":"08148f79-a166-49ea-adb5-177cf226c6cb","server_id":"3cca217c-aff0-4541-a55f-e1e7a765132f","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:24:03.025113+00:00","id":"b4868c6d-2d73-4884-bcbf-7c8d6b48b198","ipam_ip_ids":["6e60e3d3-f2b2-40a6-953c-07a1b9f9616f","08f4bb9e-4daa-44e2-a012-9cfd957ea156"],"mac_address":"02:00:00:13:f0:22","modification_date":"2025-02-11T14:24:34.859513+00:00","private_network_id":"fb66d58e-9e88-426c-9dc8-70cf1124701e","server_id":"0545e66f-0214-4827-9aee-577b41b0ac91","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "475"
@@ -1779,9 +1779,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:49 GMT
+                - Tue, 11 Feb 2025 14:24:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1789,10 +1789,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1482c333-17a4-48c4-b6cb-ab8512725d2e
+                - 3e082570-2177-4f95-b9e9-a96f5e1880b0
         status: 200 OK
         code: 200
-        duration: 82.57275ms
+        duration: 83.859459ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1808,8 +1808,57 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f/private_nics/e79a2b17-16b1-472d-95f2-68877a95f3dc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91/private_nics/b4868c6d-2d73-4884-bcbf-7c8d6b48b198
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 475
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:24:03.025113+00:00","id":"b4868c6d-2d73-4884-bcbf-7c8d6b48b198","ipam_ip_ids":["6e60e3d3-f2b2-40a6-953c-07a1b9f9616f","08f4bb9e-4daa-44e2-a012-9cfd957ea156"],"mac_address":"02:00:00:13:f0:22","modification_date":"2025-02-11T14:24:34.859513+00:00","private_network_id":"fb66d58e-9e88-426c-9dc8-70cf1124701e","server_id":"0545e66f-0214-4827-9aee-577b41b0ac91","state":"available","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "475"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f8eb048d-d692-47cb-b95f-718188f23268
+        status: 200 OK
+        code: 200
+        duration: 81.660625ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91/private_nics/b4868c6d-2d73-4884-bcbf-7c8d6b48b198
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1826,9 +1875,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:50 GMT
+                - Tue, 11 Feb 2025 14:24:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1836,59 +1885,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b216eef8-b24d-4f70-a81a-ca3de9ecd20d
+                - f3d9c20f-7656-44a6-853c-0ef447ae7858
         status: 204 No Content
         code: 204
-        duration: 420.8125ms
-    - id: 37
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f/private_nics/e79a2b17-16b1-472d-95f2-68877a95f3dc
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 148
-        uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"e79a2b17-16b1-472d-95f2-68877a95f3dc","type":"not_found"}'
-        headers:
-            Content-Length:
-                - "148"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:50 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 71813265-7248-4ca7-a70c-50d460a82110
-        status: 404 Not Found
-        code: 404
-        duration: 100.38575ms
+        duration: 414.010541ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1904,8 +1904,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91/private_nics/b4868c6d-2d73-4884-bcbf-7c8d6b48b198
         method: GET
       response:
         proto: HTTP/2.0
@@ -1913,20 +1913,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2292
+        content_length: 148
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:54.026950+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-condescending-ritchie","id":"3cca217c-aff0-4541-a55f-e1e7a765132f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"49","hypervisor_id":"302","node_id":"33","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:49","maintenances":[],"modification_date":"2025-01-27T13:50:08.747474+00:00","name":"tf-srv-condescending-ritchie","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:54.026950+00:00","export_uri":null,"id":"6d3751c6-6e80-4d35-ba02-8575652e491c","modification_date":"2025-01-27T13:49:54.026950+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3cca217c-aff0-4541-a55f-e1e7a765132f","name":"tf-srv-condescending-ritchie"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"b4868c6d-2d73-4884-bcbf-7c8d6b48b198","type":"not_found"}'
         headers:
             Content-Length:
-                - "2292"
+                - "148"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:50 GMT
+                - Tue, 11 Feb 2025 14:24:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1934,11 +1934,109 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1d63d244-acc3-45d6-8209-9f6c292e81c6
+                - 44a4c095-bb6a-4017-bb3a-8435b6fda863
+        status: 404 Not Found
+        code: 404
+        duration: 90.081583ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1825
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:55.442736+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-bassi","id":"0545e66f-0214-4827-9aee-577b41b0ac91","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"604","node_id":"7","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:fb","maintenances":[],"modification_date":"2025-02-11T14:24:01.281072+00:00","name":"tf-srv-nervous-bassi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"589485f8-15b2-410e-85d4-3d74f9296dd6","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1825"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d289bddb-8d7c-4ed9-95f5-f5772b530d05
         status: 200 OK
         code: 200
-        duration: 171.285ms
-    - id: 39
+        duration: 192.470334ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/589485f8-15b2-410e-85d4-3d74f9296dd6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:23:55.640162Z","id":"589485f8-15b2-410e-85d4-3d74f9296dd6","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:55.640162Z","id":"95219529-f98a-4b98-8da4-20cc832a881f","product_resource_id":"0545e66f-0214-4827-9aee-577b41b0ac91","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:55.640162Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9768b10b-22d9-4838-99d4-4009840bd7e1
+        status: 200 OK
+        code: 200
+        duration: 70.350209ms
+    - id: 41
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1955,8 +2053,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -1966,7 +2064,7 @@ interactions:
         trailer: {}
         content_length: 352
         uncompressed: false
-        body: '{"task":{"description":"server_poweroff","href_from":"/servers/3cca217c-aff0-4541-a55f-e1e7a765132f/action","href_result":"/servers/3cca217c-aff0-4541-a55f-e1e7a765132f","id":"101413b3-a152-4747-8596-c873b402bb5c","progress":0,"started_at":"2025-01-27T13:50:51.086899+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_poweroff","href_from":"/servers/0545e66f-0214-4827-9aee-577b41b0ac91/action","href_result":"/servers/0545e66f-0214-4827-9aee-577b41b0ac91","id":"18d5023c-088f-48eb-89f1-ae6ab30d0383","progress":0,"started_at":"2025-02-11T14:24:42.170838+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "352"
@@ -1975,11 +2073,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:50 GMT
+                - Tue, 11 Feb 2025 14:24:42 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/101413b3-a152-4747-8596-c873b402bb5c
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/18d5023c-088f-48eb-89f1-ae6ab30d0383
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1987,106 +2085,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e9671b4e-09ec-4df5-9c67-1a2ab2f3db07
+                - 6d8fd9a7-15fc-4591-8aee-9f3be5ad9b60
         status: 202 Accepted
         code: 202
-        duration: 245.461791ms
-    - id: 40
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2252
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:54.026950+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-condescending-ritchie","id":"3cca217c-aff0-4541-a55f-e1e7a765132f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"49","hypervisor_id":"302","node_id":"33","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:49","maintenances":[],"modification_date":"2025-01-27T13:50:50.907157+00:00","name":"tf-srv-condescending-ritchie","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:54.026950+00:00","export_uri":null,"id":"6d3751c6-6e80-4d35-ba02-8575652e491c","modification_date":"2025-01-27T13:49:54.026950+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3cca217c-aff0-4541-a55f-e1e7a765132f","name":"tf-srv-condescending-ritchie"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2252"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:51 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 3ef81965-8147-4715-9817-8238a605595b
-        status: 200 OK
-        code: 200
-        duration: 192.543042ms
-    - id: 41
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/08148f79-a166-49ea-adb5-177cf226c6cb
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:51 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 4677f189-b953-49c3-8cc0-08e8f3d153df
-        status: 204 No Content
-        code: 204
-        duration: 1.2932685s
+        duration: 261.103375ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2102,8 +2104,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91
         method: GET
       response:
         proto: HTTP/2.0
@@ -2111,20 +2113,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2252
+        content_length: 1785
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:54.026950+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-condescending-ritchie","id":"3cca217c-aff0-4541-a55f-e1e7a765132f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"49","hypervisor_id":"302","node_id":"33","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:49","maintenances":[],"modification_date":"2025-01-27T13:50:50.907157+00:00","name":"tf-srv-condescending-ritchie","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:54.026950+00:00","export_uri":null,"id":"6d3751c6-6e80-4d35-ba02-8575652e491c","modification_date":"2025-01-27T13:49:54.026950+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3cca217c-aff0-4541-a55f-e1e7a765132f","name":"tf-srv-condescending-ritchie"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:55.442736+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-bassi","id":"0545e66f-0214-4827-9aee-577b41b0ac91","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"604","node_id":"7","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:fb","maintenances":[],"modification_date":"2025-02-11T14:24:41.985776+00:00","name":"tf-srv-nervous-bassi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"589485f8-15b2-410e-85d4-3d74f9296dd6","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2252"
+                - "1785"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:56 GMT
+                - Tue, 11 Feb 2025 14:24:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2132,10 +2134,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3c99e4d1-f744-477a-afe5-2cff94b99ca6
+                - d006ee05-ac15-4978-b3a4-084386693862
         status: 200 OK
         code: 200
-        duration: 150.337791ms
+        duration: 153.341416ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2151,29 +2153,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/fb66d58e-9e88-426c-9dc8-70cf1124701e
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2252
+        content_length: 0
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:54.026950+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-condescending-ritchie","id":"3cca217c-aff0-4541-a55f-e1e7a765132f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"49","hypervisor_id":"302","node_id":"33","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:49","maintenances":[],"modification_date":"2025-01-27T13:50:50.907157+00:00","name":"tf-srv-condescending-ritchie","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:54.026950+00:00","export_uri":null,"id":"6d3751c6-6e80-4d35-ba02-8575652e491c","modification_date":"2025-01-27T13:49:54.026950+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3cca217c-aff0-4541-a55f-e1e7a765132f","name":"tf-srv-condescending-ritchie"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: ""
         headers:
-            Content-Length:
-                - "2252"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:01 GMT
+                - Tue, 11 Feb 2025 14:24:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2181,10 +2181,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 71affc73-2465-4fee-b357-6131f2861e15
-        status: 200 OK
-        code: 200
-        duration: 214.122125ms
+                - 64611af9-1b9c-4928-95c5-1938386dadb1
+        status: 204 No Content
+        code: 204
+        duration: 1.142627708s
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2200,8 +2200,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91
         method: GET
       response:
         proto: HTTP/2.0
@@ -2209,20 +2209,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2252
+        content_length: 1785
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:54.026950+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-condescending-ritchie","id":"3cca217c-aff0-4541-a55f-e1e7a765132f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"49","hypervisor_id":"302","node_id":"33","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:49","maintenances":[],"modification_date":"2025-01-27T13:50:50.907157+00:00","name":"tf-srv-condescending-ritchie","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:54.026950+00:00","export_uri":null,"id":"6d3751c6-6e80-4d35-ba02-8575652e491c","modification_date":"2025-01-27T13:49:54.026950+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3cca217c-aff0-4541-a55f-e1e7a765132f","name":"tf-srv-condescending-ritchie"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:55.442736+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-bassi","id":"0545e66f-0214-4827-9aee-577b41b0ac91","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"604","node_id":"7","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:fb","maintenances":[],"modification_date":"2025-02-11T14:24:41.985776+00:00","name":"tf-srv-nervous-bassi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"589485f8-15b2-410e-85d4-3d74f9296dd6","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2252"
+                - "1785"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:06 GMT
+                - Tue, 11 Feb 2025 14:24:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2230,10 +2230,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 33de196b-d633-4253-9e76-9e1671b30011
+                - 45524fa3-de23-42bd-a612-b920eea9b354
         status: 200 OK
         code: 200
-        duration: 147.371959ms
+        duration: 189.352417ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2249,8 +2249,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91
         method: GET
       response:
         proto: HTTP/2.0
@@ -2258,20 +2258,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2252
+        content_length: 1785
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:54.026950+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-condescending-ritchie","id":"3cca217c-aff0-4541-a55f-e1e7a765132f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"49","hypervisor_id":"302","node_id":"33","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:49","maintenances":[],"modification_date":"2025-01-27T13:50:50.907157+00:00","name":"tf-srv-condescending-ritchie","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:54.026950+00:00","export_uri":null,"id":"6d3751c6-6e80-4d35-ba02-8575652e491c","modification_date":"2025-01-27T13:49:54.026950+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3cca217c-aff0-4541-a55f-e1e7a765132f","name":"tf-srv-condescending-ritchie"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:55.442736+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-bassi","id":"0545e66f-0214-4827-9aee-577b41b0ac91","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"604","node_id":"7","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:fb","maintenances":[],"modification_date":"2025-02-11T14:24:41.985776+00:00","name":"tf-srv-nervous-bassi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"589485f8-15b2-410e-85d4-3d74f9296dd6","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2252"
+                - "1785"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:11 GMT
+                - Tue, 11 Feb 2025 14:24:52 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2279,10 +2279,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9cc0ec27-4946-4d90-af85-5349184f4b71
+                - f2044856-264d-4988-8c3e-734912d417d5
         status: 200 OK
         code: 200
-        duration: 164.736125ms
+        duration: 170.830458ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2298,8 +2298,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91
         method: GET
       response:
         proto: HTTP/2.0
@@ -2307,20 +2307,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 1785
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:54.026950+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-condescending-ritchie","id":"3cca217c-aff0-4541-a55f-e1e7a765132f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:49","maintenances":[],"modification_date":"2025-01-27T13:51:14.603805+00:00","name":"tf-srv-condescending-ritchie","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:54.026950+00:00","export_uri":null,"id":"6d3751c6-6e80-4d35-ba02-8575652e491c","modification_date":"2025-01-27T13:49:54.026950+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3cca217c-aff0-4541-a55f-e1e7a765132f","name":"tf-srv-condescending-ritchie"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:55.442736+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-bassi","id":"0545e66f-0214-4827-9aee-577b41b0ac91","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"604","node_id":"7","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:fb","maintenances":[],"modification_date":"2025-02-11T14:24:41.985776+00:00","name":"tf-srv-nervous-bassi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"589485f8-15b2-410e-85d4-3d74f9296dd6","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "1785"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:16 GMT
+                - Tue, 11 Feb 2025 14:24:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2328,10 +2328,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c8cfe47b-f381-4e9e-9707-2d7bd5891dd8
+                - 25c1f86e-b5f6-4657-9fa8-30b78fbeae33
         status: 200 OK
         code: 200
-        duration: 136.747667ms
+        duration: 204.150625ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2347,8 +2347,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91
         method: GET
       response:
         proto: HTTP/2.0
@@ -2356,20 +2356,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 1670
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:49:54.026950+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-condescending-ritchie","id":"3cca217c-aff0-4541-a55f-e1e7a765132f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:49","maintenances":[],"modification_date":"2025-01-27T13:51:14.603805+00:00","name":"tf-srv-condescending-ritchie","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:49:54.026950+00:00","export_uri":null,"id":"6d3751c6-6e80-4d35-ba02-8575652e491c","modification_date":"2025-01-27T13:49:54.026950+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3cca217c-aff0-4541-a55f-e1e7a765132f","name":"tf-srv-condescending-ritchie"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:55.442736+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-bassi","id":"0545e66f-0214-4827-9aee-577b41b0ac91","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:fb","maintenances":[],"modification_date":"2025-02-11T14:25:02.277816+00:00","name":"tf-srv-nervous-bassi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"589485f8-15b2-410e-85d4-3d74f9296dd6","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "1670"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:16 GMT
+                - Tue, 11 Feb 2025 14:25:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2377,10 +2377,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - acd5b2c2-519a-4db5-912c-b0a8202f40b8
+                - dbf2cc28-bceb-4be2-8841-a956a2841b32
         status: 200 OK
         code: 200
-        duration: 163.381458ms
+        duration: 142.463167ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2396,27 +2396,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 1670
         uncompressed: false
-        body: ""
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:55.442736+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-bassi","id":"0545e66f-0214-4827-9aee-577b41b0ac91","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:fb","maintenances":[],"modification_date":"2025-02-11T14:25:02.277816+00:00","name":"tf-srv-nervous-bassi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"589485f8-15b2-410e-85d4-3d74f9296dd6","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
+            Content-Length:
+                - "1670"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:17 GMT
+                - Tue, 11 Feb 2025 14:25:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2424,10 +2426,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1d5cb5bc-c2be-4b64-8967-4eaa73902ffd
-        status: 204 No Content
-        code: 204
-        duration: 165.919667ms
+                - a3f1b2df-f12c-4388-b99b-149f090a6dc4
+        status: 200 OK
+        code: 200
+        duration: 167.016166ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2443,106 +2445,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 143
-        uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"3cca217c-aff0-4541-a55f-e1e7a765132f","type":"not_found"}'
-        headers:
-            Content-Length:
-                - "143"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:17 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 17bbcdeb-13ac-4dc5-b7ec-26e1f8da199d
-        status: 404 Not Found
-        code: 404
-        duration: 89.788125ms
-    - id: 50
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/6d3751c6-6e80-4d35-ba02-8575652e491c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 446
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:49:54.026950+00:00","export_uri":null,"id":"6d3751c6-6e80-4d35-ba02-8575652e491c","modification_date":"2025-01-27T13:51:17.327768+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "446"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:17 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 8ca12014-1713-429a-b149-e491852d49ec
-        status: 200 OK
-        code: 200
-        duration: 107.703209ms
-    - id: 51
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/6d3751c6-6e80-4d35-ba02-8575652e491c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2559,9 +2463,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:17 GMT
+                - Tue, 11 Feb 2025 14:25:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2569,10 +2473,108 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a19b5bfd-89bb-4ff1-ad1b-51a084c6a842
+                - d9d00c2d-b504-4c5c-a0ca-afcfb2493df9
         status: 204 No Content
         code: 204
-        duration: 160.74975ms
+        duration: 247.977917ms
+    - id: 50
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"0545e66f-0214-4827-9aee-577b41b0ac91","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4e58a349-335d-4f50-881b-d4b1af6bab42
+        status: 404 Not Found
+        code: 404
+        duration: 90.806ms
+    - id: 51
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/589485f8-15b2-410e-85d4-3d74f9296dd6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"589485f8-15b2-410e-85d4-3d74f9296dd6","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - cca05781-68d6-4b9a-9b46-426bdc1ae6c9
+        status: 404 Not Found
+        code: 404
+        duration: 34.267375ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -2588,8 +2590,104 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3cca217c-aff0-4541-a55f-e1e7a765132f/private_nics/e79a2b17-16b1-472d-95f2-68877a95f3dc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/589485f8-15b2-410e-85d4-3d74f9296dd6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 494
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:23:55.640162Z","id":"589485f8-15b2-410e-85d4-3d74f9296dd6","last_detached_at":"2025-02-11T14:25:03.584076Z","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:25:03.584076Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "494"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - adaa00dc-20ed-4464-9301-6fb1c52d2b52
+        status: 200 OK
+        code: 200
+        duration: 86.734667ms
+    - id: 53
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/589485f8-15b2-410e-85d4-3d74f9296dd6
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - bb87c065-84f7-4fb4-982b-5fd52ec1a003
+        status: 204 No Content
+        code: 204
+        duration: 140.3455ms
+    - id: 54
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0545e66f-0214-4827-9aee-577b41b0ac91/private_nics/b4868c6d-2d73-4884-bcbf-7c8d6b48b198
         method: GET
       response:
         proto: HTTP/2.0
@@ -2599,7 +2697,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"3cca217c-aff0-4541-a55f-e1e7a765132f","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"0545e66f-0214-4827-9aee-577b41b0ac91","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -2608,9 +2706,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:17 GMT
+                - Tue, 11 Feb 2025 14:25:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2618,7 +2716,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 327c1974-db77-4890-9086-b638a1db4d11
+                - 37a07bca-1b9b-494c-9899-f890a091c176
         status: 404 Not Found
         code: 404
-        duration: 36.524708ms
+        duration: 29.8345ms

--- a/internal/services/instance/testdata/server-additional-volumes-detach.cassette.yaml
+++ b/internal/services/instance/testdata/server-additional-volumes-detach.cassette.yaml
@@ -18,7 +18,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes
         method: POST
       response:
@@ -29,7 +29,7 @@ interactions:
         trailer: {}
         content_length: 427
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:08.241549+00:00","export_uri":null,"id":"582cb88e-1142-42c7-95c6-5c9b9dfe74e5","modification_date":"2025-01-27T13:51:08.241549+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T15:28:45.073822+00:00","export_uri":null,"id":"df96dde1-31f6-48f8-9ad5-43bda9f53c68","modification_date":"2025-02-11T15:28:45.073822+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "427"
@@ -38,11 +38,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:08 GMT
+                - Tue, 11 Feb 2025 15:28:44 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/582cb88e-1142-42c7-95c6-5c9b9dfe74e5
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/df96dde1-31f6-48f8-9ad5-43bda9f53c68
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -50,10 +50,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e51f3616-ba56-497a-b154-44f94d993364
+                - 21f2a2df-bbb5-4b04-bfde-dc501f0319bb
         status: 201 Created
         code: 201
-        duration: 195.365958ms
+        duration: 456.532875ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -69,8 +69,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/582cb88e-1142-42c7-95c6-5c9b9dfe74e5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/df96dde1-31f6-48f8-9ad5-43bda9f53c68
         method: GET
       response:
         proto: HTTP/2.0
@@ -80,7 +80,7 @@ interactions:
         trailer: {}
         content_length: 427
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:08.241549+00:00","export_uri":null,"id":"582cb88e-1142-42c7-95c6-5c9b9dfe74e5","modification_date":"2025-01-27T13:51:08.241549+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T15:28:45.073822+00:00","export_uri":null,"id":"df96dde1-31f6-48f8-9ad5-43bda9f53c68","modification_date":"2025-02-11T15:28:45.073822+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "427"
@@ -89,9 +89,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:07 GMT
+                - Tue, 11 Feb 2025 15:28:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -99,10 +99,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f7b5463d-237a-47e5-a76a-c599f7bd85ef
+                - 9b818858-a374-44fa-b5e3-82e73e218253
         status: 200 OK
         code: 200
-        duration: 72.7205ms
+        duration: 99.675459ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -118,8 +118,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/582cb88e-1142-42c7-95c6-5c9b9dfe74e5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/df96dde1-31f6-48f8-9ad5-43bda9f53c68
         method: GET
       response:
         proto: HTTP/2.0
@@ -129,7 +129,7 @@ interactions:
         trailer: {}
         content_length: 427
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:08.241549+00:00","export_uri":null,"id":"582cb88e-1142-42c7-95c6-5c9b9dfe74e5","modification_date":"2025-01-27T13:51:08.241549+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T15:28:45.073822+00:00","export_uri":null,"id":"df96dde1-31f6-48f8-9ad5-43bda9f53c68","modification_date":"2025-02-11T15:28:45.073822+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "427"
@@ -138,9 +138,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:08 GMT
+                - Tue, 11 Feb 2025 15:28:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -148,10 +148,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9c7cba03-21d8-4fa6-bb3c-6561823f1c6d
+                - e6666d84-1b03-4d2c-a2d4-fed78d69b68d
         status: 200 OK
         code: 200
-        duration: 85.004542ms
+        duration: 106.368875ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -167,7 +167,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
         method: GET
       response:
@@ -176,22 +176,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 38539
+        content_length: 35639
         uncompressed: false
-        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
+        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
         headers:
             Content-Length:
-                - "38539"
+                - "35639"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:08 GMT
+                - Tue, 11 Feb 2025 15:28:45 GMT
             Link:
                 - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -199,12 +199,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ca1daf8c-ea09-457a-a277-042e970fedd3
+                - 89c90451-18ac-4930-89b6-b167bcf15b8a
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 45.839167ms
+        duration: 106.940833ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -220,7 +220,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
         method: GET
       response:
@@ -229,22 +229,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 14208
+        content_length: 13164
         uncompressed: false
-        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
         headers:
             Content-Length:
-                - "14208"
+                - "13164"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:08 GMT
+                - Tue, 11 Feb 2025 15:28:45 GMT
             Link:
                 - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -252,12 +252,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ba5d02f0-6eed-4f49-8d17-7b3fcf070b76
+                - 4fe471eb-1fa1-401e-ba86-9cde92fd2503
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 44.450917ms
+        duration: 64.29075ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -273,8 +273,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/582cb88e-1142-42c7-95c6-5c9b9dfe74e5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/df96dde1-31f6-48f8-9ad5-43bda9f53c68
         method: GET
       response:
         proto: HTTP/2.0
@@ -284,7 +284,7 @@ interactions:
         trailer: {}
         content_length: 427
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:08.241549+00:00","export_uri":null,"id":"582cb88e-1142-42c7-95c6-5c9b9dfe74e5","modification_date":"2025-01-27T13:51:08.241549+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T15:28:45.073822+00:00","export_uri":null,"id":"df96dde1-31f6-48f8-9ad5-43bda9f53c68","modification_date":"2025-02-11T15:28:45.073822+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "427"
@@ -293,9 +293,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:08 GMT
+                - Tue, 11 Feb 2025 15:28:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -303,10 +303,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b5fcb796-d1b4-4009-bb10-abc6853b581f
+                - ebf77e39-8d58-49cc-a6b8-e3d8a5d7366f
         status: 200 OK
         code: 200
-        duration: 85.996916ms
+        duration: 114.806291ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -322,8 +322,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_local&zone=fr-par-1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_sbs&zone=fr-par-1
         method: GET
       response:
         proto: HTTP/2.0
@@ -331,20 +331,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1300
+        content_length: 1296
         uncompressed: false
-        body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"56d4019c-8305-467a-a3f2-70498ad799df","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
+        body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"57509e82-ac3b-49b7-9970-97b60f40ff72","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"9b647e1e-253a-41e7-8c15-911c622ee2dc","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"}],"total_count":2}'
         headers:
             Content-Length:
-                - "1300"
+                - "1296"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:08 GMT
+                - Tue, 11 Feb 2025 15:28:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -352,28 +352,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5612a4b4-f043-4283-9084-8c92d69efedc
+                - 0dd32210-50c5-4f37-a4a3-0e64bcdc06a4
         status: 200 OK
         code: 200
-        duration: 73.114166ms
+        duration: 110.878ms
     - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 325
+        content_length: 284
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"foobar","dynamic_ip_required":true,"commercial_type":"DEV1-S","image":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"},"1":{"id":"582cb88e-1142-42c7-95c6-5c9b9dfe74e5","name":"foobar"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+        body: '{"name":"foobar","dynamic_ip_required":true,"commercial_type":"DEV1-S","image":"57509e82-ac3b-49b7-9970-97b60f40ff72","volumes":{"0":{"boot":false},"1":{"id":"df96dde1-31f6-48f8-9ad5-43bda9f53c68","name":"foobar"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
         method: POST
       response:
@@ -382,22 +382,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2566
+        content_length: 2178
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:09.216259+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:b7","maintenances":[],"modification_date":"2025-01-27T13:51:09.216259+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:09.216259+00:00","export_uri":null,"id":"1dc7ee0d-10fd-409b-b3c4-042d394791a5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:08.241549+00:00","export_uri":null,"id":"582cb88e-1142-42c7-95c6-5c9b9dfe74e5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"admin_password_encrypted_value":null,"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T15:28:46.367923+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"50065cc5-82db-40fb-8481-43b9d6d58709","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:71:a3","maintenances":[],"modification_date":"2025-02-11T15:28:46.367923+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T15:28:45.073822+00:00","export_uri":null,"id":"df96dde1-31f6-48f8-9ad5-43bda9f53c68","modification_date":"2025-02-11T15:28:46.367923+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"50065cc5-82db-40fb-8481-43b9d6d58709","name":"foobar"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2566"
+                - "2178"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:09 GMT
+                - Tue, 11 Feb 2025 15:28:46 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -405,10 +405,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0ed45431-006c-4921-ac23-f62379353b76
+                - 71049aa9-6212-4201-b9fe-f11eb3e398cf
         status: 201 Created
         code: 201
-        duration: 999.786667ms
+        duration: 1.464108708s
     - id: 8
       request:
         proto: HTTP/1.1
@@ -424,8 +424,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709
         method: GET
       response:
         proto: HTTP/2.0
@@ -433,20 +433,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2566
+        content_length: 2138
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:09.216259+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:b7","maintenances":[],"modification_date":"2025-01-27T13:51:09.216259+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:09.216259+00:00","export_uri":null,"id":"1dc7ee0d-10fd-409b-b3c4-042d394791a5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:08.241549+00:00","export_uri":null,"id":"582cb88e-1142-42c7-95c6-5c9b9dfe74e5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T15:28:46.367923+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"50065cc5-82db-40fb-8481-43b9d6d58709","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:71:a3","maintenances":[],"modification_date":"2025-02-11T15:28:46.367923+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T15:28:45.073822+00:00","export_uri":null,"id":"df96dde1-31f6-48f8-9ad5-43bda9f53c68","modification_date":"2025-02-11T15:28:46.367923+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"50065cc5-82db-40fb-8481-43b9d6d58709","name":"foobar"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2566"
+                - "2138"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:09 GMT
+                - Tue, 11 Feb 2025 15:28:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -454,10 +454,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 23b4dc66-ec35-42e9-a814-5391f3dc6d73
+                - 9ff5a1fc-011a-4d3a-845f-266bf6a282fa
         status: 200 OK
         code: 200
-        duration: 172.759291ms
+        duration: 206.415084ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -473,8 +473,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709
         method: GET
       response:
         proto: HTTP/2.0
@@ -482,20 +482,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2566
+        content_length: 2138
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:09.216259+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:b7","maintenances":[],"modification_date":"2025-01-27T13:51:09.216259+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:09.216259+00:00","export_uri":null,"id":"1dc7ee0d-10fd-409b-b3c4-042d394791a5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:08.241549+00:00","export_uri":null,"id":"582cb88e-1142-42c7-95c6-5c9b9dfe74e5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T15:28:46.367923+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"50065cc5-82db-40fb-8481-43b9d6d58709","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:71:a3","maintenances":[],"modification_date":"2025-02-11T15:28:46.367923+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T15:28:45.073822+00:00","export_uri":null,"id":"df96dde1-31f6-48f8-9ad5-43bda9f53c68","modification_date":"2025-02-11T15:28:46.367923+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"50065cc5-82db-40fb-8481-43b9d6d58709","name":"foobar"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2566"
+                - "2138"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:09 GMT
+                - Tue, 11 Feb 2025 15:28:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -503,11 +503,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4066ea45-217f-4460-a977-2cf93c487894
+                - b7ff25df-24c5-4569-ab08-4df7de20e810
         status: 200 OK
         code: 200
-        duration: 155.748459ms
+        duration: 307.830584ms
     - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/1c9d9721-c5d6-4b91-99fb-771a503d1478
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T15:28:46.586882Z","id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T15:28:46.586882Z","id":"173006c5-5a64-486f-829e-9a5a813fcd5f","product_resource_id":"50065cc5-82db-40fb-8481-43b9d6d58709","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T15:28:46.586882Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 15:28:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - dfd83083-24e3-4e57-8b75-e9b7530553a8
+        status: 200 OK
+        code: 200
+        duration: 92.918417ms
+    - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -524,8 +573,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -535,7 +584,7 @@ interactions:
         trailer: {}
         content_length: 357
         uncompressed: false
-        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16/action","href_result":"/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","id":"ad29b8a1-e082-4a14-b651-e9f95b60929b","progress":0,"started_at":"2025-01-27T13:51:10.268816+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/50065cc5-82db-40fb-8481-43b9d6d58709/action","href_result":"/servers/50065cc5-82db-40fb-8481-43b9d6d58709","id":"8fc1bfc3-83f1-4715-af71-7d6321300fe9","progress":0,"started_at":"2025-02-11T15:28:48.414886+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -544,11 +593,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:09 GMT
+                - Tue, 11 Feb 2025 15:28:47 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/ad29b8a1-e082-4a14-b651-e9f95b60929b
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/8fc1bfc3-83f1-4715-af71-7d6321300fe9
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -556,59 +605,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8b825e19-ed01-4895-8e44-708af42a7f4d
+                - dbd5794e-f5e3-4dcf-9c11-ab9c85ddbb1c
         status: 202 Accepted
         code: 202
-        duration: 260.302709ms
-    - id: 11
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2588
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:09.216259+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:b7","maintenances":[],"modification_date":"2025-01-27T13:51:10.064290+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:09.216259+00:00","export_uri":null,"id":"1dc7ee0d-10fd-409b-b3c4-042d394791a5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:08.241549+00:00","export_uri":null,"id":"582cb88e-1142-42c7-95c6-5c9b9dfe74e5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2588"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:10 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 28d46f72-8955-407e-8596-528b34ef8d29
-        status: 200 OK
-        code: 200
-        duration: 369.99875ms
+        duration: 606.992833ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -624,8 +624,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709
         method: GET
       response:
         proto: HTTP/2.0
@@ -633,20 +633,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3218
+        content_length: 2160
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:09.216259+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"304","node_id":"2","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:b7","maintenances":[],"modification_date":"2025-01-27T13:51:10.064290+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"282107ff-ee6c-44e3-b916-36268b17e232","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"282107ff-ee6c-44e3-b916-36268b17e232","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:09.216259+00:00","export_uri":null,"id":"1dc7ee0d-10fd-409b-b3c4-042d394791a5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:08.241549+00:00","export_uri":null,"id":"582cb88e-1142-42c7-95c6-5c9b9dfe74e5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T15:28:46.367923+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"50065cc5-82db-40fb-8481-43b9d6d58709","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:71:a3","maintenances":[],"modification_date":"2025-02-11T15:28:47.883247+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T15:28:45.073822+00:00","export_uri":null,"id":"df96dde1-31f6-48f8-9ad5-43bda9f53c68","modification_date":"2025-02-11T15:28:46.367923+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"50065cc5-82db-40fb-8481-43b9d6d58709","name":"foobar"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "3218"
+                - "2160"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:15 GMT
+                - Tue, 11 Feb 2025 15:28:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -654,10 +654,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9c65cd31-8f0a-495d-999b-841ba63301a1
+                - 53eaf697-541e-4c5c-adfe-8887555de58c
         status: 200 OK
         code: 200
-        duration: 183.890208ms
+        duration: 211.0615ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -673,8 +673,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709
         method: GET
       response:
         proto: HTTP/2.0
@@ -682,20 +682,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3218
+        content_length: 2817
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:09.216259+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"304","node_id":"2","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:b7","maintenances":[],"modification_date":"2025-01-27T13:51:10.064290+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"282107ff-ee6c-44e3-b916-36268b17e232","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"282107ff-ee6c-44e3-b916-36268b17e232","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:09.216259+00:00","export_uri":null,"id":"1dc7ee0d-10fd-409b-b3c4-042d394791a5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:08.241549+00:00","export_uri":null,"id":"582cb88e-1142-42c7-95c6-5c9b9dfe74e5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T15:28:46.367923+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"50065cc5-82db-40fb-8481-43b9d6d58709","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"604","node_id":"9","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:71:a3","maintenances":[],"modification_date":"2025-02-11T15:28:52.731637+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"72d0ef4e-8b26-41af-9d61-ff736f90f605","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"72d0ef4e-8b26-41af-9d61-ff736f90f605","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T15:28:45.073822+00:00","export_uri":null,"id":"df96dde1-31f6-48f8-9ad5-43bda9f53c68","modification_date":"2025-02-11T15:28:46.367923+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"50065cc5-82db-40fb-8481-43b9d6d58709","name":"foobar"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "3218"
+                - "2817"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:20 GMT
+                - Tue, 11 Feb 2025 15:28:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -703,10 +703,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5c0b4ada-008d-4fd9-a0ae-60ed986b6488
+                - 048970d3-a3cd-48c9-8da8-c4f2039da44e
         status: 200 OK
         code: 200
-        duration: 178.161542ms
+        duration: 794.139417ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -722,8 +722,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709
         method: GET
       response:
         proto: HTTP/2.0
@@ -731,20 +731,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3249
+        content_length: 2817
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:09.216259+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"304","node_id":"2","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:b7","maintenances":[],"modification_date":"2025-01-27T13:51:25.679829+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"282107ff-ee6c-44e3-b916-36268b17e232","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"282107ff-ee6c-44e3-b916-36268b17e232","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:09.216259+00:00","export_uri":null,"id":"1dc7ee0d-10fd-409b-b3c4-042d394791a5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:08.241549+00:00","export_uri":null,"id":"582cb88e-1142-42c7-95c6-5c9b9dfe74e5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T15:28:46.367923+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"50065cc5-82db-40fb-8481-43b9d6d58709","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"604","node_id":"9","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:71:a3","maintenances":[],"modification_date":"2025-02-11T15:28:52.731637+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"72d0ef4e-8b26-41af-9d61-ff736f90f605","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"72d0ef4e-8b26-41af-9d61-ff736f90f605","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T15:28:45.073822+00:00","export_uri":null,"id":"df96dde1-31f6-48f8-9ad5-43bda9f53c68","modification_date":"2025-02-11T15:28:46.367923+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"50065cc5-82db-40fb-8481-43b9d6d58709","name":"foobar"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "3249"
+                - "2817"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:26 GMT
+                - Tue, 11 Feb 2025 15:28:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -752,10 +752,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 70c99ba4-f506-4851-ab5a-b2648b5d56d5
+                - 00ac00fb-1634-4ffe-9877-07b4a962955a
         status: 200 OK
         code: 200
-        duration: 145.614208ms
+        duration: 203.113125ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -771,8 +771,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/1c9d9721-c5d6-4b91-99fb-771a503d1478
         method: GET
       response:
         proto: HTTP/2.0
@@ -780,20 +780,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3249
+        content_length: 143
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:09.216259+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"304","node_id":"2","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:b7","maintenances":[],"modification_date":"2025-01-27T13:51:25.679829+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"282107ff-ee6c-44e3-b916-36268b17e232","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"282107ff-ee6c-44e3-b916-36268b17e232","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:09.216259+00:00","export_uri":null,"id":"1dc7ee0d-10fd-409b-b3c4-042d394791a5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:08.241549+00:00","export_uri":null,"id":"582cb88e-1142-42c7-95c6-5c9b9dfe74e5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","type":"not_found"}'
         headers:
             Content-Length:
-                - "3249"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:25 GMT
+                - Tue, 11 Feb 2025 15:28:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -801,10 +801,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e4753f0d-c408-493f-9baf-996e49c8407a
-        status: 200 OK
-        code: 200
-        duration: 133.303917ms
+                - b27ca352-76d7-47fb-a505-794702ad21a7
+        status: 404 Not Found
+        code: 404
+        duration: 55.742ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -820,8 +820,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/1dc7ee0d-10fd-409b-b3c4-042d394791a5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/1c9d9721-c5d6-4b91-99fb-771a503d1478
         method: GET
       response:
         proto: HTTP/2.0
@@ -829,20 +829,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 506
+        content_length: 701
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:09.216259+00:00","export_uri":null,"id":"1dc7ee0d-10fd-409b-b3c4-042d394791a5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T15:28:46.586882Z","id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T15:28:46.586882Z","id":"173006c5-5a64-486f-829e-9a5a813fcd5f","product_resource_id":"50065cc5-82db-40fb-8481-43b9d6d58709","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T15:28:46.586882Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "506"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:25 GMT
+                - Tue, 11 Feb 2025 15:28:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -850,10 +850,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3abbd8fc-a9e0-4e7a-a8f9-c3f103bb6230
+                - a6cb0659-ea5f-43ca-ac6c-0e5e90a9db2d
         status: 200 OK
         code: 200
-        duration: 82.5435ms
+        duration: 79.615916ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -869,8 +869,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -889,9 +889,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:26 GMT
+                - Tue, 11 Feb 2025 15:28:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -899,10 +899,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 388c7ff2-472f-45a8-b144-a197eaa9d7e5
+                - 5c025006-25ff-4dfd-b445-980d21aa361f
         status: 200 OK
         code: 200
-        duration: 85.153167ms
+        duration: 104.097708ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -918,8 +918,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -938,11 +938,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:26 GMT
+                - Tue, 11 Feb 2025 15:28:54 GMT
             Link:
-                - </servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/50065cc5-82db-40fb-8481-43b9d6d58709/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -950,12 +950,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f8d7a47f-8ae2-4698-a50b-13097a68a110
+                - 0628510b-90c2-4255-8dcb-21da4e1c62a5
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 89.856375ms
+        duration: 108.403041ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -971,8 +971,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/582cb88e-1142-42c7-95c6-5c9b9dfe74e5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/df96dde1-31f6-48f8-9ad5-43bda9f53c68
         method: GET
       response:
         proto: HTTP/2.0
@@ -982,7 +982,7 @@ interactions:
         trailer: {}
         content_length: 487
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:08.241549+00:00","export_uri":null,"id":"582cb88e-1142-42c7-95c6-5c9b9dfe74e5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T15:28:45.073822+00:00","export_uri":null,"id":"df96dde1-31f6-48f8-9ad5-43bda9f53c68","modification_date":"2025-02-11T15:28:46.367923+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"50065cc5-82db-40fb-8481-43b9d6d58709","name":"foobar"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "487"
@@ -991,9 +991,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:26 GMT
+                - Tue, 11 Feb 2025 15:28:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1001,10 +1001,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 22db535e-b4c4-417e-b68d-2d82b5e58ddb
+                - c4b89a04-1368-4811-a0f2-ae80f62edcc7
         status: 200 OK
         code: 200
-        duration: 98.693916ms
+        duration: 112.385958ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1020,8 +1020,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709
         method: GET
       response:
         proto: HTTP/2.0
@@ -1029,20 +1029,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3249
+        content_length: 2817
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:09.216259+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"304","node_id":"2","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:b7","maintenances":[],"modification_date":"2025-01-27T13:51:25.679829+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"282107ff-ee6c-44e3-b916-36268b17e232","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"282107ff-ee6c-44e3-b916-36268b17e232","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:09.216259+00:00","export_uri":null,"id":"1dc7ee0d-10fd-409b-b3c4-042d394791a5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:08.241549+00:00","export_uri":null,"id":"582cb88e-1142-42c7-95c6-5c9b9dfe74e5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T15:28:46.367923+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"50065cc5-82db-40fb-8481-43b9d6d58709","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"604","node_id":"9","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:71:a3","maintenances":[],"modification_date":"2025-02-11T15:28:52.731637+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"72d0ef4e-8b26-41af-9d61-ff736f90f605","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"72d0ef4e-8b26-41af-9d61-ff736f90f605","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T15:28:45.073822+00:00","export_uri":null,"id":"df96dde1-31f6-48f8-9ad5-43bda9f53c68","modification_date":"2025-02-11T15:28:46.367923+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"50065cc5-82db-40fb-8481-43b9d6d58709","name":"foobar"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "3249"
+                - "2817"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:26 GMT
+                - Tue, 11 Feb 2025 15:28:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1050,10 +1050,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 61acabd7-c214-45ee-9b1c-75c23eea1155
+                - c6d9b411-059f-43e8-80de-1beea5d32fe8
         status: 200 OK
         code: 200
-        duration: 143.346833ms
+        duration: 331.610541ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1069,8 +1069,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/1dc7ee0d-10fd-409b-b3c4-042d394791a5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/1c9d9721-c5d6-4b91-99fb-771a503d1478
         method: GET
       response:
         proto: HTTP/2.0
@@ -1078,20 +1078,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 506
+        content_length: 143
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:09.216259+00:00","export_uri":null,"id":"1dc7ee0d-10fd-409b-b3c4-042d394791a5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","type":"not_found"}'
         headers:
             Content-Length:
-                - "506"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:26 GMT
+                - Tue, 11 Feb 2025 15:28:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1099,10 +1099,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 32b849f7-f5be-48a2-9d5a-1acd3399dfd6
-        status: 200 OK
-        code: 200
-        duration: 91.448541ms
+                - 85a0ae78-9212-400f-81d4-6678a0f6c1d8
+        status: 404 Not Found
+        code: 404
+        duration: 65.093375ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1118,8 +1118,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/1c9d9721-c5d6-4b91-99fb-771a503d1478
         method: GET
       response:
         proto: HTTP/2.0
@@ -1127,20 +1127,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 701
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"created_at":"2025-02-11T15:28:46.586882Z","id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T15:28:46.586882Z","id":"173006c5-5a64-486f-829e-9a5a813fcd5f","product_resource_id":"50065cc5-82db-40fb-8481-43b9d6d58709","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T15:28:46.586882Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "17"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:27 GMT
+                - Tue, 11 Feb 2025 15:28:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1148,10 +1148,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5b4c3ca4-1de3-4adf-b4c6-96e5c31c92ff
+                - 5a51ce32-9887-4e2b-add0-95dbdda149ba
         status: 200 OK
         code: 200
-        duration: 99.915209ms
+        duration: 101.854167ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1167,8 +1167,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1176,22 +1176,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 17
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "20"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:27 GMT
-            Link:
-                - </servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 15:28:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1199,12 +1197,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9b771fd2-745f-4ad8-ad9c-9d031b784cb1
-            X-Total-Count:
-                - "0"
+                - d2b30e3b-f96c-4b51-ae95-7e9a6b2d120d
         status: 200 OK
         code: 200
-        duration: 94.037959ms
+        duration: 91.608959ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1220,8 +1216,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/582cb88e-1142-42c7-95c6-5c9b9dfe74e5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1229,20 +1225,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 487
+        content_length: 20
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:08.241549+00:00","export_uri":null,"id":"582cb88e-1142-42c7-95c6-5c9b9dfe74e5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "487"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:27 GMT
+                - Tue, 11 Feb 2025 15:28:55 GMT
+            Link:
+                - </servers/50065cc5-82db-40fb-8481-43b9d6d58709/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1250,10 +1248,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7717b967-0f3e-4d91-8317-9628b0958c57
+                - 258f0e22-a193-47cd-b29e-4aff2063a005
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 93.536792ms
+        duration: 117.438333ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1269,8 +1269,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/df96dde1-31f6-48f8-9ad5-43bda9f53c68
         method: GET
       response:
         proto: HTTP/2.0
@@ -1278,20 +1278,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3249
+        content_length: 487
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:09.216259+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"304","node_id":"2","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:b7","maintenances":[],"modification_date":"2025-01-27T13:51:25.679829+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"282107ff-ee6c-44e3-b916-36268b17e232","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"282107ff-ee6c-44e3-b916-36268b17e232","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:09.216259+00:00","export_uri":null,"id":"1dc7ee0d-10fd-409b-b3c4-042d394791a5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:08.241549+00:00","export_uri":null,"id":"582cb88e-1142-42c7-95c6-5c9b9dfe74e5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T15:28:45.073822+00:00","export_uri":null,"id":"df96dde1-31f6-48f8-9ad5-43bda9f53c68","modification_date":"2025-02-11T15:28:46.367923+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"50065cc5-82db-40fb-8481-43b9d6d58709","name":"foobar"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "3249"
+                - "487"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:27 GMT
+                - Tue, 11 Feb 2025 15:28:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1299,10 +1299,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9a7bbada-7a97-4f68-86c8-a20dc2d0b762
+                - ee699458-fb9d-496e-841f-591c0c18b65e
         status: 200 OK
         code: 200
-        duration: 167.138792ms
+        duration: 103.044958ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1318,8 +1318,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/1dc7ee0d-10fd-409b-b3c4-042d394791a5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709
         method: GET
       response:
         proto: HTTP/2.0
@@ -1327,20 +1327,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 506
+        content_length: 2817
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:09.216259+00:00","export_uri":null,"id":"1dc7ee0d-10fd-409b-b3c4-042d394791a5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T15:28:46.367923+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"50065cc5-82db-40fb-8481-43b9d6d58709","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"604","node_id":"9","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:71:a3","maintenances":[],"modification_date":"2025-02-11T15:28:52.731637+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"72d0ef4e-8b26-41af-9d61-ff736f90f605","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"72d0ef4e-8b26-41af-9d61-ff736f90f605","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T15:28:45.073822+00:00","export_uri":null,"id":"df96dde1-31f6-48f8-9ad5-43bda9f53c68","modification_date":"2025-02-11T15:28:46.367923+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"50065cc5-82db-40fb-8481-43b9d6d58709","name":"foobar"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "506"
+                - "2817"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:27 GMT
+                - Tue, 11 Feb 2025 15:28:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1348,10 +1348,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - eaac398c-af3b-4992-ba9c-3196e6edaad0
+                - ed678963-47bd-458a-94cb-fb5be9bf7ba1
         status: 200 OK
         code: 200
-        duration: 91.913458ms
+        duration: 217.997083ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1367,8 +1367,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/1c9d9721-c5d6-4b91-99fb-771a503d1478
         method: GET
       response:
         proto: HTTP/2.0
@@ -1376,20 +1376,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 143
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","type":"not_found"}'
         headers:
             Content-Length:
-                - "17"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:27 GMT
+                - Tue, 11 Feb 2025 15:28:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1397,10 +1397,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 94ddeff9-01d9-481f-bdfe-2b2df513cd93
-        status: 200 OK
-        code: 200
-        duration: 92.566958ms
+                - c5aff6b8-b953-4f23-b21d-57e2ed3aba1c
+        status: 404 Not Found
+        code: 404
+        duration: 62.181708ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1416,8 +1416,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/1c9d9721-c5d6-4b91-99fb-771a503d1478
         method: GET
       response:
         proto: HTTP/2.0
@@ -1425,22 +1425,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 701
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"created_at":"2025-02-11T15:28:46.586882Z","id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T15:28:46.586882Z","id":"173006c5-5a64-486f-829e-9a5a813fcd5f","product_resource_id":"50065cc5-82db-40fb-8481-43b9d6d58709","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T15:28:46.586882Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "20"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:27 GMT
-            Link:
-                - </servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 15:28:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1448,12 +1446,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c1581ed1-f6b2-4963-93b3-9d067bb0451f
-            X-Total-Count:
-                - "0"
+                - 19b9f4e8-02b1-4fd6-a08a-47483489629e
         status: 200 OK
         code: 200
-        duration: 72.3925ms
+        duration: 92.81475ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1469,8 +1465,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1478,20 +1474,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3249
+        content_length: 17
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:09.216259+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"304","node_id":"2","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:b7","maintenances":[],"modification_date":"2025-01-27T13:51:25.679829+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"282107ff-ee6c-44e3-b916-36268b17e232","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"282107ff-ee6c-44e3-b916-36268b17e232","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:09.216259+00:00","export_uri":null,"id":"1dc7ee0d-10fd-409b-b3c4-042d394791a5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:08.241549+00:00","export_uri":null,"id":"582cb88e-1142-42c7-95c6-5c9b9dfe74e5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "3249"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:28 GMT
+                - Tue, 11 Feb 2025 15:28:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1499,50 +1495,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3dd93ec2-2a5e-4e53-a810-067ac8e56f31
+                - 6ad7c497-4d87-49c8-8a7d-969d51bd8cbc
         status: 200 OK
         code: 200
-        duration: 164.393583ms
+        duration: 99.737584ms
     - id: 30
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 106
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"volumes":{"0":{"id":"1dc7ee0d-10fd-409b-b3c4-042d394791a5","boot":false,"name":"tf-vol-admiring-cerf"}}}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16
-        method: PATCH
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709/private_nics
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2752
+        content_length: 20
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:09.216259+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"304","node_id":"2","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:b7","maintenances":[],"modification_date":"2025-01-27T13:51:25.679829+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"282107ff-ee6c-44e3-b916-36268b17e232","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"282107ff-ee6c-44e3-b916-36268b17e232","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:09.216259+00:00","export_uri":null,"id":"1dc7ee0d-10fd-409b-b3c4-042d394791a5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "2752"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:28 GMT
+                - Tue, 11 Feb 2025 15:28:56 GMT
+            Link:
+                - </servers/50065cc5-82db-40fb-8481-43b9d6d58709/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1550,10 +1546,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3feda7da-c451-4b73-92d9-bdb3a0905e47
+                - 12428c91-6712-470d-95d3-7ac2e8b6fdb4
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 612.186084ms
+        duration: 101.123166ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1569,8 +1567,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709
         method: GET
       response:
         proto: HTTP/2.0
@@ -1578,20 +1576,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2752
+        content_length: 2817
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:09.216259+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"304","node_id":"2","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:b7","maintenances":[],"modification_date":"2025-01-27T13:51:25.679829+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"282107ff-ee6c-44e3-b916-36268b17e232","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"282107ff-ee6c-44e3-b916-36268b17e232","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:09.216259+00:00","export_uri":null,"id":"1dc7ee0d-10fd-409b-b3c4-042d394791a5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T15:28:46.367923+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"50065cc5-82db-40fb-8481-43b9d6d58709","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"604","node_id":"9","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:71:a3","maintenances":[],"modification_date":"2025-02-11T15:28:52.731637+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"72d0ef4e-8b26-41af-9d61-ff736f90f605","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"72d0ef4e-8b26-41af-9d61-ff736f90f605","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T15:28:45.073822+00:00","export_uri":null,"id":"df96dde1-31f6-48f8-9ad5-43bda9f53c68","modification_date":"2025-02-11T15:28:46.367923+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"50065cc5-82db-40fb-8481-43b9d6d58709","name":"foobar"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2752"
+                - "2817"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:29 GMT
+                - Tue, 11 Feb 2025 15:28:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1599,48 +1597,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3f353ada-3f7e-453e-b78c-40c43aa3306f
+                - 7c1f2d0f-1594-4bdd-8547-82215ec73389
         status: 200 OK
         code: 200
-        duration: 152.536ms
+        duration: 194.540375ms
     - id: 32
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 107
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"volumes":{"0":{"id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","boot":false,"name":"tf-vol-happy-meninsky"}}}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709
+        method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2752
+        content_length: 2320
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:09.216259+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"304","node_id":"2","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:b7","maintenances":[],"modification_date":"2025-01-27T13:51:25.679829+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"282107ff-ee6c-44e3-b916-36268b17e232","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"282107ff-ee6c-44e3-b916-36268b17e232","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:09.216259+00:00","export_uri":null,"id":"1dc7ee0d-10fd-409b-b3c4-042d394791a5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T15:28:46.367923+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"50065cc5-82db-40fb-8481-43b9d6d58709","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"604","node_id":"9","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:71:a3","maintenances":[],"modification_date":"2025-02-11T15:28:52.731637+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"72d0ef4e-8b26-41af-9d61-ff736f90f605","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"72d0ef4e-8b26-41af-9d61-ff736f90f605","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2752"
+                - "2320"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:29 GMT
+                - Tue, 11 Feb 2025 15:28:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1648,10 +1648,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5cf02b96-3cd5-400f-a328-083948726716
+                - 7d77dc64-abc8-4cfa-aaec-6069bec6f0af
         status: 200 OK
         code: 200
-        duration: 157.676708ms
+        duration: 824.363167ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1667,8 +1667,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/1dc7ee0d-10fd-409b-b3c4-042d394791a5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709
         method: GET
       response:
         proto: HTTP/2.0
@@ -1676,20 +1676,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 506
+        content_length: 2320
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:09.216259+00:00","export_uri":null,"id":"1dc7ee0d-10fd-409b-b3c4-042d394791a5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T15:28:46.367923+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"50065cc5-82db-40fb-8481-43b9d6d58709","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"604","node_id":"9","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:71:a3","maintenances":[],"modification_date":"2025-02-11T15:28:52.731637+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"72d0ef4e-8b26-41af-9d61-ff736f90f605","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"72d0ef4e-8b26-41af-9d61-ff736f90f605","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "506"
+                - "2320"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:28 GMT
+                - Tue, 11 Feb 2025 15:28:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1697,10 +1697,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 53dd9367-6a35-4380-a058-0394baa54598
+                - fdabf947-6ec3-4c23-b585-c524af0b5f01
         status: 200 OK
         code: 200
-        duration: 93.169875ms
+        duration: 215.864292ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1716,8 +1716,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709
         method: GET
       response:
         proto: HTTP/2.0
@@ -1725,20 +1725,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 2320
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T15:28:46.367923+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"50065cc5-82db-40fb-8481-43b9d6d58709","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"604","node_id":"9","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:71:a3","maintenances":[],"modification_date":"2025-02-11T15:28:52.731637+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"72d0ef4e-8b26-41af-9d61-ff736f90f605","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"72d0ef4e-8b26-41af-9d61-ff736f90f605","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "17"
+                - "2320"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:29 GMT
+                - Tue, 11 Feb 2025 15:28:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1746,10 +1746,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0e399283-96f8-4e71-ada8-41155bae778e
+                - cef49943-1687-488d-94ed-eb3ece11359a
         status: 200 OK
         code: 200
-        duration: 74.93575ms
+        duration: 284.290667ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1765,8 +1765,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/1c9d9721-c5d6-4b91-99fb-771a503d1478
         method: GET
       response:
         proto: HTTP/2.0
@@ -1774,22 +1774,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 143
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","type":"not_found"}'
         headers:
             Content-Length:
-                - "20"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:29 GMT
-            Link:
-                - </servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 15:28:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1797,12 +1795,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 484e7adf-aa01-4c14-8229-bed81138938b
-            X-Total-Count:
-                - "0"
-        status: 200 OK
-        code: 200
-        duration: 82.34275ms
+                - 2bf57112-82d3-49d5-8342-71e6c94546b3
+        status: 404 Not Found
+        code: 404
+        duration: 56.079125ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1818,8 +1814,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/582cb88e-1142-42c7-95c6-5c9b9dfe74e5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/1c9d9721-c5d6-4b91-99fb-771a503d1478
         method: GET
       response:
         proto: HTTP/2.0
@@ -1827,20 +1823,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 428
+        content_length: 701
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:08.241549+00:00","export_uri":null,"id":"582cb88e-1142-42c7-95c6-5c9b9dfe74e5","modification_date":"2025-01-27T13:51:28.502967+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T15:28:46.586882Z","id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T15:28:46.586882Z","id":"173006c5-5a64-486f-829e-9a5a813fcd5f","product_resource_id":"50065cc5-82db-40fb-8481-43b9d6d58709","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T15:28:46.586882Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "428"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:29 GMT
+                - Tue, 11 Feb 2025 15:28:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1848,10 +1844,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 215d9d36-1d99-47be-af03-e67dcb03ded8
+                - f1ff9546-4912-4210-a634-c8c13f091a44
         status: 200 OK
         code: 200
-        duration: 79.8225ms
+        duration: 92.725208ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1867,155 +1863,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/582cb88e-1142-42c7-95c6-5c9b9dfe74e5
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 428
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:08.241549+00:00","export_uri":null,"id":"582cb88e-1142-42c7-95c6-5c9b9dfe74e5","modification_date":"2025-01-27T13:51:28.502967+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "428"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:29 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 3defb600-50b6-4e41-b50e-01baab4f8790
-        status: 200 OK
-        code: 200
-        duration: 88.777541ms
-    - id: 38
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2752
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:09.216259+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"304","node_id":"2","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:b7","maintenances":[],"modification_date":"2025-01-27T13:51:25.679829+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"282107ff-ee6c-44e3-b916-36268b17e232","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"282107ff-ee6c-44e3-b916-36268b17e232","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:09.216259+00:00","export_uri":null,"id":"1dc7ee0d-10fd-409b-b3c4-042d394791a5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2752"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:29 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 2b7e89c7-2daa-4a4b-a889-1eaac34296bd
-        status: 200 OK
-        code: 200
-        duration: 165.985625ms
-    - id: 39
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/1dc7ee0d-10fd-409b-b3c4-042d394791a5
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 506
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:09.216259+00:00","export_uri":null,"id":"1dc7ee0d-10fd-409b-b3c4-042d394791a5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "506"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:29 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - c7220151-c26d-4e44-b50b-7f8e90781f0b
-        status: 200 OK
-        code: 200
-        duration: 85.547375ms
-    - id: 40
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -2034,9 +1883,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:30 GMT
+                - Tue, 11 Feb 2025 15:28:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2044,11 +1893,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 22312b48-2214-4603-9aa1-f995f6bcf72b
+                - b283d43c-6403-4c61-ae79-98701d0c100b
         status: 200 OK
         code: 200
-        duration: 77.779917ms
-    - id: 41
+        duration: 95.68625ms
+    - id: 38
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2063,8 +1912,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -2083,11 +1932,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:29 GMT
+                - Tue, 11 Feb 2025 15:28:58 GMT
             Link:
-                - </servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/50065cc5-82db-40fb-8481-43b9d6d58709/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2095,12 +1944,159 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 03842471-caa8-4190-9386-8c7cf7e226ee
+                - 320bea38-f42a-49d8-b947-6d8c99c72193
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 91.221875ms
+        duration: 108.508542ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/df96dde1-31f6-48f8-9ad5-43bda9f53c68
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 428
+        uncompressed: false
+        body: '{"volume":{"creation_date":"2025-02-11T15:28:45.073822+00:00","export_uri":null,"id":"df96dde1-31f6-48f8-9ad5-43bda9f53c68","modification_date":"2025-02-11T15:28:57.466065+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "428"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 15:28:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4e98065a-0ea4-426f-8fc6-51528141b2c3
+        status: 200 OK
+        code: 200
+        duration: 122.154125ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/df96dde1-31f6-48f8-9ad5-43bda9f53c68
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 428
+        uncompressed: false
+        body: '{"volume":{"creation_date":"2025-02-11T15:28:45.073822+00:00","export_uri":null,"id":"df96dde1-31f6-48f8-9ad5-43bda9f53c68","modification_date":"2025-02-11T15:28:57.466065+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "428"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 15:28:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d472da2c-c561-4c26-8844-5bba7961c512
+        status: 200 OK
+        code: 200
+        duration: 103.535667ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2320
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T15:28:46.367923+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"50065cc5-82db-40fb-8481-43b9d6d58709","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"604","node_id":"9","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:71:a3","maintenances":[],"modification_date":"2025-02-11T15:28:52.731637+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"72d0ef4e-8b26-41af-9d61-ff736f90f605","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"72d0ef4e-8b26-41af-9d61-ff736f90f605","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2320"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 15:28:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 28e281d2-919f-4dcb-80ed-4f32684e42fe
+        status: 200 OK
+        code: 200
+        duration: 176.229584ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2116,8 +2112,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/582cb88e-1142-42c7-95c6-5c9b9dfe74e5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/1c9d9721-c5d6-4b91-99fb-771a503d1478
         method: GET
       response:
         proto: HTTP/2.0
@@ -2125,20 +2121,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 428
+        content_length: 143
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:08.241549+00:00","export_uri":null,"id":"582cb88e-1142-42c7-95c6-5c9b9dfe74e5","modification_date":"2025-01-27T13:51:28.502967+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","type":"not_found"}'
         headers:
             Content-Length:
-                - "428"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:30 GMT
+                - Tue, 11 Feb 2025 15:28:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2146,10 +2142,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8f02f0a9-c90e-4703-bbcd-7e1c177e7b13
-        status: 200 OK
-        code: 200
-        duration: 75.408042ms
+                - 5605fd09-7069-41ef-8b97-8e8dc873e085
+        status: 404 Not Found
+        code: 404
+        duration: 51.329667ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2165,8 +2161,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/1c9d9721-c5d6-4b91-99fb-771a503d1478
         method: GET
       response:
         proto: HTTP/2.0
@@ -2174,20 +2170,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2752
+        content_length: 701
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:09.216259+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"304","node_id":"2","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:b7","maintenances":[],"modification_date":"2025-01-27T13:51:25.679829+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"282107ff-ee6c-44e3-b916-36268b17e232","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"282107ff-ee6c-44e3-b916-36268b17e232","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:09.216259+00:00","export_uri":null,"id":"1dc7ee0d-10fd-409b-b3c4-042d394791a5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T15:28:46.586882Z","id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T15:28:46.586882Z","id":"173006c5-5a64-486f-829e-9a5a813fcd5f","product_resource_id":"50065cc5-82db-40fb-8481-43b9d6d58709","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T15:28:46.586882Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2752"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:30 GMT
+                - Tue, 11 Feb 2025 15:28:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2195,11 +2191,260 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c9ffc779-c755-4de9-a670-d9eb5e5d75c2
+                - aa9d7181-1c43-41c4-a7ac-d90d2c250c9d
         status: 200 OK
         code: 200
-        duration: 138.725833ms
+        duration: 96.710167ms
     - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709/user_data
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 17
+        uncompressed: false
+        body: '{"user_data":[]}'
+        headers:
+            Content-Length:
+                - "17"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 15:28:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0913d75f-7258-4aa7-a83f-46876461b142
+        status: 200 OK
+        code: 200
+        duration: 274.771292ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 20
+        uncompressed: false
+        body: '{"private_nics":[]}'
+        headers:
+            Content-Length:
+                - "20"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 15:28:59 GMT
+            Link:
+                - </servers/50065cc5-82db-40fb-8481-43b9d6d58709/private_nics?page=0&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6f32454c-961d-4045-b21b-88c5b5ec1acb
+            X-Total-Count:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 101.127041ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/df96dde1-31f6-48f8-9ad5-43bda9f53c68
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 428
+        uncompressed: false
+        body: '{"volume":{"creation_date":"2025-02-11T15:28:45.073822+00:00","export_uri":null,"id":"df96dde1-31f6-48f8-9ad5-43bda9f53c68","modification_date":"2025-02-11T15:28:57.466065+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "428"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 15:29:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 221b4490-6fec-4dc3-9513-7d942bb5768c
+        status: 200 OK
+        code: 200
+        duration: 103.003375ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2320
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T15:28:46.367923+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"50065cc5-82db-40fb-8481-43b9d6d58709","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"604","node_id":"9","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:71:a3","maintenances":[],"modification_date":"2025-02-11T15:28:52.731637+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"72d0ef4e-8b26-41af-9d61-ff736f90f605","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"72d0ef4e-8b26-41af-9d61-ff736f90f605","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2320"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 15:29:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d6068bc8-8f9a-40fa-ae9a-42508bc00063
+        status: 200 OK
+        code: 200
+        duration: 240.741333ms
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/1c9d9721-c5d6-4b91-99fb-771a503d1478
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T15:28:46.586882Z","id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T15:28:46.586882Z","id":"173006c5-5a64-486f-829e-9a5a813fcd5f","product_resource_id":"50065cc5-82db-40fb-8481-43b9d6d58709","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T15:28:46.586882Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 15:29:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 43b09aaa-0c0b-4c21-b81c-aa2fb8542088
+        status: 200 OK
+        code: 200
+        duration: 117.226792ms
+    - id: 49
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2216,8 +2461,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -2227,7 +2472,7 @@ interactions:
         trailer: {}
         content_length: 352
         uncompressed: false
-        body: '{"task":{"description":"server_poweroff","href_from":"/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16/action","href_result":"/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","id":"240ef554-6e11-483e-9d14-de20f5800b60","progress":0,"started_at":"2025-01-27T13:51:30.932158+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_poweroff","href_from":"/servers/50065cc5-82db-40fb-8481-43b9d6d58709/action","href_result":"/servers/50065cc5-82db-40fb-8481-43b9d6d58709","id":"3c1d5702-0566-4ab3-8f3c-c4244e3200b6","progress":0,"started_at":"2025-02-11T15:29:01.007960+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "352"
@@ -2236,11 +2481,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:30 GMT
+                - Tue, 11 Feb 2025 15:29:00 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/240ef554-6e11-483e-9d14-de20f5800b60
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/3c1d5702-0566-4ab3-8f3c-c4244e3200b6
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2248,255 +2493,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dbdf7d4c-ece5-4414-b81a-90e49406f646
+                - 40854988-616c-43a8-8101-f45217ea6645
         status: 202 Accepted
         code: 202
-        duration: 212.179ms
-    - id: 45
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2712
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:09.216259+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"304","node_id":"2","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:b7","maintenances":[],"modification_date":"2025-01-27T13:51:30.763207+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"282107ff-ee6c-44e3-b916-36268b17e232","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"282107ff-ee6c-44e3-b916-36268b17e232","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:09.216259+00:00","export_uri":null,"id":"1dc7ee0d-10fd-409b-b3c4-042d394791a5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2712"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:30 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - d6feff48-6421-4e4f-b6a2-318f3f4c20ce
-        status: 200 OK
-        code: 200
-        duration: 157.736583ms
-    - id: 46
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/582cb88e-1142-42c7-95c6-5c9b9dfe74e5
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 428
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:08.241549+00:00","export_uri":null,"id":"582cb88e-1142-42c7-95c6-5c9b9dfe74e5","modification_date":"2025-01-27T13:51:28.502967+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "428"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:35 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 2ec9b96c-8399-49e2-b18a-a2d65767de12
-        status: 200 OK
-        code: 200
-        duration: 96.743542ms
-    - id: 47
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2184
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:09.216259+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"304","node_id":"2","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:b7","maintenances":[],"modification_date":"2025-01-27T13:51:30.763207+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:09.216259+00:00","export_uri":null,"id":"1dc7ee0d-10fd-409b-b3c4-042d394791a5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2184"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:36 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 1aae14c4-bd9e-44b7-b783-29991430eda9
-        status: 200 OK
-        code: 200
-        duration: 189.354959ms
-    - id: 48
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/582cb88e-1142-42c7-95c6-5c9b9dfe74e5
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 428
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:08.241549+00:00","export_uri":null,"id":"582cb88e-1142-42c7-95c6-5c9b9dfe74e5","modification_date":"2025-01-27T13:51:28.502967+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "428"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:40 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 26970062-d459-4b16-ba2a-795deb0927ad
-        status: 200 OK
-        code: 200
-        duration: 112.529459ms
-    - id: 49
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2184
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:09.216259+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"304","node_id":"2","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:b7","maintenances":[],"modification_date":"2025-01-27T13:51:30.763207+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:09.216259+00:00","export_uri":null,"id":"1dc7ee0d-10fd-409b-b3c4-042d394791a5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2184"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:41 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - c360828a-9473-4b4b-bbfb-127b0c1e4952
-        status: 200 OK
-        code: 200
-        duration: 276.692ms
+        duration: 273.737166ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -2512,8 +2512,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/582cb88e-1142-42c7-95c6-5c9b9dfe74e5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709
         method: GET
       response:
         proto: HTTP/2.0
@@ -2521,20 +2521,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 428
+        content_length: 2280
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:08.241549+00:00","export_uri":null,"id":"582cb88e-1142-42c7-95c6-5c9b9dfe74e5","modification_date":"2025-01-27T13:51:28.502967+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T15:28:46.367923+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"50065cc5-82db-40fb-8481-43b9d6d58709","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"604","node_id":"9","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:71:a3","maintenances":[],"modification_date":"2025-02-11T15:29:00.811804+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"72d0ef4e-8b26-41af-9d61-ff736f90f605","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"72d0ef4e-8b26-41af-9d61-ff736f90f605","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "428"
+                - "2280"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:45 GMT
+                - Tue, 11 Feb 2025 15:29:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2542,10 +2542,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 47b13417-d4ef-420f-9912-f1e554b7e544
+                - 83070408-28c6-4f12-886f-c7ef3bc412e4
         status: 200 OK
         code: 200
-        duration: 76.84325ms
+        duration: 312.848042ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2561,8 +2561,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/df96dde1-31f6-48f8-9ad5-43bda9f53c68
         method: GET
       response:
         proto: HTTP/2.0
@@ -2570,20 +2570,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2184
+        content_length: 428
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:09.216259+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"304","node_id":"2","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:b7","maintenances":[],"modification_date":"2025-01-27T13:51:30.763207+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:09.216259+00:00","export_uri":null,"id":"1dc7ee0d-10fd-409b-b3c4-042d394791a5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T15:28:45.073822+00:00","export_uri":null,"id":"df96dde1-31f6-48f8-9ad5-43bda9f53c68","modification_date":"2025-02-11T15:28:57.466065+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2184"
+                - "428"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:46 GMT
+                - Tue, 11 Feb 2025 15:29:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2591,10 +2591,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ad10a9f3-1e16-4049-83fc-f68837177f4d
+                - aeedb06c-8ba1-4dbc-ac8e-58fea36a430e
         status: 200 OK
         code: 200
-        duration: 186.816084ms
+        duration: 103.697333ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -2610,8 +2610,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/582cb88e-1142-42c7-95c6-5c9b9dfe74e5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709
         method: GET
       response:
         proto: HTTP/2.0
@@ -2619,20 +2619,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 428
+        content_length: 1756
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:08.241549+00:00","export_uri":null,"id":"582cb88e-1142-42c7-95c6-5c9b9dfe74e5","modification_date":"2025-01-27T13:51:28.502967+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T15:28:46.367923+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"50065cc5-82db-40fb-8481-43b9d6d58709","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"604","node_id":"9","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:71:a3","maintenances":[],"modification_date":"2025-02-11T15:29:00.811804+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "428"
+                - "1756"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:50 GMT
+                - Tue, 11 Feb 2025 15:29:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2640,10 +2640,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 80ac1f63-34b7-41dc-8e61-9154a718e8d0
+                - 0b2e629b-8ba2-41e3-953c-a20864da09f9
         status: 200 OK
         code: 200
-        duration: 80.881708ms
+        duration: 188.879375ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -2659,8 +2659,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/df96dde1-31f6-48f8-9ad5-43bda9f53c68
         method: GET
       response:
         proto: HTTP/2.0
@@ -2668,20 +2668,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2184
+        content_length: 428
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:09.216259+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"304","node_id":"2","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:b7","maintenances":[],"modification_date":"2025-01-27T13:51:30.763207+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:09.216259+00:00","export_uri":null,"id":"1dc7ee0d-10fd-409b-b3c4-042d394791a5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T15:28:45.073822+00:00","export_uri":null,"id":"df96dde1-31f6-48f8-9ad5-43bda9f53c68","modification_date":"2025-02-11T15:28:57.466065+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2184"
+                - "428"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:51 GMT
+                - Tue, 11 Feb 2025 15:29:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2689,10 +2689,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ca044fe8-d715-4841-90f5-5aff90581ec9
+                - 179bb2eb-0867-4a2f-9ebc-e8d9b75805b7
         status: 200 OK
         code: 200
-        duration: 189.315334ms
+        duration: 112.693ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -2708,8 +2708,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/582cb88e-1142-42c7-95c6-5c9b9dfe74e5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709
         method: GET
       response:
         proto: HTTP/2.0
@@ -2717,20 +2717,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 428
+        content_length: 1756
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:08.241549+00:00","export_uri":null,"id":"582cb88e-1142-42c7-95c6-5c9b9dfe74e5","modification_date":"2025-01-27T13:51:28.502967+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T15:28:46.367923+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"50065cc5-82db-40fb-8481-43b9d6d58709","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"604","node_id":"9","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:71:a3","maintenances":[],"modification_date":"2025-02-11T15:29:00.811804+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "428"
+                - "1756"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:55 GMT
+                - Tue, 11 Feb 2025 15:29:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2738,10 +2738,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9bd6c986-1172-41fc-b7ae-7d1f98dd5b25
+                - 9ad3ad56-aff1-45f2-83c2-e8f206c8e65d
         status: 200 OK
         code: 200
-        duration: 86.230375ms
+        duration: 180.93575ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -2757,8 +2757,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/df96dde1-31f6-48f8-9ad5-43bda9f53c68
         method: GET
       response:
         proto: HTTP/2.0
@@ -2766,20 +2766,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2184
+        content_length: 428
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:09.216259+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"304","node_id":"2","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:b7","maintenances":[],"modification_date":"2025-01-27T13:51:30.763207+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:09.216259+00:00","export_uri":null,"id":"1dc7ee0d-10fd-409b-b3c4-042d394791a5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T15:28:45.073822+00:00","export_uri":null,"id":"df96dde1-31f6-48f8-9ad5-43bda9f53c68","modification_date":"2025-02-11T15:28:57.466065+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2184"
+                - "428"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:56 GMT
+                - Tue, 11 Feb 2025 15:29:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2787,10 +2787,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 447fb545-09ff-4a33-8e33-9d8e1eff51b4
+                - e1edce90-5bfb-4fed-96f7-531bcb0672f4
         status: 200 OK
         code: 200
-        duration: 190.74025ms
+        duration: 261.912ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2806,8 +2806,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/582cb88e-1142-42c7-95c6-5c9b9dfe74e5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709
         method: GET
       response:
         proto: HTTP/2.0
@@ -2815,20 +2815,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 428
+        content_length: 1756
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:08.241549+00:00","export_uri":null,"id":"582cb88e-1142-42c7-95c6-5c9b9dfe74e5","modification_date":"2025-01-27T13:51:28.502967+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T15:28:46.367923+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"50065cc5-82db-40fb-8481-43b9d6d58709","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"604","node_id":"9","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:71:a3","maintenances":[],"modification_date":"2025-02-11T15:29:00.811804+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "428"
+                - "1756"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:01 GMT
+                - Tue, 11 Feb 2025 15:29:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2836,10 +2836,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 99b050c0-5ca3-46b3-bac2-6e6cf4d56ba7
+                - 3681a0df-8b65-4f7d-82f3-1645ec03f237
         status: 200 OK
         code: 200
-        duration: 96.538833ms
+        duration: 165.477333ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2855,8 +2855,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/df96dde1-31f6-48f8-9ad5-43bda9f53c68
         method: GET
       response:
         proto: HTTP/2.0
@@ -2864,20 +2864,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2184
+        content_length: 428
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:09.216259+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"304","node_id":"2","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:b7","maintenances":[],"modification_date":"2025-01-27T13:51:30.763207+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:09.216259+00:00","export_uri":null,"id":"1dc7ee0d-10fd-409b-b3c4-042d394791a5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T15:28:45.073822+00:00","export_uri":null,"id":"df96dde1-31f6-48f8-9ad5-43bda9f53c68","modification_date":"2025-02-11T15:28:57.466065+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2184"
+                - "428"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:01 GMT
+                - Tue, 11 Feb 2025 15:29:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2885,10 +2885,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4c48e7d5-c958-484c-a6db-b2309b77e25e
+                - b60ea05f-99c0-4f10-ae4d-0ef04080d7d6
         status: 200 OK
         code: 200
-        duration: 153.013125ms
+        duration: 92.118417ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -2904,8 +2904,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/582cb88e-1142-42c7-95c6-5c9b9dfe74e5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709
         method: GET
       response:
         proto: HTTP/2.0
@@ -2913,20 +2913,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 428
+        content_length: 1756
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:08.241549+00:00","export_uri":null,"id":"582cb88e-1142-42c7-95c6-5c9b9dfe74e5","modification_date":"2025-01-27T13:51:28.502967+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T15:28:46.367923+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"50065cc5-82db-40fb-8481-43b9d6d58709","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"604","node_id":"9","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:71:a3","maintenances":[],"modification_date":"2025-02-11T15:29:00.811804+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "428"
+                - "1756"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:06 GMT
+                - Tue, 11 Feb 2025 15:29:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2934,10 +2934,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3a0b2c52-e4fd-4a0c-9945-fd57dde240a5
+                - 0d12f281-b3f5-430b-97d9-56451cd9b98a
         status: 200 OK
         code: 200
-        duration: 83.664667ms
+        duration: 186.199333ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -2953,8 +2953,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/df96dde1-31f6-48f8-9ad5-43bda9f53c68
         method: GET
       response:
         proto: HTTP/2.0
@@ -2962,20 +2962,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2184
+        content_length: 428
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:09.216259+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"304","node_id":"2","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:b7","maintenances":[],"modification_date":"2025-01-27T13:51:30.763207+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:09.216259+00:00","export_uri":null,"id":"1dc7ee0d-10fd-409b-b3c4-042d394791a5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T15:28:45.073822+00:00","export_uri":null,"id":"df96dde1-31f6-48f8-9ad5-43bda9f53c68","modification_date":"2025-02-11T15:28:57.466065+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2184"
+                - "428"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:07 GMT
+                - Tue, 11 Feb 2025 15:29:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2983,10 +2983,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ec5dfa2c-2f73-4019-ba37-52303968e6db
+                - 5f3ce41d-b39d-4c21-abb0-397eeb6d387e
         status: 200 OK
         code: 200
-        duration: 199.552958ms
+        duration: 113.454666ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -3002,8 +3002,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/582cb88e-1142-42c7-95c6-5c9b9dfe74e5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709
         method: GET
       response:
         proto: HTTP/2.0
@@ -3011,20 +3011,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 428
+        content_length: 1802
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:08.241549+00:00","export_uri":null,"id":"582cb88e-1142-42c7-95c6-5c9b9dfe74e5","modification_date":"2025-01-27T13:51:28.502967+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"admin_password_encryption_ssh_key_id":null,"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T15:28:46.367923+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"50065cc5-82db-40fb-8481-43b9d6d58709","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"604","node_id":"9","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:71:a3","maintenances":[],"modification_date":"2025-02-11T15:29:00.811804+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "428"
+                - "1802"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:11 GMT
+                - Tue, 11 Feb 2025 15:29:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3032,10 +3032,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e16e49ef-0f64-4331-97d0-140d61cc8fbb
+                - 31126f76-f878-43dd-adec-fb1ceb4c56c7
         status: 200 OK
         code: 200
-        duration: 77.061625ms
+        duration: 234.448958ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -3051,8 +3051,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/df96dde1-31f6-48f8-9ad5-43bda9f53c68
         method: GET
       response:
         proto: HTTP/2.0
@@ -3060,20 +3060,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2069
+        content_length: 428
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:09.216259+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:b7","maintenances":[],"modification_date":"2025-01-27T13:52:11.789369+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:09.216259+00:00","export_uri":null,"id":"1dc7ee0d-10fd-409b-b3c4-042d394791a5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T15:28:45.073822+00:00","export_uri":null,"id":"df96dde1-31f6-48f8-9ad5-43bda9f53c68","modification_date":"2025-02-11T15:28:57.466065+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2069"
+                - "428"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:12 GMT
+                - Tue, 11 Feb 2025 15:29:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3081,10 +3081,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cf36c6e2-4dca-4bf2-a195-2fa88dde41e0
+                - a545168c-08dd-4e54-b320-62449033c521
         status: 200 OK
         code: 200
-        duration: 178.626667ms
+        duration: 94.601709ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -3100,8 +3100,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709
         method: GET
       response:
         proto: HTTP/2.0
@@ -3109,20 +3109,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2069
+        content_length: 1802
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:09.216259+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:b7","maintenances":[],"modification_date":"2025-01-27T13:52:11.789369+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:09.216259+00:00","export_uri":null,"id":"1dc7ee0d-10fd-409b-b3c4-042d394791a5","modification_date":"2025-01-27T13:51:09.216259+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","name":"foobar"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"admin_password_encryption_ssh_key_id":null,"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T15:28:46.367923+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"50065cc5-82db-40fb-8481-43b9d6d58709","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"604","node_id":"9","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:71:a3","maintenances":[],"modification_date":"2025-02-11T15:29:00.811804+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2069"
+                - "1802"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:12 GMT
+                - Tue, 11 Feb 2025 15:29:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3130,10 +3130,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1bcb48e0-2528-4442-8881-cab5d384e1a2
+                - 5d59a478-c607-450f-a1d2-7ce053ec9319
         status: 200 OK
         code: 200
-        duration: 205.222125ms
+        duration: 211.849166ms
     - id: 63
       request:
         proto: HTTP/1.1
@@ -3149,27 +3149,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/df96dde1-31f6-48f8-9ad5-43bda9f53c68
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 428
         uncompressed: false
-        body: ""
+        body: '{"volume":{"creation_date":"2025-02-11T15:28:45.073822+00:00","export_uri":null,"id":"df96dde1-31f6-48f8-9ad5-43bda9f53c68","modification_date":"2025-02-11T15:28:57.466065+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
+            Content-Length:
+                - "428"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:13 GMT
+                - Tue, 11 Feb 2025 15:29:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3177,10 +3179,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d3337f9c-bfe6-4805-bb09-dde8af52c82e
-        status: 204 No Content
-        code: 204
-        duration: 248.162334ms
+                - f007d832-4a8d-4cd6-b83a-1e129fc10160
+        status: 200 OK
+        code: 200
+        duration: 112.899458ms
     - id: 64
       request:
         proto: HTTP/1.1
@@ -3196,8 +3198,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709
         method: GET
       response:
         proto: HTTP/2.0
@@ -3205,20 +3207,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 143
+        content_length: 1756
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","type":"not_found"}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T15:28:46.367923+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"50065cc5-82db-40fb-8481-43b9d6d58709","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"604","node_id":"9","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:71:a3","maintenances":[],"modification_date":"2025-02-11T15:29:00.811804+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "143"
+                - "1756"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:12 GMT
+                - Tue, 11 Feb 2025 15:29:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3226,10 +3228,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e05e7450-4b0c-4b1c-a213-1070f7ac18a3
-        status: 404 Not Found
-        code: 404
-        duration: 154.705666ms
+                - 61189300-4f14-43a3-aac1-bf329d13184e
+        status: 200 OK
+        code: 200
+        duration: 199.257625ms
     - id: 65
       request:
         proto: HTTP/1.1
@@ -3245,8 +3247,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/1dc7ee0d-10fd-409b-b3c4-042d394791a5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/df96dde1-31f6-48f8-9ad5-43bda9f53c68
         method: GET
       response:
         proto: HTTP/2.0
@@ -3254,20 +3256,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 446
+        content_length: 428
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:09.216259+00:00","export_uri":null,"id":"1dc7ee0d-10fd-409b-b3c4-042d394791a5","modification_date":"2025-01-27T13:52:12.921108+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T15:28:45.073822+00:00","export_uri":null,"id":"df96dde1-31f6-48f8-9ad5-43bda9f53c68","modification_date":"2025-02-11T15:28:57.466065+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "446"
+                - "428"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:13 GMT
+                - Tue, 11 Feb 2025 15:29:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3275,10 +3277,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 47342336-d83b-476d-8fae-76af9611e2a3
+                - af67271f-5007-4a22-9c75-f5522301dff4
         status: 200 OK
         code: 200
-        duration: 148.174125ms
+        duration: 105.429791ms
     - id: 66
       request:
         proto: HTTP/1.1
@@ -3294,27 +3296,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/1dc7ee0d-10fd-409b-b3c4-042d394791a5
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 1756
         uncompressed: false
-        body: ""
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T15:28:46.367923+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"50065cc5-82db-40fb-8481-43b9d6d58709","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"604","node_id":"9","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:71:a3","maintenances":[],"modification_date":"2025-02-11T15:29:00.811804+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
+            Content-Length:
+                - "1756"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:13 GMT
+                - Tue, 11 Feb 2025 15:29:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3322,10 +3326,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 95e29b53-145e-4945-8e5d-9b2ab38778e6
-        status: 204 No Content
-        code: 204
-        duration: 183.703833ms
+                - b30344cb-f691-4203-8a3d-1f37e9bc4e7b
+        status: 200 OK
+        code: 200
+        duration: 224.991542ms
     - id: 67
       request:
         proto: HTTP/1.1
@@ -3341,8 +3345,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/582cb88e-1142-42c7-95c6-5c9b9dfe74e5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/df96dde1-31f6-48f8-9ad5-43bda9f53c68
         method: GET
       response:
         proto: HTTP/2.0
@@ -3352,7 +3356,7 @@ interactions:
         trailer: {}
         content_length: 427
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:08.241549+00:00","export_uri":null,"id":"582cb88e-1142-42c7-95c6-5c9b9dfe74e5","modification_date":"2025-01-27T13:52:11.789369+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T15:28:45.073822+00:00","export_uri":null,"id":"df96dde1-31f6-48f8-9ad5-43bda9f53c68","modification_date":"2025-02-11T15:29:43.736342+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "427"
@@ -3361,9 +3365,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:16 GMT
+                - Tue, 11 Feb 2025 15:29:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3371,10 +3375,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e121c16f-f47a-4eb8-a977-78c14701ccea
+                - ea6e14d8-7522-46cf-b6a7-3ee2596fbfe0
         status: 200 OK
         code: 200
-        duration: 84.628208ms
+        duration: 503.659834ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -3390,8 +3394,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/582cb88e-1142-42c7-95c6-5c9b9dfe74e5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/df96dde1-31f6-48f8-9ad5-43bda9f53c68
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3408,9 +3412,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:16 GMT
+                - Tue, 11 Feb 2025 15:29:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3418,10 +3422,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f598558c-4638-4362-90d3-069bad52927d
+                - 9e6c3afd-72a9-42e9-923e-bd29ad66b815
         status: 204 No Content
         code: 204
-        duration: 202.180667ms
+        duration: 188.274125ms
     - id: 69
       request:
         proto: HTTP/1.1
@@ -3437,8 +3441,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/582cb88e-1142-42c7-95c6-5c9b9dfe74e5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709
         method: GET
       response:
         proto: HTTP/2.0
@@ -3446,20 +3450,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 143
+        content_length: 1641
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"582cb88e-1142-42c7-95c6-5c9b9dfe74e5","type":"not_found"}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T15:28:46.367923+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"50065cc5-82db-40fb-8481-43b9d6d58709","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:71:a3","maintenances":[],"modification_date":"2025-02-11T15:29:43.736342+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "143"
+                - "1641"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:16 GMT
+                - Tue, 11 Feb 2025 15:29:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3467,10 +3471,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 55c1ac5e-23a7-45fe-91b8-3b29f5656162
-        status: 404 Not Found
-        code: 404
-        duration: 35.945042ms
+                - dd01059b-0bc5-4bba-bdf4-321b9fa7e6e7
+        status: 200 OK
+        code: 200
+        duration: 189.976792ms
     - id: 70
       request:
         proto: HTTP/1.1
@@ -3486,8 +3490,104 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/aa0e9fcd-7ff9-42dc-80d5-cbd995176c16
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1641
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T15:28:46.367923+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"foobar","id":"50065cc5-82db-40fb-8481-43b9d6d58709","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:71:a3","maintenances":[],"modification_date":"2025-02-11T15:29:43.736342+00:00","name":"foobar","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1641"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 15:29:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2d3a974e-bbc6-45ec-ae4c-86f5ea33d468
+        status: 200 OK
+        code: 200
+        duration: 179.897542ms
+    - id: 71
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 15:29:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d797b95a-e747-453b-b414-e18713999f70
+        status: 204 No Content
+        code: 204
+        duration: 421.114333ms
+    - id: 72
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709
         method: GET
       response:
         proto: HTTP/2.0
@@ -3497,7 +3597,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"aa0e9fcd-7ff9-42dc-80d5-cbd995176c16","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"50065cc5-82db-40fb-8481-43b9d6d58709","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -3506,9 +3606,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:16 GMT
+                - Tue, 11 Feb 2025 15:29:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3516,7 +3616,250 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a31a6f61-733d-475b-9c6a-abcb2a23bee0
+                - f31391c0-ff73-4fdb-a7b9-6183e2280509
         status: 404 Not Found
         code: 404
-        duration: 120.958916ms
+        duration: 117.733542ms
+    - id: 73
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/1c9d9721-c5d6-4b91-99fb-771a503d1478
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 15:29:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 58dc6ba4-9c77-4072-aba9-4da62de19794
+        status: 404 Not Found
+        code: 404
+        duration: 66.115ms
+    - id: 74
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/1c9d9721-c5d6-4b91-99fb-771a503d1478
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 494
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T15:28:46.586882Z","id":"1c9d9721-c5d6-4b91-99fb-771a503d1478","last_detached_at":"2025-02-11T15:29:48.721980Z","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T15:29:48.721980Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "494"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 15:29:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5f36df41-4d95-4d91-a717-33369c7685a9
+        status: 200 OK
+        code: 200
+        duration: 81.800875ms
+    - id: 75
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/1c9d9721-c5d6-4b91-99fb-771a503d1478
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 15:29:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b9478f5e-0991-4d8d-8d3b-c27125291ec1
+        status: 204 No Content
+        code: 204
+        duration: 135.640458ms
+    - id: 76
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/df96dde1-31f6-48f8-9ad5-43bda9f53c68
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"df96dde1-31f6-48f8-9ad5-43bda9f53c68","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 15:29:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 393a01df-d453-452a-a9ec-e18e26f8547d
+        status: 404 Not Found
+        code: 404
+        duration: 58.182667ms
+    - id: 77
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/50065cc5-82db-40fb-8481-43b9d6d58709
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"50065cc5-82db-40fb-8481-43b9d6d58709","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 15:29:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e8e4ed9b-fe53-47f7-9c06-0d0a0b80dd47
+        status: 404 Not Found
+        code: 404
+        duration: 112.748792ms

--- a/internal/services/instance/testdata/server-additional-volumes.cassette.yaml
+++ b/internal/services/instance/testdata/server-additional-volumes.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 120
+        content_length: 121
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-vol-serene-gauss","project":"105bdce1-64c0-48ab-899d-868455867ecf","volume_type":"l_ssd","size":10000000000}'
+        body: '{"name":"tf-vol-nifty-lehmann","project":"105bdce1-64c0-48ab-899d-868455867ecf","volume_type":"l_ssd","size":10000000000}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes
         method: POST
       response:
@@ -27,22 +27,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 441
+        content_length: 442
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:00.556095+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:36.140861+00:00","export_uri":null,"id":"96f61139-ede1-403c-bbe8-78bc1b5eda75","modification_date":"2025-02-11T14:22:36.140861+00:00","name":"tf-vol-nifty-lehmann","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "441"
+                - "442"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:00 GMT
+                - Tue, 11 Feb 2025 14:22:36 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/84b7800d-31c1-4f1e-b309-2976fd55456b
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/96f61139-ede1-403c-bbe8-78bc1b5eda75
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -50,10 +50,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 861cb15a-f147-4fcd-ad51-de4b9f67da65
+                - b861a98d-1e3f-4a03-92e5-a169ef5ff76a
         status: 201 Created
         code: 201
-        duration: 197.701333ms
+        duration: 479.029375ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -69,8 +69,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/84b7800d-31c1-4f1e-b309-2976fd55456b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/96f61139-ede1-403c-bbe8-78bc1b5eda75
         method: GET
       response:
         proto: HTTP/2.0
@@ -78,20 +78,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 441
+        content_length: 442
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:00.556095+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:36.140861+00:00","export_uri":null,"id":"96f61139-ede1-403c-bbe8-78bc1b5eda75","modification_date":"2025-02-11T14:22:36.140861+00:00","name":"tf-vol-nifty-lehmann","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "441"
+                - "442"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:00 GMT
+                - Tue, 11 Feb 2025 14:22:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -99,10 +99,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2db8472f-5425-4843-a9ce-ab17f0dfd155
+                - c4f479d0-fe22-4fca-b662-cd53c8d884b2
         status: 200 OK
         code: 200
-        duration: 78.678959ms
+        duration: 100.27125ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -118,8 +118,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/84b7800d-31c1-4f1e-b309-2976fd55456b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/96f61139-ede1-403c-bbe8-78bc1b5eda75
         method: GET
       response:
         proto: HTTP/2.0
@@ -127,20 +127,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 441
+        content_length: 442
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:00.556095+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:36.140861+00:00","export_uri":null,"id":"96f61139-ede1-403c-bbe8-78bc1b5eda75","modification_date":"2025-02-11T14:22:36.140861+00:00","name":"tf-vol-nifty-lehmann","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "441"
+                - "442"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:00 GMT
+                - Tue, 11 Feb 2025 14:22:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -148,10 +148,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5b4742a8-b989-4de6-9b19-05ea2a011db8
+                - 61853926-8d4f-48be-8da3-2f26a5e3a643
         status: 200 OK
         code: 200
-        duration: 94.1075ms
+        duration: 77.583959ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -167,7 +167,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
         method: GET
       response:
@@ -176,22 +176,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 38539
+        content_length: 35639
         uncompressed: false
-        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
+        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
         headers:
             Content-Length:
-                - "38539"
+                - "35639"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:00 GMT
+                - Tue, 11 Feb 2025 14:22:36 GMT
             Link:
                 - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -199,12 +199,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8811ac7c-3252-4cdc-bc79-b76cf9bb4824
+                - 6dc8d66f-a08e-4e08-b96c-e5613f75ae2c
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 46.794916ms
+        duration: 48.066667ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -220,7 +220,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
         method: GET
       response:
@@ -229,22 +229,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 14208
+        content_length: 13164
         uncompressed: false
-        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
         headers:
             Content-Length:
-                - "14208"
+                - "13164"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:00 GMT
+                - Tue, 11 Feb 2025 14:22:36 GMT
             Link:
                 - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -252,12 +252,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 18359fd8-50a9-4fe2-a7fb-b83a61860417
+                - fa0aa176-78a4-409c-bae9-5dcc240baf55
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 53.8945ms
+        duration: 54.09325ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -273,8 +273,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/84b7800d-31c1-4f1e-b309-2976fd55456b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/96f61139-ede1-403c-bbe8-78bc1b5eda75
         method: GET
       response:
         proto: HTTP/2.0
@@ -282,20 +282,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 441
+        content_length: 442
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:00.556095+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:36.140861+00:00","export_uri":null,"id":"96f61139-ede1-403c-bbe8-78bc1b5eda75","modification_date":"2025-02-11T14:22:36.140861+00:00","name":"tf-vol-nifty-lehmann","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "441"
+                - "442"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:00 GMT
+                - Tue, 11 Feb 2025 14:22:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -303,10 +303,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 35c2fa82-f3fd-473c-ab77-75dbf1ed2034
+                - 6a05b2c3-c6d7-49af-87ea-6492c28a3b9b
         status: 200 OK
         code: 200
-        duration: 76.774167ms
+        duration: 83.688666ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -322,8 +322,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_local&zone=fr-par-1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_sbs&zone=fr-par-1
         method: GET
       response:
         proto: HTTP/2.0
@@ -331,20 +331,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1300
+        content_length: 1296
         uncompressed: false
-        body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"56d4019c-8305-467a-a3f2-70498ad799df","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
+        body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"57509e82-ac3b-49b7-9970-97b60f40ff72","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"9b647e1e-253a-41e7-8c15-911c622ee2dc","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"}],"total_count":2}'
         headers:
             Content-Length:
-                - "1300"
+                - "1296"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:01 GMT
+                - Tue, 11 Feb 2025 14:22:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -352,28 +352,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 909b5871-e9b4-40fc-ae16-c1c57c70cb57
+                - 03b3addb-26e4-4611-91e7-d7e1b4bdf14f
         status: 200 OK
         code: 200
-        duration: 81.266875ms
+        duration: 79.5255ms
     - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 433
+        content_length: 409
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-srv-reverent-ganguly","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","volumes":{"0":{"boot":false,"size":10000000000,"volume_type":"l_ssd"},"1":{"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","name":"tf-vol-serene-gauss"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"]}'
+        body: '{"name":"tf-srv-goofy-germain","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"57509e82-ac3b-49b7-9970-97b60f40ff72","volumes":{"0":{"boot":false,"size":10000000000},"1":{"id":"96f61139-ede1-403c-bbe8-78bc1b5eda75","name":"tf-vol-nifty-lehmann"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"]}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
         method: POST
       response:
@@ -382,22 +382,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2718
+        content_length: 2265
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:01.307055+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-ganguly","id":"9602fa58-9cc7-4216-85e9-10132151b8e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:ab","maintenances":[],"modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-srv-reverent-ganguly","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:01.307055+00:00","export_uri":null,"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.325511+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-germain","id":"b3e931e5-840f-4b53-b781-46d8d011c59d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:db","maintenances":[],"modification_date":"2025-02-11T14:22:37.325511+00:00","name":"tf-srv-goofy-germain","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140861+00:00","export_uri":null,"id":"96f61139-ede1-403c-bbe8-78bc1b5eda75","modification_date":"2025-02-11T14:22:37.325511+00:00","name":"tf-vol-nifty-lehmann","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2718"
+                - "2265"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:01 GMT
+                - Tue, 11 Feb 2025 14:22:37 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -405,10 +405,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8d5ae053-5dc3-4977-87c6-1f2ec74268ae
+                - 51308984-9036-43b0-8933-929cdfcd194c
         status: 201 Created
         code: 201
-        duration: 621.0765ms
+        duration: 1.4082995s
     - id: 8
       request:
         proto: HTTP/1.1
@@ -424,8 +424,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d
         method: GET
       response:
         proto: HTTP/2.0
@@ -433,20 +433,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2718
+        content_length: 2265
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:01.307055+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-ganguly","id":"9602fa58-9cc7-4216-85e9-10132151b8e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:ab","maintenances":[],"modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-srv-reverent-ganguly","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:01.307055+00:00","export_uri":null,"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.325511+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-germain","id":"b3e931e5-840f-4b53-b781-46d8d011c59d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:db","maintenances":[],"modification_date":"2025-02-11T14:22:37.325511+00:00","name":"tf-srv-goofy-germain","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140861+00:00","export_uri":null,"id":"96f61139-ede1-403c-bbe8-78bc1b5eda75","modification_date":"2025-02-11T14:22:37.325511+00:00","name":"tf-vol-nifty-lehmann","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2718"
+                - "2265"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:01 GMT
+                - Tue, 11 Feb 2025 14:22:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -454,10 +454,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fbc80a6d-5d46-4159-9e80-e9e5b218b859
+                - f3520278-353e-4fa4-8176-b2793703fe58
         status: 200 OK
         code: 200
-        duration: 141.071583ms
+        duration: 143.129875ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -473,8 +473,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d
         method: GET
       response:
         proto: HTTP/2.0
@@ -482,20 +482,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2718
+        content_length: 2265
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:01.307055+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-ganguly","id":"9602fa58-9cc7-4216-85e9-10132151b8e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:ab","maintenances":[],"modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-srv-reverent-ganguly","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:01.307055+00:00","export_uri":null,"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.325511+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-germain","id":"b3e931e5-840f-4b53-b781-46d8d011c59d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:db","maintenances":[],"modification_date":"2025-02-11T14:22:37.325511+00:00","name":"tf-srv-goofy-germain","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140861+00:00","export_uri":null,"id":"96f61139-ede1-403c-bbe8-78bc1b5eda75","modification_date":"2025-02-11T14:22:37.325511+00:00","name":"tf-vol-nifty-lehmann","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2718"
+                - "2265"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:01 GMT
+                - Tue, 11 Feb 2025 14:22:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -503,11 +503,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ad4fc32d-3395-41d8-a483-c714cf5a6d73
+                - a93c6471-36ba-4b7f-a600-e1fb75cb22b9
         status: 200 OK
         code: 200
-        duration: 142.282375ms
+        duration: 186.444708ms
     - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/ec2186d1-6fe2-4c53-823c-71823657a4d1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:22:37.565262Z","id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:37.565262Z","id":"451128d5-8ffe-4120-882f-ffd892ece8b1","product_resource_id":"b3e931e5-840f-4b53-b781-46d8d011c59d","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:37.565262Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:22:38 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2478140a-0363-446c-a73c-cd03ebcf2c1d
+        status: 200 OK
+        code: 200
+        duration: 73.686167ms
+    - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -524,8 +573,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -535,7 +584,7 @@ interactions:
         trailer: {}
         content_length: 357
         uncompressed: false
-        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/9602fa58-9cc7-4216-85e9-10132151b8e6/action","href_result":"/servers/9602fa58-9cc7-4216-85e9-10132151b8e6","id":"082c974c-62ed-4dbc-ac82-e856d32eef09","progress":0,"started_at":"2025-01-27T13:51:02.183861+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/b3e931e5-840f-4b53-b781-46d8d011c59d/action","href_result":"/servers/b3e931e5-840f-4b53-b781-46d8d011c59d","id":"b7174d4a-fc07-460f-af9e-276bcbdd0266","progress":0,"started_at":"2025-02-11T14:22:38.688161+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -544,11 +593,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:02 GMT
+                - Tue, 11 Feb 2025 14:22:38 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/082c974c-62ed-4dbc-ac82-e856d32eef09
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/b7174d4a-fc07-460f-af9e-276bcbdd0266
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -556,59 +605,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d817459a-59ad-4405-9b33-14886856543e
+                - 71dbcd45-1ed8-4e8f-a1be-6fd4472073c3
         status: 202 Accepted
         code: 202
-        duration: 263.30175ms
-    - id: 11
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2740
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:01.307055+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-ganguly","id":"9602fa58-9cc7-4216-85e9-10132151b8e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:ab","maintenances":[],"modification_date":"2025-01-27T13:51:01.984844+00:00","name":"tf-srv-reverent-ganguly","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:01.307055+00:00","export_uri":null,"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2740"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:02 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 0403603e-6ab1-4166-81a3-77ad14eafe75
-        status: 200 OK
-        code: 200
-        duration: 173.500709ms
+        duration: 248.920916ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -624,8 +624,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d
         method: GET
       response:
         proto: HTTP/2.0
@@ -633,20 +633,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2844
+        content_length: 2287
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:01.307055+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-ganguly","id":"9602fa58-9cc7-4216-85e9-10132151b8e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1202","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ab","maintenances":[],"modification_date":"2025-01-27T13:51:01.984844+00:00","name":"tf-srv-reverent-ganguly","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:01.307055+00:00","export_uri":null,"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.325511+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-germain","id":"b3e931e5-840f-4b53-b781-46d8d011c59d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:db","maintenances":[],"modification_date":"2025-02-11T14:22:38.492441+00:00","name":"tf-srv-goofy-germain","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140861+00:00","export_uri":null,"id":"96f61139-ede1-403c-bbe8-78bc1b5eda75","modification_date":"2025-02-11T14:22:37.325511+00:00","name":"tf-vol-nifty-lehmann","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2844"
+                - "2287"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:07 GMT
+                - Tue, 11 Feb 2025 14:22:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -654,10 +654,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 22deb2bf-9f43-4da8-912f-f421d41de9b0
+                - 51e39a74-d43a-4ad2-a1c3-43ae423b5046
         status: 200 OK
         code: 200
-        duration: 443.862166ms
+        duration: 157.548584ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -673,8 +673,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d
         method: GET
       response:
         proto: HTTP/2.0
@@ -682,20 +682,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2844
+        content_length: 2390
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:01.307055+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-ganguly","id":"9602fa58-9cc7-4216-85e9-10132151b8e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1202","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ab","maintenances":[],"modification_date":"2025-01-27T13:51:01.984844+00:00","name":"tf-srv-reverent-ganguly","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:01.307055+00:00","export_uri":null,"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.325511+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-germain","id":"b3e931e5-840f-4b53-b781-46d8d011c59d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"201","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:db","maintenances":[],"modification_date":"2025-02-11T14:22:38.492441+00:00","name":"tf-srv-goofy-germain","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140861+00:00","export_uri":null,"id":"96f61139-ede1-403c-bbe8-78bc1b5eda75","modification_date":"2025-02-11T14:22:37.325511+00:00","name":"tf-vol-nifty-lehmann","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2844"
+                - "2390"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:12 GMT
+                - Tue, 11 Feb 2025 14:22:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -703,10 +703,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f900b194-c236-4e18-a090-41313774307a
+                - 2cdadfb5-4e3e-4cca-a4f2-cb2460f629c5
         status: 200 OK
         code: 200
-        duration: 159.5175ms
+        duration: 187.503417ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -722,8 +722,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d
         method: GET
       response:
         proto: HTTP/2.0
@@ -731,20 +731,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2875
+        content_length: 2421
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:01.307055+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-ganguly","id":"9602fa58-9cc7-4216-85e9-10132151b8e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1202","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ab","maintenances":[],"modification_date":"2025-01-27T13:51:17.312021+00:00","name":"tf-srv-reverent-ganguly","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:01.307055+00:00","export_uri":null,"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.325511+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-germain","id":"b3e931e5-840f-4b53-b781-46d8d011c59d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"201","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:db","maintenances":[],"modification_date":"2025-02-11T14:22:45.255608+00:00","name":"tf-srv-goofy-germain","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140861+00:00","export_uri":null,"id":"96f61139-ede1-403c-bbe8-78bc1b5eda75","modification_date":"2025-02-11T14:22:37.325511+00:00","name":"tf-vol-nifty-lehmann","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2875"
+                - "2421"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:17 GMT
+                - Tue, 11 Feb 2025 14:22:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -752,10 +752,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 558dfe62-b749-4f2f-8d77-0f247afd128b
+                - 56cfffd7-7259-447a-a44b-eea6de5d9385
         status: 200 OK
         code: 200
-        duration: 133.887834ms
+        duration: 180.74675ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -771,8 +771,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d
         method: GET
       response:
         proto: HTTP/2.0
@@ -780,20 +780,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2875
+        content_length: 2421
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:01.307055+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-ganguly","id":"9602fa58-9cc7-4216-85e9-10132151b8e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1202","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ab","maintenances":[],"modification_date":"2025-01-27T13:51:17.312021+00:00","name":"tf-srv-reverent-ganguly","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:01.307055+00:00","export_uri":null,"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.325511+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-germain","id":"b3e931e5-840f-4b53-b781-46d8d011c59d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"201","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:db","maintenances":[],"modification_date":"2025-02-11T14:22:45.255608+00:00","name":"tf-srv-goofy-germain","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140861+00:00","export_uri":null,"id":"96f61139-ede1-403c-bbe8-78bc1b5eda75","modification_date":"2025-02-11T14:22:37.325511+00:00","name":"tf-vol-nifty-lehmann","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2875"
+                - "2421"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:18 GMT
+                - Tue, 11 Feb 2025 14:22:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -801,10 +801,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - aab0952f-ac7a-47ef-8aa6-f4ee25e53393
+                - 9aadb866-4dcd-4083-87a9-f876fa8a1d33
         status: 200 OK
         code: 200
-        duration: 209.331625ms
+        duration: 329.000042ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -820,8 +820,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/c8ed1355-378b-4d5b-a63e-570651a0c958
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/ec2186d1-6fe2-4c53-823c-71823657a4d1
         method: GET
       response:
         proto: HTTP/2.0
@@ -829,20 +829,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 523
+        content_length: 143
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:01.307055+00:00","export_uri":null,"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","type":"not_found"}'
         headers:
             Content-Length:
-                - "523"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:17 GMT
+                - Tue, 11 Feb 2025 14:22:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -850,10 +850,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 44b86910-b9b3-4ca4-8e11-850137079796
-        status: 200 OK
-        code: 200
-        duration: 105.984333ms
+                - ff34d812-e56d-4aad-8de9-6bc44dfcab23
+        status: 404 Not Found
+        code: 404
+        duration: 44.420166ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -869,8 +869,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/ec2186d1-6fe2-4c53-823c-71823657a4d1
         method: GET
       response:
         proto: HTTP/2.0
@@ -878,20 +878,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 701
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"created_at":"2025-02-11T14:22:37.565262Z","id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:37.565262Z","id":"451128d5-8ffe-4120-882f-ffd892ece8b1","product_resource_id":"b3e931e5-840f-4b53-b781-46d8d011c59d","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:37.565262Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "17"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:18 GMT
+                - Tue, 11 Feb 2025 14:22:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -899,10 +899,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6f40a1fd-5594-4b52-ab6a-a60c9e677a6f
+                - 1d9e0c2b-4e49-4e5f-bd30-4183db28b1b7
         status: 200 OK
         code: 200
-        duration: 99.815958ms
+        duration: 61.520875ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -918,8 +918,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -927,22 +927,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 17
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "20"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:18 GMT
-            Link:
-                - </servers/9602fa58-9cc7-4216-85e9-10132151b8e6/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:22:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -950,12 +948,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 64ab5ed8-9b3b-4d8e-aa93-7d181521cdf1
-            X-Total-Count:
-                - "0"
+                - b35a0859-9215-4e25-9fdc-8b21c5853a99
         status: 200 OK
         code: 200
-        duration: 93.551667ms
+        duration: 115.30025ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -971,8 +967,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -980,20 +976,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2875
+        content_length: 20
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:01.307055+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-ganguly","id":"9602fa58-9cc7-4216-85e9-10132151b8e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1202","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ab","maintenances":[],"modification_date":"2025-01-27T13:51:17.312021+00:00","name":"tf-srv-reverent-ganguly","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:01.307055+00:00","export_uri":null,"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "2875"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:18 GMT
+                - Tue, 11 Feb 2025 14:22:49 GMT
+            Link:
+                - </servers/b3e931e5-840f-4b53-b781-46d8d011c59d/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1001,10 +999,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fde11f09-33d4-4f27-b901-a835e4266897
+                - 7ae55d3b-9204-493e-9583-70aca528bbc2
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 157.938334ms
+        duration: 89.8875ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1020,8 +1020,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/84b7800d-31c1-4f1e-b309-2976fd55456b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1029,20 +1029,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 518
+        content_length: 2421
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.325511+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-germain","id":"b3e931e5-840f-4b53-b781-46d8d011c59d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"201","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:db","maintenances":[],"modification_date":"2025-02-11T14:22:45.255608+00:00","name":"tf-srv-goofy-germain","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140861+00:00","export_uri":null,"id":"96f61139-ede1-403c-bbe8-78bc1b5eda75","modification_date":"2025-02-11T14:22:37.325511+00:00","name":"tf-vol-nifty-lehmann","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "518"
+                - "2421"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:19 GMT
+                - Tue, 11 Feb 2025 14:22:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1050,10 +1050,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ef14e61c-0cd1-4447-b2d2-349feafef88c
+                - cc3719ee-5a11-4cf9-9dd1-6a0bab3a6795
         status: 200 OK
         code: 200
-        duration: 95.8335ms
+        duration: 155.579875ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1069,8 +1069,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/96f61139-ede1-403c-bbe8-78bc1b5eda75
         method: GET
       response:
         proto: HTTP/2.0
@@ -1078,20 +1078,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2875
+        content_length: 516
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:01.307055+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-ganguly","id":"9602fa58-9cc7-4216-85e9-10132151b8e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1202","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ab","maintenances":[],"modification_date":"2025-01-27T13:51:17.312021+00:00","name":"tf-srv-reverent-ganguly","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:01.307055+00:00","export_uri":null,"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:36.140861+00:00","export_uri":null,"id":"96f61139-ede1-403c-bbe8-78bc1b5eda75","modification_date":"2025-02-11T14:22:37.325511+00:00","name":"tf-vol-nifty-lehmann","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2875"
+                - "516"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:19 GMT
+                - Tue, 11 Feb 2025 14:22:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1099,10 +1099,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 675567ed-41e8-4afe-bb5b-33bd060eca35
+                - fec8adb8-ccda-4352-b2d6-7cd7da8b4f93
         status: 200 OK
         code: 200
-        duration: 179.789417ms
+        duration: 104.99575ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1118,8 +1118,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/c8ed1355-378b-4d5b-a63e-570651a0c958
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1127,20 +1127,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 523
+        content_length: 2421
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:01.307055+00:00","export_uri":null,"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.325511+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-germain","id":"b3e931e5-840f-4b53-b781-46d8d011c59d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"201","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:db","maintenances":[],"modification_date":"2025-02-11T14:22:45.255608+00:00","name":"tf-srv-goofy-germain","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140861+00:00","export_uri":null,"id":"96f61139-ede1-403c-bbe8-78bc1b5eda75","modification_date":"2025-02-11T14:22:37.325511+00:00","name":"tf-vol-nifty-lehmann","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "523"
+                - "2421"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:19 GMT
+                - Tue, 11 Feb 2025 14:22:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1148,10 +1148,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 16e2a6ab-3a69-4df4-989a-78b0e0aec1ce
+                - d9d7b322-6eae-4987-b59b-811ca2d00a39
         status: 200 OK
         code: 200
-        duration: 98.340708ms
+        duration: 172.54625ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1167,8 +1167,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/ec2186d1-6fe2-4c53-823c-71823657a4d1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1176,20 +1176,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 143
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","type":"not_found"}'
         headers:
             Content-Length:
-                - "17"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:19 GMT
+                - Tue, 11 Feb 2025 14:22:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1197,10 +1197,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c8c80bf2-cce6-4f25-bad0-c7170855e246
-        status: 200 OK
-        code: 200
-        duration: 92.300792ms
+                - 12078aee-1909-41a5-88ed-46613d149277
+        status: 404 Not Found
+        code: 404
+        duration: 30.204084ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1216,8 +1216,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/ec2186d1-6fe2-4c53-823c-71823657a4d1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1225,22 +1225,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 701
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"created_at":"2025-02-11T14:22:37.565262Z","id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:37.565262Z","id":"451128d5-8ffe-4120-882f-ffd892ece8b1","product_resource_id":"b3e931e5-840f-4b53-b781-46d8d011c59d","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:37.565262Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "20"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:19 GMT
-            Link:
-                - </servers/9602fa58-9cc7-4216-85e9-10132151b8e6/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:22:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1248,12 +1246,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1dc1611d-6c9f-4dfc-8a93-7f11da01921c
-            X-Total-Count:
-                - "0"
+                - 643be5be-1e4f-43c9-84e3-4f779223e3cb
         status: 200 OK
         code: 200
-        duration: 92.390375ms
+        duration: 68.689625ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1269,8 +1265,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/84b7800d-31c1-4f1e-b309-2976fd55456b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1278,20 +1274,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 518
+        content_length: 17
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "518"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:19 GMT
+                - Tue, 11 Feb 2025 14:22:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1299,10 +1295,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6abe8d13-994d-4094-99d8-039101254877
+                - 4af3ef03-f793-48a0-8bd7-a816de5fb635
         status: 200 OK
         code: 200
-        duration: 91.945041ms
+        duration: 98.640292ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1318,8 +1314,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1327,20 +1323,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2875
+        content_length: 20
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:01.307055+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-ganguly","id":"9602fa58-9cc7-4216-85e9-10132151b8e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1202","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ab","maintenances":[],"modification_date":"2025-01-27T13:51:17.312021+00:00","name":"tf-srv-reverent-ganguly","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:01.307055+00:00","export_uri":null,"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "2875"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:19 GMT
+                - Tue, 11 Feb 2025 14:22:50 GMT
+            Link:
+                - </servers/b3e931e5-840f-4b53-b781-46d8d011c59d/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1348,10 +1346,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7cdf148f-ee57-44db-98f9-ff01d614d45e
+                - 77513e7e-d666-4768-a236-6cd3f6a7df4d
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 149.92075ms
+        duration: 73.546375ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1367,8 +1367,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/c8ed1355-378b-4d5b-a63e-570651a0c958
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/96f61139-ede1-403c-bbe8-78bc1b5eda75
         method: GET
       response:
         proto: HTTP/2.0
@@ -1376,20 +1376,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 523
+        content_length: 516
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:01.307055+00:00","export_uri":null,"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:36.140861+00:00","export_uri":null,"id":"96f61139-ede1-403c-bbe8-78bc1b5eda75","modification_date":"2025-02-11T14:22:37.325511+00:00","name":"tf-vol-nifty-lehmann","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "523"
+                - "516"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:20 GMT
+                - Tue, 11 Feb 2025 14:22:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1397,10 +1397,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4ea5b87f-c617-4117-bc02-df80355c3a68
+                - 5bd962c5-eb02-44c8-a4ac-d7e7a913d13b
         status: 200 OK
         code: 200
-        duration: 77.628958ms
+        duration: 102.812333ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1416,8 +1416,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1425,20 +1425,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 2421
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.325511+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-germain","id":"b3e931e5-840f-4b53-b781-46d8d011c59d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"201","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:db","maintenances":[],"modification_date":"2025-02-11T14:22:45.255608+00:00","name":"tf-srv-goofy-germain","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140861+00:00","export_uri":null,"id":"96f61139-ede1-403c-bbe8-78bc1b5eda75","modification_date":"2025-02-11T14:22:37.325511+00:00","name":"tf-vol-nifty-lehmann","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "17"
+                - "2421"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:19 GMT
+                - Tue, 11 Feb 2025 14:22:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1446,10 +1446,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 95400cb8-5592-482f-9562-692a41494336
+                - 316ef8d3-44a2-4595-8d83-6afb81b75d66
         status: 200 OK
         code: 200
-        duration: 77.746083ms
+        duration: 172.55ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1465,8 +1465,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/ec2186d1-6fe2-4c53-823c-71823657a4d1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1474,22 +1474,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 143
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","type":"not_found"}'
         headers:
             Content-Length:
-                - "20"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:19 GMT
-            Link:
-                - </servers/9602fa58-9cc7-4216-85e9-10132151b8e6/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:22:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1497,54 +1495,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 839bf916-e496-4a6a-97cf-d826c60e851c
-            X-Total-Count:
-                - "0"
-        status: 200 OK
-        code: 200
-        duration: 103.09ms
+                - 0f7230ac-457d-461a-a52f-88abff541a5c
+        status: 404 Not Found
+        code: 404
+        duration: 29.667708ms
     - id: 30
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 122
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-vol-gracious-dirac","project":"105bdce1-64c0-48ab-899d-868455867ecf","volume_type":"b_ssd","size":10000000000}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/ec2186d1-6fe2-4c53-823c-71823657a4d1
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 443
+        content_length: 701
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:20.775250+00:00","export_uri":null,"id":"3d9546a3-708d-4cf7-a4df-d4a99ff33df8","modification_date":"2025-01-27T13:51:20.775250+00:00","name":"tf-vol-gracious-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T14:22:37.565262Z","id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:37.565262Z","id":"451128d5-8ffe-4120-882f-ffd892ece8b1","product_resource_id":"b3e931e5-840f-4b53-b781-46d8d011c59d","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:37.565262Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "443"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:20 GMT
-            Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/3d9546a3-708d-4cf7-a4df-d4a99ff33df8
+                - Tue, 11 Feb 2025 14:22:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1552,10 +1544,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6601e070-5630-4f95-b465-1943f8a5b53f
-        status: 201 Created
-        code: 201
-        duration: 185.726583ms
+                - 33d95d83-0b7b-47d3-aafe-36d02fddfae3
+        status: 200 OK
+        code: 200
+        duration: 66.828625ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1571,8 +1563,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/3d9546a3-708d-4cf7-a4df-d4a99ff33df8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1580,20 +1572,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 443
+        content_length: 17
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:20.775250+00:00","export_uri":null,"id":"3d9546a3-708d-4cf7-a4df-d4a99ff33df8","modification_date":"2025-01-27T13:51:20.775250+00:00","name":"tf-vol-gracious-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "443"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:20 GMT
+                - Tue, 11 Feb 2025 14:22:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1601,10 +1593,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e486af03-eddf-4e6b-86b7-7c9e27c8fa63
+                - 47eedf2f-e00c-4029-bf0a-5ebc891056b0
         status: 200 OK
         code: 200
-        duration: 72.341625ms
+        duration: 87.112708ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1620,8 +1612,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/3d9546a3-708d-4cf7-a4df-d4a99ff33df8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1629,20 +1621,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 443
+        content_length: 20
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:20.775250+00:00","export_uri":null,"id":"3d9546a3-708d-4cf7-a4df-d4a99ff33df8","modification_date":"2025-01-27T13:51:20.775250+00:00","name":"tf-vol-gracious-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "443"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:20 GMT
+                - Tue, 11 Feb 2025 14:22:51 GMT
+            Link:
+                - </servers/b3e931e5-840f-4b53-b781-46d8d011c59d/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1650,48 +1644,54 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f0eb993c-6fef-46b7-9b4d-549921ed6305
+                - 24fb7ae9-365f-49ef-9811-687f9f06625b
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 85.853708ms
+        duration: 89.094208ms
     - id: 33
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 123
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"name":"tf-vol-heuristic-dirac","project":"105bdce1-64c0-48ab-899d-868455867ecf","volume_type":"b_ssd","size":10000000000}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2875
+        content_length: 444
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:01.307055+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-ganguly","id":"9602fa58-9cc7-4216-85e9-10132151b8e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1202","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ab","maintenances":[],"modification_date":"2025-01-27T13:51:17.312021+00:00","name":"tf-srv-reverent-ganguly","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:01.307055+00:00","export_uri":null,"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:52.063543+00:00","export_uri":null,"id":"2dd5e2ea-8bd8-4e04-a8c7-aea840937543","modification_date":"2025-02-11T14:22:52.063543+00:00","name":"tf-vol-heuristic-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2875"
+                - "444"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:20 GMT
+                - Tue, 11 Feb 2025 14:22:51 GMT
+            Location:
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/2dd5e2ea-8bd8-4e04-a8c7-aea840937543
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1699,10 +1699,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - be469d3f-a2f8-459a-a6af-e5fd3b7f9876
-        status: 200 OK
-        code: 200
-        duration: 166.169792ms
+                - 100f0834-efac-4c47-a11c-f3217083d028
+        status: 201 Created
+        code: 201
+        duration: 212.404416ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1718,8 +1718,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/84b7800d-31c1-4f1e-b309-2976fd55456b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/2dd5e2ea-8bd8-4e04-a8c7-aea840937543
         method: GET
       response:
         proto: HTTP/2.0
@@ -1727,20 +1727,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 518
+        content_length: 444
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:52.063543+00:00","export_uri":null,"id":"2dd5e2ea-8bd8-4e04-a8c7-aea840937543","modification_date":"2025-02-11T14:22:52.063543+00:00","name":"tf-vol-heuristic-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "518"
+                - "444"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:21 GMT
+                - Tue, 11 Feb 2025 14:22:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1748,10 +1748,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5aea9307-4034-402f-b0bb-e234375ccb12
+                - 6165e4e5-b321-41ed-a6f7-759b9fff07f9
         status: 200 OK
         code: 200
-        duration: 105.14575ms
+        duration: 70.2485ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1767,8 +1767,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/3d9546a3-708d-4cf7-a4df-d4a99ff33df8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/2dd5e2ea-8bd8-4e04-a8c7-aea840937543
         method: GET
       response:
         proto: HTTP/2.0
@@ -1776,20 +1776,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 443
+        content_length: 444
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:20.775250+00:00","export_uri":null,"id":"3d9546a3-708d-4cf7-a4df-d4a99ff33df8","modification_date":"2025-01-27T13:51:20.775250+00:00","name":"tf-vol-gracious-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:52.063543+00:00","export_uri":null,"id":"2dd5e2ea-8bd8-4e04-a8c7-aea840937543","modification_date":"2025-02-11T14:22:52.063543+00:00","name":"tf-vol-heuristic-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "443"
+                - "444"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:20 GMT
+                - Tue, 11 Feb 2025 14:22:52 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1797,50 +1797,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ce2c2e10-8904-4ec4-8b02-4cc34c4668bc
+                - 2798c0db-0258-4041-8c3d-2a3edddca827
         status: 200 OK
         code: 200
-        duration: 91.4035ms
+        duration: 88.019333ms
     - id: 36
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 269
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"volumes":{"0":{"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","boot":false,"name":"tf-vol-amazing-ishizaka"},"1":{"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","name":"tf-vol-serene-gauss"},"2":{"id":"3d9546a3-708d-4cf7-a4df-d4a99ff33df8","name":"tf-vol-gracious-dirac"}}}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6
-        method: PATCH
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3346
+        content_length: 2421
         uncompressed: false
-        body: '{"server":{"allowed_actions":[],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:01.307055+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-ganguly","id":"9602fa58-9cc7-4216-85e9-10132151b8e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1202","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ab","maintenances":[],"modification_date":"2025-01-27T13:51:17.312021+00:00","name":"tf-srv-reverent-ganguly","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:01.307055+00:00","export_uri":null,"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"2":{"boot":false,"creation_date":"2025-01-27T13:51:20.775250+00:00","export_uri":null,"id":"3d9546a3-708d-4cf7-a4df-d4a99ff33df8","modification_date":"2025-01-27T13:51:21.419557+00:00","name":"tf-vol-gracious-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.325511+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-germain","id":"b3e931e5-840f-4b53-b781-46d8d011c59d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"201","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:db","maintenances":[],"modification_date":"2025-02-11T14:22:45.255608+00:00","name":"tf-srv-goofy-germain","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140861+00:00","export_uri":null,"id":"96f61139-ede1-403c-bbe8-78bc1b5eda75","modification_date":"2025-02-11T14:22:37.325511+00:00","name":"tf-vol-nifty-lehmann","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "3346"
+                - "2421"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:21 GMT
+                - Tue, 11 Feb 2025 14:22:52 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1848,10 +1846,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 24e313ba-0ef8-402d-9188-e9715a4727f6
+                - 5fc7f997-bdff-4929-9607-b7b826fab3ba
         status: 200 OK
         code: 200
-        duration: 397.903959ms
+        duration: 194.358084ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1867,8 +1865,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/96f61139-ede1-403c-bbe8-78bc1b5eda75
         method: GET
       response:
         proto: HTTP/2.0
@@ -1876,20 +1874,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3346
+        content_length: 516
         uncompressed: false
-        body: '{"server":{"allowed_actions":[],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:01.307055+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-ganguly","id":"9602fa58-9cc7-4216-85e9-10132151b8e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1202","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ab","maintenances":[],"modification_date":"2025-01-27T13:51:17.312021+00:00","name":"tf-srv-reverent-ganguly","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:01.307055+00:00","export_uri":null,"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"2":{"boot":false,"creation_date":"2025-01-27T13:51:20.775250+00:00","export_uri":null,"id":"3d9546a3-708d-4cf7-a4df-d4a99ff33df8","modification_date":"2025-01-27T13:51:21.419557+00:00","name":"tf-vol-gracious-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:36.140861+00:00","export_uri":null,"id":"96f61139-ede1-403c-bbe8-78bc1b5eda75","modification_date":"2025-02-11T14:22:37.325511+00:00","name":"tf-vol-nifty-lehmann","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "3346"
+                - "516"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:21 GMT
+                - Tue, 11 Feb 2025 14:22:52 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1897,10 +1895,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2be7d3c3-0ecd-45fb-8cc4-b88a5b651f38
+                - 94ba75ad-3513-4084-ba39-f76388765b9b
         status: 200 OK
         code: 200
-        duration: 184.598417ms
+        duration: 82.794917ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1916,8 +1914,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/2dd5e2ea-8bd8-4e04-a8c7-aea840937543
         method: GET
       response:
         proto: HTTP/2.0
@@ -1925,20 +1923,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3346
+        content_length: 444
         uncompressed: false
-        body: '{"server":{"allowed_actions":[],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:01.307055+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-ganguly","id":"9602fa58-9cc7-4216-85e9-10132151b8e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1202","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ab","maintenances":[],"modification_date":"2025-01-27T13:51:17.312021+00:00","name":"tf-srv-reverent-ganguly","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:01.307055+00:00","export_uri":null,"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"2":{"boot":false,"creation_date":"2025-01-27T13:51:20.775250+00:00","export_uri":null,"id":"3d9546a3-708d-4cf7-a4df-d4a99ff33df8","modification_date":"2025-01-27T13:51:21.419557+00:00","name":"tf-vol-gracious-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:52.063543+00:00","export_uri":null,"id":"2dd5e2ea-8bd8-4e04-a8c7-aea840937543","modification_date":"2025-02-11T14:22:52.063543+00:00","name":"tf-vol-heuristic-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "3346"
+                - "444"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:21 GMT
+                - Tue, 11 Feb 2025 14:22:52 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1946,48 +1944,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9f74aed9-b783-4190-8f49-29cb55c6ca38
+                - 284910a8-0c83-4524-8ac5-0f2e28df1bb1
         status: 200 OK
         code: 200
-        duration: 135.611625ms
+        duration: 167.780625ms
     - id: 39
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 269
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"volumes":{"0":{"id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","boot":false,"name":"tf-vol-zealous-shtern"},"1":{"id":"96f61139-ede1-403c-bbe8-78bc1b5eda75","name":"tf-vol-nifty-lehmann"},"2":{"id":"2dd5e2ea-8bd8-4e04-a8c7-aea840937543","name":"tf-vol-heuristic-dirac"}}}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/c8ed1355-378b-4d5b-a63e-570651a0c958
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d
+        method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 523
+        content_length: 2890
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:01.307055+00:00","export_uri":null,"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":[],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.325511+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-germain","id":"b3e931e5-840f-4b53-b781-46d8d011c59d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"201","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:db","maintenances":[],"modification_date":"2025-02-11T14:22:45.255608+00:00","name":"tf-srv-goofy-germain","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140861+00:00","export_uri":null,"id":"96f61139-ede1-403c-bbe8-78bc1b5eda75","modification_date":"2025-02-11T14:22:37.325511+00:00","name":"tf-vol-nifty-lehmann","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"2":{"boot":false,"creation_date":"2025-02-11T14:22:52.063543+00:00","export_uri":null,"id":"2dd5e2ea-8bd8-4e04-a8c7-aea840937543","modification_date":"2025-02-11T14:22:52.825506+00:00","name":"tf-vol-heuristic-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "523"
+                - "2890"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:21 GMT
+                - Tue, 11 Feb 2025 14:22:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1995,10 +1995,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ad4975fb-72ff-4077-95c3-f1d88ca6e5aa
+                - 63eccc96-31ee-4c6e-ba3e-942e489c70f6
         status: 200 OK
         code: 200
-        duration: 87.853334ms
+        duration: 467.069875ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2014,8 +2014,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d
         method: GET
       response:
         proto: HTTP/2.0
@@ -2023,20 +2023,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 2890
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"server":{"allowed_actions":[],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.325511+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-germain","id":"b3e931e5-840f-4b53-b781-46d8d011c59d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"201","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:db","maintenances":[],"modification_date":"2025-02-11T14:22:45.255608+00:00","name":"tf-srv-goofy-germain","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140861+00:00","export_uri":null,"id":"96f61139-ede1-403c-bbe8-78bc1b5eda75","modification_date":"2025-02-11T14:22:37.325511+00:00","name":"tf-vol-nifty-lehmann","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"2":{"boot":false,"creation_date":"2025-02-11T14:22:52.063543+00:00","export_uri":null,"id":"2dd5e2ea-8bd8-4e04-a8c7-aea840937543","modification_date":"2025-02-11T14:22:52.825506+00:00","name":"tf-vol-heuristic-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "17"
+                - "2890"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:22 GMT
+                - Tue, 11 Feb 2025 14:22:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2044,10 +2044,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e70dd736-b444-43b4-b61d-ea77d56a7a7e
+                - add33de7-a332-43aa-a87a-41fa97854364
         status: 200 OK
         code: 200
-        duration: 80.391792ms
+        duration: 232.647084ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2063,8 +2063,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d
         method: GET
       response:
         proto: HTTP/2.0
@@ -2072,22 +2072,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 2890
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"server":{"allowed_actions":[],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.325511+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-germain","id":"b3e931e5-840f-4b53-b781-46d8d011c59d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"201","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:db","maintenances":[],"modification_date":"2025-02-11T14:22:45.255608+00:00","name":"tf-srv-goofy-germain","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140861+00:00","export_uri":null,"id":"96f61139-ede1-403c-bbe8-78bc1b5eda75","modification_date":"2025-02-11T14:22:37.325511+00:00","name":"tf-vol-nifty-lehmann","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"2":{"boot":false,"creation_date":"2025-02-11T14:22:52.063543+00:00","export_uri":null,"id":"2dd5e2ea-8bd8-4e04-a8c7-aea840937543","modification_date":"2025-02-11T14:22:52.825506+00:00","name":"tf-vol-heuristic-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "20"
+                - "2890"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:22 GMT
-            Link:
-                - </servers/9602fa58-9cc7-4216-85e9-10132151b8e6/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:22:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2095,12 +2093,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 97ad20c0-7e34-4fcf-9c8e-4600d4a4961f
-            X-Total-Count:
-                - "0"
+                - 04902300-78f2-4c23-a643-b08fcd06c8d8
         status: 200 OK
         code: 200
-        duration: 87.106292ms
+        duration: 169.016458ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2116,8 +2112,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/3d9546a3-708d-4cf7-a4df-d4a99ff33df8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/ec2186d1-6fe2-4c53-823c-71823657a4d1
         method: GET
       response:
         proto: HTTP/2.0
@@ -2125,20 +2121,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 521
+        content_length: 143
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:20.775250+00:00","export_uri":null,"id":"3d9546a3-708d-4cf7-a4df-d4a99ff33df8","modification_date":"2025-01-27T13:51:21.419557+00:00","name":"tf-vol-gracious-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","type":"not_found"}'
         headers:
             Content-Length:
-                - "521"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:22 GMT
+                - Tue, 11 Feb 2025 14:22:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2146,10 +2142,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c41fa4c4-a1ef-4376-b245-a6b64104091e
-        status: 200 OK
-        code: 200
-        duration: 85.558917ms
+                - bce98dbe-9cda-4b8b-9eb4-f793b5a9d66d
+        status: 404 Not Found
+        code: 404
+        duration: 35.108791ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2165,8 +2161,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/ec2186d1-6fe2-4c53-823c-71823657a4d1
         method: GET
       response:
         proto: HTTP/2.0
@@ -2174,20 +2170,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3346
+        content_length: 701
         uncompressed: false
-        body: '{"server":{"allowed_actions":[],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:01.307055+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-ganguly","id":"9602fa58-9cc7-4216-85e9-10132151b8e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1202","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ab","maintenances":[],"modification_date":"2025-01-27T13:51:17.312021+00:00","name":"tf-srv-reverent-ganguly","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:01.307055+00:00","export_uri":null,"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"2":{"boot":false,"creation_date":"2025-01-27T13:51:20.775250+00:00","export_uri":null,"id":"3d9546a3-708d-4cf7-a4df-d4a99ff33df8","modification_date":"2025-01-27T13:51:21.419557+00:00","name":"tf-vol-gracious-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T14:22:37.565262Z","id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:37.565262Z","id":"451128d5-8ffe-4120-882f-ffd892ece8b1","product_resource_id":"b3e931e5-840f-4b53-b781-46d8d011c59d","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:37.565262Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "3346"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:22 GMT
+                - Tue, 11 Feb 2025 14:22:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2195,10 +2191,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e4f38876-18f1-4a5d-be56-118a5ba6e6bb
+                - 96c7043b-590f-46ce-9602-8976cc059a25
         status: 200 OK
         code: 200
-        duration: 146.695167ms
+        duration: 62.789417ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2214,204 +2210,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/84b7800d-31c1-4f1e-b309-2976fd55456b
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 518
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "518"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:22 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 0a7b684d-261f-49cc-b5a5-1167339afe85
-        status: 200 OK
-        code: 200
-        duration: 87.986208ms
-    - id: 45
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/3d9546a3-708d-4cf7-a4df-d4a99ff33df8
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 521
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:20.775250+00:00","export_uri":null,"id":"3d9546a3-708d-4cf7-a4df-d4a99ff33df8","modification_date":"2025-01-27T13:51:21.419557+00:00","name":"tf-vol-gracious-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "521"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:22 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 100493ab-9db0-4c84-a8db-eece1b9bc0fe
-        status: 200 OK
-        code: 200
-        duration: 109.389375ms
-    - id: 46
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 3346
-        uncompressed: false
-        body: '{"server":{"allowed_actions":[],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:01.307055+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-ganguly","id":"9602fa58-9cc7-4216-85e9-10132151b8e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1202","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ab","maintenances":[],"modification_date":"2025-01-27T13:51:17.312021+00:00","name":"tf-srv-reverent-ganguly","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:01.307055+00:00","export_uri":null,"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"2":{"boot":false,"creation_date":"2025-01-27T13:51:20.775250+00:00","export_uri":null,"id":"3d9546a3-708d-4cf7-a4df-d4a99ff33df8","modification_date":"2025-01-27T13:51:21.419557+00:00","name":"tf-vol-gracious-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "3346"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:22 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 09834b4f-1650-4f80-8a64-bc30068db4da
-        status: 200 OK
-        code: 200
-        duration: 177.220667ms
-    - id: 47
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/c8ed1355-378b-4d5b-a63e-570651a0c958
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 523
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:01.307055+00:00","export_uri":null,"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "523"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:23 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - eb891d0e-3e91-42be-bfca-0c5855e78210
-        status: 200 OK
-        code: 200
-        duration: 80.495166ms
-    - id: 48
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -2430,9 +2230,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:22 GMT
+                - Tue, 11 Feb 2025 14:22:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2440,11 +2240,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 19c657d6-434e-4cf6-9c5c-9cf9cf452ef9
+                - ffae38de-9d7f-42c6-9f4b-0c7ed6b4611c
         status: 200 OK
         code: 200
-        duration: 73.360083ms
-    - id: 49
+        duration: 86.082791ms
+    - id: 45
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2459,8 +2259,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -2479,11 +2279,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:23 GMT
+                - Tue, 11 Feb 2025 14:22:53 GMT
             Link:
-                - </servers/9602fa58-9cc7-4216-85e9-10132151b8e6/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/b3e931e5-840f-4b53-b781-46d8d011c59d/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2491,12 +2291,208 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - abd4f438-e950-4a0f-ba4f-9cbdd04153dc
+                - c4110d90-e6cc-43f1-871e-11a5320cde28
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 83.161167ms
+        duration: 91.270333ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/2dd5e2ea-8bd8-4e04-a8c7-aea840937543
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 519
+        uncompressed: false
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:52.063543+00:00","export_uri":null,"id":"2dd5e2ea-8bd8-4e04-a8c7-aea840937543","modification_date":"2025-02-11T14:22:52.825506+00:00","name":"tf-vol-heuristic-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "519"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:22:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c232bda5-4530-4afc-b931-a6464f7132b7
+        status: 200 OK
+        code: 200
+        duration: 177.37525ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2890
+        uncompressed: false
+        body: '{"server":{"allowed_actions":[],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.325511+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-germain","id":"b3e931e5-840f-4b53-b781-46d8d011c59d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"201","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:db","maintenances":[],"modification_date":"2025-02-11T14:22:45.255608+00:00","name":"tf-srv-goofy-germain","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140861+00:00","export_uri":null,"id":"96f61139-ede1-403c-bbe8-78bc1b5eda75","modification_date":"2025-02-11T14:22:37.325511+00:00","name":"tf-vol-nifty-lehmann","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"2":{"boot":false,"creation_date":"2025-02-11T14:22:52.063543+00:00","export_uri":null,"id":"2dd5e2ea-8bd8-4e04-a8c7-aea840937543","modification_date":"2025-02-11T14:22:52.825506+00:00","name":"tf-vol-heuristic-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2890"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:22:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 746da850-021e-45ac-ae3b-fdcdba21056a
+        status: 200 OK
+        code: 200
+        duration: 142.042375ms
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/96f61139-ede1-403c-bbe8-78bc1b5eda75
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 516
+        uncompressed: false
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:36.140861+00:00","export_uri":null,"id":"96f61139-ede1-403c-bbe8-78bc1b5eda75","modification_date":"2025-02-11T14:22:37.325511+00:00","name":"tf-vol-nifty-lehmann","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "516"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:22:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ae641f43-a8f2-476b-ac89-9260d17f4cc8
+        status: 200 OK
+        code: 200
+        duration: 70.878166ms
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/2dd5e2ea-8bd8-4e04-a8c7-aea840937543
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 519
+        uncompressed: false
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:52.063543+00:00","export_uri":null,"id":"2dd5e2ea-8bd8-4e04-a8c7-aea840937543","modification_date":"2025-02-11T14:22:52.825506+00:00","name":"tf-vol-heuristic-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "519"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:22:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5edb4b44-6a7c-4917-99a7-e6d270d7044e
+        status: 200 OK
+        code: 200
+        duration: 73.687458ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -2512,8 +2508,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d
         method: GET
       response:
         proto: HTTP/2.0
@@ -2521,20 +2517,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3346
+        content_length: 2890
         uncompressed: false
-        body: '{"server":{"allowed_actions":[],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:01.307055+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-ganguly","id":"9602fa58-9cc7-4216-85e9-10132151b8e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1202","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ab","maintenances":[],"modification_date":"2025-01-27T13:51:17.312021+00:00","name":"tf-srv-reverent-ganguly","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:01.307055+00:00","export_uri":null,"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"2":{"boot":false,"creation_date":"2025-01-27T13:51:20.775250+00:00","export_uri":null,"id":"3d9546a3-708d-4cf7-a4df-d4a99ff33df8","modification_date":"2025-01-27T13:51:21.419557+00:00","name":"tf-vol-gracious-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":[],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.325511+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-germain","id":"b3e931e5-840f-4b53-b781-46d8d011c59d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"201","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:db","maintenances":[],"modification_date":"2025-02-11T14:22:45.255608+00:00","name":"tf-srv-goofy-germain","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140861+00:00","export_uri":null,"id":"96f61139-ede1-403c-bbe8-78bc1b5eda75","modification_date":"2025-02-11T14:22:37.325511+00:00","name":"tf-vol-nifty-lehmann","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"2":{"boot":false,"creation_date":"2025-02-11T14:22:52.063543+00:00","export_uri":null,"id":"2dd5e2ea-8bd8-4e04-a8c7-aea840937543","modification_date":"2025-02-11T14:22:52.825506+00:00","name":"tf-vol-heuristic-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "3346"
+                - "2890"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:23 GMT
+                - Tue, 11 Feb 2025 14:22:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2542,10 +2538,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1949c521-324d-4142-96d7-59083e0bdb38
+                - 86814b42-8dc5-487c-8043-b0312099039d
         status: 200 OK
         code: 200
-        duration: 158.98475ms
+        duration: 172.623042ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2561,8 +2557,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/3d9546a3-708d-4cf7-a4df-d4a99ff33df8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/ec2186d1-6fe2-4c53-823c-71823657a4d1
         method: GET
       response:
         proto: HTTP/2.0
@@ -2570,20 +2566,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 521
+        content_length: 143
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:20.775250+00:00","export_uri":null,"id":"3d9546a3-708d-4cf7-a4df-d4a99ff33df8","modification_date":"2025-01-27T13:51:21.419557+00:00","name":"tf-vol-gracious-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","type":"not_found"}'
         headers:
             Content-Length:
-                - "521"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:23 GMT
+                - Tue, 11 Feb 2025 14:22:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2591,10 +2587,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bab3c4f7-a7d8-41f3-8586-1b154e25a9b7
-        status: 200 OK
-        code: 200
-        duration: 86.747875ms
+                - 62e8076b-f806-40c1-a0b0-e9e3cb5c47b0
+        status: 404 Not Found
+        code: 404
+        duration: 45.995875ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -2610,8 +2606,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/3d9546a3-708d-4cf7-a4df-d4a99ff33df8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/ec2186d1-6fe2-4c53-823c-71823657a4d1
         method: GET
       response:
         proto: HTTP/2.0
@@ -2619,20 +2615,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 521
+        content_length: 701
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:20.775250+00:00","export_uri":null,"id":"3d9546a3-708d-4cf7-a4df-d4a99ff33df8","modification_date":"2025-01-27T13:51:21.419557+00:00","name":"tf-vol-gracious-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T14:22:37.565262Z","id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:37.565262Z","id":"451128d5-8ffe-4120-882f-ffd892ece8b1","product_resource_id":"b3e931e5-840f-4b53-b781-46d8d011c59d","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:37.565262Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "521"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:28 GMT
+                - Tue, 11 Feb 2025 14:22:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2640,10 +2636,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 82c00f32-3162-42ad-89ef-a104cb451091
+                - 72723694-0f3b-4be0-bf5b-c888d8057ef4
         status: 200 OK
         code: 200
-        duration: 253.393833ms
+        duration: 69.902709ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -2659,8 +2655,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/3d9546a3-708d-4cf7-a4df-d4a99ff33df8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -2668,20 +2664,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 521
+        content_length: 17
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:20.775250+00:00","export_uri":null,"id":"3d9546a3-708d-4cf7-a4df-d4a99ff33df8","modification_date":"2025-01-27T13:51:21.419557+00:00","name":"tf-vol-gracious-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "521"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:33 GMT
+                - Tue, 11 Feb 2025 14:22:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2689,10 +2685,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6e32b083-19e9-4586-b479-91f607335027
+                - 3af0574a-060f-465a-a3ed-87cd95ded119
         status: 200 OK
         code: 200
-        duration: 91.167542ms
+        duration: 80.601459ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -2708,8 +2704,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/3d9546a3-708d-4cf7-a4df-d4a99ff33df8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -2717,20 +2713,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 521
+        content_length: 20
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:20.775250+00:00","export_uri":null,"id":"3d9546a3-708d-4cf7-a4df-d4a99ff33df8","modification_date":"2025-01-27T13:51:21.419557+00:00","name":"tf-vol-gracious-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "521"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:38 GMT
+                - Tue, 11 Feb 2025 14:22:54 GMT
+            Link:
+                - </servers/b3e931e5-840f-4b53-b781-46d8d011c59d/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2738,10 +2736,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6ffa377c-f89c-42f2-814d-a1b99e7f4f32
+                - de09a8bc-760d-4467-982d-a2fdc84904f0
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 96.391084ms
+        duration: 86.592416ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -2757,8 +2757,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/3d9546a3-708d-4cf7-a4df-d4a99ff33df8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d
         method: GET
       response:
         proto: HTTP/2.0
@@ -2766,20 +2766,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 521
+        content_length: 2890
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:20.775250+00:00","export_uri":null,"id":"3d9546a3-708d-4cf7-a4df-d4a99ff33df8","modification_date":"2025-01-27T13:51:21.419557+00:00","name":"tf-vol-gracious-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":[],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.325511+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-germain","id":"b3e931e5-840f-4b53-b781-46d8d011c59d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"201","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:db","maintenances":[],"modification_date":"2025-02-11T14:22:45.255608+00:00","name":"tf-srv-goofy-germain","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140861+00:00","export_uri":null,"id":"96f61139-ede1-403c-bbe8-78bc1b5eda75","modification_date":"2025-02-11T14:22:37.325511+00:00","name":"tf-vol-nifty-lehmann","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"2":{"boot":false,"creation_date":"2025-02-11T14:22:52.063543+00:00","export_uri":null,"id":"2dd5e2ea-8bd8-4e04-a8c7-aea840937543","modification_date":"2025-02-11T14:22:52.825506+00:00","name":"tf-vol-heuristic-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "521"
+                - "2890"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:44 GMT
+                - Tue, 11 Feb 2025 14:22:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2787,10 +2787,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 12688542-e829-4726-9132-7bb1abe7e22c
+                - 37cfb4a9-2111-445a-80f7-190a2f1c028e
         status: 200 OK
         code: 200
-        duration: 105.519167ms
+        duration: 145.516291ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2806,8 +2806,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/3d9546a3-708d-4cf7-a4df-d4a99ff33df8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/ec2186d1-6fe2-4c53-823c-71823657a4d1
         method: GET
       response:
         proto: HTTP/2.0
@@ -2815,20 +2815,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 521
+        content_length: 701
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:20.775250+00:00","export_uri":null,"id":"3d9546a3-708d-4cf7-a4df-d4a99ff33df8","modification_date":"2025-01-27T13:51:21.419557+00:00","name":"tf-vol-gracious-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T14:22:37.565262Z","id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:37.565262Z","id":"451128d5-8ffe-4120-882f-ffd892ece8b1","product_resource_id":"b3e931e5-840f-4b53-b781-46d8d011c59d","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:37.565262Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "521"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:49 GMT
+                - Tue, 11 Feb 2025 14:22:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2836,10 +2836,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7af786d6-462a-423f-97f1-dc2b19e56b97
+                - cb80e1bd-e513-4e68-81df-9b7943f2c039
         status: 200 OK
         code: 200
-        duration: 100.257958ms
+        duration: 68.319166ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2855,8 +2855,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/3d9546a3-708d-4cf7-a4df-d4a99ff33df8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/2dd5e2ea-8bd8-4e04-a8c7-aea840937543
         method: GET
       response:
         proto: HTTP/2.0
@@ -2864,20 +2864,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 520
+        content_length: 519
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:20.775250+00:00","export_uri":null,"id":"3d9546a3-708d-4cf7-a4df-d4a99ff33df8","modification_date":"2025-01-27T13:51:53.355582+00:00","name":"tf-vol-gracious-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:52.063543+00:00","export_uri":null,"id":"2dd5e2ea-8bd8-4e04-a8c7-aea840937543","modification_date":"2025-02-11T14:22:52.825506+00:00","name":"tf-vol-heuristic-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "520"
+                - "519"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:54 GMT
+                - Tue, 11 Feb 2025 14:22:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2885,11 +2885,207 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 97d66c36-d524-45b2-b2a5-7f390440f528
+                - f3ba8567-1314-47b3-8aa3-f4bd0483c169
         status: 200 OK
         code: 200
-        duration: 111.234209ms
+        duration: 97.618417ms
     - id: 58
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/2dd5e2ea-8bd8-4e04-a8c7-aea840937543
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 519
+        uncompressed: false
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:52.063543+00:00","export_uri":null,"id":"2dd5e2ea-8bd8-4e04-a8c7-aea840937543","modification_date":"2025-02-11T14:22:52.825506+00:00","name":"tf-vol-heuristic-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "519"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7c3315cd-fa3a-4833-a28b-ee5ab0fcfa7a
+        status: 200 OK
+        code: 200
+        duration: 87.5795ms
+    - id: 59
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/2dd5e2ea-8bd8-4e04-a8c7-aea840937543
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 519
+        uncompressed: false
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:52.063543+00:00","export_uri":null,"id":"2dd5e2ea-8bd8-4e04-a8c7-aea840937543","modification_date":"2025-02-11T14:22:52.825506+00:00","name":"tf-vol-heuristic-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "519"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 834716d3-fb7b-41b2-88bf-bc2ba378370f
+        status: 200 OK
+        code: 200
+        duration: 85.329667ms
+    - id: 60
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/2dd5e2ea-8bd8-4e04-a8c7-aea840937543
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 519
+        uncompressed: false
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:52.063543+00:00","export_uri":null,"id":"2dd5e2ea-8bd8-4e04-a8c7-aea840937543","modification_date":"2025-02-11T14:22:52.825506+00:00","name":"tf-vol-heuristic-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"hotsyncing","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "519"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:10 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e531b188-efb2-400e-afaa-462984228fbf
+        status: 200 OK
+        code: 200
+        duration: 77.624958ms
+    - id: 61
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/2dd5e2ea-8bd8-4e04-a8c7-aea840937543
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 518
+        uncompressed: false
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:52.063543+00:00","export_uri":null,"id":"2dd5e2ea-8bd8-4e04-a8c7-aea840937543","modification_date":"2025-02-11T14:23:14.492520+00:00","name":"tf-vol-heuristic-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "518"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:15 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f264672a-e6ce-453a-8822-2554b5ecfc4e
+        status: 200 OK
+        code: 200
+        duration: 120.89875ms
+    - id: 62
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2906,8 +3102,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -2917,7 +3113,7 @@ interactions:
         trailer: {}
         content_length: 352
         uncompressed: false
-        body: '{"task":{"description":"server_poweroff","href_from":"/servers/9602fa58-9cc7-4216-85e9-10132151b8e6/action","href_result":"/servers/9602fa58-9cc7-4216-85e9-10132151b8e6","id":"16e36ae2-a03b-468e-8f6b-aca8d165ce56","progress":0,"started_at":"2025-01-27T13:51:54.856125+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_poweroff","href_from":"/servers/b3e931e5-840f-4b53-b781-46d8d011c59d/action","href_result":"/servers/b3e931e5-840f-4b53-b781-46d8d011c59d","id":"3566b20a-8dbc-48fd-858c-e5c0897c1aa6","progress":0,"started_at":"2025-02-11T14:23:16.245448+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "352"
@@ -2926,11 +3122,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:54 GMT
+                - Tue, 11 Feb 2025 14:23:15 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/16e36ae2-a03b-468e-8f6b-aca8d165ce56
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/3566b20a-8dbc-48fd-858c-e5c0897c1aa6
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2938,206 +3134,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b17d8647-55f5-424a-91f7-02b9fc17202a
+                - d9f6fc73-6529-4c85-9e0e-02e3def6aa37
         status: 202 Accepted
         code: 202
-        duration: 264.246292ms
-    - id: 59
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 3365
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:01.307055+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-ganguly","id":"9602fa58-9cc7-4216-85e9-10132151b8e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1202","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ab","maintenances":[],"modification_date":"2025-01-27T13:51:54.659066+00:00","name":"tf-srv-reverent-ganguly","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:01.307055+00:00","export_uri":null,"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"2":{"boot":false,"creation_date":"2025-01-27T13:51:20.775250+00:00","export_uri":null,"id":"3d9546a3-708d-4cf7-a4df-d4a99ff33df8","modification_date":"2025-01-27T13:51:53.355582+00:00","name":"tf-vol-gracious-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "3365"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:54 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 6df747eb-4880-467d-9bd8-774302b84101
-        status: 200 OK
-        code: 200
-        duration: 165.253916ms
-    - id: 60
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 3365
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:01.307055+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-ganguly","id":"9602fa58-9cc7-4216-85e9-10132151b8e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1202","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ab","maintenances":[],"modification_date":"2025-01-27T13:51:54.659066+00:00","name":"tf-srv-reverent-ganguly","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:01.307055+00:00","export_uri":null,"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"2":{"boot":false,"creation_date":"2025-01-27T13:51:20.775250+00:00","export_uri":null,"id":"3d9546a3-708d-4cf7-a4df-d4a99ff33df8","modification_date":"2025-01-27T13:51:53.355582+00:00","name":"tf-vol-gracious-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "3365"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:59 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - fca182db-3426-4ce8-be80-d5c74af7ddf1
-        status: 200 OK
-        code: 200
-        duration: 206.247958ms
-    - id: 61
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 3365
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:01.307055+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-ganguly","id":"9602fa58-9cc7-4216-85e9-10132151b8e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1202","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ab","maintenances":[],"modification_date":"2025-01-27T13:51:54.659066+00:00","name":"tf-srv-reverent-ganguly","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:01.307055+00:00","export_uri":null,"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"2":{"boot":false,"creation_date":"2025-01-27T13:51:20.775250+00:00","export_uri":null,"id":"3d9546a3-708d-4cf7-a4df-d4a99ff33df8","modification_date":"2025-01-27T13:51:53.355582+00:00","name":"tf-vol-gracious-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "3365"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:52:05 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - b296e17d-a8bd-48b4-bd7c-559950f0d032
-        status: 200 OK
-        code: 200
-        duration: 195.765208ms
-    - id: 62
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 3365
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:01.307055+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-ganguly","id":"9602fa58-9cc7-4216-85e9-10132151b8e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1202","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ab","maintenances":[],"modification_date":"2025-01-27T13:51:54.659066+00:00","name":"tf-srv-reverent-ganguly","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:01.307055+00:00","export_uri":null,"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"2":{"boot":false,"creation_date":"2025-01-27T13:51:20.775250+00:00","export_uri":null,"id":"3d9546a3-708d-4cf7-a4df-d4a99ff33df8","modification_date":"2025-01-27T13:51:53.355582+00:00","name":"tf-vol-gracious-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "3365"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:52:10 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 0b4c1b76-87c3-4273-87f1-a37c6c17117a
-        status: 200 OK
-        code: 200
-        duration: 163.28725ms
+        duration: 238.229ms
     - id: 63
       request:
         proto: HTTP/1.1
@@ -3153,8 +3153,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d
         method: GET
       response:
         proto: HTTP/2.0
@@ -3162,20 +3162,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3365
+        content_length: 2909
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:01.307055+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-ganguly","id":"9602fa58-9cc7-4216-85e9-10132151b8e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1202","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ab","maintenances":[],"modification_date":"2025-01-27T13:51:54.659066+00:00","name":"tf-srv-reverent-ganguly","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:01.307055+00:00","export_uri":null,"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"2":{"boot":false,"creation_date":"2025-01-27T13:51:20.775250+00:00","export_uri":null,"id":"3d9546a3-708d-4cf7-a4df-d4a99ff33df8","modification_date":"2025-01-27T13:51:53.355582+00:00","name":"tf-vol-gracious-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.325511+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-germain","id":"b3e931e5-840f-4b53-b781-46d8d011c59d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"201","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:db","maintenances":[],"modification_date":"2025-02-11T14:23:16.063192+00:00","name":"tf-srv-goofy-germain","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140861+00:00","export_uri":null,"id":"96f61139-ede1-403c-bbe8-78bc1b5eda75","modification_date":"2025-02-11T14:22:37.325511+00:00","name":"tf-vol-nifty-lehmann","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"2":{"boot":false,"creation_date":"2025-02-11T14:22:52.063543+00:00","export_uri":null,"id":"2dd5e2ea-8bd8-4e04-a8c7-aea840937543","modification_date":"2025-02-11T14:23:14.492520+00:00","name":"tf-vol-heuristic-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "3365"
+                - "2909"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:15 GMT
+                - Tue, 11 Feb 2025 14:23:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3183,10 +3183,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b79f9ff3-766c-4207-8078-62b46357c8b1
+                - f53d3c1d-dedf-4817-89e9-dc1725e6a4f6
         status: 200 OK
         code: 200
-        duration: 238.061792ms
+        duration: 191.789875ms
     - id: 64
       request:
         proto: HTTP/1.1
@@ -3202,8 +3202,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d
         method: GET
       response:
         proto: HTTP/2.0
@@ -3211,20 +3211,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3365
+        content_length: 2909
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:01.307055+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-ganguly","id":"9602fa58-9cc7-4216-85e9-10132151b8e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1202","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ab","maintenances":[],"modification_date":"2025-01-27T13:51:54.659066+00:00","name":"tf-srv-reverent-ganguly","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:01.307055+00:00","export_uri":null,"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"2":{"boot":false,"creation_date":"2025-01-27T13:51:20.775250+00:00","export_uri":null,"id":"3d9546a3-708d-4cf7-a4df-d4a99ff33df8","modification_date":"2025-01-27T13:51:53.355582+00:00","name":"tf-vol-gracious-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.325511+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-germain","id":"b3e931e5-840f-4b53-b781-46d8d011c59d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"201","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:db","maintenances":[],"modification_date":"2025-02-11T14:23:16.063192+00:00","name":"tf-srv-goofy-germain","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140861+00:00","export_uri":null,"id":"96f61139-ede1-403c-bbe8-78bc1b5eda75","modification_date":"2025-02-11T14:22:37.325511+00:00","name":"tf-vol-nifty-lehmann","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"2":{"boot":false,"creation_date":"2025-02-11T14:22:52.063543+00:00","export_uri":null,"id":"2dd5e2ea-8bd8-4e04-a8c7-aea840937543","modification_date":"2025-02-11T14:23:14.492520+00:00","name":"tf-vol-heuristic-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "3365"
+                - "2909"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:20 GMT
+                - Tue, 11 Feb 2025 14:23:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3232,10 +3232,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 493d164f-f91d-4b65-8a3c-283dccf8643d
+                - e2fa8fc6-9088-4878-9747-c9ba865d6adc
         status: 200 OK
         code: 200
-        duration: 243.168125ms
+        duration: 167.603334ms
     - id: 65
       request:
         proto: HTTP/1.1
@@ -3251,8 +3251,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d
         method: GET
       response:
         proto: HTTP/2.0
@@ -3260,20 +3260,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3365
+        content_length: 2909
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:01.307055+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-ganguly","id":"9602fa58-9cc7-4216-85e9-10132151b8e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1202","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ab","maintenances":[],"modification_date":"2025-01-27T13:51:54.659066+00:00","name":"tf-srv-reverent-ganguly","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:01.307055+00:00","export_uri":null,"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"2":{"boot":false,"creation_date":"2025-01-27T13:51:20.775250+00:00","export_uri":null,"id":"3d9546a3-708d-4cf7-a4df-d4a99ff33df8","modification_date":"2025-01-27T13:51:53.355582+00:00","name":"tf-vol-gracious-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.325511+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-germain","id":"b3e931e5-840f-4b53-b781-46d8d011c59d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"201","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:db","maintenances":[],"modification_date":"2025-02-11T14:23:16.063192+00:00","name":"tf-srv-goofy-germain","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140861+00:00","export_uri":null,"id":"96f61139-ede1-403c-bbe8-78bc1b5eda75","modification_date":"2025-02-11T14:22:37.325511+00:00","name":"tf-vol-nifty-lehmann","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"2":{"boot":false,"creation_date":"2025-02-11T14:22:52.063543+00:00","export_uri":null,"id":"2dd5e2ea-8bd8-4e04-a8c7-aea840937543","modification_date":"2025-02-11T14:23:14.492520+00:00","name":"tf-vol-heuristic-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "3365"
+                - "2909"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:26 GMT
+                - Tue, 11 Feb 2025 14:23:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3281,10 +3281,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 16189459-32f5-425e-92a6-f2716467c8d1
+                - 1712d9ed-3402-4142-bb29-51f77826c766
         status: 200 OK
         code: 200
-        duration: 164.781584ms
+        duration: 173.829125ms
     - id: 66
       request:
         proto: HTTP/1.1
@@ -3300,8 +3300,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d
         method: GET
       response:
         proto: HTTP/2.0
@@ -3309,20 +3309,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3365
+        content_length: 2909
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:01.307055+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-ganguly","id":"9602fa58-9cc7-4216-85e9-10132151b8e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1202","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ab","maintenances":[],"modification_date":"2025-01-27T13:51:54.659066+00:00","name":"tf-srv-reverent-ganguly","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:01.307055+00:00","export_uri":null,"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"2":{"boot":false,"creation_date":"2025-01-27T13:51:20.775250+00:00","export_uri":null,"id":"3d9546a3-708d-4cf7-a4df-d4a99ff33df8","modification_date":"2025-01-27T13:51:53.355582+00:00","name":"tf-vol-gracious-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.325511+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-germain","id":"b3e931e5-840f-4b53-b781-46d8d011c59d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"201","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:db","maintenances":[],"modification_date":"2025-02-11T14:23:16.063192+00:00","name":"tf-srv-goofy-germain","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140861+00:00","export_uri":null,"id":"96f61139-ede1-403c-bbe8-78bc1b5eda75","modification_date":"2025-02-11T14:22:37.325511+00:00","name":"tf-vol-nifty-lehmann","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"2":{"boot":false,"creation_date":"2025-02-11T14:22:52.063543+00:00","export_uri":null,"id":"2dd5e2ea-8bd8-4e04-a8c7-aea840937543","modification_date":"2025-02-11T14:23:14.492520+00:00","name":"tf-vol-heuristic-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "3365"
+                - "2909"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:31 GMT
+                - Tue, 11 Feb 2025 14:23:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3330,10 +3330,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d41d0eae-9132-4811-bb2d-d96e6abf6d3f
+                - 4ff87514-8f50-44ef-99a7-4102cc9e85c0
         status: 200 OK
         code: 200
-        duration: 237.009958ms
+        duration: 223.011167ms
     - id: 67
       request:
         proto: HTTP/1.1
@@ -3349,8 +3349,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d
         method: GET
       response:
         proto: HTTP/2.0
@@ -3358,20 +3358,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3365
+        content_length: 2909
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:01.307055+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-ganguly","id":"9602fa58-9cc7-4216-85e9-10132151b8e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1202","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ab","maintenances":[],"modification_date":"2025-01-27T13:51:54.659066+00:00","name":"tf-srv-reverent-ganguly","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:01.307055+00:00","export_uri":null,"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"2":{"boot":false,"creation_date":"2025-01-27T13:51:20.775250+00:00","export_uri":null,"id":"3d9546a3-708d-4cf7-a4df-d4a99ff33df8","modification_date":"2025-01-27T13:51:53.355582+00:00","name":"tf-vol-gracious-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.325511+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-germain","id":"b3e931e5-840f-4b53-b781-46d8d011c59d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"201","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:db","maintenances":[],"modification_date":"2025-02-11T14:23:16.063192+00:00","name":"tf-srv-goofy-germain","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140861+00:00","export_uri":null,"id":"96f61139-ede1-403c-bbe8-78bc1b5eda75","modification_date":"2025-02-11T14:22:37.325511+00:00","name":"tf-vol-nifty-lehmann","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"2":{"boot":false,"creation_date":"2025-02-11T14:22:52.063543+00:00","export_uri":null,"id":"2dd5e2ea-8bd8-4e04-a8c7-aea840937543","modification_date":"2025-02-11T14:23:14.492520+00:00","name":"tf-vol-heuristic-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "3365"
+                - "2909"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:36 GMT
+                - Tue, 11 Feb 2025 14:23:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3379,10 +3379,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0b7c35b1-0e33-40b8-abc2-75114ce6a360
+                - ea14cbaf-cba3-4ac6-8847-9e4217879f86
         status: 200 OK
         code: 200
-        duration: 330.261834ms
+        duration: 229.108041ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -3398,8 +3398,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d
         method: GET
       response:
         proto: HTTP/2.0
@@ -3407,20 +3407,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3365
+        content_length: 2909
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:01.307055+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-ganguly","id":"9602fa58-9cc7-4216-85e9-10132151b8e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1202","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ab","maintenances":[],"modification_date":"2025-01-27T13:51:54.659066+00:00","name":"tf-srv-reverent-ganguly","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:01.307055+00:00","export_uri":null,"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"2":{"boot":false,"creation_date":"2025-01-27T13:51:20.775250+00:00","export_uri":null,"id":"3d9546a3-708d-4cf7-a4df-d4a99ff33df8","modification_date":"2025-01-27T13:51:53.355582+00:00","name":"tf-vol-gracious-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.325511+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-germain","id":"b3e931e5-840f-4b53-b781-46d8d011c59d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"201","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:db","maintenances":[],"modification_date":"2025-02-11T14:23:16.063192+00:00","name":"tf-srv-goofy-germain","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140861+00:00","export_uri":null,"id":"96f61139-ede1-403c-bbe8-78bc1b5eda75","modification_date":"2025-02-11T14:22:37.325511+00:00","name":"tf-vol-nifty-lehmann","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"2":{"boot":false,"creation_date":"2025-02-11T14:22:52.063543+00:00","export_uri":null,"id":"2dd5e2ea-8bd8-4e04-a8c7-aea840937543","modification_date":"2025-02-11T14:23:14.492520+00:00","name":"tf-vol-heuristic-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "3365"
+                - "2909"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:41 GMT
+                - Tue, 11 Feb 2025 14:23:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3428,10 +3428,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a6b9a0bf-2fa8-46f6-a28f-c4cbb15a57b0
+                - 7baa04e0-d007-49c2-ab52-1e899db1d89a
         status: 200 OK
         code: 200
-        duration: 157.683458ms
+        duration: 175.407167ms
     - id: 69
       request:
         proto: HTTP/1.1
@@ -3447,8 +3447,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d
         method: GET
       response:
         proto: HTTP/2.0
@@ -3456,20 +3456,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3365
+        content_length: 2909
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:01.307055+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-ganguly","id":"9602fa58-9cc7-4216-85e9-10132151b8e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1202","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ab","maintenances":[],"modification_date":"2025-01-27T13:51:54.659066+00:00","name":"tf-srv-reverent-ganguly","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:01.307055+00:00","export_uri":null,"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"2":{"boot":false,"creation_date":"2025-01-27T13:51:20.775250+00:00","export_uri":null,"id":"3d9546a3-708d-4cf7-a4df-d4a99ff33df8","modification_date":"2025-01-27T13:51:53.355582+00:00","name":"tf-vol-gracious-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.325511+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-germain","id":"b3e931e5-840f-4b53-b781-46d8d011c59d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"201","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:db","maintenances":[],"modification_date":"2025-02-11T14:23:16.063192+00:00","name":"tf-srv-goofy-germain","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140861+00:00","export_uri":null,"id":"96f61139-ede1-403c-bbe8-78bc1b5eda75","modification_date":"2025-02-11T14:22:37.325511+00:00","name":"tf-vol-nifty-lehmann","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"2":{"boot":false,"creation_date":"2025-02-11T14:22:52.063543+00:00","export_uri":null,"id":"2dd5e2ea-8bd8-4e04-a8c7-aea840937543","modification_date":"2025-02-11T14:23:14.492520+00:00","name":"tf-vol-heuristic-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "3365"
+                - "2909"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:47 GMT
+                - Tue, 11 Feb 2025 14:23:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3477,10 +3477,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 33717dc4-9852-4dcb-9128-c8150fea0786
+                - bc43ac18-7050-4035-86dc-392d9772ec5b
         status: 200 OK
         code: 200
-        duration: 184.861584ms
+        duration: 205.199667ms
     - id: 70
       request:
         proto: HTTP/1.1
@@ -3496,8 +3496,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d
         method: GET
       response:
         proto: HTTP/2.0
@@ -3505,20 +3505,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3248
+        content_length: 2793
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:01.307055+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-ganguly","id":"9602fa58-9cc7-4216-85e9-10132151b8e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:ab","maintenances":[],"modification_date":"2025-01-27T13:52:48.503604+00:00","name":"tf-srv-reverent-ganguly","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:01.307055+00:00","export_uri":null,"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"2":{"boot":false,"creation_date":"2025-01-27T13:51:20.775250+00:00","export_uri":null,"id":"3d9546a3-708d-4cf7-a4df-d4a99ff33df8","modification_date":"2025-01-27T13:51:53.355582+00:00","name":"tf-vol-gracious-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.325511+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-germain","id":"b3e931e5-840f-4b53-b781-46d8d011c59d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:db","maintenances":[],"modification_date":"2025-02-11T14:23:52.431434+00:00","name":"tf-srv-goofy-germain","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140861+00:00","export_uri":null,"id":"96f61139-ede1-403c-bbe8-78bc1b5eda75","modification_date":"2025-02-11T14:22:37.325511+00:00","name":"tf-vol-nifty-lehmann","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"2":{"boot":false,"creation_date":"2025-02-11T14:22:52.063543+00:00","export_uri":null,"id":"2dd5e2ea-8bd8-4e04-a8c7-aea840937543","modification_date":"2025-02-11T14:23:14.492520+00:00","name":"tf-vol-heuristic-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "3248"
+                - "2793"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:52 GMT
+                - Tue, 11 Feb 2025 14:23:52 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3526,10 +3526,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ac7bf171-a9b4-46fd-900b-84e8099f86e3
+                - 25e6bf1f-2d45-4edc-aefd-1f948917fc42
         status: 200 OK
         code: 200
-        duration: 776.767458ms
+        duration: 193.664291ms
     - id: 71
       request:
         proto: HTTP/1.1
@@ -3545,8 +3545,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d
         method: GET
       response:
         proto: HTTP/2.0
@@ -3554,20 +3554,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3248
+        content_length: 2793
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:01.307055+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-reverent-ganguly","id":"9602fa58-9cc7-4216-85e9-10132151b8e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:ab","maintenances":[],"modification_date":"2025-01-27T13:52:48.503604+00:00","name":"tf-srv-reverent-ganguly","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:01.307055+00:00","export_uri":null,"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:51:01.307055+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"2":{"boot":false,"creation_date":"2025-01-27T13:51:20.775250+00:00","export_uri":null,"id":"3d9546a3-708d-4cf7-a4df-d4a99ff33df8","modification_date":"2025-01-27T13:51:53.355582+00:00","name":"tf-vol-gracious-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9602fa58-9cc7-4216-85e9-10132151b8e6","name":"tf-srv-reverent-ganguly"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.325511+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-germain","id":"b3e931e5-840f-4b53-b781-46d8d011c59d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:db","maintenances":[],"modification_date":"2025-02-11T14:23:52.431434+00:00","name":"tf-srv-goofy-germain","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","additional_volume_ids"],"volumes":{"0":{"boot":false,"id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140861+00:00","export_uri":null,"id":"96f61139-ede1-403c-bbe8-78bc1b5eda75","modification_date":"2025-02-11T14:22:37.325511+00:00","name":"tf-vol-nifty-lehmann","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"2":{"boot":false,"creation_date":"2025-02-11T14:22:52.063543+00:00","export_uri":null,"id":"2dd5e2ea-8bd8-4e04-a8c7-aea840937543","modification_date":"2025-02-11T14:23:14.492520+00:00","name":"tf-vol-heuristic-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b3e931e5-840f-4b53-b781-46d8d011c59d","name":"tf-srv-goofy-germain"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "3248"
+                - "2793"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:53 GMT
+                - Tue, 11 Feb 2025 14:23:52 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3575,10 +3575,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fd741b92-17e8-4dc9-aba1-bbed6b41b63c
+                - 5b7709de-4265-488c-ad70-b189ad215878
         status: 200 OK
         code: 200
-        duration: 193.1795ms
+        duration: 172.66475ms
     - id: 72
       request:
         proto: HTTP/1.1
@@ -3594,8 +3594,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3612,9 +3612,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:53 GMT
+                - Tue, 11 Feb 2025 14:23:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3622,10 +3622,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 26b3a73e-0a47-4315-af75-74f8f391bacf
+                - 04563a61-9130-4f0e-b1ec-a55c09c1ddfa
         status: 204 No Content
         code: 204
-        duration: 199.611125ms
+        duration: 521.692667ms
     - id: 73
       request:
         proto: HTTP/1.1
@@ -3641,8 +3641,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d
         method: GET
       response:
         proto: HTTP/2.0
@@ -3652,7 +3652,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"9602fa58-9cc7-4216-85e9-10132151b8e6","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"b3e931e5-840f-4b53-b781-46d8d011c59d","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -3661,9 +3661,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:53 GMT
+                - Tue, 11 Feb 2025 14:23:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3671,10 +3671,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0918e8af-907b-41eb-a6a6-69a65cbb0862
+                - 6722e617-9d68-419e-9544-c0c4f85549fe
         status: 404 Not Found
         code: 404
-        duration: 142.279ms
+        duration: 98.374792ms
     - id: 74
       request:
         proto: HTTP/1.1
@@ -3690,8 +3690,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/c8ed1355-378b-4d5b-a63e-570651a0c958
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/ec2186d1-6fe2-4c53-823c-71823657a4d1
         method: GET
       response:
         proto: HTTP/2.0
@@ -3699,20 +3699,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 446
+        content_length: 143
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:01.307055+00:00","export_uri":null,"id":"c8ed1355-378b-4d5b-a63e-570651a0c958","modification_date":"2025-01-27T13:52:53.199503+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","type":"not_found"}'
         headers:
             Content-Length:
-                - "446"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:53 GMT
+                - Tue, 11 Feb 2025 14:23:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3720,10 +3720,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 36bca587-5a59-4fc6-bed5-ec9c7458e946
-        status: 200 OK
-        code: 200
-        duration: 81.552917ms
+                - 4fc59528-e728-4b6c-9708-ce4c5cea58bc
+        status: 404 Not Found
+        code: 404
+        duration: 31.821042ms
     - id: 75
       request:
         proto: HTTP/1.1
@@ -3739,27 +3739,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/c8ed1355-378b-4d5b-a63e-570651a0c958
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/ec2186d1-6fe2-4c53-823c-71823657a4d1
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 494
         uncompressed: false
-        body: ""
+        body: '{"created_at":"2025-02-11T14:22:37.565262Z","id":"ec2186d1-6fe2-4c53-823c-71823657a4d1","last_detached_at":"2025-02-11T14:23:53.640126Z","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:53.640126Z","zone":"fr-par-1"}'
         headers:
+            Content-Length:
+                - "494"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:53 GMT
+                - Tue, 11 Feb 2025 14:23:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3767,10 +3769,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 396fed59-9811-46ca-8232-537672b5c335
-        status: 204 No Content
-        code: 204
-        duration: 651.266208ms
+                - 8cba3755-f215-456b-8d17-5903aecd3c5b
+        status: 200 OK
+        code: 200
+        duration: 76.797ms
     - id: 76
       request:
         proto: HTTP/1.1
@@ -3786,29 +3788,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/3d9546a3-708d-4cf7-a4df-d4a99ff33df8
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/ec2186d1-6fe2-4c53-823c-71823657a4d1
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 443
+        content_length: 0
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:20.775250+00:00","export_uri":null,"id":"3d9546a3-708d-4cf7-a4df-d4a99ff33df8","modification_date":"2025-01-27T13:52:53.199503+00:00","name":"tf-vol-gracious-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: ""
         headers:
-            Content-Length:
-                - "443"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:54 GMT
+                - Tue, 11 Feb 2025 14:23:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3816,10 +3816,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 841489c0-a3a7-4c22-9e16-e4f012d8cb0a
-        status: 200 OK
-        code: 200
-        duration: 105.312916ms
+                - ccd218f1-3f18-46f1-96d7-ebbe80ea923c
+        status: 204 No Content
+        code: 204
+        duration: 128.490417ms
     - id: 77
       request:
         proto: HTTP/1.1
@@ -3835,8 +3835,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/84b7800d-31c1-4f1e-b309-2976fd55456b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/2dd5e2ea-8bd8-4e04-a8c7-aea840937543
         method: GET
       response:
         proto: HTTP/2.0
@@ -3844,20 +3844,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 441
+        content_length: 444
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:00.556095+00:00","export_uri":null,"id":"84b7800d-31c1-4f1e-b309-2976fd55456b","modification_date":"2025-01-27T13:52:53.199503+00:00","name":"tf-vol-serene-gauss","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:52.063543+00:00","export_uri":null,"id":"2dd5e2ea-8bd8-4e04-a8c7-aea840937543","modification_date":"2025-02-11T14:23:53.059585+00:00","name":"tf-vol-heuristic-dirac","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "441"
+                - "444"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:54 GMT
+                - Tue, 11 Feb 2025 14:23:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3865,10 +3865,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 975af298-1117-415f-9eb6-30cc1928b57c
+                - 0884bd3a-7746-46f1-8de2-7375d1887f8d
         status: 200 OK
         code: 200
-        duration: 525.047667ms
+        duration: 76.807583ms
     - id: 78
       request:
         proto: HTTP/1.1
@@ -3884,27 +3884,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/3d9546a3-708d-4cf7-a4df-d4a99ff33df8
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/96f61139-ede1-403c-bbe8-78bc1b5eda75
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 442
         uncompressed: false
-        body: ""
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:36.140861+00:00","export_uri":null,"id":"96f61139-ede1-403c-bbe8-78bc1b5eda75","modification_date":"2025-02-11T14:23:53.059585+00:00","name":"tf-vol-nifty-lehmann","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
+            Content-Length:
+                - "442"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:54 GMT
+                - Tue, 11 Feb 2025 14:23:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3912,10 +3914,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9384e9d4-3bc9-438a-ba68-da9e510fff22
-        status: 204 No Content
-        code: 204
-        duration: 581.868208ms
+                - 79339eff-3b21-42bc-a0c7-b4c49d87e2da
+        status: 200 OK
+        code: 200
+        duration: 77.089209ms
     - id: 79
       request:
         proto: HTTP/1.1
@@ -3931,8 +3933,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/84b7800d-31c1-4f1e-b309-2976fd55456b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/2dd5e2ea-8bd8-4e04-a8c7-aea840937543
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3949,9 +3951,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:55 GMT
+                - Tue, 11 Feb 2025 14:23:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3959,10 +3961,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 532d9112-7562-49d8-855e-99527836eb64
+                - a6832345-9ab6-464b-9b20-838f633bd6d9
         status: 204 No Content
         code: 204
-        duration: 493.158125ms
+        duration: 237.887833ms
     - id: 80
       request:
         proto: HTTP/1.1
@@ -3978,8 +3980,55 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9602fa58-9cc7-4216-85e9-10132151b8e6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/96f61139-ede1-403c-bbe8-78bc1b5eda75
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5faa899d-c20a-4af0-a429-38276c16365c
+        status: 204 No Content
+        code: 204
+        duration: 252.715667ms
+    - id: 81
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b3e931e5-840f-4b53-b781-46d8d011c59d
         method: GET
       response:
         proto: HTTP/2.0
@@ -3989,7 +4038,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"9602fa58-9cc7-4216-85e9-10132151b8e6","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"b3e931e5-840f-4b53-b781-46d8d011c59d","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -3998,9 +4047,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:55 GMT
+                - Tue, 11 Feb 2025 14:23:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4008,7 +4057,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 74f2a3d7-501d-40f6-b951-5122ea8a90e9
+                - 5fed4cf1-73ec-468f-aec6-ae2ede664e2b
         status: 404 Not Found
         code: 404
-        duration: 368.469291ms
+        duration: 115.616209ms

--- a/internal/services/instance/testdata/server-alter-tags.cassette.yaml
+++ b/internal/services/instance/testdata/server-alter-tags.cassette.yaml
@@ -16,7 +16,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
         method: GET
       response:
@@ -25,22 +25,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 38539
+        content_length: 35639
         uncompressed: false
-        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
+        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
         headers:
             Content-Length:
-                - "38539"
+                - "35639"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:14 GMT
+                - Tue, 11 Feb 2025 14:24:27 GMT
             Link:
                 - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,12 +48,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5a5ae465-a095-4b72-b006-b40ee0723411
+                - 74adee15-dd50-44f1-8705-564d750b0462
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 169.748542ms
+        duration: 64.866208ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -69,7 +69,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
         method: GET
       response:
@@ -78,22 +78,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 14208
+        content_length: 13164
         uncompressed: false
-        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
         headers:
             Content-Length:
-                - "14208"
+                - "13164"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:14 GMT
+                - Tue, 11 Feb 2025 14:24:27 GMT
             Link:
                 - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -101,12 +101,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7802f573-dd7f-4ee3-a06c-1e271d6e4de9
+                - 302a5390-9445-4d70-87ff-9ce23f4f0ea3
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 50.082375ms
+        duration: 51.195792ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -122,8 +122,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_local&zone=fr-par-1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_sbs&zone=fr-par-1
         method: GET
       response:
         proto: HTTP/2.0
@@ -131,20 +131,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1300
+        content_length: 1296
         uncompressed: false
-        body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"56d4019c-8305-467a-a3f2-70498ad799df","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
+        body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"57509e82-ac3b-49b7-9970-97b60f40ff72","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"9b647e1e-253a-41e7-8c15-911c622ee2dc","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"}],"total_count":2}'
         headers:
             Content-Length:
-                - "1300"
+                - "1296"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:15 GMT
+                - Tue, 11 Feb 2025 14:24:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -152,28 +152,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a1ab18b6-8ae4-48b1-a05e-53676fdc74eb
+                - 603fdf6b-7ab3-451f-88cd-f7fe66bf3bdd
         status: 200 OK
         code: 200
-        duration: 68.690625ms
+        duration: 81.456167ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 300
+        content_length: 267
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-srv-great-chatterjee","dynamic_ip_required":false,"commercial_type":"DEV1-L","image":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","volumes":{"0":{"boot":false,"size":80000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":["front","web"]}'
+        body: '{"name":"tf-srv-mystifying-proskuriakova","dynamic_ip_required":false,"commercial_type":"DEV1-L","image":"57509e82-ac3b-49b7-9970-97b60f40ff72","volumes":{"0":{"boot":false}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":["front","web"]}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
         method: POST
       response:
@@ -182,22 +182,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2135
+        content_length: 1706
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-L","creation_date":"2025-01-27T13:50:15.251562+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-chatterjee","id":"d8516adf-032e-440b-b49b-cfb0680d0df7","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:79","maintenances":[],"modification_date":"2025-01-27T13:50:15.251562+00:00","name":"tf-srv-great-chatterjee","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["front","web"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:15.251562+00:00","export_uri":null,"id":"77e7811b-88a8-4be0-b07b-58985ab787ac","modification_date":"2025-01-27T13:50:15.251562+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d8516adf-032e-440b-b49b-cfb0680d0df7","name":"tf-srv-great-chatterjee"},"size":80000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-L","creation_date":"2025-02-11T14:24:28.480567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-proskuriakova","id":"72b170ac-2b54-4219-9e5f-0da522be47e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:0b","maintenances":[],"modification_date":"2025-02-11T14:24:28.480567+00:00","name":"tf-srv-mystifying-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["front","web"],"volumes":{"0":{"boot":false,"id":"48771966-8a68-4382-ae0b-f6ce5b4a0cb9","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2135"
+                - "1706"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:15 GMT
+                - Tue, 11 Feb 2025 14:24:28 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d8516adf-032e-440b-b49b-cfb0680d0df7
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72b170ac-2b54-4219-9e5f-0da522be47e6
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -205,10 +205,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 76a409c5-ae20-4910-b025-40204a77a537
+                - 759ba9d3-a49e-41ac-9e6b-030db171179f
         status: 201 Created
         code: 201
-        duration: 1.05518875s
+        duration: 927.950333ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -224,8 +224,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d8516adf-032e-440b-b49b-cfb0680d0df7
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72b170ac-2b54-4219-9e5f-0da522be47e6
         method: GET
       response:
         proto: HTTP/2.0
@@ -233,20 +233,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2135
+        content_length: 1706
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-L","creation_date":"2025-01-27T13:50:15.251562+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-chatterjee","id":"d8516adf-032e-440b-b49b-cfb0680d0df7","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:79","maintenances":[],"modification_date":"2025-01-27T13:50:15.251562+00:00","name":"tf-srv-great-chatterjee","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["front","web"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:15.251562+00:00","export_uri":null,"id":"77e7811b-88a8-4be0-b07b-58985ab787ac","modification_date":"2025-01-27T13:50:15.251562+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d8516adf-032e-440b-b49b-cfb0680d0df7","name":"tf-srv-great-chatterjee"},"size":80000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-L","creation_date":"2025-02-11T14:24:28.480567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-proskuriakova","id":"72b170ac-2b54-4219-9e5f-0da522be47e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:0b","maintenances":[],"modification_date":"2025-02-11T14:24:28.480567+00:00","name":"tf-srv-mystifying-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["front","web"],"volumes":{"0":{"boot":false,"id":"48771966-8a68-4382-ae0b-f6ce5b4a0cb9","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2135"
+                - "1706"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:16 GMT
+                - Tue, 11 Feb 2025 14:24:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -254,10 +254,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5b0fba67-4a3b-4090-bf31-4e2bb0a01dae
+                - 0f5ed238-92a3-4722-8bc5-0a17f0983a9f
         status: 200 OK
         code: 200
-        duration: 186.3165ms
+        duration: 133.296125ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -273,8 +273,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d8516adf-032e-440b-b49b-cfb0680d0df7
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72b170ac-2b54-4219-9e5f-0da522be47e6
         method: GET
       response:
         proto: HTTP/2.0
@@ -282,20 +282,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2135
+        content_length: 1706
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-L","creation_date":"2025-01-27T13:50:15.251562+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-chatterjee","id":"d8516adf-032e-440b-b49b-cfb0680d0df7","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:79","maintenances":[],"modification_date":"2025-01-27T13:50:15.251562+00:00","name":"tf-srv-great-chatterjee","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["front","web"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:15.251562+00:00","export_uri":null,"id":"77e7811b-88a8-4be0-b07b-58985ab787ac","modification_date":"2025-01-27T13:50:15.251562+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d8516adf-032e-440b-b49b-cfb0680d0df7","name":"tf-srv-great-chatterjee"},"size":80000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-L","creation_date":"2025-02-11T14:24:28.480567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-proskuriakova","id":"72b170ac-2b54-4219-9e5f-0da522be47e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:0b","maintenances":[],"modification_date":"2025-02-11T14:24:28.480567+00:00","name":"tf-srv-mystifying-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["front","web"],"volumes":{"0":{"boot":false,"id":"48771966-8a68-4382-ae0b-f6ce5b4a0cb9","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2135"
+                - "1706"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:15 GMT
+                - Tue, 11 Feb 2025 14:24:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -303,10 +303,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b8ef323f-8f18-4114-b8d2-0768fa52d7d9
+                - eb7981f9-aba5-4d1e-b68b-a93bab45e43b
         status: 200 OK
         code: 200
-        duration: 139.625375ms
+        duration: 146.062959ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -322,8 +322,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d8516adf-032e-440b-b49b-cfb0680d0df7
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72b170ac-2b54-4219-9e5f-0da522be47e6
         method: GET
       response:
         proto: HTTP/2.0
@@ -331,20 +331,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2135
+        content_length: 1706
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-L","creation_date":"2025-01-27T13:50:15.251562+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-chatterjee","id":"d8516adf-032e-440b-b49b-cfb0680d0df7","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:79","maintenances":[],"modification_date":"2025-01-27T13:50:15.251562+00:00","name":"tf-srv-great-chatterjee","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["front","web"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:15.251562+00:00","export_uri":null,"id":"77e7811b-88a8-4be0-b07b-58985ab787ac","modification_date":"2025-01-27T13:50:15.251562+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d8516adf-032e-440b-b49b-cfb0680d0df7","name":"tf-srv-great-chatterjee"},"size":80000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-L","creation_date":"2025-02-11T14:24:28.480567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-proskuriakova","id":"72b170ac-2b54-4219-9e5f-0da522be47e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:0b","maintenances":[],"modification_date":"2025-02-11T14:24:28.480567+00:00","name":"tf-srv-mystifying-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["front","web"],"volumes":{"0":{"boot":false,"id":"48771966-8a68-4382-ae0b-f6ce5b4a0cb9","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2135"
+                - "1706"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:16 GMT
+                - Tue, 11 Feb 2025 14:24:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -352,10 +352,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d24b5832-99f8-4411-9933-423fcb5c1d9a
+                - a7b5211c-b29a-424c-b368-e19b14ca1827
         status: 200 OK
         code: 200
-        duration: 119.989167ms
+        duration: 169.849167ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -371,8 +371,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/77e7811b-88a8-4be0-b07b-58985ab787ac
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/48771966-8a68-4382-ae0b-f6ce5b4a0cb9
         method: GET
       response:
         proto: HTTP/2.0
@@ -380,20 +380,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 523
+        content_length: 143
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:50:15.251562+00:00","export_uri":null,"id":"77e7811b-88a8-4be0-b07b-58985ab787ac","modification_date":"2025-01-27T13:50:15.251562+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d8516adf-032e-440b-b49b-cfb0680d0df7","name":"tf-srv-great-chatterjee"},"size":80000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"48771966-8a68-4382-ae0b-f6ce5b4a0cb9","type":"not_found"}'
         headers:
             Content-Length:
-                - "523"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:16 GMT
+                - Tue, 11 Feb 2025 14:24:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -401,10 +401,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 24791cd6-f7e6-47b9-a561-e90b700645b3
-        status: 200 OK
-        code: 200
-        duration: 88.416625ms
+                - 8b6b886e-9887-4f95-86f0-cb4b6051a838
+        status: 404 Not Found
+        code: 404
+        duration: 34.859458ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -420,8 +420,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d8516adf-032e-440b-b49b-cfb0680d0df7/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/48771966-8a68-4382-ae0b-f6ce5b4a0cb9
         method: GET
       response:
         proto: HTTP/2.0
@@ -429,20 +429,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 701
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"created_at":"2025-02-11T14:24:28.670554Z","id":"48771966-8a68-4382-ae0b-f6ce5b4a0cb9","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:24:28.670554Z","id":"e3f45618-fca7-4967-aff4-2f0eb6ad02ee","product_resource_id":"72b170ac-2b54-4219-9e5f-0da522be47e6","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:24:28.670554Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "17"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:16 GMT
+                - Tue, 11 Feb 2025 14:24:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -450,10 +450,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cddd93a4-4a0a-4c98-9a44-a7788991e5cc
+                - 00db572d-6de1-443e-812b-4c37188127e0
         status: 200 OK
         code: 200
-        duration: 78.239875ms
+        duration: 63.557416ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -469,8 +469,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d8516adf-032e-440b-b49b-cfb0680d0df7/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72b170ac-2b54-4219-9e5f-0da522be47e6/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -478,22 +478,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 17
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "20"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:17 GMT
-            Link:
-                - </servers/d8516adf-032e-440b-b49b-cfb0680d0df7/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:24:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -501,12 +499,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6aab635c-3041-42de-b1de-3c3b0f778f11
-            X-Total-Count:
-                - "0"
+                - 12d33883-8eca-4180-938e-f1145608ae91
         status: 200 OK
         code: 200
-        duration: 766.050917ms
+        duration: 81.454ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -522,8 +518,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d8516adf-032e-440b-b49b-cfb0680d0df7
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72b170ac-2b54-4219-9e5f-0da522be47e6/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -531,20 +527,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2135
+        content_length: 20
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-L","creation_date":"2025-01-27T13:50:15.251562+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-chatterjee","id":"d8516adf-032e-440b-b49b-cfb0680d0df7","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:79","maintenances":[],"modification_date":"2025-01-27T13:50:15.251562+00:00","name":"tf-srv-great-chatterjee","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["front","web"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:15.251562+00:00","export_uri":null,"id":"77e7811b-88a8-4be0-b07b-58985ab787ac","modification_date":"2025-01-27T13:50:15.251562+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d8516adf-032e-440b-b49b-cfb0680d0df7","name":"tf-srv-great-chatterjee"},"size":80000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "2135"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:17 GMT
+                - Tue, 11 Feb 2025 14:24:29 GMT
+            Link:
+                - </servers/72b170ac-2b54-4219-9e5f-0da522be47e6/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -552,10 +550,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 22035dbd-b5b2-48d7-8d2c-bede4707ce28
+                - 7c033907-45e2-4926-9ae1-9a57d1d9d0aa
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 169.723125ms
+        duration: 82.623125ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -571,8 +571,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d8516adf-032e-440b-b49b-cfb0680d0df7
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72b170ac-2b54-4219-9e5f-0da522be47e6
         method: GET
       response:
         proto: HTTP/2.0
@@ -580,20 +580,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2135
+        content_length: 1706
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-L","creation_date":"2025-01-27T13:50:15.251562+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-chatterjee","id":"d8516adf-032e-440b-b49b-cfb0680d0df7","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:79","maintenances":[],"modification_date":"2025-01-27T13:50:15.251562+00:00","name":"tf-srv-great-chatterjee","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["front","web"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:15.251562+00:00","export_uri":null,"id":"77e7811b-88a8-4be0-b07b-58985ab787ac","modification_date":"2025-01-27T13:50:15.251562+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d8516adf-032e-440b-b49b-cfb0680d0df7","name":"tf-srv-great-chatterjee"},"size":80000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-L","creation_date":"2025-02-11T14:24:28.480567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-proskuriakova","id":"72b170ac-2b54-4219-9e5f-0da522be47e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:0b","maintenances":[],"modification_date":"2025-02-11T14:24:28.480567+00:00","name":"tf-srv-mystifying-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["front","web"],"volumes":{"0":{"boot":false,"id":"48771966-8a68-4382-ae0b-f6ce5b4a0cb9","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2135"
+                - "1706"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:17 GMT
+                - Tue, 11 Feb 2025 14:24:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -601,10 +601,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2949fb82-8817-497d-97c9-3835a4eb9145
+                - fa9a3836-74e3-4694-be9d-b58f2a204e36
         status: 200 OK
         code: 200
-        duration: 142.141083ms
+        duration: 146.390417ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -620,8 +620,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/77e7811b-88a8-4be0-b07b-58985ab787ac
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72b170ac-2b54-4219-9e5f-0da522be47e6
         method: GET
       response:
         proto: HTTP/2.0
@@ -629,20 +629,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 523
+        content_length: 1706
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:50:15.251562+00:00","export_uri":null,"id":"77e7811b-88a8-4be0-b07b-58985ab787ac","modification_date":"2025-01-27T13:50:15.251562+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d8516adf-032e-440b-b49b-cfb0680d0df7","name":"tf-srv-great-chatterjee"},"size":80000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-L","creation_date":"2025-02-11T14:24:28.480567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-proskuriakova","id":"72b170ac-2b54-4219-9e5f-0da522be47e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:0b","maintenances":[],"modification_date":"2025-02-11T14:24:28.480567+00:00","name":"tf-srv-mystifying-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["front","web"],"volumes":{"0":{"boot":false,"id":"48771966-8a68-4382-ae0b-f6ce5b4a0cb9","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "523"
+                - "1706"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:17 GMT
+                - Tue, 11 Feb 2025 14:24:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -650,10 +650,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b9b9f2ba-03ac-43f7-8d7d-916091a1b9a4
+                - 88d83db1-6314-44dd-9c37-2f5aaf911679
         status: 200 OK
         code: 200
-        duration: 106.701459ms
+        duration: 155.030542ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -669,8 +669,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d8516adf-032e-440b-b49b-cfb0680d0df7/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/48771966-8a68-4382-ae0b-f6ce5b4a0cb9
         method: GET
       response:
         proto: HTTP/2.0
@@ -678,20 +678,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 143
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"48771966-8a68-4382-ae0b-f6ce5b4a0cb9","type":"not_found"}'
         headers:
             Content-Length:
-                - "17"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:18 GMT
+                - Tue, 11 Feb 2025 14:24:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -699,10 +699,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1fb7bc25-131f-4730-87c7-08d00041a49c
-        status: 200 OK
-        code: 200
-        duration: 110.956959ms
+                - 348e7662-f308-4204-9ebc-3e177e44c5d3
+        status: 404 Not Found
+        code: 404
+        duration: 60.167042ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -718,8 +718,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d8516adf-032e-440b-b49b-cfb0680d0df7/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/48771966-8a68-4382-ae0b-f6ce5b4a0cb9
         method: GET
       response:
         proto: HTTP/2.0
@@ -727,22 +727,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 701
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"created_at":"2025-02-11T14:24:28.670554Z","id":"48771966-8a68-4382-ae0b-f6ce5b4a0cb9","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:24:28.670554Z","id":"e3f45618-fca7-4967-aff4-2f0eb6ad02ee","product_resource_id":"72b170ac-2b54-4219-9e5f-0da522be47e6","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:24:28.670554Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "20"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:18 GMT
-            Link:
-                - </servers/d8516adf-032e-440b-b49b-cfb0680d0df7/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:24:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -750,12 +748,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f26223d8-8732-493c-b63e-f52059ddb347
-            X-Total-Count:
-                - "0"
+                - e75c81be-4d67-41b4-81e7-11c7f6dc110b
         status: 200 OK
         code: 200
-        duration: 101.155209ms
+        duration: 59.559792ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -771,106 +767,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d8516adf-032e-440b-b49b-cfb0680d0df7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2135
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-L","creation_date":"2025-01-27T13:50:15.251562+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-chatterjee","id":"d8516adf-032e-440b-b49b-cfb0680d0df7","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:79","maintenances":[],"modification_date":"2025-01-27T13:50:15.251562+00:00","name":"tf-srv-great-chatterjee","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["front","web"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:15.251562+00:00","export_uri":null,"id":"77e7811b-88a8-4be0-b07b-58985ab787ac","modification_date":"2025-01-27T13:50:15.251562+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d8516adf-032e-440b-b49b-cfb0680d0df7","name":"tf-srv-great-chatterjee"},"size":80000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2135"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:18 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 17613694-53f5-43f9-928f-306f314ac6e3
-        status: 200 OK
-        code: 200
-        duration: 159.565458ms
-    - id: 16
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/77e7811b-88a8-4be0-b07b-58985ab787ac
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 523
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:50:15.251562+00:00","export_uri":null,"id":"77e7811b-88a8-4be0-b07b-58985ab787ac","modification_date":"2025-01-27T13:50:15.251562+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d8516adf-032e-440b-b49b-cfb0680d0df7","name":"tf-srv-great-chatterjee"},"size":80000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "523"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:18 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - bd2d2ae8-a9ed-48d4-be64-fe3d52e771a2
-        status: 200 OK
-        code: 200
-        duration: 93.958209ms
-    - id: 17
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d8516adf-032e-440b-b49b-cfb0680d0df7/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72b170ac-2b54-4219-9e5f-0da522be47e6/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -889,9 +787,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:18 GMT
+                - Tue, 11 Feb 2025 14:24:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -899,11 +797,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4aaea335-f584-47fc-9204-3eb87ba60135
+                - b9f93a40-1b39-4f56-a6d4-77fb12e41a08
         status: 200 OK
         code: 200
-        duration: 115.701333ms
-    - id: 18
+        duration: 79.798708ms
+    - id: 16
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -918,8 +816,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d8516adf-032e-440b-b49b-cfb0680d0df7/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72b170ac-2b54-4219-9e5f-0da522be47e6/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -938,11 +836,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:18 GMT
+                - Tue, 11 Feb 2025 14:24:30 GMT
             Link:
-                - </servers/d8516adf-032e-440b-b49b-cfb0680d0df7/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/72b170ac-2b54-4219-9e5f-0da522be47e6/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -950,12 +848,110 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bebc532a-bfe9-4c85-8982-33a67df8b360
+                - 27af1934-442b-4023-ae6e-6bbdd8337957
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 75.156792ms
+        duration: 105.780333ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72b170ac-2b54-4219-9e5f-0da522be47e6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1706
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-L","creation_date":"2025-02-11T14:24:28.480567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-proskuriakova","id":"72b170ac-2b54-4219-9e5f-0da522be47e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:0b","maintenances":[],"modification_date":"2025-02-11T14:24:28.480567+00:00","name":"tf-srv-mystifying-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["front","web"],"volumes":{"0":{"boot":false,"id":"48771966-8a68-4382-ae0b-f6ce5b4a0cb9","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1706"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3361fecc-7c85-41eb-aa2f-958a1649b1a2
+        status: 200 OK
+        code: 200
+        duration: 447.04525ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/48771966-8a68-4382-ae0b-f6ce5b4a0cb9
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"48771966-8a68-4382-ae0b-f6ce5b4a0cb9","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 53da765f-6ca6-4b59-b0fa-39e80236cedd
+        status: 404 Not Found
+        code: 404
+        duration: 35.126167ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -971,8 +967,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d8516adf-032e-440b-b49b-cfb0680d0df7
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/48771966-8a68-4382-ae0b-f6ce5b4a0cb9
         method: GET
       response:
         proto: HTTP/2.0
@@ -980,20 +976,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2135
+        content_length: 701
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-L","creation_date":"2025-01-27T13:50:15.251562+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-chatterjee","id":"d8516adf-032e-440b-b49b-cfb0680d0df7","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:79","maintenances":[],"modification_date":"2025-01-27T13:50:15.251562+00:00","name":"tf-srv-great-chatterjee","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["front","web"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:15.251562+00:00","export_uri":null,"id":"77e7811b-88a8-4be0-b07b-58985ab787ac","modification_date":"2025-01-27T13:50:15.251562+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d8516adf-032e-440b-b49b-cfb0680d0df7","name":"tf-srv-great-chatterjee"},"size":80000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T14:24:28.670554Z","id":"48771966-8a68-4382-ae0b-f6ce5b4a0cb9","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:24:28.670554Z","id":"e3f45618-fca7-4967-aff4-2f0eb6ad02ee","product_resource_id":"72b170ac-2b54-4219-9e5f-0da522be47e6","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:24:28.670554Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2135"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:19 GMT
+                - Tue, 11 Feb 2025 14:24:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1001,11 +997,162 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 43160a93-ee01-4677-8a1e-f4e84c46ac13
+                - e55d7a47-19fb-4014-9536-e31dc9f547b7
         status: 200 OK
         code: 200
-        duration: 155.275958ms
+        duration: 62.752833ms
     - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72b170ac-2b54-4219-9e5f-0da522be47e6/user_data
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 17
+        uncompressed: false
+        body: '{"user_data":[]}'
+        headers:
+            Content-Length:
+                - "17"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:31 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 42f22704-2f47-47c3-825a-7225f2c7e08e
+        status: 200 OK
+        code: 200
+        duration: 93.729333ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72b170ac-2b54-4219-9e5f-0da522be47e6/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 20
+        uncompressed: false
+        body: '{"private_nics":[]}'
+        headers:
+            Content-Length:
+                - "20"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:31 GMT
+            Link:
+                - </servers/72b170ac-2b54-4219-9e5f-0da522be47e6/private_nics?page=0&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5e4d5624-ae8e-4575-89e0-4d305fa9e209
+            X-Total-Count:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 93.982375ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72b170ac-2b54-4219-9e5f-0da522be47e6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1706
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-L","creation_date":"2025-02-11T14:24:28.480567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-proskuriakova","id":"72b170ac-2b54-4219-9e5f-0da522be47e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:0b","maintenances":[],"modification_date":"2025-02-11T14:24:28.480567+00:00","name":"tf-srv-mystifying-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["front","web"],"volumes":{"0":{"boot":false,"id":"48771966-8a68-4382-ae0b-f6ce5b4a0cb9","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1706"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:31 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 446cc093-6786-48fd-a5af-afcaeb7d7609
+        status: 200 OK
+        code: 200
+        duration: 142.030875ms
+    - id: 23
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1022,8 +1169,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d8516adf-032e-440b-b49b-cfb0680d0df7
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72b170ac-2b54-4219-9e5f-0da522be47e6
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -1031,20 +1178,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2128
+        content_length: 1699
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-L","creation_date":"2025-01-27T13:50:15.251562+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-chatterjee","id":"d8516adf-032e-440b-b49b-cfb0680d0df7","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:79","maintenances":[],"modification_date":"2025-01-27T13:50:19.808101+00:00","name":"tf-srv-great-chatterjee","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["front"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:15.251562+00:00","export_uri":null,"id":"77e7811b-88a8-4be0-b07b-58985ab787ac","modification_date":"2025-01-27T13:50:15.251562+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d8516adf-032e-440b-b49b-cfb0680d0df7","name":"tf-srv-great-chatterjee"},"size":80000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-L","creation_date":"2025-02-11T14:24:28.480567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-proskuriakova","id":"72b170ac-2b54-4219-9e5f-0da522be47e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:0b","maintenances":[],"modification_date":"2025-02-11T14:24:32.343814+00:00","name":"tf-srv-mystifying-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["front"],"volumes":{"0":{"boot":false,"id":"48771966-8a68-4382-ae0b-f6ce5b4a0cb9","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2128"
+                - "1699"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:19 GMT
+                - Tue, 11 Feb 2025 14:24:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1052,157 +1199,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0f047920-2009-43f1-a320-d79ef4e05137
+                - 4e983af7-a169-4f49-8e13-dcdec8a92ef5
         status: 200 OK
         code: 200
-        duration: 615.852167ms
-    - id: 21
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d8516adf-032e-440b-b49b-cfb0680d0df7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2128
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-L","creation_date":"2025-01-27T13:50:15.251562+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-chatterjee","id":"d8516adf-032e-440b-b49b-cfb0680d0df7","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:79","maintenances":[],"modification_date":"2025-01-27T13:50:19.808101+00:00","name":"tf-srv-great-chatterjee","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["front"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:15.251562+00:00","export_uri":null,"id":"77e7811b-88a8-4be0-b07b-58985ab787ac","modification_date":"2025-01-27T13:50:15.251562+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d8516adf-032e-440b-b49b-cfb0680d0df7","name":"tf-srv-great-chatterjee"},"size":80000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2128"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:19 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 306d2a94-c9aa-476a-94d3-1f7f64066c62
-        status: 200 OK
-        code: 200
-        duration: 165.046042ms
-    - id: 22
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d8516adf-032e-440b-b49b-cfb0680d0df7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2128
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-L","creation_date":"2025-01-27T13:50:15.251562+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-chatterjee","id":"d8516adf-032e-440b-b49b-cfb0680d0df7","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:79","maintenances":[],"modification_date":"2025-01-27T13:50:19.808101+00:00","name":"tf-srv-great-chatterjee","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["front"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:15.251562+00:00","export_uri":null,"id":"77e7811b-88a8-4be0-b07b-58985ab787ac","modification_date":"2025-01-27T13:50:15.251562+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d8516adf-032e-440b-b49b-cfb0680d0df7","name":"tf-srv-great-chatterjee"},"size":80000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2128"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:20 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 033bbbf8-3b06-4837-a373-3f595e5fa155
-        status: 200 OK
-        code: 200
-        duration: 112.78675ms
-    - id: 23
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/77e7811b-88a8-4be0-b07b-58985ab787ac
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 523
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:50:15.251562+00:00","export_uri":null,"id":"77e7811b-88a8-4be0-b07b-58985ab787ac","modification_date":"2025-01-27T13:50:15.251562+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d8516adf-032e-440b-b49b-cfb0680d0df7","name":"tf-srv-great-chatterjee"},"size":80000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "523"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:20 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - b243335e-de42-4e44-b288-69eff1e7ecf1
-        status: 200 OK
-        code: 200
-        duration: 77.868833ms
+        duration: 557.682542ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1218,8 +1218,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d8516adf-032e-440b-b49b-cfb0680d0df7/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72b170ac-2b54-4219-9e5f-0da522be47e6
         method: GET
       response:
         proto: HTTP/2.0
@@ -1227,20 +1227,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 1699
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-L","creation_date":"2025-02-11T14:24:28.480567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-proskuriakova","id":"72b170ac-2b54-4219-9e5f-0da522be47e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:0b","maintenances":[],"modification_date":"2025-02-11T14:24:32.343814+00:00","name":"tf-srv-mystifying-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["front"],"volumes":{"0":{"boot":false,"id":"48771966-8a68-4382-ae0b-f6ce5b4a0cb9","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "17"
+                - "1699"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:20 GMT
+                - Tue, 11 Feb 2025 14:24:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1248,10 +1248,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e84424bb-faf9-40df-84c3-23e78ebbe5e9
+                - a11fdf55-1e70-46dc-a97c-425db260716b
         status: 200 OK
         code: 200
-        duration: 105.319208ms
+        duration: 730.775084ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1267,8 +1267,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d8516adf-032e-440b-b49b-cfb0680d0df7/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72b170ac-2b54-4219-9e5f-0da522be47e6
         method: GET
       response:
         proto: HTTP/2.0
@@ -1276,22 +1276,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 1699
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-L","creation_date":"2025-02-11T14:24:28.480567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-proskuriakova","id":"72b170ac-2b54-4219-9e5f-0da522be47e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:0b","maintenances":[],"modification_date":"2025-02-11T14:24:32.343814+00:00","name":"tf-srv-mystifying-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["front"],"volumes":{"0":{"boot":false,"id":"48771966-8a68-4382-ae0b-f6ce5b4a0cb9","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "20"
+                - "1699"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:20 GMT
-            Link:
-                - </servers/d8516adf-032e-440b-b49b-cfb0680d0df7/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:24:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1299,12 +1297,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c63620ca-710d-44d0-a44a-7120226e8ed4
-            X-Total-Count:
-                - "0"
+                - 1c2370ea-2a43-489e-b1d0-2b1fe1c5e85c
         status: 200 OK
         code: 200
-        duration: 92.933833ms
+        duration: 168.278084ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1320,8 +1316,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d8516adf-032e-440b-b49b-cfb0680d0df7
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/48771966-8a68-4382-ae0b-f6ce5b4a0cb9
         method: GET
       response:
         proto: HTTP/2.0
@@ -1329,20 +1325,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2128
+        content_length: 143
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-L","creation_date":"2025-01-27T13:50:15.251562+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-chatterjee","id":"d8516adf-032e-440b-b49b-cfb0680d0df7","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:79","maintenances":[],"modification_date":"2025-01-27T13:50:19.808101+00:00","name":"tf-srv-great-chatterjee","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["front"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:15.251562+00:00","export_uri":null,"id":"77e7811b-88a8-4be0-b07b-58985ab787ac","modification_date":"2025-01-27T13:50:15.251562+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d8516adf-032e-440b-b49b-cfb0680d0df7","name":"tf-srv-great-chatterjee"},"size":80000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"48771966-8a68-4382-ae0b-f6ce5b4a0cb9","type":"not_found"}'
         headers:
             Content-Length:
-                - "2128"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:20 GMT
+                - Tue, 11 Feb 2025 14:24:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1350,10 +1346,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 86462b8e-43e4-4891-b56e-03d9bdea0df5
-        status: 200 OK
-        code: 200
-        duration: 171.391209ms
+                - 52e363e4-3736-4729-a0c8-d118679e6ff5
+        status: 404 Not Found
+        code: 404
+        duration: 32.1325ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1369,8 +1365,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d8516adf-032e-440b-b49b-cfb0680d0df7
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/48771966-8a68-4382-ae0b-f6ce5b4a0cb9
         method: GET
       response:
         proto: HTTP/2.0
@@ -1378,20 +1374,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2128
+        content_length: 701
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-L","creation_date":"2025-01-27T13:50:15.251562+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-chatterjee","id":"d8516adf-032e-440b-b49b-cfb0680d0df7","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:79","maintenances":[],"modification_date":"2025-01-27T13:50:19.808101+00:00","name":"tf-srv-great-chatterjee","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["front"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:15.251562+00:00","export_uri":null,"id":"77e7811b-88a8-4be0-b07b-58985ab787ac","modification_date":"2025-01-27T13:50:15.251562+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d8516adf-032e-440b-b49b-cfb0680d0df7","name":"tf-srv-great-chatterjee"},"size":80000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T14:24:28.670554Z","id":"48771966-8a68-4382-ae0b-f6ce5b4a0cb9","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:24:28.670554Z","id":"e3f45618-fca7-4967-aff4-2f0eb6ad02ee","product_resource_id":"72b170ac-2b54-4219-9e5f-0da522be47e6","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:24:28.670554Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2128"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:20 GMT
+                - Tue, 11 Feb 2025 14:24:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1399,10 +1395,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2d1a84d4-0aa2-4d65-b052-2233fe54a92b
+                - f56e3a77-ba82-47a7-bcff-ba3f7a99fe2a
         status: 200 OK
         code: 200
-        duration: 121.037916ms
+        duration: 72.001125ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1418,57 +1414,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/77e7811b-88a8-4be0-b07b-58985ab787ac
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 523
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:50:15.251562+00:00","export_uri":null,"id":"77e7811b-88a8-4be0-b07b-58985ab787ac","modification_date":"2025-01-27T13:50:15.251562+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d8516adf-032e-440b-b49b-cfb0680d0df7","name":"tf-srv-great-chatterjee"},"size":80000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "523"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:20 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - cb73919a-73ba-4b94-b321-7bfd2638aef7
-        status: 200 OK
-        code: 200
-        duration: 81.826875ms
-    - id: 29
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d8516adf-032e-440b-b49b-cfb0680d0df7/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72b170ac-2b54-4219-9e5f-0da522be47e6/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1487,9 +1434,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:21 GMT
+                - Tue, 11 Feb 2025 14:24:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1497,11 +1444,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8e6ae631-feed-480c-99dc-a7387dc5778c
+                - 5946f23b-6690-481a-9e42-f225226d933d
         status: 200 OK
         code: 200
-        duration: 112.252584ms
-    - id: 30
+        duration: 79.048125ms
+    - id: 29
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1516,8 +1463,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d8516adf-032e-440b-b49b-cfb0680d0df7/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72b170ac-2b54-4219-9e5f-0da522be47e6/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1536,11 +1483,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:21 GMT
+                - Tue, 11 Feb 2025 14:24:33 GMT
             Link:
-                - </servers/d8516adf-032e-440b-b49b-cfb0680d0df7/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/72b170ac-2b54-4219-9e5f-0da522be47e6/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1548,12 +1495,61 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d43115c6-ca64-4d14-a809-58d7eb57a1d5
+                - fb1eaa70-4a49-4f75-a20a-11422a9950a4
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 94.239708ms
+        duration: 116.602958ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72b170ac-2b54-4219-9e5f-0da522be47e6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1699
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-L","creation_date":"2025-02-11T14:24:28.480567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-proskuriakova","id":"72b170ac-2b54-4219-9e5f-0da522be47e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:0b","maintenances":[],"modification_date":"2025-02-11T14:24:32.343814+00:00","name":"tf-srv-mystifying-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["front"],"volumes":{"0":{"boot":false,"id":"48771966-8a68-4382-ae0b-f6ce5b4a0cb9","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1699"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 61e14d60-a359-40d7-9963-160642132baa
+        status: 200 OK
+        code: 200
+        duration: 150.86075ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1569,8 +1565,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d8516adf-032e-440b-b49b-cfb0680d0df7
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72b170ac-2b54-4219-9e5f-0da522be47e6
         method: GET
       response:
         proto: HTTP/2.0
@@ -1578,20 +1574,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2128
+        content_length: 1699
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-L","creation_date":"2025-01-27T13:50:15.251562+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-chatterjee","id":"d8516adf-032e-440b-b49b-cfb0680d0df7","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:79","maintenances":[],"modification_date":"2025-01-27T13:50:19.808101+00:00","name":"tf-srv-great-chatterjee","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["front"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:15.251562+00:00","export_uri":null,"id":"77e7811b-88a8-4be0-b07b-58985ab787ac","modification_date":"2025-01-27T13:50:15.251562+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d8516adf-032e-440b-b49b-cfb0680d0df7","name":"tf-srv-great-chatterjee"},"size":80000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-L","creation_date":"2025-02-11T14:24:28.480567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-proskuriakova","id":"72b170ac-2b54-4219-9e5f-0da522be47e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:0b","maintenances":[],"modification_date":"2025-02-11T14:24:32.343814+00:00","name":"tf-srv-mystifying-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["front"],"volumes":{"0":{"boot":false,"id":"48771966-8a68-4382-ae0b-f6ce5b4a0cb9","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2128"
+                - "1699"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:21 GMT
+                - Tue, 11 Feb 2025 14:24:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1599,10 +1595,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 853884ff-2400-40d0-a9e8-72f5564f6bfd
+                - 39229de6-2a51-4afd-bb64-84908daf1638
         status: 200 OK
         code: 200
-        duration: 159.323708ms
+        duration: 134.973334ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1618,8 +1614,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d8516adf-032e-440b-b49b-cfb0680d0df7
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/48771966-8a68-4382-ae0b-f6ce5b4a0cb9
         method: GET
       response:
         proto: HTTP/2.0
@@ -1627,20 +1623,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2128
+        content_length: 143
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-L","creation_date":"2025-01-27T13:50:15.251562+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-chatterjee","id":"d8516adf-032e-440b-b49b-cfb0680d0df7","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:79","maintenances":[],"modification_date":"2025-01-27T13:50:19.808101+00:00","name":"tf-srv-great-chatterjee","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["front"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:15.251562+00:00","export_uri":null,"id":"77e7811b-88a8-4be0-b07b-58985ab787ac","modification_date":"2025-01-27T13:50:15.251562+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d8516adf-032e-440b-b49b-cfb0680d0df7","name":"tf-srv-great-chatterjee"},"size":80000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"48771966-8a68-4382-ae0b-f6ce5b4a0cb9","type":"not_found"}'
         headers:
             Content-Length:
-                - "2128"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:21 GMT
+                - Tue, 11 Feb 2025 14:24:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1648,10 +1644,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8cc300e4-543c-4e8f-8083-9ed294d9fb88
-        status: 200 OK
-        code: 200
-        duration: 117.109833ms
+                - 7ad45187-e168-4356-9e24-6776ca8e0150
+        status: 404 Not Found
+        code: 404
+        duration: 29.622625ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1667,27 +1663,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d8516adf-032e-440b-b49b-cfb0680d0df7
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/48771966-8a68-4382-ae0b-f6ce5b4a0cb9
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 701
         uncompressed: false
-        body: ""
+        body: '{"created_at":"2025-02-11T14:24:28.670554Z","id":"48771966-8a68-4382-ae0b-f6ce5b4a0cb9","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:24:28.670554Z","id":"e3f45618-fca7-4967-aff4-2f0eb6ad02ee","product_resource_id":"72b170ac-2b54-4219-9e5f-0da522be47e6","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:24:28.670554Z","zone":"fr-par-1"}'
         headers:
+            Content-Length:
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:22 GMT
+                - Tue, 11 Feb 2025 14:24:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1695,10 +1693,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 19e9800b-9bc4-48a9-9576-6b62cca7dbcb
-        status: 204 No Content
-        code: 204
-        duration: 180.417208ms
+                - dfeb1691-8101-4ecf-bec2-a6a9c9af9dbd
+        status: 200 OK
+        code: 200
+        duration: 64.079875ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1714,8 +1712,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d8516adf-032e-440b-b49b-cfb0680d0df7
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72b170ac-2b54-4219-9e5f-0da522be47e6/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1723,20 +1721,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 143
+        content_length: 17
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"d8516adf-032e-440b-b49b-cfb0680d0df7","type":"not_found"}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "143"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:22 GMT
+                - Tue, 11 Feb 2025 14:24:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1744,10 +1742,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 83fb3b62-073a-4362-89dd-45944b28d1f7
-        status: 404 Not Found
-        code: 404
-        duration: 107.369458ms
+                - a686c61f-935e-455a-9ced-46710083a7ac
+        status: 200 OK
+        code: 200
+        duration: 73.902625ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1763,8 +1761,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/77e7811b-88a8-4be0-b07b-58985ab787ac
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72b170ac-2b54-4219-9e5f-0da522be47e6/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1772,20 +1770,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 446
+        content_length: 20
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:50:15.251562+00:00","export_uri":null,"id":"77e7811b-88a8-4be0-b07b-58985ab787ac","modification_date":"2025-01-27T13:50:22.014350+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":80000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "446"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:22 GMT
+                - Tue, 11 Feb 2025 14:24:34 GMT
+            Link:
+                - </servers/72b170ac-2b54-4219-9e5f-0da522be47e6/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1793,10 +1793,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d12ff1a3-3b59-4545-a22a-d373950f0281
+                - d6c9b6b6-d6cf-490c-9f62-206617d9e7dc
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 84.125708ms
+        duration: 114.06875ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1812,8 +1814,106 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/77e7811b-88a8-4be0-b07b-58985ab787ac
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72b170ac-2b54-4219-9e5f-0da522be47e6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1699
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-L","creation_date":"2025-02-11T14:24:28.480567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-proskuriakova","id":"72b170ac-2b54-4219-9e5f-0da522be47e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:0b","maintenances":[],"modification_date":"2025-02-11T14:24:32.343814+00:00","name":"tf-srv-mystifying-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["front"],"volumes":{"0":{"boot":false,"id":"48771966-8a68-4382-ae0b-f6ce5b4a0cb9","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1699"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a362f62c-f9f7-4660-bf4f-de6f64bee306
+        status: 200 OK
+        code: 200
+        duration: 183.229958ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72b170ac-2b54-4219-9e5f-0da522be47e6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1699
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-L","creation_date":"2025-02-11T14:24:28.480567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-mystifying-proskuriakova","id":"72b170ac-2b54-4219-9e5f-0da522be47e6","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:0b","maintenances":[],"modification_date":"2025-02-11T14:24:32.343814+00:00","name":"tf-srv-mystifying-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["front"],"volumes":{"0":{"boot":false,"id":"48771966-8a68-4382-ae0b-f6ce5b4a0cb9","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1699"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9ece1346-93b1-4c8e-a75d-546d5097efb7
+        status: 200 OK
+        code: 200
+        duration: 153.599ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72b170ac-2b54-4219-9e5f-0da522be47e6
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1830,9 +1930,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:22 GMT
+                - Tue, 11 Feb 2025 14:24:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1840,11 +1940,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bbec6e3b-4deb-4d95-b930-6ecc36431058
+                - a5e00357-df57-4b47-9133-3882d6684337
         status: 204 No Content
         code: 204
-        duration: 184.230959ms
-    - id: 37
+        duration: 273.463209ms
+    - id: 39
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1859,8 +1959,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d8516adf-032e-440b-b49b-cfb0680d0df7
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72b170ac-2b54-4219-9e5f-0da522be47e6
         method: GET
       response:
         proto: HTTP/2.0
@@ -1870,7 +1970,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"d8516adf-032e-440b-b49b-cfb0680d0df7","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"72b170ac-2b54-4219-9e5f-0da522be47e6","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -1879,9 +1979,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:22 GMT
+                - Tue, 11 Feb 2025 14:24:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1889,7 +1989,201 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bb2c32c2-dd8a-42ee-81e3-8eba6139af50
+                - 1fd5f152-99bd-42f1-9553-e7e1632d3f87
         status: 404 Not Found
         code: 404
-        duration: 83.495292ms
+        duration: 83.599625ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/48771966-8a68-4382-ae0b-f6ce5b4a0cb9
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"48771966-8a68-4382-ae0b-f6ce5b4a0cb9","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0550b16c-6510-48da-a32f-2f2f67219d89
+        status: 404 Not Found
+        code: 404
+        duration: 26.880875ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/48771966-8a68-4382-ae0b-f6ce5b4a0cb9
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 494
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:24:28.670554Z","id":"48771966-8a68-4382-ae0b-f6ce5b4a0cb9","last_detached_at":"2025-02-11T14:24:35.481925Z","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:24:35.481925Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "494"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b4b56700-e5c8-4e2b-ab3a-82dd55ad2181
+        status: 200 OK
+        code: 200
+        duration: 108.342542ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/48771966-8a68-4382-ae0b-f6ce5b4a0cb9
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 018c1999-9ba1-4f84-b3f7-aa5f72e2bf09
+        status: 204 No Content
+        code: 204
+        duration: 114.166458ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72b170ac-2b54-4219-9e5f-0da522be47e6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"72b170ac-2b54-4219-9e5f-0da522be47e6","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6aba54c9-c70e-4c8c-a8d4-de1b55a93f90
+        status: 404 Not Found
+        code: 404
+        duration: 113.511792ms

--- a/internal/services/instance/testdata/server-custom-diff-image.cassette.yaml
+++ b/internal/services/instance/testdata/server-custom-diff-image.cassette.yaml
@@ -16,7 +16,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
         method: GET
       response:
@@ -25,22 +25,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 38539
+        content_length: 35639
         uncompressed: false
-        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
+        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
         headers:
             Content-Length:
-                - "38539"
+                - "35639"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:55 GMT
+                - Tue, 11 Feb 2025 14:20:03 GMT
             Link:
                 - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,12 +48,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 244c9bcb-2110-4d90-94e0-8176d77010ae
+                - 782b8b8a-64cd-4931-9c7e-759b37988c47
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 65.378041ms
+        duration: 201.068667ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -69,7 +69,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
         method: GET
       response:
@@ -78,22 +78,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 14208
+        content_length: 13164
         uncompressed: false
-        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
         headers:
             Content-Length:
-                - "14208"
+                - "13164"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:55 GMT
+                - Tue, 11 Feb 2025 14:20:03 GMT
             Link:
                 - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -101,12 +101,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 534579cf-0372-476f-b010-e4bb62861f81
+                - 33aced85-478f-45a0-9115-018ade81cf98
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 42.708125ms
+        duration: 51.5015ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -122,7 +122,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=type_asc&type=instance_local&zone=fr-par-1
         method: GET
       response:
@@ -142,9 +142,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:56 GMT
+                - Tue, 11 Feb 2025 14:20:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -152,28 +152,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8aafca34-7bdd-4a62-a95b-e25d37302d22
+                - 39d1d1bc-0d75-4c72-971e-d8f675eaf2c2
         status: 200 OK
         code: 200
-        duration: 106.16625ms
+        duration: 89.289334ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 278
+        content_length: 274
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-srv-interesting-haibt","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+        body: '{"name":"tf-srv-sleepy-keller","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
         method: POST
       response:
@@ -182,22 +182,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 2124
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:56 GMT
+                - Tue, 11 Feb 2025 14:20:03 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -205,10 +205,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a33c3868-a870-44cc-b6ec-4e585805f92e
+                - b40c45e0-ecbc-4162-a398-70ee2e33dee4
         status: 201 Created
         code: 201
-        duration: 522.816292ms
+        duration: 718.046875ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -224,8 +224,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -233,20 +233,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 2124
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:56 GMT
+                - Tue, 11 Feb 2025 14:20:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -254,10 +254,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 43abfddf-1e91-4429-b873-061da26fc26f
+                - d7ca20b8-300b-449b-8b2d-3144a66089cb
         status: 200 OK
         code: 200
-        duration: 149.831041ms
+        duration: 140.573084ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -273,8 +273,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -282,20 +282,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 2124
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:56 GMT
+                - Tue, 11 Feb 2025 14:20:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -303,10 +303,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c9536f8d-2b3f-4592-8d3e-29b72911e516
+                - 1a0c53f0-5147-40bb-81de-7a05f9ec375a
         status: 200 OK
         code: 200
-        duration: 151.492625ms
+        duration: 296.179417ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -322,8 +322,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -331,20 +331,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 2124
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:56 GMT
+                - Tue, 11 Feb 2025 14:20:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -352,10 +352,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a1b5e0ae-565b-4440-83ec-74a405bf773f
+                - 7ae82341-1d5f-4f5b-a27a-b5d68667ed44
         status: 200 OK
         code: 200
-        duration: 163.515042ms
+        duration: 162.816042ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -371,8 +371,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/514d0afb-1730-46f3-8fa7-fe8f4d785dd4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f7ebe259-690e-47ab-9cc7-d2c915fb6ee7
         method: GET
       response:
         proto: HTTP/2.0
@@ -380,20 +380,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 528
+        content_length: 524
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "528"
+                - "524"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:56 GMT
+                - Tue, 11 Feb 2025 14:20:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -401,10 +401,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 57a05e69-2179-4eaf-a1f1-f47866bf915c
+                - 71337f18-7b22-4529-8dc3-b504239077c1
         status: 200 OK
         code: 200
-        duration: 124.065125ms
+        duration: 82.195625ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -420,8 +420,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -440,9 +440,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:56 GMT
+                - Tue, 11 Feb 2025 14:20:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -450,10 +450,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d0b09ca7-365a-432f-9826-a4ebeb0eeac0
+                - fd7022fd-0321-4a51-8026-f9c7c427f051
         status: 200 OK
         code: 200
-        duration: 104.903791ms
+        duration: 89.748833ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -469,8 +469,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -489,11 +489,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:57 GMT
+                - Tue, 11 Feb 2025 14:20:04 GMT
             Link:
-                - </servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/82be23cc-5a25-4d4a-8605-65b8376d1588/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -501,12 +501,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3d466251-1104-4f06-afd1-5e53de333ce4
+                - 837bc6bb-fb76-44c0-a706-bfae2b2cc534
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 128.887334ms
+        duration: 87.947875ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -522,8 +522,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -531,20 +531,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 2124
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:57 GMT
+                - Tue, 11 Feb 2025 14:20:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -552,10 +552,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5cd6e79d-e6e5-454a-9ba5-fa83d3ddc511
+                - 8f3c5363-22e4-466a-b192-9a322ba4382e
         status: 200 OK
         code: 200
-        duration: 178.96375ms
+        duration: 169.778083ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -571,8 +571,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -580,20 +580,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 2124
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:57 GMT
+                - Tue, 11 Feb 2025 14:20:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -601,10 +601,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8bb1833d-57b3-42cb-ae1f-12eadebd69d1
+                - 7328214e-7b86-41cd-b681-582f222c9f94
         status: 200 OK
         code: 200
-        duration: 260.599416ms
+        duration: 138.338542ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -620,8 +620,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/514d0afb-1730-46f3-8fa7-fe8f4d785dd4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f7ebe259-690e-47ab-9cc7-d2c915fb6ee7
         method: GET
       response:
         proto: HTTP/2.0
@@ -629,20 +629,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 528
+        content_length: 524
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "528"
+                - "524"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:57 GMT
+                - Tue, 11 Feb 2025 14:20:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -650,10 +650,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 77102f60-c291-4a2a-bbb5-1432128f3619
+                - c9b5d2a7-8fab-4248-81ac-7f0d73bf31d0
         status: 200 OK
         code: 200
-        duration: 123.644917ms
+        duration: 88.820625ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -669,8 +669,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -689,9 +689,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:57 GMT
+                - Tue, 11 Feb 2025 14:20:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -699,10 +699,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - eae0301b-9b40-4404-9ddd-8263cf5e0c06
+                - 9baabbd3-5bf6-4ea2-ab89-c5ab1bbaf9c5
         status: 200 OK
         code: 200
-        duration: 180.846792ms
+        duration: 109.678417ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -718,8 +718,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -738,11 +738,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:57 GMT
+                - Tue, 11 Feb 2025 14:20:05 GMT
             Link:
-                - </servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/82be23cc-5a25-4d4a-8605-65b8376d1588/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -750,12 +750,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3e5da5f0-bdc3-46d0-add4-525a333863e9
+                - 3c62c18e-7aff-40b8-be76-7c877aa44e8a
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 175.98025ms
+        duration: 277.445291ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -771,8 +771,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -780,20 +780,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 2124
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:58 GMT
+                - Tue, 11 Feb 2025 14:20:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -801,10 +801,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1394e976-9450-4e5d-b835-b6152f2fae1a
+                - 0699acf2-d220-4759-b7ac-c637d5538f3c
         status: 200 OK
         code: 200
-        duration: 281.471292ms
+        duration: 110.657917ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -820,8 +820,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/514d0afb-1730-46f3-8fa7-fe8f4d785dd4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f7ebe259-690e-47ab-9cc7-d2c915fb6ee7
         method: GET
       response:
         proto: HTTP/2.0
@@ -829,20 +829,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 528
+        content_length: 524
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "528"
+                - "524"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:58 GMT
+                - Tue, 11 Feb 2025 14:20:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -850,10 +850,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e29d6bb9-101c-4d64-96e7-c9e044f43ce5
+                - 284e97a5-9537-45d7-aec4-71b6a8eee1c3
         status: 200 OK
         code: 200
-        duration: 133.268583ms
+        duration: 108.939709ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -869,8 +869,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -889,9 +889,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:58 GMT
+                - Tue, 11 Feb 2025 14:20:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -899,10 +899,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b807b642-c3ef-49f2-8a57-2d8551a6c30c
+                - 9a1acc4c-3353-41da-802f-8802f43b19fd
         status: 200 OK
         code: 200
-        duration: 186.522041ms
+        duration: 102.402292ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -918,8 +918,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -938,11 +938,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:59 GMT
+                - Tue, 11 Feb 2025 14:20:06 GMT
             Link:
-                - </servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/82be23cc-5a25-4d4a-8605-65b8376d1588/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -950,12 +950,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f1d9b9c1-7949-4838-ae65-444e620bcd52
+                - 7eba00c7-27ff-4d76-a7c0-fc768824a310
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 161.588083ms
+        duration: 99.102625ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -971,7 +971,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=type_asc&type=instance_local&zone=fr-par-1
         method: GET
       response:
@@ -991,9 +991,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:59 GMT
+                - Tue, 11 Feb 2025 14:20:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1001,10 +1001,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1b46ba3e-5e24-4e44-a1bd-325a7a61f317
+                - a85c8490-fddf-4c03-898d-2bce2447ea64
         status: 200 OK
         code: 200
-        duration: 181.573584ms
+        duration: 93.256791ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1020,8 +1020,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -1029,20 +1029,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 2124
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:59 GMT
+                - Tue, 11 Feb 2025 14:20:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1050,10 +1050,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a0f7c0b6-3527-4353-9599-4f91e8684824
+                - 76286f29-0f9b-41c2-ba37-547990d0c7f5
         status: 200 OK
         code: 200
-        duration: 214.207708ms
+        duration: 143.682125ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1069,8 +1069,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/514d0afb-1730-46f3-8fa7-fe8f4d785dd4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f7ebe259-690e-47ab-9cc7-d2c915fb6ee7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1078,20 +1078,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 528
+        content_length: 524
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "528"
+                - "524"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:59 GMT
+                - Tue, 11 Feb 2025 14:20:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1099,10 +1099,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 51aef70a-318c-42a2-b964-effdaa667f0e
+                - e153bc53-8f9a-449c-9679-91527591d324
         status: 200 OK
         code: 200
-        duration: 105.65775ms
+        duration: 74.26525ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1118,8 +1118,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -1127,20 +1127,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 2124
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:59 GMT
+                - Tue, 11 Feb 2025 14:20:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1148,10 +1148,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0116fca1-d9cd-4808-b11c-a6a8c6084ed3
+                - 067abf05-1809-4d64-8ba9-8c13b18cd55c
         status: 200 OK
         code: 200
-        duration: 137.367375ms
+        duration: 126.167958ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1167,8 +1167,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1187,9 +1187,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:59 GMT
+                - Tue, 11 Feb 2025 14:20:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1197,10 +1197,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 742ceea6-8652-4775-bd59-80737c70ab31
+                - 19ff1653-de4f-4309-b168-b26042812613
         status: 200 OK
         code: 200
-        duration: 311.591542ms
+        duration: 93.177041ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1216,8 +1216,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/514d0afb-1730-46f3-8fa7-fe8f4d785dd4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f7ebe259-690e-47ab-9cc7-d2c915fb6ee7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1225,20 +1225,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 528
+        content_length: 524
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "528"
+                - "524"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:00 GMT
+                - Tue, 11 Feb 2025 14:20:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1246,10 +1246,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5ae82547-9e80-4dba-a7ae-4301156baa35
+                - cebe792c-40b3-4abf-b5bb-84e9f3a1002f
         status: 200 OK
         code: 200
-        duration: 311.429709ms
+        duration: 109.442417ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1265,8 +1265,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1285,9 +1285,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:00 GMT
+                - Tue, 11 Feb 2025 14:20:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1295,10 +1295,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 255ebe39-4faa-49dc-b4ea-df4c0d00f161
+                - 3ef8e90f-c5bc-41e8-a6fc-01b2f3d4d583
         status: 200 OK
         code: 200
-        duration: 179.551916ms
+        duration: 94.559959ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1314,8 +1314,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1334,11 +1334,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:00 GMT
+                - Tue, 11 Feb 2025 14:20:07 GMT
             Link:
-                - </servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/82be23cc-5a25-4d4a-8605-65b8376d1588/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1346,12 +1346,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - da5f702f-1702-4920-bce8-a092f7f85e80
+                - af0a497a-4622-4a3e-a4de-25c746421cef
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 180.784792ms
+        duration: 179.047ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1367,8 +1367,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1387,11 +1387,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:00 GMT
+                - Tue, 11 Feb 2025 14:20:06 GMT
             Link:
-                - </servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/82be23cc-5a25-4d4a-8605-65b8376d1588/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1399,12 +1399,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4a1b1e9c-9f0b-45d9-abbb-6b7a1d389c84
+                - 1a2bf918-367f-4a49-bca6-fb219cc4574d
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 92.865583ms
+        duration: 131.393208ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1420,8 +1420,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -1429,20 +1429,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 2124
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:00 GMT
+                - Tue, 11 Feb 2025 14:20:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1450,10 +1450,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4971e234-9666-4515-8a6e-d36bf2a2aed2
+                - ccdd4474-bdca-420f-be31-e8082250bf9d
         status: 200 OK
         code: 200
-        duration: 176.335708ms
+        duration: 181.584334ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1469,8 +1469,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -1478,20 +1478,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 2124
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:00 GMT
+                - Tue, 11 Feb 2025 14:20:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1499,10 +1499,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1a7a3e69-5c9d-4f0d-8f71-f7602aa2365f
+                - 2b9af435-2639-43e8-9302-ca2fd13c6ced
         status: 200 OK
         code: 200
-        duration: 266.291625ms
+        duration: 166.012083ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1518,7 +1518,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/marketplace/v2/local-images/bc50e86c-a6c7-401a-8fbb-2ef17ce87aee
         method: GET
       response:
@@ -1538,9 +1538,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:00 GMT
+                - Tue, 11 Feb 2025 14:20:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1548,10 +1548,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - deb505a0-8870-4afa-920b-98142222a9bc
+                - a4668549-0abf-43d4-82bc-38f81ea3729f
         status: 200 OK
         code: 200
-        duration: 95.016416ms
+        duration: 210.473833ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1567,7 +1567,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=type_asc&type=instance_local&zone=fr-par-1
         method: GET
       response:
@@ -1587,9 +1587,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:01 GMT
+                - Tue, 11 Feb 2025 14:20:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1597,10 +1597,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 242a69ed-becd-4b8b-b64d-9495935bc501
+                - d9a1a4d8-06a2-4d11-9496-1134b1e8e3ae
         status: 200 OK
         code: 200
-        duration: 269.839584ms
+        duration: 86.960167ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1616,8 +1616,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -1625,20 +1625,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 2124
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:00 GMT
+                - Tue, 11 Feb 2025 14:20:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1646,10 +1646,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5d2a8521-7bb2-431d-8333-5684f1a5cf99
+                - 190cf4fb-5543-4320-9394-67f72caa4cef
         status: 200 OK
         code: 200
-        duration: 267.336708ms
+        duration: 154.924334ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1665,7 +1665,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/marketplace/v2/local-images/bc50e86c-a6c7-401a-8fbb-2ef17ce87aee
         method: GET
       response:
@@ -1685,9 +1685,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:01 GMT
+                - Tue, 11 Feb 2025 14:20:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1695,10 +1695,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1f15a721-d98b-4f5b-b025-78503a976eb4
+                - db4f0c21-0040-406d-88c0-8a4a7f233c63
         status: 200 OK
         code: 200
-        duration: 103.674625ms
+        duration: 82.974875ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1714,8 +1714,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -1723,20 +1723,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 2124
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:00 GMT
+                - Tue, 11 Feb 2025 14:20:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1744,10 +1744,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f9bf2b9b-45b9-4734-aa7c-c83c017d17e6
+                - 7a4bb1a6-019d-4307-b839-a3bd340174a1
         status: 200 OK
         code: 200
-        duration: 278.720416ms
+        duration: 157.976709ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1763,8 +1763,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -1772,20 +1772,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 2124
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:01 GMT
+                - Tue, 11 Feb 2025 14:20:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1793,10 +1793,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6753fae8-2d6f-4759-9e65-557269bf9e4f
+                - e29ec40f-fa90-4600-90bd-bae12ea9ab8c
         status: 200 OK
         code: 200
-        duration: 192.274833ms
+        duration: 162.450083ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1812,8 +1812,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -1821,20 +1821,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 2124
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:01 GMT
+                - Tue, 11 Feb 2025 14:20:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1842,10 +1842,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - af6a490f-3679-49a4-9c70-0d916b1684d2
+                - 92733afc-d994-4f92-a503-daa9ce10ad82
         status: 200 OK
         code: 200
-        duration: 221.016917ms
+        duration: 175.132167ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1861,7 +1861,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/marketplace/v2/local-images/bc50e86c-a6c7-401a-8fbb-2ef17ce87aee
         method: GET
       response:
@@ -1881,9 +1881,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:01 GMT
+                - Tue, 11 Feb 2025 14:20:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1891,10 +1891,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1a008a64-baec-4256-b4e5-7b3bccecd2e9
+                - d20105cb-91c2-4fa0-bc92-c2fdc03c151b
         status: 200 OK
         code: 200
-        duration: 75.55575ms
+        duration: 85.784042ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1910,8 +1910,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -1919,20 +1919,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 2124
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:01 GMT
+                - Tue, 11 Feb 2025 14:20:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1940,10 +1940,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e83fc444-eccd-4325-9a57-be0a200dc5e8
+                - 0e4dffbe-4103-4fd9-98ea-1bc417d302fa
         status: 200 OK
         code: 200
-        duration: 196.915875ms
+        duration: 152.381833ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1959,8 +1959,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -1968,20 +1968,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 2124
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:01 GMT
+                - Tue, 11 Feb 2025 14:20:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1989,10 +1989,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b3b2418c-6599-428b-a496-f2fd61ef10b2
+                - e11d93c9-0654-4328-a71c-e6b4e7a28f27
         status: 200 OK
         code: 200
-        duration: 151.567458ms
+        duration: 238.2185ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2008,8 +2008,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -2017,20 +2017,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 2124
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:02 GMT
+                - Tue, 11 Feb 2025 14:20:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2038,10 +2038,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e5d1e253-f47d-457e-acb0-676ce2800568
+                - ae2766d9-84fb-4cb1-b459-fb59bddbbbe4
         status: 200 OK
         code: 200
-        duration: 142.692375ms
+        duration: 161.935041ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2057,8 +2057,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -2066,20 +2066,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 2124
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:02 GMT
+                - Tue, 11 Feb 2025 14:20:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2087,10 +2087,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c0dade11-90c4-4a60-8220-5e91a8eade61
+                - 9d6daf3f-02b5-45bd-aac9-280ffac1addf
         status: 200 OK
         code: 200
-        duration: 163.915584ms
+        duration: 157.253458ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2106,8 +2106,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -2115,20 +2115,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 2124
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:02 GMT
+                - Tue, 11 Feb 2025 14:20:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2136,10 +2136,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1ee34755-4034-4c66-aa3f-64c064d6f33a
+                - 6c88165f-0850-41e1-bb54-7a7f8e74f9df
         status: 200 OK
         code: 200
-        duration: 133.857917ms
+        duration: 136.378417ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2155,8 +2155,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -2164,20 +2164,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 2124
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:02 GMT
+                - Tue, 11 Feb 2025 14:20:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2185,10 +2185,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 80b5c76b-765f-4c19-af1d-4650e051f61f
+                - a51f5504-e30f-4d69-95a3-bfcf83e67e40
         status: 200 OK
         code: 200
-        duration: 156.5215ms
+        duration: 171.429583ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2204,8 +2204,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/514d0afb-1730-46f3-8fa7-fe8f4d785dd4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f7ebe259-690e-47ab-9cc7-d2c915fb6ee7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2213,20 +2213,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 528
+        content_length: 524
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "528"
+                - "524"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:02 GMT
+                - Tue, 11 Feb 2025 14:20:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2234,10 +2234,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f95d8bb7-60f7-4566-90df-fac451943171
+                - 84f4925b-28ab-4fb6-aad3-d2e5c007bbac
         status: 200 OK
         code: 200
-        duration: 71.03375ms
+        duration: 76.389542ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2253,8 +2253,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/514d0afb-1730-46f3-8fa7-fe8f4d785dd4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f7ebe259-690e-47ab-9cc7-d2c915fb6ee7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2262,20 +2262,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 528
+        content_length: 524
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "528"
+                - "524"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:02 GMT
+                - Tue, 11 Feb 2025 14:20:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2283,10 +2283,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c83ccfbe-ee8b-48e6-80f4-8e127438c7d0
+                - 297ca855-b017-4188-ae38-35f9bb803e17
         status: 200 OK
         code: 200
-        duration: 83.478584ms
+        duration: 84.155958ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2302,8 +2302,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -2322,9 +2322,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:02 GMT
+                - Tue, 11 Feb 2025 14:20:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2332,10 +2332,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4360fe04-7cc6-4646-9ca1-aefd2336dc5f
+                - 65608355-78a4-476a-8870-ccd729251306
         status: 200 OK
         code: 200
-        duration: 98.589791ms
+        duration: 77.778584ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2351,8 +2351,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -2371,9 +2371,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:02 GMT
+                - Tue, 11 Feb 2025 14:20:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2381,10 +2381,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3c802562-2a2f-4b27-88aa-74853e88b709
+                - fdca0c39-0814-4380-80a2-905a6b560be7
         status: 200 OK
         code: 200
-        duration: 94.317375ms
+        duration: 93.52925ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2400,8 +2400,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -2420,11 +2420,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:02 GMT
+                - Tue, 11 Feb 2025 14:20:09 GMT
             Link:
-                - </servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/82be23cc-5a25-4d4a-8605-65b8376d1588/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2432,12 +2432,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f602a134-ca9d-4126-914b-1d374482d11e
+                - 95d1bd26-085f-448e-a5df-09599df72a75
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 92.961083ms
+        duration: 80.273792ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2453,8 +2453,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -2473,11 +2473,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:02 GMT
+                - Tue, 11 Feb 2025 14:20:08 GMT
             Link:
-                - </servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/82be23cc-5a25-4d4a-8605-65b8376d1588/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2485,12 +2485,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 498f0e4a-44c8-4ac2-9b4b-5c4b0279a96f
+                - 6a4cc311-d102-4120-aa07-43f900a9c0a8
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 94.55225ms
+        duration: 73.223833ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -2506,8 +2506,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -2515,20 +2515,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 2124
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:02 GMT
+                - Tue, 11 Feb 2025 14:20:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2536,10 +2536,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6b491fea-41ac-47b8-b9d0-334049785d8e
+                - b7467716-8c55-4dfb-b9bd-cc599f6c38a6
         status: 200 OK
         code: 200
-        duration: 121.345834ms
+        duration: 166.072334ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2555,8 +2555,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -2564,20 +2564,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 2124
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:02 GMT
+                - Tue, 11 Feb 2025 14:20:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2585,10 +2585,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - be94fcfb-4f36-4ba3-8738-7dcbd3b66170
+                - e1fc2352-9e50-482c-9aff-544d91cb893d
         status: 200 OK
         code: 200
-        duration: 128.1345ms
+        duration: 130.551875ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -2604,7 +2604,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=type_asc&type=instance_local&zone=fr-par-1
         method: GET
       response:
@@ -2624,9 +2624,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:03 GMT
+                - Tue, 11 Feb 2025 14:20:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2634,10 +2634,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a0fdce3d-24e4-4fde-b26a-8f61576dc625
+                - 34c04640-8244-457a-a0e5-9883fbe11435
         status: 200 OK
         code: 200
-        duration: 92.7935ms
+        duration: 85.330875ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -2653,7 +2653,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=type_asc&type=instance_local&zone=fr-par-1
         method: GET
       response:
@@ -2673,9 +2673,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:03 GMT
+                - Tue, 11 Feb 2025 14:20:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2683,10 +2683,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - eeb0c052-f5df-4a35-ab92-4b2b6bb47fe6
+                - 69b5470e-ddff-47dc-a2ff-dd309225c1e1
         status: 200 OK
         code: 200
-        duration: 66.869083ms
+        duration: 73.020958ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -2702,8 +2702,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -2711,20 +2711,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 2124
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:03 GMT
+                - Tue, 11 Feb 2025 14:20:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2732,10 +2732,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2d543cf3-83cd-499b-a092-861cd777fa7c
+                - 04b20e2d-76c1-4bb3-9cb5-bfd2385dd4d3
         status: 200 OK
         code: 200
-        duration: 161.674708ms
+        duration: 138.260208ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -2751,8 +2751,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/514d0afb-1730-46f3-8fa7-fe8f4d785dd4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -2760,20 +2760,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 528
+        content_length: 2124
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "528"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:03 GMT
+                - Tue, 11 Feb 2025 14:20:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2781,10 +2781,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4abce0f5-aca1-48a4-a97e-69ad399c8290
+                - d829ca7b-c8ff-4c50-9518-9b359c98a9ff
         status: 200 OK
         code: 200
-        duration: 70.930834ms
+        duration: 115.368875ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2800,8 +2800,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f7ebe259-690e-47ab-9cc7-d2c915fb6ee7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2809,20 +2809,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 524
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "524"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:03 GMT
+                - Tue, 11 Feb 2025 14:20:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2830,10 +2830,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 112580ee-e228-4a2e-8bf7-df7f2968e693
+                - 4e64269b-e42e-4ed9-9469-51eb058868cd
         status: 200 OK
         code: 200
-        duration: 162.572917ms
+        duration: 91.611459ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2849,8 +2849,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/514d0afb-1730-46f3-8fa7-fe8f4d785dd4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f7ebe259-690e-47ab-9cc7-d2c915fb6ee7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2858,20 +2858,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 528
+        content_length: 524
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "528"
+                - "524"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:03 GMT
+                - Tue, 11 Feb 2025 14:20:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2879,10 +2879,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a57209a7-d114-4282-a75b-40cdaddd6bfa
+                - a70a09fb-bb18-4d5a-85d1-213b739a2a29
         status: 200 OK
         code: 200
-        duration: 77.349042ms
+        duration: 90.355458ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -2898,8 +2898,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -2918,9 +2918,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:03 GMT
+                - Tue, 11 Feb 2025 14:20:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2928,10 +2928,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 28c29c5b-a698-4836-a9c2-ecf7dd0bdae2
+                - 6bc2a3ae-792b-4883-8fa0-9ac17dddb760
         status: 200 OK
         code: 200
-        duration: 81.032916ms
+        duration: 125.427875ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -2947,8 +2947,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -2967,9 +2967,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:03 GMT
+                - Tue, 11 Feb 2025 14:20:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2977,10 +2977,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cacc9794-c941-4ca9-97dd-334947c091d6
+                - 29f08ca9-f470-472f-b28f-ea3c48cd3db2
         status: 200 OK
         code: 200
-        duration: 86.550875ms
+        duration: 90.705209ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -2996,8 +2996,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -3016,11 +3016,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:03 GMT
+                - Tue, 11 Feb 2025 14:20:09 GMT
             Link:
-                - </servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/82be23cc-5a25-4d4a-8605-65b8376d1588/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3028,12 +3028,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 28d96552-bfe3-4b27-ae82-6fb237554d2d
+                - 9696c2be-fb1b-493f-9fab-24d627289a8a
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 91.043083ms
+        duration: 106.039625ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -3049,8 +3049,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -3069,11 +3069,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:03 GMT
+                - Tue, 11 Feb 2025 14:20:09 GMT
             Link:
-                - </servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/82be23cc-5a25-4d4a-8605-65b8376d1588/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3081,12 +3081,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ccb3cbd8-b0e4-4a76-b07e-cc55e1d34199
+                - ed57e7e8-9037-413f-9976-d8bfba4ea190
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 76.389541ms
+        duration: 102.76625ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -3102,7 +3102,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=type_asc&type=instance_local&zone=fr-par-1
         method: GET
       response:
@@ -3122,9 +3122,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:03 GMT
+                - Tue, 11 Feb 2025 14:20:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3132,10 +3132,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ea1ad306-a024-4acb-b1ed-9205e9f2c389
+                - 59054ef9-b821-48b9-bfb5-91ee47a09381
         status: 200 OK
         code: 200
-        duration: 72.515291ms
+        duration: 80.438792ms
     - id: 63
       request:
         proto: HTTP/1.1
@@ -3151,7 +3151,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=type_asc&type=instance_local&zone=fr-par-1
         method: GET
       response:
@@ -3171,9 +3171,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:04 GMT
+                - Tue, 11 Feb 2025 14:20:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3181,10 +3181,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5b2010b9-cfcc-4d71-85a4-34d779f001dc
+                - 822ed0fb-000e-4cd8-8d0f-a7250a3223ac
         status: 200 OK
         code: 200
-        duration: 70.666292ms
+        duration: 87.4665ms
     - id: 64
       request:
         proto: HTTP/1.1
@@ -3200,8 +3200,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -3209,20 +3209,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 2124
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:04 GMT
+                - Tue, 11 Feb 2025 14:20:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3230,10 +3230,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7ae32c2f-d335-49ff-acf2-df5ab3d0a50d
+                - 71dfb51c-de33-448a-93a4-684df5d83ea1
         status: 200 OK
         code: 200
-        duration: 138.631541ms
+        duration: 122.388708ms
     - id: 65
       request:
         proto: HTTP/1.1
@@ -3249,8 +3249,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f7ebe259-690e-47ab-9cc7-d2c915fb6ee7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3258,20 +3258,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 524
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "524"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:04 GMT
+                - Tue, 11 Feb 2025 14:20:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3279,10 +3279,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 928d119f-29ab-4333-951c-a9bfdc29f93e
+                - 0a399f61-fb98-47b5-a3ac-b9f1233a8f69
         status: 200 OK
         code: 200
-        duration: 124.69275ms
+        duration: 90.803875ms
     - id: 66
       request:
         proto: HTTP/1.1
@@ -3298,8 +3298,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/514d0afb-1730-46f3-8fa7-fe8f4d785dd4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -3307,20 +3307,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 528
+        content_length: 2124
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "528"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:03 GMT
+                - Tue, 11 Feb 2025 14:20:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3328,10 +3328,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cdfec19b-3bfc-4041-bb3a-d986b5f68cfc
+                - 2ad07a95-b347-4167-baef-4c07f7475a5e
         status: 200 OK
         code: 200
-        duration: 86.302291ms
+        duration: 164.791208ms
     - id: 67
       request:
         proto: HTTP/1.1
@@ -3347,8 +3347,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/514d0afb-1730-46f3-8fa7-fe8f4d785dd4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -3356,20 +3356,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 528
+        content_length: 17
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "528"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:03 GMT
+                - Tue, 11 Feb 2025 14:20:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3377,10 +3377,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d8a2656c-c0a4-4b1f-b688-e41e33794698
+                - a702ddbe-de4e-41d2-824c-94a9f0153400
         status: 200 OK
         code: 200
-        duration: 88.232708ms
+        duration: 98.519375ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -3396,8 +3396,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f7ebe259-690e-47ab-9cc7-d2c915fb6ee7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3405,20 +3405,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 524
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "17"
+                - "524"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:04 GMT
+                - Tue, 11 Feb 2025 14:20:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3426,10 +3426,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5c48f38b-2795-4d64-b2ba-6446ff06d285
+                - c00a70b4-b1e3-4287-bc26-7d36ed5a2dd6
         status: 200 OK
         code: 200
-        duration: 97.263167ms
+        duration: 74.9415ms
     - id: 69
       request:
         proto: HTTP/1.1
@@ -3445,8 +3445,61 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 20
+        uncompressed: false
+        body: '{"private_nics":[]}'
+        headers:
+            Content-Length:
+                - "20"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:20:10 GMT
+            Link:
+                - </servers/82be23cc-5a25-4d4a-8605-65b8376d1588/private_nics?page=0&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - da7d51e6-8850-4c6c-a25b-9b775e475df4
+            X-Total-Count:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 85.049875ms
+    - id: 70
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -3465,9 +3518,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:03 GMT
+                - Tue, 11 Feb 2025 14:20:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3475,63 +3528,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e4b5b7cf-cea1-4158-b769-2808516ea5d1
+                - dff62348-133f-4968-a7f5-1bad65a1c37f
         status: 200 OK
         code: 200
-        duration: 113.635791ms
-    - id: 70
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/private_nics
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 20
-        uncompressed: false
-        body: '{"private_nics":[]}'
-        headers:
-            Content-Length:
-                - "20"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:49:04 GMT
-            Link:
-                - </servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/private_nics?page=0&per_page=50&>; rel="last"
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 0fc0f829-5801-4800-937a-778875129e6c
-            X-Total-Count:
-                - "0"
-        status: 200 OK
-        code: 200
-        duration: 96.491042ms
+        duration: 92.606667ms
     - id: 71
       request:
         proto: HTTP/1.1
@@ -3547,8 +3547,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -3567,11 +3567,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:04 GMT
+                - Tue, 11 Feb 2025 14:20:10 GMT
             Link:
-                - </servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/82be23cc-5a25-4d4a-8605-65b8376d1588/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3579,12 +3579,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1e9d400f-aa8e-48eb-be20-8852a8e82430
+                - fb8e7354-ec1d-4cba-80e0-bd0a2b055bed
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 75.5235ms
+        duration: 99.69175ms
     - id: 72
       request:
         proto: HTTP/1.1
@@ -3600,8 +3600,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -3609,20 +3609,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 2124
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:04 GMT
+                - Tue, 11 Feb 2025 14:20:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3630,10 +3630,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2ac53bc2-dd1c-4695-b221-d8d9c67fe6ee
+                - 31b61f90-c3cb-42e6-8706-19ffe0da00b8
         status: 200 OK
         code: 200
-        duration: 166.532875ms
+        duration: 280.386833ms
     - id: 73
       request:
         proto: HTTP/1.1
@@ -3649,8 +3649,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -3658,20 +3658,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 2124
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:04 GMT
+                - Tue, 11 Feb 2025 14:20:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3679,10 +3679,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 33179232-9bb7-4784-a70e-882e420cea7f
+                - 0e4b2564-8730-4a0c-825b-b3b271c14086
         status: 200 OK
         code: 200
-        duration: 147.018833ms
+        duration: 135.649ms
     - id: 74
       request:
         proto: HTTP/1.1
@@ -3698,7 +3698,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=type_asc&type=instance_local&zone=fr-par-1
         method: GET
       response:
@@ -3718,9 +3718,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:05 GMT
+                - Tue, 11 Feb 2025 14:20:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3728,10 +3728,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c0b97166-f0d9-4a6a-a560-d67f10e08043
+                - 06ae2f9b-288e-48cd-82cb-c40b20276b9e
         status: 200 OK
         code: 200
-        duration: 60.053333ms
+        duration: 116.329833ms
     - id: 75
       request:
         proto: HTTP/1.1
@@ -3747,7 +3747,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_local&zone=fr-par-1
         method: GET
       response:
@@ -3767,9 +3767,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:05 GMT
+                - Tue, 11 Feb 2025 14:20:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3777,10 +3777,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 490e31e9-c084-4f73-bfcd-bfc1a65773c7
+                - d52bbd52-4e9a-49a7-87dd-bd747f173a35
         status: 200 OK
         code: 200
-        duration: 79.149333ms
+        duration: 99.500375ms
     - id: 76
       request:
         proto: HTTP/1.1
@@ -3796,8 +3796,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -3805,20 +3805,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 2124
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:05 GMT
+                - Tue, 11 Feb 2025 14:20:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3826,10 +3826,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ab2d9a4f-37ac-482a-85b6-1d9aa3e3115f
+                - 9aafd7c5-3b92-4294-b9aa-6e3199f01048
         status: 200 OK
         code: 200
-        duration: 120.320125ms
+        duration: 168.164667ms
     - id: 77
       request:
         proto: HTTP/1.1
@@ -3845,8 +3845,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f7ebe259-690e-47ab-9cc7-d2c915fb6ee7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3854,20 +3854,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 524
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "524"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:04 GMT
+                - Tue, 11 Feb 2025 14:20:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3875,10 +3875,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 712bfa4c-f2db-44bf-84ed-40e9e1e164b3
+                - 28cdaca8-fa39-42cc-b066-103867d630b7
         status: 200 OK
         code: 200
-        duration: 116.189125ms
+        duration: 84.216834ms
     - id: 78
       request:
         proto: HTTP/1.1
@@ -3894,8 +3894,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/514d0afb-1730-46f3-8fa7-fe8f4d785dd4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -3903,20 +3903,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 528
+        content_length: 2124
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "528"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:04 GMT
+                - Tue, 11 Feb 2025 14:20:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3924,10 +3924,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f3300eb8-753a-45a6-8859-181eec31e030
+                - 54ad337f-02f4-43f5-b9ca-79ce10014da4
         status: 200 OK
         code: 200
-        duration: 83.519542ms
+        duration: 189.124334ms
     - id: 79
       request:
         proto: HTTP/1.1
@@ -3943,8 +3943,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/514d0afb-1730-46f3-8fa7-fe8f4d785dd4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -3952,20 +3952,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 528
+        content_length: 17
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "528"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:05 GMT
+                - Tue, 11 Feb 2025 14:20:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3973,10 +3973,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 17b72b36-db6d-4ee1-8a89-a14b218c9290
+                - fefa1820-9945-4b7d-9f26-15ccedd623d0
         status: 200 OK
         code: 200
-        duration: 78.843333ms
+        duration: 84.826334ms
     - id: 80
       request:
         proto: HTTP/1.1
@@ -3992,8 +3992,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f7ebe259-690e-47ab-9cc7-d2c915fb6ee7
         method: GET
       response:
         proto: HTTP/2.0
@@ -4001,20 +4001,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 524
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "17"
+                - "524"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:04 GMT
+                - Tue, 11 Feb 2025 14:20:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4022,10 +4022,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8d8e8298-5302-4c37-9406-e85befcb9dd8
+                - bdec63ff-6711-440f-a3c8-5829b78eb372
         status: 200 OK
         code: 200
-        duration: 87.975458ms
+        duration: 83.6365ms
     - id: 81
       request:
         proto: HTTP/1.1
@@ -4041,8 +4041,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -4050,20 +4050,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 20
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "17"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:05 GMT
+                - Tue, 11 Feb 2025 14:20:12 GMT
+            Link:
+                - </servers/82be23cc-5a25-4d4a-8605-65b8376d1588/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4071,10 +4073,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 07953416-4f56-4dfd-b46c-70c7c2a4828f
+                - ae8e8398-220a-442f-99d8-3b50e67d6832
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 113.882875ms
+        duration: 102.069334ms
     - id: 82
       request:
         proto: HTTP/1.1
@@ -4090,8 +4094,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -4099,22 +4103,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 17
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "20"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:05 GMT
-            Link:
-                - </servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:20:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4122,12 +4124,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ff19d3af-e0b0-400c-bdb0-8a5e730b4c3c
-            X-Total-Count:
-                - "0"
+                - 6776b699-d153-4671-ab33-2d47b5f08178
         status: 200 OK
         code: 200
-        duration: 126.667708ms
+        duration: 92.005542ms
     - id: 83
       request:
         proto: HTTP/1.1
@@ -4143,8 +4143,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -4163,11 +4163,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:05 GMT
+                - Tue, 11 Feb 2025 14:20:12 GMT
             Link:
-                - </servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/82be23cc-5a25-4d4a-8605-65b8376d1588/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4175,12 +4175,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4237f747-515f-4e4d-9801-f32d9aeb0a2b
+                - 8e85e599-ce0b-4030-820b-ccb39155db56
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 136.29625ms
+        duration: 85.215417ms
     - id: 84
       request:
         proto: HTTP/1.1
@@ -4196,8 +4196,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -4205,20 +4205,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 2124
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:05 GMT
+                - Tue, 11 Feb 2025 14:20:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4226,10 +4226,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e0491f5d-4389-4c7a-a440-a217a7793094
+                - 9ac84ace-50b7-4a6f-a832-d9b112417915
         status: 200 OK
         code: 200
-        duration: 144.834333ms
+        duration: 156.478833ms
     - id: 85
       request:
         proto: HTTP/1.1
@@ -4245,7 +4245,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/marketplace/v2/local-images/bc50e86c-a6c7-401a-8fbb-2ef17ce87aee
         method: GET
       response:
@@ -4265,9 +4265,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:05 GMT
+                - Tue, 11 Feb 2025 14:20:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4275,10 +4275,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a51fa7cb-5f09-4d53-817b-97d3e0f32008
+                - f68a50ac-27d9-4eb0-8f24-ab9f9798014e
         status: 200 OK
         code: 200
-        duration: 85.421958ms
+        duration: 72.210542ms
     - id: 86
       request:
         proto: HTTP/1.1
@@ -4294,7 +4294,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_local&zone=fr-par-1
         method: GET
       response:
@@ -4314,9 +4314,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:06 GMT
+                - Tue, 11 Feb 2025 14:20:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4324,10 +4324,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 67288819-dea8-4540-a8ca-5f53b5c84d36
+                - fe1834b3-abce-43c7-8b61-bb76754c7cc5
         status: 200 OK
         code: 200
-        duration: 69.930333ms
+        duration: 92.4735ms
     - id: 87
       request:
         proto: HTTP/1.1
@@ -4343,8 +4343,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -4352,20 +4352,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 2124
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:05 GMT
+                - Tue, 11 Feb 2025 14:20:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4373,10 +4373,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f6d06d39-24b5-474d-90aa-6851e0ba7eed
+                - 26de546e-53fc-426d-9be0-a65996ec91e7
         status: 200 OK
         code: 200
-        duration: 125.21975ms
+        duration: 178.583958ms
     - id: 88
       request:
         proto: HTTP/1.1
@@ -4392,7 +4392,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/marketplace/v2/local-images/bc50e86c-a6c7-401a-8fbb-2ef17ce87aee
         method: GET
       response:
@@ -4412,9 +4412,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:06 GMT
+                - Tue, 11 Feb 2025 14:20:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4422,10 +4422,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 498a23c2-6ec0-40e0-be10-d4174b9b6144
+                - a33023cb-90d8-404b-abb6-5d6fb3c3745f
         status: 200 OK
         code: 200
-        duration: 92.05675ms
+        duration: 86.416917ms
     - id: 89
       request:
         proto: HTTP/1.1
@@ -4441,7 +4441,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_local&zone=fr-par-1
         method: GET
       response:
@@ -4461,9 +4461,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:06 GMT
+                - Tue, 11 Feb 2025 14:20:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4471,10 +4471,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d6841c89-7891-400d-b642-128890f913a9
+                - 599c187f-0add-4ede-b401-2fc6a419447c
         status: 200 OK
         code: 200
-        duration: 62.1355ms
+        duration: 85.411125ms
     - id: 90
       request:
         proto: HTTP/1.1
@@ -4490,8 +4490,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -4499,20 +4499,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 2124
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:06 GMT
+                - Tue, 11 Feb 2025 14:20:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4520,10 +4520,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0437333e-f5b2-45ad-a280-3f277fba1b46
+                - 49bf1879-52a5-40e3-b0f2-7f3b87d92c4e
         status: 200 OK
         code: 200
-        duration: 131.197584ms
+        duration: 189.806333ms
     - id: 91
       request:
         proto: HTTP/1.1
@@ -4539,8 +4539,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/514d0afb-1730-46f3-8fa7-fe8f4d785dd4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -4548,20 +4548,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 528
+        content_length: 2124
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "528"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:06 GMT
+                - Tue, 11 Feb 2025 14:20:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4569,10 +4569,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f4a183a1-093f-4496-9cac-2a25d1f6c1e0
+                - 4a892c91-cdc1-47d9-88ac-6fc8c16bfeb4
         status: 200 OK
         code: 200
-        duration: 82.549458ms
+        duration: 130.470167ms
     - id: 92
       request:
         proto: HTTP/1.1
@@ -4588,8 +4588,106 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f7ebe259-690e-47ab-9cc7-d2c915fb6ee7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 524
+        uncompressed: false
+        body: '{"volume":{"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "524"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:20:13 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - bf2e8a0b-d2f3-41bd-8396-8363a5b4fc56
+        status: 200 OK
+        code: 200
+        duration: 87.343458ms
+    - id: 93
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f7ebe259-690e-47ab-9cc7-d2c915fb6ee7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 524
+        uncompressed: false
+        body: '{"volume":{"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "524"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:20:13 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e6dbf959-0309-4a6d-a9e7-36a0bb7f1693
+        status: 200 OK
+        code: 200
+        duration: 87.674375ms
+    - id: 94
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -4608,9 +4706,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:06 GMT
+                - Tue, 11 Feb 2025 14:20:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4618,11 +4716,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fbc8cd8e-2010-41ad-a141-d94d61ef1020
+                - cd684d3c-68c8-4142-85cb-f42df35d95c3
         status: 200 OK
         code: 200
-        duration: 86.932459ms
-    - id: 93
+        duration: 158.291292ms
+    - id: 95
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4637,8 +4735,57 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588/user_data
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 17
+        uncompressed: false
+        body: '{"user_data":[]}'
+        headers:
+            Content-Length:
+                - "17"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:20:13 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1aee75b3-7867-44c9-a01f-f3e7a13934da
+        status: 200 OK
+        code: 200
+        duration: 187.10525ms
+    - id: 96
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -4657,11 +4804,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:06 GMT
+                - Tue, 11 Feb 2025 14:20:13 GMT
             Link:
-                - </servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/82be23cc-5a25-4d4a-8605-65b8376d1588/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4669,159 +4816,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b6898596-d4c1-4d2e-b0b6-07001459ca25
+                - 58eefcec-1f7c-41bf-9dea-c54dc4f2af2d
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 103.302833ms
-    - id: 94
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2136
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2136"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:49:06 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - c247d7e8-42be-411a-b8d2-aed1f020558e
-        status: 200 OK
-        code: 200
-        duration: 501.883083ms
-    - id: 95
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/514d0afb-1730-46f3-8fa7-fe8f4d785dd4
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 528
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "528"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:49:07 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 670ff67f-2428-40c1-a37d-5cb64fa3a708
-        status: 200 OK
-        code: 200
-        duration: 88.569459ms
-    - id: 96
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2136
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2136"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:49:06 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 24db39be-8319-4b0d-8e2f-034b42b1dbd2
-        status: 200 OK
-        code: 200
-        duration: 146.929542ms
+        duration: 90.550458ms
     - id: 97
       request:
         proto: HTTP/1.1
@@ -4837,8 +4837,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -4846,20 +4846,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 20
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "17"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:07 GMT
+                - Tue, 11 Feb 2025 14:20:13 GMT
+            Link:
+                - </servers/82be23cc-5a25-4d4a-8605-65b8376d1588/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4867,10 +4869,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a1e99da6-f2de-499d-9c9f-f02f1889a46e
+                - 3d4ac40c-34b5-4733-a340-04a2da0a8c48
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 113.16025ms
+        duration: 99.08175ms
     - id: 98
       request:
         proto: HTTP/1.1
@@ -4886,7 +4890,56 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2124
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2124"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:20:13 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - db35fcfe-8f58-4d06-8734-1d93c9fe9444
+        status: 200 OK
+        code: 200
+        duration: 154.520541ms
+    - id: 99
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/marketplace/v2/local-images/bc50e86c-a6c7-401a-8fbb-2ef17ce87aee
         method: GET
       response:
@@ -4906,9 +4959,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:07 GMT
+                - Tue, 11 Feb 2025 14:20:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4916,63 +4969,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ef28edb2-f4cc-42c7-93b2-5c259eff6505
+                - db8d7472-5b35-418f-bd5e-54c635d5048a
         status: 200 OK
         code: 200
-        duration: 99.455208ms
-    - id: 99
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/private_nics
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 20
-        uncompressed: false
-        body: '{"private_nics":[]}'
-        headers:
-            Content-Length:
-                - "20"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:49:06 GMT
-            Link:
-                - </servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549/private_nics?page=0&per_page=50&>; rel="last"
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 42604bad-b5ab-468d-9792-60f2ee7de95b
-            X-Total-Count:
-                - "0"
-        status: 200 OK
-        code: 200
-        duration: 124.198625ms
+        duration: 95.071417ms
     - id: 100
       request:
         proto: HTTP/1.1
@@ -4988,7 +4988,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_local&zone=fr-par-1
         method: GET
       response:
@@ -5008,9 +5008,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:07 GMT
+                - Tue, 11 Feb 2025 14:20:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5018,10 +5018,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 75c2d065-52be-4d4b-897e-439151d936d2
+                - 2f522525-aa38-4972-9bab-986df0753c67
         status: 200 OK
         code: 200
-        duration: 93.284084ms
+        duration: 91.314584ms
     - id: 101
       request:
         proto: HTTP/1.1
@@ -5037,8 +5037,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -5046,20 +5046,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 2124
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:07 GMT
+                - Tue, 11 Feb 2025 14:20:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5067,10 +5067,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d2f64577-121c-46f2-9644-7f05bf60b76d
+                - 38fd20e1-d8b3-4a3f-b150-4d8ccf0440c3
         status: 200 OK
         code: 200
-        duration: 142.194667ms
+        duration: 130.566959ms
     - id: 102
       request:
         proto: HTTP/1.1
@@ -5086,7 +5086,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/marketplace/v2/local-images/bc50e86c-a6c7-401a-8fbb-2ef17ce87aee
         method: GET
       response:
@@ -5106,9 +5106,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:07 GMT
+                - Tue, 11 Feb 2025 14:20:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5116,10 +5116,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9d0b8b21-7695-415e-b392-d01555be84de
+                - 1b123e85-8afe-4f17-98ae-5bd67f7f23c8
         status: 200 OK
         code: 200
-        duration: 92.087292ms
+        duration: 64.708125ms
     - id: 103
       request:
         proto: HTTP/1.1
@@ -5135,8 +5135,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -5144,20 +5144,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 2124
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:07 GMT
+                - Tue, 11 Feb 2025 14:20:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5165,10 +5165,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 59cbe839-351d-4d33-8688-fd604f8b16f0
+                - 4b3265e2-89ea-48a7-947d-0e1f12c4615a
         status: 200 OK
         code: 200
-        duration: 136.928542ms
+        duration: 134.989541ms
     - id: 104
       request:
         proto: HTTP/1.1
@@ -5184,8 +5184,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -5193,20 +5193,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 2124
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:07 GMT
+                - Tue, 11 Feb 2025 14:20:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5214,10 +5214,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3b98a17f-9d18-41f6-8dac-976239e87520
+                - 20be915b-d51b-4f85-aa32-2b1bf5f6fbea
         status: 200 OK
         code: 200
-        duration: 146.12225ms
+        duration: 138.814542ms
     - id: 105
       request:
         proto: HTTP/1.1
@@ -5233,8 +5233,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -5242,20 +5242,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 2124
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:08 GMT
+                - Tue, 11 Feb 2025 14:20:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5263,10 +5263,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7f45c4c9-fca6-424a-b2f9-746dc5314c8e
+                - c3a23c6c-a720-4063-94a8-e42ad747603f
         status: 200 OK
         code: 200
-        duration: 133.02475ms
+        duration: 150.834625ms
     - id: 106
       request:
         proto: HTTP/1.1
@@ -5282,8 +5282,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -5291,20 +5291,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2136
+        content_length: 2124
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:56.265931+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-interesting-haibt","id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:05","maintenances":[],"modification_date":"2025-01-27T13:48:56.265931+00:00","name":"tf-srv-interesting-haibt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:48:56.265931+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","name":"tf-srv-interesting-haibt"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:20:03.640758+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sleepy-keller","id":"82be23cc-5a25-4d4a-8605-65b8376d1588","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:08.941837+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","modification_date":"2024-10-07T11:39:08.941837+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f1efdd5c-375b-431e-ac06-daaf1518369b","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ab","maintenances":[],"modification_date":"2025-02-11T14:20:03.640758+00:00","name":"tf-srv-sleepy-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:03.640758+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"82be23cc-5a25-4d4a-8605-65b8376d1588","name":"tf-srv-sleepy-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2136"
+                - "2124"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:07 GMT
+                - Tue, 11 Feb 2025 14:20:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5312,10 +5312,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cf2feb42-420d-4794-b78f-6b20210ff6f5
+                - 2cf6f681-d7e9-428b-be9c-04a494fb9d93
         status: 200 OK
         code: 200
-        duration: 153.848333ms
+        duration: 162.230709ms
     - id: 107
       request:
         proto: HTTP/1.1
@@ -5331,8 +5331,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5342,7 +5342,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"82be23cc-5a25-4d4a-8605-65b8376d1588","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -5351,9 +5351,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:08 GMT
+                - Tue, 11 Feb 2025 14:20:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5361,10 +5361,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8d91618b-006d-44bf-9176-dffc71d27557
+                - 4524ebbc-5a69-473c-86ec-6061ed879fdc
         status: 404 Not Found
         code: 404
-        duration: 191.248792ms
+        duration: 221.810083ms
     - id: 108
       request:
         proto: HTTP/1.1
@@ -5380,8 +5380,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5398,9 +5398,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:08 GMT
+                - Tue, 11 Feb 2025 14:20:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5408,10 +5408,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6fc2ae57-6e5d-4bbe-98ca-6a42fafbdd3d
+                - e3f1222d-26d5-474a-b6c0-715bfce26613
         status: 204 No Content
         code: 204
-        duration: 194.003584ms
+        duration: 206.907833ms
     - id: 109
       request:
         proto: HTTP/1.1
@@ -5427,8 +5427,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -5438,7 +5438,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"82be23cc-5a25-4d4a-8605-65b8376d1588","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -5447,9 +5447,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:08 GMT
+                - Tue, 11 Feb 2025 14:20:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5457,10 +5457,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9fcac5a5-a33d-4467-ac56-d29fa242c340
+                - 285cdb7a-c055-41f2-bcf4-4737bbb15587
         status: 404 Not Found
         code: 404
-        duration: 96.22975ms
+        duration: 87.631375ms
     - id: 110
       request:
         proto: HTTP/1.1
@@ -5476,8 +5476,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f7ebe259-690e-47ab-9cc7-d2c915fb6ee7
         method: GET
       response:
         proto: HTTP/2.0
@@ -5485,20 +5485,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 143
+        content_length: 450
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","type":"not_found"}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:20:03.640758+00:00","export_uri":null,"id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","modification_date":"2025-02-11T14:20:15.205074+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "143"
+                - "450"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:08 GMT
+                - Tue, 11 Feb 2025 14:20:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5506,10 +5506,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5b28992f-7ee5-4c2d-8aac-e9ee490ee2e1
-        status: 404 Not Found
-        code: 404
-        duration: 156.588583ms
+                - 6f449846-ff27-44fa-bc2c-797917508ce5
+        status: 200 OK
+        code: 200
+        duration: 80.811291ms
     - id: 111
       request:
         proto: HTTP/1.1
@@ -5525,29 +5525,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/514d0afb-1730-46f3-8fa7-fe8f4d785dd4
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f7ebe259-690e-47ab-9cc7-d2c915fb6ee7
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 450
+        content_length: 0
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:49:08.267773+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: ""
         headers:
-            Content-Length:
-                - "450"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:08 GMT
+                - Tue, 11 Feb 2025 14:20:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5555,10 +5553,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 51828c43-628c-42fb-97c5-01c4115d3b7c
-        status: 200 OK
-        code: 200
-        duration: 93.991542ms
+                - 248f33d3-72cf-42be-849e-658b8847cda2
+        status: 204 No Content
+        code: 204
+        duration: 155.464084ms
     - id: 112
       request:
         proto: HTTP/1.1
@@ -5574,8 +5572,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/514d0afb-1730-46f3-8fa7-fe8f4d785dd4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -5583,20 +5581,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 450
+        content_length: 143
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:56.265931+00:00","export_uri":null,"id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","modification_date":"2025-01-27T13:49:08.267773+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"82be23cc-5a25-4d4a-8605-65b8376d1588","type":"not_found"}'
         headers:
             Content-Length:
-                - "450"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:08 GMT
+                - Tue, 11 Feb 2025 14:20:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5604,10 +5602,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - be6116e5-8e56-4e66-8cff-e55088c05398
-        status: 200 OK
-        code: 200
-        duration: 78.19825ms
+                - 392d262c-87e5-441f-82f8-b5fee74b9cfe
+        status: 404 Not Found
+        code: 404
+        duration: 451.768916ms
     - id: 113
       request:
         proto: HTTP/1.1
@@ -5623,27 +5621,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/514d0afb-1730-46f3-8fa7-fe8f4d785dd4
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f7ebe259-690e-47ab-9cc7-d2c915fb6ee7
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 143
         uncompressed: false
-        body: ""
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","type":"not_found"}'
         headers:
+            Content-Length:
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:08 GMT
+                - Tue, 11 Feb 2025 14:20:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5651,10 +5651,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - de181acc-c155-46f4-8ddf-869d33ab8c86
-        status: 204 No Content
-        code: 204
-        duration: 138.682458ms
+                - 4e0f1937-9412-403f-bbc2-837668730732
+        status: 404 Not Found
+        code: 404
+        duration: 26.906375ms
     - id: 114
       request:
         proto: HTTP/1.1
@@ -5670,29 +5670,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/514d0afb-1730-46f3-8fa7-fe8f4d785dd4
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/f7ebe259-690e-47ab-9cc7-d2c915fb6ee7
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 143
+        content_length: 127
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"514d0afb-1730-46f3-8fa7-fe8f4d785dd4","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"volume","resource_id":"f7ebe259-690e-47ab-9cc7-d2c915fb6ee7","type":"not_found"}'
         headers:
             Content-Length:
-                - "143"
+                - "127"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:08 GMT
+                - Tue, 11 Feb 2025 14:20:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5700,10 +5700,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - da34610a-26e2-4442-a18a-76ccd17dcda8
+                - f747e2cb-94a9-409f-87e6-1a5d124c06f2
         status: 404 Not Found
         code: 404
-        duration: 146.118125ms
+        duration: 23.082125ms
     - id: 115
       request:
         proto: HTTP/1.1
@@ -5719,8 +5719,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -5730,7 +5730,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"82be23cc-5a25-4d4a-8605-65b8376d1588","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -5739,9 +5739,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:08 GMT
+                - Tue, 11 Feb 2025 14:20:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5749,10 +5749,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a6414b23-ac8b-409a-96a5-d1071492f45f
+                - d7d92cc5-2ef3-465c-9152-77e4dbb77cfa
         status: 404 Not Found
         code: 404
-        duration: 126.6435ms
+        duration: 96.656792ms
     - id: 116
       request:
         proto: HTTP/1.1
@@ -5768,8 +5768,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26ffd0f1-74c7-4e9d-8ad0-879bf28f6549
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82be23cc-5a25-4d4a-8605-65b8376d1588
         method: GET
       response:
         proto: HTTP/2.0
@@ -5779,7 +5779,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"26ffd0f1-74c7-4e9d-8ad0-879bf28f6549","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"82be23cc-5a25-4d4a-8605-65b8376d1588","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -5788,9 +5788,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:08 GMT
+                - Tue, 11 Feb 2025 14:20:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5798,7 +5798,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 785b9e3f-e2de-4f9e-99c8-71211cb231f3
+                - 74afbdf9-8946-4e90-ab4d-4e5748c952c2
         status: 404 Not Found
         code: 404
-        duration: 99.825459ms
+        duration: 92.059625ms

--- a/internal/services/instance/testdata/server-minimal1.cassette.yaml
+++ b/internal/services/instance/testdata/server-minimal1.cassette.yaml
@@ -16,7 +16,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
         method: GET
       response:
@@ -25,22 +25,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 38539
+        content_length: 35639
         uncompressed: false
-        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
+        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
         headers:
             Content-Length:
-                - "38539"
+                - "35639"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:03 GMT
+                - Tue, 11 Feb 2025 14:23:33 GMT
             Link:
                 - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,12 +48,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d214f0a5-2ee6-48df-a0d2-84fd180b72b4
+                - cc9d4fd6-489e-4d26-8fc2-99fa5a3a56f2
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 71.6205ms
+        duration: 53.344541ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -69,7 +69,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
         method: GET
       response:
@@ -78,22 +78,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 14208
+        content_length: 13164
         uncompressed: false
-        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
         headers:
             Content-Length:
-                - "14208"
+                - "13164"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:03 GMT
+                - Tue, 11 Feb 2025 14:23:34 GMT
             Link:
                 - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -101,12 +101,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b7c86b0d-d98d-48ea-98e9-1bce49461ad7
+                - b3c94ea6-12d7-4d70-8181-72035df2bb02
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 63.223666ms
+        duration: 49.783542ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -122,8 +122,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_local&zone=fr-par-1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_sbs&zone=fr-par-1
         method: GET
       response:
         proto: HTTP/2.0
@@ -131,20 +131,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1300
+        content_length: 1296
         uncompressed: false
-        body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"56d4019c-8305-467a-a3f2-70498ad799df","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
+        body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"57509e82-ac3b-49b7-9970-97b60f40ff72","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"9b647e1e-253a-41e7-8c15-911c622ee2dc","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"}],"total_count":2}'
         headers:
             Content-Length:
-                - "1300"
+                - "1296"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:03 GMT
+                - Tue, 11 Feb 2025 14:23:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -152,28 +152,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 53b9764d-f4f0-4d4f-bed9-a59d310f28cc
+                - fda3e623-9972-44a3-b690-8040ccd6afc8
         status: 200 OK
         code: 200
-        duration: 148.882917ms
+        duration: 95.916625ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 341
+        content_length: 298
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-srv-musing-lichterman","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":["terraform-test","scaleway_instance_server","minimal"]}'
+        body: '{"name":"tf-srv-musing-mahavira","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"57509e82-ac3b-49b7-9970-97b60f40ff72","volumes":{"0":{"boot":false}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":["terraform-test","scaleway_instance_server","minimal"]}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
         method: POST
       response:
@@ -182,22 +182,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2179
+        content_length: 1729
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.876840+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-lichterman","id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:6d","maintenances":[],"modification_date":"2025-01-27T13:47:03.876840+00:00","name":"tf-srv-musing-lichterman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.876840+00:00","export_uri":null,"id":"fc93ab0f-214e-4234-86c1-42f78d623c93","modification_date":"2025-01-27T13:47:03.876840+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","name":"tf-srv-musing-lichterman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:34.585562+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-mahavira","id":"b4055bbb-4c99-4606-8871-6b6a2c0b0bb4","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:f5","maintenances":[],"modification_date":"2025-02-11T14:23:34.585562+00:00","name":"tf-srv-musing-mahavira","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"id":"7ffe5df6-12fa-4a96-8120-6ec10c129dbc","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2179"
+                - "1729"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:03 GMT
+                - Tue, 11 Feb 2025 14:23:35 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -205,10 +205,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a1b97b40-e57d-49d6-ad7d-e51492da27ba
+                - 929e28c7-b23d-4124-9775-614e85416e7e
         status: 201 Created
         code: 201
-        duration: 598.769542ms
+        duration: 719.532791ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -224,8 +224,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4
         method: GET
       response:
         proto: HTTP/2.0
@@ -233,20 +233,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2179
+        content_length: 1729
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.876840+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-lichterman","id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:6d","maintenances":[],"modification_date":"2025-01-27T13:47:03.876840+00:00","name":"tf-srv-musing-lichterman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.876840+00:00","export_uri":null,"id":"fc93ab0f-214e-4234-86c1-42f78d623c93","modification_date":"2025-01-27T13:47:03.876840+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","name":"tf-srv-musing-lichterman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:34.585562+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-mahavira","id":"b4055bbb-4c99-4606-8871-6b6a2c0b0bb4","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:f5","maintenances":[],"modification_date":"2025-02-11T14:23:34.585562+00:00","name":"tf-srv-musing-mahavira","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"id":"7ffe5df6-12fa-4a96-8120-6ec10c129dbc","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2179"
+                - "1729"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:03 GMT
+                - Tue, 11 Feb 2025 14:23:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -254,10 +254,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a671543a-b47c-48c0-b789-ae14653f3565
+                - 53a0a52c-c86e-429e-b9b3-945465409da7
         status: 200 OK
         code: 200
-        duration: 135.882833ms
+        duration: 151.211709ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -273,8 +273,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4
         method: GET
       response:
         proto: HTTP/2.0
@@ -282,20 +282,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2179
+        content_length: 1729
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.876840+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-lichterman","id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:6d","maintenances":[],"modification_date":"2025-01-27T13:47:03.876840+00:00","name":"tf-srv-musing-lichterman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.876840+00:00","export_uri":null,"id":"fc93ab0f-214e-4234-86c1-42f78d623c93","modification_date":"2025-01-27T13:47:03.876840+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","name":"tf-srv-musing-lichterman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:34.585562+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-mahavira","id":"b4055bbb-4c99-4606-8871-6b6a2c0b0bb4","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:f5","maintenances":[],"modification_date":"2025-02-11T14:23:34.585562+00:00","name":"tf-srv-musing-mahavira","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"id":"7ffe5df6-12fa-4a96-8120-6ec10c129dbc","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2179"
+                - "1729"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:04 GMT
+                - Tue, 11 Feb 2025 14:23:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -303,11 +303,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bb04cbf2-9a1f-4ca1-8ec0-21a6e1dde5d4
+                - 7dac981f-2a45-4483-b70e-6cdbce58e7cf
         status: 200 OK
         code: 200
-        duration: 139.534292ms
+        duration: 143.006291ms
     - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/7ffe5df6-12fa-4a96-8120-6ec10c129dbc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:23:34.820460Z","id":"7ffe5df6-12fa-4a96-8120-6ec10c129dbc","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:34.820460Z","id":"b3d14ca9-b16f-4211-9ef2-8c1a7aba78e2","product_resource_id":"b4055bbb-4c99-4606-8871-6b6a2c0b0bb4","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:34.820460Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1b8d7ef3-ad5a-4065-a1dd-e5aaef0d2250
+        status: 200 OK
+        code: 200
+        duration: 78.695334ms
+    - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -324,8 +373,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -335,7 +384,7 @@ interactions:
         trailer: {}
         content_length: 357
         uncompressed: false
-        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9/action","href_result":"/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9","id":"efa17be8-2ac6-4945-abb4-7f2a451cf559","progress":0,"started_at":"2025-01-27T13:47:04.995853+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4/action","href_result":"/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4","id":"7c5ea847-a397-4016-a234-91e4b5d58316","progress":0,"started_at":"2025-02-11T14:23:35.685928+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -344,11 +393,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:04 GMT
+                - Tue, 11 Feb 2025 14:23:35 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/efa17be8-2ac6-4945-abb4-7f2a451cf559
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/7c5ea847-a397-4016-a234-91e4b5d58316
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -356,59 +405,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1a5d7662-3271-42a4-b5fa-88daf1ff2c90
+                - e96eaf27-15c1-405a-a4eb-a4a5eecb3a94
         status: 202 Accepted
         code: 202
-        duration: 519.761166ms
-    - id: 7
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2201
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.876840+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-lichterman","id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:6d","maintenances":[],"modification_date":"2025-01-27T13:47:04.540923+00:00","name":"tf-srv-musing-lichterman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.876840+00:00","export_uri":null,"id":"fc93ab0f-214e-4234-86c1-42f78d623c93","modification_date":"2025-01-27T13:47:03.876840+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","name":"tf-srv-musing-lichterman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2201"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:47:05 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 53e88245-d341-4109-b0c3-675be2635783
-        status: 200 OK
-        code: 200
-        duration: 147.205583ms
+        duration: 240.052625ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -424,8 +424,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4
         method: GET
       response:
         proto: HTTP/2.0
@@ -433,20 +433,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2304
+        content_length: 1751
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.876840+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-lichterman","id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"501","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:6d","maintenances":[],"modification_date":"2025-01-27T13:47:04.540923+00:00","name":"tf-srv-musing-lichterman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.876840+00:00","export_uri":null,"id":"fc93ab0f-214e-4234-86c1-42f78d623c93","modification_date":"2025-01-27T13:47:03.876840+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","name":"tf-srv-musing-lichterman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:34.585562+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-mahavira","id":"b4055bbb-4c99-4606-8871-6b6a2c0b0bb4","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:f5","maintenances":[],"modification_date":"2025-02-11T14:23:35.515902+00:00","name":"tf-srv-musing-mahavira","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"id":"7ffe5df6-12fa-4a96-8120-6ec10c129dbc","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2304"
+                - "1751"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:09 GMT
+                - Tue, 11 Feb 2025 14:23:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -454,10 +454,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 594af14e-d7b1-4c3e-b67b-3086ad4f2154
+                - 06214c81-cf98-4797-807f-4197c80d0e49
         status: 200 OK
         code: 200
-        duration: 167.796792ms
+        duration: 155.74525ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -473,8 +473,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4
         method: GET
       response:
         proto: HTTP/2.0
@@ -482,20 +482,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2304
+        content_length: 1884
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.876840+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-lichterman","id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"501","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:6d","maintenances":[],"modification_date":"2025-01-27T13:47:04.540923+00:00","name":"tf-srv-musing-lichterman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.876840+00:00","export_uri":null,"id":"fc93ab0f-214e-4234-86c1-42f78d623c93","modification_date":"2025-01-27T13:47:03.876840+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","name":"tf-srv-musing-lichterman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:34.585562+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-mahavira","id":"b4055bbb-4c99-4606-8871-6b6a2c0b0bb4","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"201","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f5","maintenances":[],"modification_date":"2025-02-11T14:23:39.236207+00:00","name":"tf-srv-musing-mahavira","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"id":"7ffe5df6-12fa-4a96-8120-6ec10c129dbc","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2304"
+                - "1884"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:15 GMT
+                - Tue, 11 Feb 2025 14:23:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -503,10 +503,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 073bdd4a-6e2f-4e2f-bec9-99e322bdce06
+                - f3a7c545-4eed-4122-9c83-d9b0235cfef2
         status: 200 OK
         code: 200
-        duration: 134.85275ms
+        duration: 249.3355ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -522,8 +522,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4
         method: GET
       response:
         proto: HTTP/2.0
@@ -531,20 +531,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2304
+        content_length: 1884
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.876840+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-lichterman","id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"501","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:6d","maintenances":[],"modification_date":"2025-01-27T13:47:04.540923+00:00","name":"tf-srv-musing-lichterman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.876840+00:00","export_uri":null,"id":"fc93ab0f-214e-4234-86c1-42f78d623c93","modification_date":"2025-01-27T13:47:03.876840+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","name":"tf-srv-musing-lichterman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:34.585562+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-mahavira","id":"b4055bbb-4c99-4606-8871-6b6a2c0b0bb4","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"201","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f5","maintenances":[],"modification_date":"2025-02-11T14:23:39.236207+00:00","name":"tf-srv-musing-mahavira","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"id":"7ffe5df6-12fa-4a96-8120-6ec10c129dbc","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2304"
+                - "1884"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:20 GMT
+                - Tue, 11 Feb 2025 14:23:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -552,10 +552,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4506a162-5a45-4c6e-8263-fe2fb860bc47
+                - 1ae339f3-3455-4630-b055-f2624ac11477
         status: 200 OK
         code: 200
-        duration: 174.1255ms
+        duration: 152.31375ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -571,8 +571,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/7ffe5df6-12fa-4a96-8120-6ec10c129dbc
         method: GET
       response:
         proto: HTTP/2.0
@@ -580,20 +580,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2335
+        content_length: 143
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.876840+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-lichterman","id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"501","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:6d","maintenances":[],"modification_date":"2025-01-27T13:47:25.197884+00:00","name":"tf-srv-musing-lichterman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.876840+00:00","export_uri":null,"id":"fc93ab0f-214e-4234-86c1-42f78d623c93","modification_date":"2025-01-27T13:47:03.876840+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","name":"tf-srv-musing-lichterman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"7ffe5df6-12fa-4a96-8120-6ec10c129dbc","type":"not_found"}'
         headers:
             Content-Length:
-                - "2335"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:25 GMT
+                - Tue, 11 Feb 2025 14:23:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -601,10 +601,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4d913351-46a6-4841-8bca-63df6536dd9d
-        status: 200 OK
-        code: 200
-        duration: 162.914333ms
+                - 52f2edd4-eb5e-4a5a-b340-7dbf9bfac85a
+        status: 404 Not Found
+        code: 404
+        duration: 47.393875ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -620,8 +620,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/7ffe5df6-12fa-4a96-8120-6ec10c129dbc
         method: GET
       response:
         proto: HTTP/2.0
@@ -629,20 +629,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2335
+        content_length: 701
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.876840+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-lichterman","id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"501","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:6d","maintenances":[],"modification_date":"2025-01-27T13:47:25.197884+00:00","name":"tf-srv-musing-lichterman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.876840+00:00","export_uri":null,"id":"fc93ab0f-214e-4234-86c1-42f78d623c93","modification_date":"2025-01-27T13:47:03.876840+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","name":"tf-srv-musing-lichterman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T14:23:34.820460Z","id":"7ffe5df6-12fa-4a96-8120-6ec10c129dbc","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:34.820460Z","id":"b3d14ca9-b16f-4211-9ef2-8c1a7aba78e2","product_resource_id":"b4055bbb-4c99-4606-8871-6b6a2c0b0bb4","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:34.820460Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2335"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:25 GMT
+                - Tue, 11 Feb 2025 14:23:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -650,10 +650,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9892b3a2-885a-463a-ab62-d120c08f1dba
+                - 6f1ef957-7397-4450-abad-403939142cb5
         status: 200 OK
         code: 200
-        duration: 225.164792ms
+        duration: 64.856125ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -669,8 +669,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/fc93ab0f-214e-4234-86c1-42f78d623c93
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -678,20 +678,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 524
+        content_length: 17
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:47:03.876840+00:00","export_uri":null,"id":"fc93ab0f-214e-4234-86c1-42f78d623c93","modification_date":"2025-01-27T13:47:03.876840+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","name":"tf-srv-musing-lichterman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "524"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:26 GMT
+                - Tue, 11 Feb 2025 14:23:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -699,10 +699,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e12f6f0c-fdd4-44e5-b104-f70bc6e349e6
+                - 320090ce-69a9-4da6-a909-90cc79bdd63d
         status: 200 OK
         code: 200
-        duration: 87.370167ms
+        duration: 90.529208ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -718,8 +718,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -727,20 +727,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 20
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "17"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:26 GMT
+                - Tue, 11 Feb 2025 14:23:41 GMT
+            Link:
+                - </servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -748,10 +750,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 32746627-1cec-4d24-840c-56a83d21f644
+                - 4ddc0707-e415-4f4b-b40f-c827789aa316
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 98.327625ms
+        duration: 80.211666ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -767,8 +771,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4
         method: GET
       response:
         proto: HTTP/2.0
@@ -776,22 +780,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 1884
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:34.585562+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-mahavira","id":"b4055bbb-4c99-4606-8871-6b6a2c0b0bb4","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"201","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f5","maintenances":[],"modification_date":"2025-02-11T14:23:39.236207+00:00","name":"tf-srv-musing-mahavira","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"id":"7ffe5df6-12fa-4a96-8120-6ec10c129dbc","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "20"
+                - "1884"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:26 GMT
-            Link:
-                - </servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:23:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -799,12 +801,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bb2e0a3d-77f0-463b-8348-b01c79dc9f0b
-            X-Total-Count:
-                - "0"
+                - d863c0f5-d79e-4b55-baed-e405f124f9dd
         status: 200 OK
         code: 200
-        duration: 89.451584ms
+        duration: 159.941916ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -820,8 +820,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4
         method: GET
       response:
         proto: HTTP/2.0
@@ -829,20 +829,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2335
+        content_length: 1884
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.876840+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-lichterman","id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"501","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:6d","maintenances":[],"modification_date":"2025-01-27T13:47:25.197884+00:00","name":"tf-srv-musing-lichterman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.876840+00:00","export_uri":null,"id":"fc93ab0f-214e-4234-86c1-42f78d623c93","modification_date":"2025-01-27T13:47:03.876840+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","name":"tf-srv-musing-lichterman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:34.585562+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-mahavira","id":"b4055bbb-4c99-4606-8871-6b6a2c0b0bb4","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"201","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f5","maintenances":[],"modification_date":"2025-02-11T14:23:39.236207+00:00","name":"tf-srv-musing-mahavira","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"id":"7ffe5df6-12fa-4a96-8120-6ec10c129dbc","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2335"
+                - "1884"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:26 GMT
+                - Tue, 11 Feb 2025 14:23:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -850,10 +850,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6dde2381-8212-44cd-8df4-adc1b3ca046a
+                - 9a451f2e-e01f-43c8-9df1-6be7b0cb695d
         status: 200 OK
         code: 200
-        duration: 166.46325ms
+        duration: 141.6065ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -869,8 +869,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/7ffe5df6-12fa-4a96-8120-6ec10c129dbc
         method: GET
       response:
         proto: HTTP/2.0
@@ -878,20 +878,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2335
+        content_length: 143
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.876840+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-lichterman","id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"501","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:6d","maintenances":[],"modification_date":"2025-01-27T13:47:25.197884+00:00","name":"tf-srv-musing-lichterman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.876840+00:00","export_uri":null,"id":"fc93ab0f-214e-4234-86c1-42f78d623c93","modification_date":"2025-01-27T13:47:03.876840+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","name":"tf-srv-musing-lichterman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"7ffe5df6-12fa-4a96-8120-6ec10c129dbc","type":"not_found"}'
         headers:
             Content-Length:
-                - "2335"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:26 GMT
+                - Tue, 11 Feb 2025 14:23:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -899,10 +899,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f4510673-4bc2-495e-b5c4-c02e106a3d9b
-        status: 200 OK
-        code: 200
-        duration: 161.090584ms
+                - bd99834b-72fe-4c59-9ba0-6f932255c161
+        status: 404 Not Found
+        code: 404
+        duration: 37.552042ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -918,8 +918,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/fc93ab0f-214e-4234-86c1-42f78d623c93
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/7ffe5df6-12fa-4a96-8120-6ec10c129dbc
         method: GET
       response:
         proto: HTTP/2.0
@@ -927,20 +927,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 524
+        content_length: 701
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:47:03.876840+00:00","export_uri":null,"id":"fc93ab0f-214e-4234-86c1-42f78d623c93","modification_date":"2025-01-27T13:47:03.876840+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","name":"tf-srv-musing-lichterman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T14:23:34.820460Z","id":"7ffe5df6-12fa-4a96-8120-6ec10c129dbc","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:34.820460Z","id":"b3d14ca9-b16f-4211-9ef2-8c1a7aba78e2","product_resource_id":"b4055bbb-4c99-4606-8871-6b6a2c0b0bb4","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:34.820460Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "524"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:27 GMT
+                - Tue, 11 Feb 2025 14:23:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -948,10 +948,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f709ed19-fbf4-4627-8357-144324f91d09
+                - 8124b7e5-fca7-4f7d-8f18-660087e0aea5
         status: 200 OK
         code: 200
-        duration: 89.754125ms
+        duration: 58.55425ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -967,8 +967,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -987,9 +987,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:27 GMT
+                - Tue, 11 Feb 2025 14:23:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -997,10 +997,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 05b2604f-76a9-4c7a-8a7d-8a94e946b8d5
+                - ba8d8f70-a20e-41a2-ae1e-dca1e1380a00
         status: 200 OK
         code: 200
-        duration: 76.6575ms
+        duration: 77.509292ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1016,8 +1016,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1036,11 +1036,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:27 GMT
+                - Tue, 11 Feb 2025 14:23:42 GMT
             Link:
-                - </servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1048,12 +1048,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4f0596e0-6413-4139-acea-cfe1a386b8f8
+                - abc750ce-957b-4daa-96e6-2cda91e4b228
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 119.809875ms
+        duration: 86.526459ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1069,8 +1069,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4
         method: GET
       response:
         proto: HTTP/2.0
@@ -1078,20 +1078,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2335
+        content_length: 1884
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.876840+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-lichterman","id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"501","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:6d","maintenances":[],"modification_date":"2025-01-27T13:47:25.197884+00:00","name":"tf-srv-musing-lichterman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.876840+00:00","export_uri":null,"id":"fc93ab0f-214e-4234-86c1-42f78d623c93","modification_date":"2025-01-27T13:47:03.876840+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","name":"tf-srv-musing-lichterman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:34.585562+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-mahavira","id":"b4055bbb-4c99-4606-8871-6b6a2c0b0bb4","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"201","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f5","maintenances":[],"modification_date":"2025-02-11T14:23:39.236207+00:00","name":"tf-srv-musing-mahavira","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"id":"7ffe5df6-12fa-4a96-8120-6ec10c129dbc","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2335"
+                - "1884"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:27 GMT
+                - Tue, 11 Feb 2025 14:23:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1099,10 +1099,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2f823b99-9a0a-4bbd-aca3-c96abad7b9ab
+                - 822dcfa9-fa60-46ad-9cfc-9e4adfb8f2b9
         status: 200 OK
         code: 200
-        duration: 159.871958ms
+        duration: 168.726875ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1118,8 +1118,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/fc93ab0f-214e-4234-86c1-42f78d623c93
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/7ffe5df6-12fa-4a96-8120-6ec10c129dbc
         method: GET
       response:
         proto: HTTP/2.0
@@ -1127,20 +1127,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 524
+        content_length: 143
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:47:03.876840+00:00","export_uri":null,"id":"fc93ab0f-214e-4234-86c1-42f78d623c93","modification_date":"2025-01-27T13:47:03.876840+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","name":"tf-srv-musing-lichterman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"7ffe5df6-12fa-4a96-8120-6ec10c129dbc","type":"not_found"}'
         headers:
             Content-Length:
-                - "524"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:27 GMT
+                - Tue, 11 Feb 2025 14:23:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1148,10 +1148,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3765a0d1-ef0f-4eae-ad42-98b138b155e7
-        status: 200 OK
-        code: 200
-        duration: 110.442583ms
+                - 91ddea0b-949f-42ac-bf81-0f01d76f0e61
+        status: 404 Not Found
+        code: 404
+        duration: 54.189792ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1167,8 +1167,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/7ffe5df6-12fa-4a96-8120-6ec10c129dbc
         method: GET
       response:
         proto: HTTP/2.0
@@ -1176,20 +1176,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 701
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"created_at":"2025-02-11T14:23:34.820460Z","id":"7ffe5df6-12fa-4a96-8120-6ec10c129dbc","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:34.820460Z","id":"b3d14ca9-b16f-4211-9ef2-8c1a7aba78e2","product_resource_id":"b4055bbb-4c99-4606-8871-6b6a2c0b0bb4","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:34.820460Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "17"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:27 GMT
+                - Tue, 11 Feb 2025 14:23:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1197,10 +1197,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 44e612bb-a4b2-451d-b457-0abb0b5b77ed
+                - ee4ff084-bd90-43a3-9136-23ed5f989cda
         status: 200 OK
         code: 200
-        duration: 96.235667ms
+        duration: 69.651042ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1216,208 +1216,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9/private_nics
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 20
-        uncompressed: false
-        body: '{"private_nics":[]}'
-        headers:
-            Content-Length:
-                - "20"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:47:27 GMT
-            Link:
-                - </servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9/private_nics?page=0&per_page=50&>; rel="last"
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 595bd1f4-bd38-4188-9a29-cc047b2509e7
-            X-Total-Count:
-                - "0"
-        status: 200 OK
-        code: 200
-        duration: 117.052292ms
-    - id: 25
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2335
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.876840+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-lichterman","id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"501","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:6d","maintenances":[],"modification_date":"2025-01-27T13:47:25.197884+00:00","name":"tf-srv-musing-lichterman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.876840+00:00","export_uri":null,"id":"fc93ab0f-214e-4234-86c1-42f78d623c93","modification_date":"2025-01-27T13:47:03.876840+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","name":"tf-srv-musing-lichterman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2335"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:47:28 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 7d9958e2-8485-4ea4-bc22-43c01a9cbef4
-        status: 200 OK
-        code: 200
-        duration: 170.025583ms
-    - id: 26
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2335
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.876840+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-lichterman","id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"501","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:6d","maintenances":[],"modification_date":"2025-01-27T13:47:25.197884+00:00","name":"tf-srv-musing-lichterman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.876840+00:00","export_uri":null,"id":"fc93ab0f-214e-4234-86c1-42f78d623c93","modification_date":"2025-01-27T13:47:03.876840+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","name":"tf-srv-musing-lichterman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2335"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:47:28 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - edd20a44-aea1-4cbd-b8fb-83eff898d2ee
-        status: 200 OK
-        code: 200
-        duration: 495.003375ms
-    - id: 27
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/fc93ab0f-214e-4234-86c1-42f78d623c93
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 524
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:47:03.876840+00:00","export_uri":null,"id":"fc93ab0f-214e-4234-86c1-42f78d623c93","modification_date":"2025-01-27T13:47:03.876840+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","name":"tf-srv-musing-lichterman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "524"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:47:29 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 39962f57-9489-4da9-8496-14bd7a4241a5
-        status: 200 OK
-        code: 200
-        duration: 101.591458ms
-    - id: 28
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1436,9 +1236,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:29 GMT
+                - Tue, 11 Feb 2025 14:23:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1446,11 +1246,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8a8b0bf4-b620-4f04-9c1d-a838c1a84120
+                - 09ba70ac-6e60-4444-976e-360d6c0cc501
         status: 200 OK
         code: 200
-        duration: 78.549625ms
-    - id: 29
+        duration: 78.285458ms
+    - id: 25
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1465,8 +1265,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1485,11 +1285,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:29 GMT
+                - Tue, 11 Feb 2025 14:23:42 GMT
             Link:
-                - </servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1497,12 +1297,208 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d5fb1ac9-3489-4d24-ac26-970d840d08f3
+                - 5726f1c5-041e-4f74-8127-a4271f23e9ec
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 97.000958ms
+        duration: 94.967167ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1884
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:34.585562+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-mahavira","id":"b4055bbb-4c99-4606-8871-6b6a2c0b0bb4","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"201","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f5","maintenances":[],"modification_date":"2025-02-11T14:23:39.236207+00:00","name":"tf-srv-musing-mahavira","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"id":"7ffe5df6-12fa-4a96-8120-6ec10c129dbc","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1884"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:43 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ba9a2f98-f885-4a7a-b7fb-1d0845416286
+        status: 200 OK
+        code: 200
+        duration: 715.723833ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1884
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:34.585562+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-mahavira","id":"b4055bbb-4c99-4606-8871-6b6a2c0b0bb4","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"201","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f5","maintenances":[],"modification_date":"2025-02-11T14:23:39.236207+00:00","name":"tf-srv-musing-mahavira","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"id":"7ffe5df6-12fa-4a96-8120-6ec10c129dbc","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1884"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 11b900a7-55b7-423c-9f30-d65f564ec5ff
+        status: 200 OK
+        code: 200
+        duration: 184.260458ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/7ffe5df6-12fa-4a96-8120-6ec10c129dbc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"7ffe5df6-12fa-4a96-8120-6ec10c129dbc","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 453a7886-b3ce-4ce8-ad01-b6f9a0b506e4
+        status: 404 Not Found
+        code: 404
+        duration: 27.76675ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/7ffe5df6-12fa-4a96-8120-6ec10c129dbc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:23:34.820460Z","id":"7ffe5df6-12fa-4a96-8120-6ec10c129dbc","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:34.820460Z","id":"b3d14ca9-b16f-4211-9ef2-8c1a7aba78e2","product_resource_id":"b4055bbb-4c99-4606-8871-6b6a2c0b0bb4","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:34.820460Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 601249d7-7cdb-4312-ad22-37f314bfefb8
+        status: 200 OK
+        code: 200
+        duration: 76.092375ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1518,8 +1514,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1527,20 +1523,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2335
+        content_length: 17
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.876840+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-lichterman","id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"501","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:6d","maintenances":[],"modification_date":"2025-01-27T13:47:25.197884+00:00","name":"tf-srv-musing-lichterman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.876840+00:00","export_uri":null,"id":"fc93ab0f-214e-4234-86c1-42f78d623c93","modification_date":"2025-01-27T13:47:03.876840+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","name":"tf-srv-musing-lichterman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "2335"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:29 GMT
+                - Tue, 11 Feb 2025 14:23:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1548,11 +1544,162 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b6337ab1-47d7-48a8-ba32-6498ef347f27
+                - 96f4b870-252f-4765-a5d6-dee11c24033b
         status: 200 OK
         code: 200
-        duration: 182.979333ms
+        duration: 169.547167ms
     - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 20
+        uncompressed: false
+        body: '{"private_nics":[]}'
+        headers:
+            Content-Length:
+                - "20"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:44 GMT
+            Link:
+                - </servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4/private_nics?page=0&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 74ca39a4-a35e-4689-b7e8-7140d967a2ac
+            X-Total-Count:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 85.245917ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1884
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:34.585562+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-mahavira","id":"b4055bbb-4c99-4606-8871-6b6a2c0b0bb4","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"201","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f5","maintenances":[],"modification_date":"2025-02-11T14:23:39.236207+00:00","name":"tf-srv-musing-mahavira","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"id":"7ffe5df6-12fa-4a96-8120-6ec10c129dbc","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1884"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - efc8e87c-45ac-424a-9a09-c1355d2880da
+        status: 200 OK
+        code: 200
+        duration: 177.999334ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/7ffe5df6-12fa-4a96-8120-6ec10c129dbc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:23:34.820460Z","id":"7ffe5df6-12fa-4a96-8120-6ec10c129dbc","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:34.820460Z","id":"b3d14ca9-b16f-4211-9ef2-8c1a7aba78e2","product_resource_id":"b4055bbb-4c99-4606-8871-6b6a2c0b0bb4","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:34.820460Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 236f66c6-bc7a-4c04-a7eb-a0fcfe9bc15d
+        status: 200 OK
+        code: 200
+        duration: 61.997708ms
+    - id: 34
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1569,8 +1716,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -1580,7 +1727,7 @@ interactions:
         trailer: {}
         content_length: 352
         uncompressed: false
-        body: '{"task":{"description":"server_poweroff","href_from":"/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9/action","href_result":"/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9","id":"0ee3142a-a580-442b-8217-babda00e654f","progress":0,"started_at":"2025-01-27T13:47:30.010414+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_poweroff","href_from":"/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4/action","href_result":"/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4","id":"6c7f2310-3676-4f59-8b58-9d14a7052c0d","progress":0,"started_at":"2025-02-11T14:23:45.450343+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "352"
@@ -1589,11 +1736,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:29 GMT
+                - Tue, 11 Feb 2025 14:23:45 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/0ee3142a-a580-442b-8217-babda00e654f
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/6c7f2310-3676-4f59-8b58-9d14a7052c0d
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1601,157 +1748,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6e0d23a1-af13-4d86-adb2-07bdda5a9cf2
+                - b915a345-77ac-4678-9039-e36cd737a969
         status: 202 Accepted
         code: 202
-        duration: 271.699375ms
-    - id: 32
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2295
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.876840+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-lichterman","id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"501","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:6d","maintenances":[],"modification_date":"2025-01-27T13:47:29.796813+00:00","name":"tf-srv-musing-lichterman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.876840+00:00","export_uri":null,"id":"fc93ab0f-214e-4234-86c1-42f78d623c93","modification_date":"2025-01-27T13:47:03.876840+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","name":"tf-srv-musing-lichterman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2295"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:47:30 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 245b8b11-53b0-4023-9a88-e46ae4254327
-        status: 200 OK
-        code: 200
-        duration: 182.598ms
-    - id: 33
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2295
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.876840+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-lichterman","id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"501","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:6d","maintenances":[],"modification_date":"2025-01-27T13:47:29.796813+00:00","name":"tf-srv-musing-lichterman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.876840+00:00","export_uri":null,"id":"fc93ab0f-214e-4234-86c1-42f78d623c93","modification_date":"2025-01-27T13:47:03.876840+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","name":"tf-srv-musing-lichterman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2295"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:47:34 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - dc850665-6f11-4396-923c-2bf7d7006472
-        status: 200 OK
-        code: 200
-        duration: 141.837667ms
-    - id: 34
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2295
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.876840+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-lichterman","id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"501","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:6d","maintenances":[],"modification_date":"2025-01-27T13:47:29.796813+00:00","name":"tf-srv-musing-lichterman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.876840+00:00","export_uri":null,"id":"fc93ab0f-214e-4234-86c1-42f78d623c93","modification_date":"2025-01-27T13:47:03.876840+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","name":"tf-srv-musing-lichterman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2295"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:47:40 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - a2bc8ec4-b85c-4da3-9439-3cb657d53bba
-        status: 200 OK
-        code: 200
-        duration: 180.966958ms
+        duration: 203.169125ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1767,8 +1767,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4
         method: GET
       response:
         proto: HTTP/2.0
@@ -1776,20 +1776,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2295
+        content_length: 1844
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.876840+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-lichterman","id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"501","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:6d","maintenances":[],"modification_date":"2025-01-27T13:47:29.796813+00:00","name":"tf-srv-musing-lichterman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.876840+00:00","export_uri":null,"id":"fc93ab0f-214e-4234-86c1-42f78d623c93","modification_date":"2025-01-27T13:47:03.876840+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","name":"tf-srv-musing-lichterman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:34.585562+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-mahavira","id":"b4055bbb-4c99-4606-8871-6b6a2c0b0bb4","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"201","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f5","maintenances":[],"modification_date":"2025-02-11T14:23:45.294486+00:00","name":"tf-srv-musing-mahavira","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"id":"7ffe5df6-12fa-4a96-8120-6ec10c129dbc","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2295"
+                - "1844"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:45 GMT
+                - Tue, 11 Feb 2025 14:23:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1797,10 +1797,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 253d99e7-06c6-48aa-bf3e-28468db1d5d7
+                - 4d07f701-324e-4123-84c4-1e9d55af17ea
         status: 200 OK
         code: 200
-        duration: 159.256833ms
+        duration: 168.996209ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1816,8 +1816,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4
         method: GET
       response:
         proto: HTTP/2.0
@@ -1825,20 +1825,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2295
+        content_length: 1844
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.876840+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-lichterman","id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"501","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:6d","maintenances":[],"modification_date":"2025-01-27T13:47:29.796813+00:00","name":"tf-srv-musing-lichterman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.876840+00:00","export_uri":null,"id":"fc93ab0f-214e-4234-86c1-42f78d623c93","modification_date":"2025-01-27T13:47:03.876840+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","name":"tf-srv-musing-lichterman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:34.585562+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-mahavira","id":"b4055bbb-4c99-4606-8871-6b6a2c0b0bb4","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"201","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f5","maintenances":[],"modification_date":"2025-02-11T14:23:45.294486+00:00","name":"tf-srv-musing-mahavira","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"id":"7ffe5df6-12fa-4a96-8120-6ec10c129dbc","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2295"
+                - "1844"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:50 GMT
+                - Tue, 11 Feb 2025 14:23:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1846,10 +1846,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - de6159cd-a9ab-47bc-9609-91711160800c
+                - a3d588cd-91f1-4cea-9352-bfff4f3a8241
         status: 200 OK
         code: 200
-        duration: 166.972708ms
+        duration: 168.360625ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1865,8 +1865,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4
         method: GET
       response:
         proto: HTTP/2.0
@@ -1874,20 +1874,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2295
+        content_length: 1844
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.876840+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-lichterman","id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"501","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:6d","maintenances":[],"modification_date":"2025-01-27T13:47:29.796813+00:00","name":"tf-srv-musing-lichterman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.876840+00:00","export_uri":null,"id":"fc93ab0f-214e-4234-86c1-42f78d623c93","modification_date":"2025-01-27T13:47:03.876840+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","name":"tf-srv-musing-lichterman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:34.585562+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-mahavira","id":"b4055bbb-4c99-4606-8871-6b6a2c0b0bb4","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"201","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f5","maintenances":[],"modification_date":"2025-02-11T14:23:45.294486+00:00","name":"tf-srv-musing-mahavira","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"id":"7ffe5df6-12fa-4a96-8120-6ec10c129dbc","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2295"
+                - "1844"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:55 GMT
+                - Tue, 11 Feb 2025 14:23:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1895,10 +1895,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3a7e4165-5bd4-4303-b2fb-06ab0b9f10a1
+                - 6db0550e-552f-41c1-8553-7e44584a5ab6
         status: 200 OK
         code: 200
-        duration: 188.21525ms
+        duration: 682.201208ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1914,8 +1914,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4
         method: GET
       response:
         proto: HTTP/2.0
@@ -1923,20 +1923,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2295
+        content_length: 1844
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.876840+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-lichterman","id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"501","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:6d","maintenances":[],"modification_date":"2025-01-27T13:47:29.796813+00:00","name":"tf-srv-musing-lichterman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.876840+00:00","export_uri":null,"id":"fc93ab0f-214e-4234-86c1-42f78d623c93","modification_date":"2025-01-27T13:47:03.876840+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","name":"tf-srv-musing-lichterman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:34.585562+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-mahavira","id":"b4055bbb-4c99-4606-8871-6b6a2c0b0bb4","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"201","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f5","maintenances":[],"modification_date":"2025-02-11T14:23:45.294486+00:00","name":"tf-srv-musing-mahavira","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"id":"7ffe5df6-12fa-4a96-8120-6ec10c129dbc","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2295"
+                - "1844"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:01 GMT
+                - Tue, 11 Feb 2025 14:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1944,10 +1944,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0ffbcf66-336a-4b24-ae8e-608930e4749b
+                - 79badd82-3635-46fb-8837-512b7f9d30bc
         status: 200 OK
         code: 200
-        duration: 173.773167ms
+        duration: 683.357208ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1963,8 +1963,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4
         method: GET
       response:
         proto: HTTP/2.0
@@ -1972,20 +1972,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2295
+        content_length: 1844
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.876840+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-lichterman","id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"501","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:6d","maintenances":[],"modification_date":"2025-01-27T13:47:29.796813+00:00","name":"tf-srv-musing-lichterman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.876840+00:00","export_uri":null,"id":"fc93ab0f-214e-4234-86c1-42f78d623c93","modification_date":"2025-01-27T13:47:03.876840+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","name":"tf-srv-musing-lichterman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:34.585562+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-mahavira","id":"b4055bbb-4c99-4606-8871-6b6a2c0b0bb4","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"201","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f5","maintenances":[],"modification_date":"2025-02-11T14:23:45.294486+00:00","name":"tf-srv-musing-mahavira","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"id":"7ffe5df6-12fa-4a96-8120-6ec10c129dbc","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2295"
+                - "1844"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:05 GMT
+                - Tue, 11 Feb 2025 14:24:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1993,10 +1993,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3de547f2-53cf-44b1-a2a5-893fa9754996
+                - 9ef9e9c7-7c4c-4204-af9f-cdb599d763ed
         status: 200 OK
         code: 200
-        duration: 188.441833ms
+        duration: 205.466209ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2012,8 +2012,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4
         method: GET
       response:
         proto: HTTP/2.0
@@ -2021,20 +2021,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2295
+        content_length: 1844
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.876840+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-lichterman","id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"501","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:6d","maintenances":[],"modification_date":"2025-01-27T13:47:29.796813+00:00","name":"tf-srv-musing-lichterman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.876840+00:00","export_uri":null,"id":"fc93ab0f-214e-4234-86c1-42f78d623c93","modification_date":"2025-01-27T13:47:03.876840+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","name":"tf-srv-musing-lichterman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:34.585562+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-mahavira","id":"b4055bbb-4c99-4606-8871-6b6a2c0b0bb4","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"201","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f5","maintenances":[],"modification_date":"2025-02-11T14:23:45.294486+00:00","name":"tf-srv-musing-mahavira","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"id":"7ffe5df6-12fa-4a96-8120-6ec10c129dbc","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2295"
+                - "1844"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:11 GMT
+                - Tue, 11 Feb 2025 14:24:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2042,10 +2042,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e87dc644-5773-4ae5-9960-499aaf4c0210
+                - 2f2ba63b-4866-4e1a-847e-f70905e5d45c
         status: 200 OK
         code: 200
-        duration: 227.601333ms
+        duration: 154.800167ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2061,8 +2061,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4
         method: GET
       response:
         proto: HTTP/2.0
@@ -2070,20 +2070,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2179
+        content_length: 1844
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.876840+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-lichterman","id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:6d","maintenances":[],"modification_date":"2025-01-27T13:48:16.314444+00:00","name":"tf-srv-musing-lichterman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.876840+00:00","export_uri":null,"id":"fc93ab0f-214e-4234-86c1-42f78d623c93","modification_date":"2025-01-27T13:47:03.876840+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","name":"tf-srv-musing-lichterman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:34.585562+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-mahavira","id":"b4055bbb-4c99-4606-8871-6b6a2c0b0bb4","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"201","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f5","maintenances":[],"modification_date":"2025-02-11T14:23:45.294486+00:00","name":"tf-srv-musing-mahavira","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"id":"7ffe5df6-12fa-4a96-8120-6ec10c129dbc","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2179"
+                - "1844"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:16 GMT
+                - Tue, 11 Feb 2025 14:24:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2091,10 +2091,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c026d17d-51a0-4566-a23d-9a2ca1b582a6
+                - 89aecca9-4dd7-4cdc-a922-cc5ed1d239a8
         status: 200 OK
         code: 200
-        duration: 135.73825ms
+        duration: 154.284792ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2110,8 +2110,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4
         method: GET
       response:
         proto: HTTP/2.0
@@ -2119,20 +2119,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2179
+        content_length: 1729
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.876840+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-lichterman","id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:6d","maintenances":[],"modification_date":"2025-01-27T13:48:16.314444+00:00","name":"tf-srv-musing-lichterman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.876840+00:00","export_uri":null,"id":"fc93ab0f-214e-4234-86c1-42f78d623c93","modification_date":"2025-01-27T13:47:03.876840+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","name":"tf-srv-musing-lichterman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:34.585562+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-mahavira","id":"b4055bbb-4c99-4606-8871-6b6a2c0b0bb4","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:f5","maintenances":[],"modification_date":"2025-02-11T14:24:18.263104+00:00","name":"tf-srv-musing-mahavira","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"id":"7ffe5df6-12fa-4a96-8120-6ec10c129dbc","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2179"
+                - "1729"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:16 GMT
+                - Tue, 11 Feb 2025 14:24:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2140,10 +2140,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a81d7344-ad0e-40f6-8ebe-e0d32da406d7
+                - 895e55d9-a848-4525-837e-5b82312560b7
         status: 200 OK
         code: 200
-        duration: 157.410584ms
+        duration: 150.293083ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2159,27 +2159,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 1729
         uncompressed: false
-        body: ""
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:34.585562+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-mahavira","id":"b4055bbb-4c99-4606-8871-6b6a2c0b0bb4","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:f5","maintenances":[],"modification_date":"2025-02-11T14:24:18.263104+00:00","name":"tf-srv-musing-mahavira","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","minimal"],"volumes":{"0":{"boot":false,"id":"7ffe5df6-12fa-4a96-8120-6ec10c129dbc","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
+            Content-Length:
+                - "1729"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:17 GMT
+                - Tue, 11 Feb 2025 14:24:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2187,10 +2189,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 08fe0513-405f-4bab-9837-0914eedaa867
-        status: 204 No Content
-        code: 204
-        duration: 155.951875ms
+                - 280e6c50-a2a3-4649-9430-589c7761f22f
+        status: 200 OK
+        code: 200
+        duration: 176.485542ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2206,106 +2208,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 143
-        uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","type":"not_found"}'
-        headers:
-            Content-Length:
-                - "143"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:48:16 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - ed45635e-8e9f-48e3-bd81-57967cc0d90a
-        status: 404 Not Found
-        code: 404
-        duration: 100.283542ms
-    - id: 45
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/fc93ab0f-214e-4234-86c1-42f78d623c93
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 446
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:47:03.876840+00:00","export_uri":null,"id":"fc93ab0f-214e-4234-86c1-42f78d623c93","modification_date":"2025-01-27T13:48:16.984013+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "446"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:48:16 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - adb5c8f6-22a2-427f-9f55-3cc43fba1d3f
-        status: 200 OK
-        code: 200
-        duration: 80.284292ms
-    - id: 46
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/fc93ab0f-214e-4234-86c1-42f78d623c93
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2322,9 +2226,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:16 GMT
+                - Tue, 11 Feb 2025 14:24:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2332,10 +2236,108 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b3d6fe95-ab64-4179-9376-c9d5ec059835
+                - b800276c-366d-4e63-82d5-c576ff8d29c0
         status: 204 No Content
         code: 204
-        duration: 163.720709ms
+        duration: 1.120175541s
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"b4055bbb-4c99-4606-8871-6b6a2c0b0bb4","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 24eb9706-a561-4700-8b63-366a816f51bb
+        status: 404 Not Found
+        code: 404
+        duration: 133.18025ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/7ffe5df6-12fa-4a96-8120-6ec10c129dbc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"7ffe5df6-12fa-4a96-8120-6ec10c129dbc","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 692f9661-686d-4f3e-bb30-3666ef500527
+        status: 404 Not Found
+        code: 404
+        duration: 33.390042ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2351,8 +2353,104 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f6b43b3-667b-40d7-ad95-19c4403a82a9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/7ffe5df6-12fa-4a96-8120-6ec10c129dbc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 494
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:23:34.820460Z","id":"7ffe5df6-12fa-4a96-8120-6ec10c129dbc","last_detached_at":"2025-02-11T14:24:23.930241Z","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:24:23.930241Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "494"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:24 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6cd8008e-4c1f-4169-80db-ece8381ce5c1
+        status: 200 OK
+        code: 200
+        duration: 61.888584ms
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/7ffe5df6-12fa-4a96-8120-6ec10c129dbc
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:24 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 68f09a33-f5eb-46e0-8a7c-d40fca9e8ef6
+        status: 204 No Content
+        code: 204
+        duration: 139.021ms
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b4055bbb-4c99-4606-8871-6b6a2c0b0bb4
         method: GET
       response:
         proto: HTTP/2.0
@@ -2362,7 +2460,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"6f6b43b3-667b-40d7-ad95-19c4403a82a9","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"b4055bbb-4c99-4606-8871-6b6a2c0b0bb4","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -2371,9 +2469,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:17 GMT
+                - Tue, 11 Feb 2025 14:24:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2381,7 +2479,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3ccda8e9-f066-45e1-bbe4-dd30cc5497d3
+                - 8edca62e-6e90-4230-aa54-f96aefe1c128
         status: 404 Not Found
         code: 404
-        duration: 106.661875ms
+        duration: 91.933292ms

--- a/internal/services/instance/testdata/server-minimal2.cassette.yaml
+++ b/internal/services/instance/testdata/server-minimal2.cassette.yaml
@@ -16,7 +16,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
         method: GET
       response:
@@ -25,22 +25,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 38539
+        content_length: 35639
         uncompressed: false
-        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
+        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
         headers:
             Content-Length:
-                - "38539"
+                - "35639"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:03 GMT
+                - Tue, 11 Feb 2025 14:23:32 GMT
             Link:
                 - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,12 +48,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 557c57ae-214e-41ce-bc2b-d2e047177ed2
+                - 4a93abf1-8662-48a2-b050-4bf81831e3a0
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 63.788375ms
+        duration: 53.553333ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -69,7 +69,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
         method: GET
       response:
@@ -78,22 +78,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 14208
+        content_length: 13164
         uncompressed: false
-        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
         headers:
             Content-Length:
-                - "14208"
+                - "13164"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:03 GMT
+                - Tue, 11 Feb 2025 14:23:32 GMT
             Link:
                 - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -101,12 +101,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cb119148-49c1-4ff2-97a2-6d3420a415e9
+                - f6d76a7f-061d-49de-873e-9dbfd41d2a32
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 46.287458ms
+        duration: 49.397167ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -122,8 +122,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_local&zone=fr-par-1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_sbs&zone=fr-par-1
         method: GET
       response:
         proto: HTTP/2.0
@@ -131,20 +131,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1300
+        content_length: 1296
         uncompressed: false
-        body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"56d4019c-8305-467a-a3f2-70498ad799df","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
+        body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"57509e82-ac3b-49b7-9970-97b60f40ff72","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"9b647e1e-253a-41e7-8c15-911c622ee2dc","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"}],"total_count":2}'
         headers:
             Content-Length:
-                - "1300"
+                - "1296"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:03 GMT
+                - Tue, 11 Feb 2025 14:23:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -152,28 +152,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6bb52657-c737-40e2-90ce-461e5efe7560
+                - 928d7696-541f-4812-bdf9-694cf61eb06a
         status: 200 OK
         code: 200
-        duration: 101.183917ms
+        duration: 78.706375ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 273
+        content_length: 234
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-srv-brave-spence","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+        body: '{"name":"tf-srv-romantic-kalam","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"57509e82-ac3b-49b7-9970-97b60f40ff72","volumes":{"0":{"boot":false}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
         method: POST
       response:
@@ -182,22 +182,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2109
+        content_length: 1672
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.826917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-brave-spence","id":"24e140e9-7335-4de2-a0f9-b75bd1294879","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:73","maintenances":[],"modification_date":"2025-01-27T13:47:03.826917+00:00","name":"tf-srv-brave-spence","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.826917+00:00","export_uri":null,"id":"76be47fc-1e77-4664-8491-2a6f15154775","modification_date":"2025-01-27T13:47:03.826917+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"24e140e9-7335-4de2-a0f9-b75bd1294879","name":"tf-srv-brave-spence"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:33.047208+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-romantic-kalam","id":"ef84c3b8-4d79-420d-a41e-228336800626","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:f3","maintenances":[],"modification_date":"2025-02-11T14:23:33.047208+00:00","name":"tf-srv-romantic-kalam","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"af78f552-6ef0-49a2-bd07-0b3032ed6a83","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2109"
+                - "1672"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:04 GMT
+                - Tue, 11 Feb 2025 14:23:33 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/24e140e9-7335-4de2-a0f9-b75bd1294879
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ef84c3b8-4d79-420d-a41e-228336800626
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -205,10 +205,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b35716f9-a352-4a86-a170-8c3820e36c55
+                - b1d863a9-9af0-4c8a-b382-281999a26bfd
         status: 201 Created
         code: 201
-        duration: 913.741584ms
+        duration: 1.085530709s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -224,8 +224,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/24e140e9-7335-4de2-a0f9-b75bd1294879
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ef84c3b8-4d79-420d-a41e-228336800626
         method: GET
       response:
         proto: HTTP/2.0
@@ -233,20 +233,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2109
+        content_length: 1672
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.826917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-brave-spence","id":"24e140e9-7335-4de2-a0f9-b75bd1294879","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:73","maintenances":[],"modification_date":"2025-01-27T13:47:03.826917+00:00","name":"tf-srv-brave-spence","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.826917+00:00","export_uri":null,"id":"76be47fc-1e77-4664-8491-2a6f15154775","modification_date":"2025-01-27T13:47:03.826917+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"24e140e9-7335-4de2-a0f9-b75bd1294879","name":"tf-srv-brave-spence"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:33.047208+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-romantic-kalam","id":"ef84c3b8-4d79-420d-a41e-228336800626","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:f3","maintenances":[],"modification_date":"2025-02-11T14:23:33.047208+00:00","name":"tf-srv-romantic-kalam","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"af78f552-6ef0-49a2-bd07-0b3032ed6a83","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2109"
+                - "1672"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:04 GMT
+                - Tue, 11 Feb 2025 14:23:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -254,10 +254,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cf71f0cd-a55e-47a1-82a5-fd7318eb0556
+                - 5b939797-82f4-469e-9991-25d4d53d53a1
         status: 200 OK
         code: 200
-        duration: 183.407459ms
+        duration: 170.431291ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -273,8 +273,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/24e140e9-7335-4de2-a0f9-b75bd1294879
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ef84c3b8-4d79-420d-a41e-228336800626
         method: GET
       response:
         proto: HTTP/2.0
@@ -282,20 +282,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2109
+        content_length: 1672
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.826917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-brave-spence","id":"24e140e9-7335-4de2-a0f9-b75bd1294879","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:73","maintenances":[],"modification_date":"2025-01-27T13:47:03.826917+00:00","name":"tf-srv-brave-spence","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.826917+00:00","export_uri":null,"id":"76be47fc-1e77-4664-8491-2a6f15154775","modification_date":"2025-01-27T13:47:03.826917+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"24e140e9-7335-4de2-a0f9-b75bd1294879","name":"tf-srv-brave-spence"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:33.047208+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-romantic-kalam","id":"ef84c3b8-4d79-420d-a41e-228336800626","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:f3","maintenances":[],"modification_date":"2025-02-11T14:23:33.047208+00:00","name":"tf-srv-romantic-kalam","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"af78f552-6ef0-49a2-bd07-0b3032ed6a83","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2109"
+                - "1672"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:04 GMT
+                - Tue, 11 Feb 2025 14:23:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -303,11 +303,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 264f4f10-daa9-4df2-b1c1-fec4224bf414
+                - c28e6093-e942-4a45-be7c-16bf47f9e3b2
         status: 200 OK
         code: 200
-        duration: 142.926333ms
+        duration: 152.65975ms
     - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/af78f552-6ef0-49a2-bd07-0b3032ed6a83
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:23:33.297370Z","id":"af78f552-6ef0-49a2-bd07-0b3032ed6a83","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:33.297370Z","id":"7ba443d7-8b90-4ede-a200-d1b3deb0ae3e","product_resource_id":"ef84c3b8-4d79-420d-a41e-228336800626","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:33.297370Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ef624d02-60fd-4e42-a114-f9f57126c38d
+        status: 200 OK
+        code: 200
+        duration: 62.688083ms
+    - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -324,8 +373,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/24e140e9-7335-4de2-a0f9-b75bd1294879/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ef84c3b8-4d79-420d-a41e-228336800626/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -335,7 +384,7 @@ interactions:
         trailer: {}
         content_length: 357
         uncompressed: false
-        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/24e140e9-7335-4de2-a0f9-b75bd1294879/action","href_result":"/servers/24e140e9-7335-4de2-a0f9-b75bd1294879","id":"9d772798-933f-4b34-9029-c43e33e8b2ff","progress":0,"started_at":"2025-01-27T13:47:05.108194+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/ef84c3b8-4d79-420d-a41e-228336800626/action","href_result":"/servers/ef84c3b8-4d79-420d-a41e-228336800626","id":"077c7545-f80a-4b36-aedf-35e01ea90997","progress":0,"started_at":"2025-02-11T14:23:34.454690+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -344,11 +393,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:04 GMT
+                - Tue, 11 Feb 2025 14:23:34 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/9d772798-933f-4b34-9029-c43e33e8b2ff
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/077c7545-f80a-4b36-aedf-35e01ea90997
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -356,59 +405,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 33bf2177-aec6-4fa6-befa-a5a9b3575f49
+                - 048207d5-f988-4e35-bddc-c0eb7d4792b4
         status: 202 Accepted
         code: 202
-        duration: 301.006083ms
-    - id: 7
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/24e140e9-7335-4de2-a0f9-b75bd1294879
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2131
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.826917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-brave-spence","id":"24e140e9-7335-4de2-a0f9-b75bd1294879","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:73","maintenances":[],"modification_date":"2025-01-27T13:47:04.868553+00:00","name":"tf-srv-brave-spence","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.826917+00:00","export_uri":null,"id":"76be47fc-1e77-4664-8491-2a6f15154775","modification_date":"2025-01-27T13:47:03.826917+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"24e140e9-7335-4de2-a0f9-b75bd1294879","name":"tf-srv-brave-spence"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2131"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:47:04 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - f883f6be-386e-4a46-a1a3-edef9cd77f40
-        status: 200 OK
-        code: 200
-        duration: 121.16825ms
+        duration: 249.99225ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -424,8 +424,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/24e140e9-7335-4de2-a0f9-b75bd1294879
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ef84c3b8-4d79-420d-a41e-228336800626
         method: GET
       response:
         proto: HTTP/2.0
@@ -433,20 +433,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2234
+        content_length: 1694
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.826917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-brave-spence","id":"24e140e9-7335-4de2-a0f9-b75bd1294879","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"203","node_id":"20","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:73","maintenances":[],"modification_date":"2025-01-27T13:47:04.868553+00:00","name":"tf-srv-brave-spence","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.826917+00:00","export_uri":null,"id":"76be47fc-1e77-4664-8491-2a6f15154775","modification_date":"2025-01-27T13:47:03.826917+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"24e140e9-7335-4de2-a0f9-b75bd1294879","name":"tf-srv-brave-spence"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:33.047208+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-romantic-kalam","id":"ef84c3b8-4d79-420d-a41e-228336800626","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:f3","maintenances":[],"modification_date":"2025-02-11T14:23:34.261072+00:00","name":"tf-srv-romantic-kalam","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"id":"af78f552-6ef0-49a2-bd07-0b3032ed6a83","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2234"
+                - "1694"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:10 GMT
+                - Tue, 11 Feb 2025 14:23:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -454,10 +454,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9041f514-8416-4e53-bede-6f950568611d
+                - fc68cc94-9b45-4886-a34c-4247971c042f
         status: 200 OK
         code: 200
-        duration: 195.377708ms
+        duration: 198.660583ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -473,8 +473,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/24e140e9-7335-4de2-a0f9-b75bd1294879
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ef84c3b8-4d79-420d-a41e-228336800626
         method: GET
       response:
         proto: HTTP/2.0
@@ -482,20 +482,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2234
+        content_length: 1829
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.826917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-brave-spence","id":"24e140e9-7335-4de2-a0f9-b75bd1294879","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"203","node_id":"20","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:73","maintenances":[],"modification_date":"2025-01-27T13:47:04.868553+00:00","name":"tf-srv-brave-spence","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.826917+00:00","export_uri":null,"id":"76be47fc-1e77-4664-8491-2a6f15154775","modification_date":"2025-01-27T13:47:03.826917+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"24e140e9-7335-4de2-a0f9-b75bd1294879","name":"tf-srv-brave-spence"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:33.047208+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-romantic-kalam","id":"ef84c3b8-4d79-420d-a41e-228336800626","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1301","node_id":"16","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f3","maintenances":[],"modification_date":"2025-02-11T14:23:38.252990+00:00","name":"tf-srv-romantic-kalam","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"af78f552-6ef0-49a2-bd07-0b3032ed6a83","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2234"
+                - "1829"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:15 GMT
+                - Tue, 11 Feb 2025 14:23:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -503,10 +503,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0de22b43-c711-4af6-9664-9d6fdb8980c9
+                - 36281557-179c-4749-ba04-799b50fcf34b
         status: 200 OK
         code: 200
-        duration: 162.876ms
+        duration: 194.152292ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -522,8 +522,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/24e140e9-7335-4de2-a0f9-b75bd1294879
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ef84c3b8-4d79-420d-a41e-228336800626
         method: GET
       response:
         proto: HTTP/2.0
@@ -531,20 +531,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2234
+        content_length: 1829
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.826917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-brave-spence","id":"24e140e9-7335-4de2-a0f9-b75bd1294879","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"203","node_id":"20","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:73","maintenances":[],"modification_date":"2025-01-27T13:47:04.868553+00:00","name":"tf-srv-brave-spence","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.826917+00:00","export_uri":null,"id":"76be47fc-1e77-4664-8491-2a6f15154775","modification_date":"2025-01-27T13:47:03.826917+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"24e140e9-7335-4de2-a0f9-b75bd1294879","name":"tf-srv-brave-spence"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:33.047208+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-romantic-kalam","id":"ef84c3b8-4d79-420d-a41e-228336800626","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1301","node_id":"16","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f3","maintenances":[],"modification_date":"2025-02-11T14:23:38.252990+00:00","name":"tf-srv-romantic-kalam","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"af78f552-6ef0-49a2-bd07-0b3032ed6a83","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2234"
+                - "1829"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:20 GMT
+                - Tue, 11 Feb 2025 14:23:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -552,10 +552,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 42d54c41-c7b7-406a-8441-5c8c41c6c67f
+                - d134d37c-b794-4f7a-986d-bef780caa772
         status: 200 OK
         code: 200
-        duration: 150.21275ms
+        duration: 149.139792ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -571,8 +571,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/24e140e9-7335-4de2-a0f9-b75bd1294879
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/af78f552-6ef0-49a2-bd07-0b3032ed6a83
         method: GET
       response:
         proto: HTTP/2.0
@@ -580,20 +580,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2265
+        content_length: 143
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.826917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-brave-spence","id":"24e140e9-7335-4de2-a0f9-b75bd1294879","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"203","node_id":"20","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:73","maintenances":[],"modification_date":"2025-01-27T13:47:21.628195+00:00","name":"tf-srv-brave-spence","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.826917+00:00","export_uri":null,"id":"76be47fc-1e77-4664-8491-2a6f15154775","modification_date":"2025-01-27T13:47:03.826917+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"24e140e9-7335-4de2-a0f9-b75bd1294879","name":"tf-srv-brave-spence"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"af78f552-6ef0-49a2-bd07-0b3032ed6a83","type":"not_found"}'
         headers:
             Content-Length:
-                - "2265"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:25 GMT
+                - Tue, 11 Feb 2025 14:23:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -601,10 +601,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b1e4577a-6b5e-4d81-9527-8de209bd5ac9
-        status: 200 OK
-        code: 200
-        duration: 143.367083ms
+                - aab9e23f-7d3f-410a-a56b-475d1e5b3add
+        status: 404 Not Found
+        code: 404
+        duration: 32.78625ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -620,8 +620,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/24e140e9-7335-4de2-a0f9-b75bd1294879
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/af78f552-6ef0-49a2-bd07-0b3032ed6a83
         method: GET
       response:
         proto: HTTP/2.0
@@ -629,20 +629,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2265
+        content_length: 701
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.826917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-brave-spence","id":"24e140e9-7335-4de2-a0f9-b75bd1294879","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"203","node_id":"20","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:73","maintenances":[],"modification_date":"2025-01-27T13:47:21.628195+00:00","name":"tf-srv-brave-spence","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.826917+00:00","export_uri":null,"id":"76be47fc-1e77-4664-8491-2a6f15154775","modification_date":"2025-01-27T13:47:03.826917+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"24e140e9-7335-4de2-a0f9-b75bd1294879","name":"tf-srv-brave-spence"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T14:23:33.297370Z","id":"af78f552-6ef0-49a2-bd07-0b3032ed6a83","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:33.297370Z","id":"7ba443d7-8b90-4ede-a200-d1b3deb0ae3e","product_resource_id":"ef84c3b8-4d79-420d-a41e-228336800626","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:33.297370Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2265"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:25 GMT
+                - Tue, 11 Feb 2025 14:23:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -650,10 +650,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4b8575d9-b4e8-4653-9ccd-b7101c5fad02
+                - 6e5e1a5e-f1f3-4838-a653-66012302161b
         status: 200 OK
         code: 200
-        duration: 155.712ms
+        duration: 73.036125ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -669,8 +669,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/76be47fc-1e77-4664-8491-2a6f15154775
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ef84c3b8-4d79-420d-a41e-228336800626/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -678,20 +678,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 519
+        content_length: 17
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:47:03.826917+00:00","export_uri":null,"id":"76be47fc-1e77-4664-8491-2a6f15154775","modification_date":"2025-01-27T13:47:03.826917+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"24e140e9-7335-4de2-a0f9-b75bd1294879","name":"tf-srv-brave-spence"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "519"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:26 GMT
+                - Tue, 11 Feb 2025 14:23:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -699,10 +699,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6b41d53e-92bd-4e3b-9b18-dce660ab358a
+                - 51fb9457-94df-4e47-98f3-e1a34f219782
         status: 200 OK
         code: 200
-        duration: 89.623084ms
+        duration: 89.23575ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -718,8 +718,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/24e140e9-7335-4de2-a0f9-b75bd1294879/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ef84c3b8-4d79-420d-a41e-228336800626/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -727,20 +727,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 20
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "17"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:26 GMT
+                - Tue, 11 Feb 2025 14:23:40 GMT
+            Link:
+                - </servers/ef84c3b8-4d79-420d-a41e-228336800626/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -748,10 +750,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 59a39c0f-e22d-4639-8543-37207bcd7b2f
+                - 6453a2ec-ca07-49eb-9f2c-39295f5394d5
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 89.4575ms
+        duration: 80.733917ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -767,8 +771,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/24e140e9-7335-4de2-a0f9-b75bd1294879/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ef84c3b8-4d79-420d-a41e-228336800626
         method: GET
       response:
         proto: HTTP/2.0
@@ -776,22 +780,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 1829
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:33.047208+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-romantic-kalam","id":"ef84c3b8-4d79-420d-a41e-228336800626","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1301","node_id":"16","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f3","maintenances":[],"modification_date":"2025-02-11T14:23:38.252990+00:00","name":"tf-srv-romantic-kalam","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"af78f552-6ef0-49a2-bd07-0b3032ed6a83","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "20"
+                - "1829"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:26 GMT
-            Link:
-                - </servers/24e140e9-7335-4de2-a0f9-b75bd1294879/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:23:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -799,12 +801,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4eb4ca80-910f-4fb3-898a-764c5297e61b
-            X-Total-Count:
-                - "0"
+                - 387b6ef4-f53f-4c18-b022-2fcd28c465a6
         status: 200 OK
         code: 200
-        duration: 96.010792ms
+        duration: 198.85775ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -820,8 +820,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/24e140e9-7335-4de2-a0f9-b75bd1294879
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ef84c3b8-4d79-420d-a41e-228336800626
         method: GET
       response:
         proto: HTTP/2.0
@@ -829,20 +829,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2265
+        content_length: 1829
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.826917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-brave-spence","id":"24e140e9-7335-4de2-a0f9-b75bd1294879","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"203","node_id":"20","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:73","maintenances":[],"modification_date":"2025-01-27T13:47:21.628195+00:00","name":"tf-srv-brave-spence","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.826917+00:00","export_uri":null,"id":"76be47fc-1e77-4664-8491-2a6f15154775","modification_date":"2025-01-27T13:47:03.826917+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"24e140e9-7335-4de2-a0f9-b75bd1294879","name":"tf-srv-brave-spence"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:33.047208+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-romantic-kalam","id":"ef84c3b8-4d79-420d-a41e-228336800626","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1301","node_id":"16","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f3","maintenances":[],"modification_date":"2025-02-11T14:23:38.252990+00:00","name":"tf-srv-romantic-kalam","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"af78f552-6ef0-49a2-bd07-0b3032ed6a83","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2265"
+                - "1829"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:26 GMT
+                - Tue, 11 Feb 2025 14:23:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -850,10 +850,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f4e2ccb8-9a7c-4d83-b092-884aa73aeaf6
+                - e9c5f919-07de-4bae-a427-d54d5e877c53
         status: 200 OK
         code: 200
-        duration: 186.185333ms
+        duration: 169.347791ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -869,8 +869,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/24e140e9-7335-4de2-a0f9-b75bd1294879
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/af78f552-6ef0-49a2-bd07-0b3032ed6a83
         method: GET
       response:
         proto: HTTP/2.0
@@ -878,20 +878,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2265
+        content_length: 143
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.826917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-brave-spence","id":"24e140e9-7335-4de2-a0f9-b75bd1294879","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"203","node_id":"20","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:73","maintenances":[],"modification_date":"2025-01-27T13:47:21.628195+00:00","name":"tf-srv-brave-spence","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.826917+00:00","export_uri":null,"id":"76be47fc-1e77-4664-8491-2a6f15154775","modification_date":"2025-01-27T13:47:03.826917+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"24e140e9-7335-4de2-a0f9-b75bd1294879","name":"tf-srv-brave-spence"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"af78f552-6ef0-49a2-bd07-0b3032ed6a83","type":"not_found"}'
         headers:
             Content-Length:
-                - "2265"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:26 GMT
+                - Tue, 11 Feb 2025 14:23:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -899,10 +899,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bfc0e28b-1735-4b35-985c-bb75a3969a99
-        status: 200 OK
-        code: 200
-        duration: 189.655541ms
+                - c762d2e3-d0b9-4c51-bd26-653011c08c9e
+        status: 404 Not Found
+        code: 404
+        duration: 87.608875ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -918,8 +918,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/76be47fc-1e77-4664-8491-2a6f15154775
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/af78f552-6ef0-49a2-bd07-0b3032ed6a83
         method: GET
       response:
         proto: HTTP/2.0
@@ -927,20 +927,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 519
+        content_length: 701
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:47:03.826917+00:00","export_uri":null,"id":"76be47fc-1e77-4664-8491-2a6f15154775","modification_date":"2025-01-27T13:47:03.826917+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"24e140e9-7335-4de2-a0f9-b75bd1294879","name":"tf-srv-brave-spence"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T14:23:33.297370Z","id":"af78f552-6ef0-49a2-bd07-0b3032ed6a83","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:33.297370Z","id":"7ba443d7-8b90-4ede-a200-d1b3deb0ae3e","product_resource_id":"ef84c3b8-4d79-420d-a41e-228336800626","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:33.297370Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "519"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:26 GMT
+                - Tue, 11 Feb 2025 14:23:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -948,10 +948,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b15eb867-3f6f-4ada-8f7c-a90bd8a5ac33
+                - 1730c6b6-1683-498b-a810-94f2d4676cae
         status: 200 OK
         code: 200
-        duration: 98.066291ms
+        duration: 91.006625ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -967,8 +967,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/24e140e9-7335-4de2-a0f9-b75bd1294879/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ef84c3b8-4d79-420d-a41e-228336800626/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -987,9 +987,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:26 GMT
+                - Tue, 11 Feb 2025 14:23:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -997,10 +997,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6cb468a9-6c33-4e6f-8acc-71493a3c9e36
+                - ca6a4a52-020e-465d-afd2-f5be57fb68b1
         status: 200 OK
         code: 200
-        duration: 98.733708ms
+        duration: 104.260292ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1016,8 +1016,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/24e140e9-7335-4de2-a0f9-b75bd1294879/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ef84c3b8-4d79-420d-a41e-228336800626/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1036,11 +1036,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:27 GMT
+                - Tue, 11 Feb 2025 14:23:40 GMT
             Link:
-                - </servers/24e140e9-7335-4de2-a0f9-b75bd1294879/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/ef84c3b8-4d79-420d-a41e-228336800626/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1048,12 +1048,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 737c5e5d-b17f-466e-a96b-3fe6dfe560f4
+                - 1b338322-bc25-4749-96ac-f913ffc68989
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 80.421375ms
+        duration: 106.957541ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1069,8 +1069,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/24e140e9-7335-4de2-a0f9-b75bd1294879
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ef84c3b8-4d79-420d-a41e-228336800626
         method: GET
       response:
         proto: HTTP/2.0
@@ -1078,20 +1078,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2265
+        content_length: 1829
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.826917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-brave-spence","id":"24e140e9-7335-4de2-a0f9-b75bd1294879","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"203","node_id":"20","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:73","maintenances":[],"modification_date":"2025-01-27T13:47:21.628195+00:00","name":"tf-srv-brave-spence","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.826917+00:00","export_uri":null,"id":"76be47fc-1e77-4664-8491-2a6f15154775","modification_date":"2025-01-27T13:47:03.826917+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"24e140e9-7335-4de2-a0f9-b75bd1294879","name":"tf-srv-brave-spence"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:33.047208+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-romantic-kalam","id":"ef84c3b8-4d79-420d-a41e-228336800626","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1301","node_id":"16","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f3","maintenances":[],"modification_date":"2025-02-11T14:23:38.252990+00:00","name":"tf-srv-romantic-kalam","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"af78f552-6ef0-49a2-bd07-0b3032ed6a83","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2265"
+                - "1829"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:28 GMT
+                - Tue, 11 Feb 2025 14:23:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1099,10 +1099,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 27cef218-a79b-4088-868f-0e1b1900ccea
+                - 1e1ce8af-c581-4608-bfd8-660cf905f8fd
         status: 200 OK
         code: 200
-        duration: 605.721875ms
+        duration: 160.728875ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1118,8 +1118,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/76be47fc-1e77-4664-8491-2a6f15154775
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/af78f552-6ef0-49a2-bd07-0b3032ed6a83
         method: GET
       response:
         proto: HTTP/2.0
@@ -1127,20 +1127,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 519
+        content_length: 143
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:47:03.826917+00:00","export_uri":null,"id":"76be47fc-1e77-4664-8491-2a6f15154775","modification_date":"2025-01-27T13:47:03.826917+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"24e140e9-7335-4de2-a0f9-b75bd1294879","name":"tf-srv-brave-spence"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"af78f552-6ef0-49a2-bd07-0b3032ed6a83","type":"not_found"}'
         headers:
             Content-Length:
-                - "519"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:27 GMT
+                - Tue, 11 Feb 2025 14:23:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1148,10 +1148,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cc5de2c0-5378-45d8-bd79-8ab4b5541c2e
-        status: 200 OK
-        code: 200
-        duration: 82.798875ms
+                - 832e8a25-5050-4afa-9c41-c00eb1284cf4
+        status: 404 Not Found
+        code: 404
+        duration: 59.809708ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1167,8 +1167,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/24e140e9-7335-4de2-a0f9-b75bd1294879/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/af78f552-6ef0-49a2-bd07-0b3032ed6a83
         method: GET
       response:
         proto: HTTP/2.0
@@ -1176,20 +1176,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 701
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"created_at":"2025-02-11T14:23:33.297370Z","id":"af78f552-6ef0-49a2-bd07-0b3032ed6a83","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:33.297370Z","id":"7ba443d7-8b90-4ede-a200-d1b3deb0ae3e","product_resource_id":"ef84c3b8-4d79-420d-a41e-228336800626","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:33.297370Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "17"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:27 GMT
+                - Tue, 11 Feb 2025 14:23:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1197,10 +1197,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d4f85ffd-a3cc-4241-8e71-0ffd7aea1ef0
+                - eb5b636a-97f6-473c-b50e-379a160b9a0b
         status: 200 OK
         code: 200
-        duration: 86.893042ms
+        duration: 77.331208ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1216,8 +1216,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/24e140e9-7335-4de2-a0f9-b75bd1294879/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ef84c3b8-4d79-420d-a41e-228336800626/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1225,22 +1225,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 17
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "20"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:28 GMT
-            Link:
-                - </servers/24e140e9-7335-4de2-a0f9-b75bd1294879/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:23:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1248,12 +1246,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 51ce1108-c96e-4ef6-b380-bdfc1f0d13f2
-            X-Total-Count:
-                - "0"
+                - 4562669c-38e1-4fc6-bf6f-536ba9d41cab
         status: 200 OK
         code: 200
-        duration: 81.725375ms
+        duration: 70.542709ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1269,8 +1265,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ef84c3b8-4d79-420d-a41e-228336800626/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1278,22 +1274,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 38539
+        content_length: 20
         uncompressed: false
-        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "38539"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:28 GMT
+                - Tue, 11 Feb 2025 14:23:41 GMT
             Link:
-                - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
+                - </servers/ef84c3b8-4d79-420d-a41e-228336800626/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1301,12 +1297,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 18cf8491-8273-482d-9e37-cb08edd9186b
+                - 16968b88-39ed-46e2-9ff8-b77c879618ef
             X-Total-Count:
-                - "68"
+                - "0"
         status: 200 OK
         code: 200
-        duration: 440.857417ms
+        duration: 81.775209ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1322,8 +1318,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/24e140e9-7335-4de2-a0f9-b75bd1294879
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1331,20 +1327,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2265
+        content_length: 35639
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.826917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-brave-spence","id":"24e140e9-7335-4de2-a0f9-b75bd1294879","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"203","node_id":"20","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:73","maintenances":[],"modification_date":"2025-01-27T13:47:21.628195+00:00","name":"tf-srv-brave-spence","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.826917+00:00","export_uri":null,"id":"76be47fc-1e77-4664-8491-2a6f15154775","modification_date":"2025-01-27T13:47:03.826917+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"24e140e9-7335-4de2-a0f9-b75bd1294879","name":"tf-srv-brave-spence"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
         headers:
             Content-Length:
-                - "2265"
+                - "35639"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:28 GMT
+                - Tue, 11 Feb 2025 14:23:42 GMT
+            Link:
+                - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1352,10 +1350,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7827b712-21af-49a1-bc09-89c1fa23ad91
+                - ca997b14-151d-46dc-906f-34611a3f315b
+            X-Total-Count:
+                - "68"
         status: 200 OK
         code: 200
-        duration: 453.059792ms
+        duration: 50.425208ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1371,7 +1371,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
         method: GET
       response:
@@ -1380,22 +1380,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 14208
+        content_length: 13164
         uncompressed: false
-        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
         headers:
             Content-Length:
-                - "14208"
+                - "13164"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:28 GMT
+                - Tue, 11 Feb 2025 14:23:42 GMT
             Link:
                 - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1403,12 +1403,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 439b9620-4931-4e92-b10b-30405c20a8ea
+                - 1bcccfaf-1d8f-473f-a7d3-0fdedb3a29ea
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 51.591541ms
+        duration: 48.094959ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1424,7 +1424,56 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ef84c3b8-4d79-420d-a41e-228336800626
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1829
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:33.047208+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-romantic-kalam","id":"ef84c3b8-4d79-420d-a41e-228336800626","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1301","node_id":"16","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f3","maintenances":[],"modification_date":"2025-02-11T14:23:38.252990+00:00","name":"tf-srv-romantic-kalam","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"af78f552-6ef0-49a2-bd07-0b3032ed6a83","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1829"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 050859e4-138a-4a2a-abb9-c07cebf8d765
+        status: 200 OK
+        code: 200
+        duration: 152.809416ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_local&zone=fr-par-1
         method: GET
       response:
@@ -1444,9 +1493,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:29 GMT
+                - Tue, 11 Feb 2025 14:23:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1454,63 +1503,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c7704d96-b78e-4666-b212-0fa14718f6a6
+                - 70a0af18-ba1f-40f1-8ad7-f1c5e28276ca
         status: 200 OK
         code: 200
-        duration: 77.904333ms
-    - id: 29
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 21
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"action":"poweroff"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/24e140e9-7335-4de2-a0f9-b75bd1294879/action
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 352
-        uncompressed: false
-        body: '{"task":{"description":"server_poweroff","href_from":"/servers/24e140e9-7335-4de2-a0f9-b75bd1294879/action","href_result":"/servers/24e140e9-7335-4de2-a0f9-b75bd1294879","id":"190ddbca-868f-4738-b6a7-335ff2d2ede2","progress":0,"started_at":"2025-01-27T13:47:29.248406+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "352"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:47:29 GMT
-            Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/190ddbca-868f-4738-b6a7-335ff2d2ede2
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 07ac86ef-90e2-4049-ad79-6ec24d7a90f6
-        status: 202 Accepted
-        code: 202
-        duration: 232.262375ms
+        duration: 89.6525ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1526,8 +1522,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/24e140e9-7335-4de2-a0f9-b75bd1294879
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/af78f552-6ef0-49a2-bd07-0b3032ed6a83
         method: GET
       response:
         proto: HTTP/2.0
@@ -1535,20 +1531,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2225
+        content_length: 701
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.826917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-brave-spence","id":"24e140e9-7335-4de2-a0f9-b75bd1294879","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"203","node_id":"20","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:73","maintenances":[],"modification_date":"2025-01-27T13:47:29.068530+00:00","name":"tf-srv-brave-spence","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.826917+00:00","export_uri":null,"id":"76be47fc-1e77-4664-8491-2a6f15154775","modification_date":"2025-01-27T13:47:03.826917+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"24e140e9-7335-4de2-a0f9-b75bd1294879","name":"tf-srv-brave-spence"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T14:23:33.297370Z","id":"af78f552-6ef0-49a2-bd07-0b3032ed6a83","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:33.297370Z","id":"7ba443d7-8b90-4ede-a200-d1b3deb0ae3e","product_resource_id":"ef84c3b8-4d79-420d-a41e-228336800626","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:33.297370Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2225"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:28 GMT
+                - Tue, 11 Feb 2025 14:23:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1556,29 +1552,29 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9fe07454-5735-4b13-b783-fb33f41a1150
+                - 3a9cc449-57eb-46c5-8cbf-119d99a8db2b
         status: 200 OK
         code: 200
-        duration: 186.450541ms
+        duration: 59.147375ms
     - id: 31
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 278
+        content_length: 21
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-srv-naughty-chaplygin","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+        body: '{"action":"poweroff"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ef84c3b8-4d79-420d-a41e-228336800626/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -1586,22 +1582,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2124
+        content_length: 352
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:29.417332+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-naughty-chaplygin","id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:8f","maintenances":[],"modification_date":"2025-01-27T13:47:29.417332+00:00","name":"tf-srv-naughty-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:29.417332+00:00","export_uri":null,"id":"0f0d9856-afcb-497e-89a9-c9a720cc1336","modification_date":"2025-01-27T13:47:29.417332+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","name":"tf-srv-naughty-chaplygin"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_poweroff","href_from":"/servers/ef84c3b8-4d79-420d-a41e-228336800626/action","href_result":"/servers/ef84c3b8-4d79-420d-a41e-228336800626","id":"473d96bb-e29b-4786-a28e-0a0009bbc32d","progress":0,"started_at":"2025-02-11T14:23:42.776229+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2124"
+                - "352"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:29 GMT
+                - Tue, 11 Feb 2025 14:23:42 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b906fc7a-351f-444a-95a8-b9bf5a20d698
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/473d96bb-e29b-4786-a28e-0a0009bbc32d
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1609,10 +1605,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c4a22242-c898-4ad0-bb73-59732a092737
-        status: 201 Created
-        code: 201
-        duration: 512.893334ms
+                - f18525eb-2a3e-4190-8d5c-88731005e969
+        status: 202 Accepted
+        code: 202
+        duration: 292.868416ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1628,8 +1624,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b906fc7a-351f-444a-95a8-b9bf5a20d698
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ef84c3b8-4d79-420d-a41e-228336800626
         method: GET
       response:
         proto: HTTP/2.0
@@ -1637,20 +1633,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2124
+        content_length: 1789
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:29.417332+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-naughty-chaplygin","id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:8f","maintenances":[],"modification_date":"2025-01-27T13:47:29.417332+00:00","name":"tf-srv-naughty-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:29.417332+00:00","export_uri":null,"id":"0f0d9856-afcb-497e-89a9-c9a720cc1336","modification_date":"2025-01-27T13:47:29.417332+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","name":"tf-srv-naughty-chaplygin"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:33.047208+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-romantic-kalam","id":"ef84c3b8-4d79-420d-a41e-228336800626","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1301","node_id":"16","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f3","maintenances":[],"modification_date":"2025-02-11T14:23:42.536612+00:00","name":"tf-srv-romantic-kalam","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"af78f552-6ef0-49a2-bd07-0b3032ed6a83","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2124"
+                - "1789"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:29 GMT
+                - Tue, 11 Feb 2025 14:23:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1658,11 +1654,64 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 79d05620-2f02-43ea-96d5-6195a7f69b46
+                - fa1a25b8-7e53-4b90-ba8b-1d5f5bfa3c1d
         status: 200 OK
         code: 200
-        duration: 113.023708ms
+        duration: 194.109208ms
     - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 273
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf-srv-loving-yalow","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2109
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:42.727591+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-yalow","id":"302bc2c7-f834-4620-84e2-2346024e4485","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:f7","maintenances":[],"modification_date":"2025-02-11T14:23:42.727591+00:00","name":"tf-srv-loving-yalow","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:23:42.727591+00:00","export_uri":null,"id":"5fc5d78d-c7d6-4a0d-9e48-705850306658","modification_date":"2025-02-11T14:23:42.727591+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"302bc2c7-f834-4620-84e2-2346024e4485","name":"tf-srv-loving-yalow"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2109"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:42 GMT
+            Location:
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/302bc2c7-f834-4620-84e2-2346024e4485
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3af9542e-4175-4daa-a22f-2b896fa6732e
+        status: 201 Created
+        code: 201
+        duration: 532.062708ms
+    - id: 34
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1677,8 +1726,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b906fc7a-351f-444a-95a8-b9bf5a20d698
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/302bc2c7-f834-4620-84e2-2346024e4485
         method: GET
       response:
         proto: HTTP/2.0
@@ -1686,20 +1735,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2124
+        content_length: 2109
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:29.417332+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-naughty-chaplygin","id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:8f","maintenances":[],"modification_date":"2025-01-27T13:47:29.417332+00:00","name":"tf-srv-naughty-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:29.417332+00:00","export_uri":null,"id":"0f0d9856-afcb-497e-89a9-c9a720cc1336","modification_date":"2025-01-27T13:47:29.417332+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","name":"tf-srv-naughty-chaplygin"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:42.727591+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-yalow","id":"302bc2c7-f834-4620-84e2-2346024e4485","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:f7","maintenances":[],"modification_date":"2025-02-11T14:23:42.727591+00:00","name":"tf-srv-loving-yalow","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:23:42.727591+00:00","export_uri":null,"id":"5fc5d78d-c7d6-4a0d-9e48-705850306658","modification_date":"2025-02-11T14:23:42.727591+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"302bc2c7-f834-4620-84e2-2346024e4485","name":"tf-srv-loving-yalow"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2124"
+                - "2109"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:29 GMT
+                - Tue, 11 Feb 2025 14:23:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1707,11 +1756,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 71233a9e-894d-4865-8179-9a62acd546e2
+                - d8bc6b41-1dda-4c86-bbc7-b98f54299a8e
         status: 200 OK
         code: 200
-        duration: 158.24075ms
-    - id: 34
+        duration: 957.069417ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/302bc2c7-f834-4620-84e2-2346024e4485
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2109
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:42.727591+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-yalow","id":"302bc2c7-f834-4620-84e2-2346024e4485","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:f7","maintenances":[],"modification_date":"2025-02-11T14:23:42.727591+00:00","name":"tf-srv-loving-yalow","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:23:42.727591+00:00","export_uri":null,"id":"5fc5d78d-c7d6-4a0d-9e48-705850306658","modification_date":"2025-02-11T14:23:42.727591+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"302bc2c7-f834-4620-84e2-2346024e4485","name":"tf-srv-loving-yalow"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2109"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0fb3f1a0-b8ab-4e77-86f8-99e422e6f4ca
+        status: 200 OK
+        code: 200
+        duration: 125.965334ms
+    - id: 36
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1728,8 +1826,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b906fc7a-351f-444a-95a8-b9bf5a20d698/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/302bc2c7-f834-4620-84e2-2346024e4485/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -1739,7 +1837,7 @@ interactions:
         trailer: {}
         content_length: 357
         uncompressed: false
-        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/b906fc7a-351f-444a-95a8-b9bf5a20d698/action","href_result":"/servers/b906fc7a-351f-444a-95a8-b9bf5a20d698","id":"5140f213-dcd4-4bdc-ac48-169a432193ec","progress":0,"started_at":"2025-01-27T13:47:30.368172+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/302bc2c7-f834-4620-84e2-2346024e4485/action","href_result":"/servers/302bc2c7-f834-4620-84e2-2346024e4485","id":"53125f59-92ef-41ce-b84f-31554ea278dd","progress":0,"started_at":"2025-02-11T14:23:44.354095+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -1748,11 +1846,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:30 GMT
+                - Tue, 11 Feb 2025 14:23:44 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/5140f213-dcd4-4bdc-ac48-169a432193ec
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/53125f59-92ef-41ce-b84f-31554ea278dd
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1760,108 +1858,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 301e9c5d-affb-4df6-ae17-5cfd973238f0
+                - 8723fa45-5310-4566-a1d2-c07626aaa85b
         status: 202 Accepted
         code: 202
-        duration: 444.825834ms
-    - id: 35
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b906fc7a-351f-444a-95a8-b9bf5a20d698
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2146
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:29.417332+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-naughty-chaplygin","id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:8f","maintenances":[],"modification_date":"2025-01-27T13:47:30.089678+00:00","name":"tf-srv-naughty-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:29.417332+00:00","export_uri":null,"id":"0f0d9856-afcb-497e-89a9-c9a720cc1336","modification_date":"2025-01-27T13:47:29.417332+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","name":"tf-srv-naughty-chaplygin"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2146"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:47:30 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 8f8c4005-285e-460c-96d2-42460ab63ac7
-        status: 200 OK
-        code: 200
-        duration: 151.537708ms
-    - id: 36
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/24e140e9-7335-4de2-a0f9-b75bd1294879
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2225
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.826917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-brave-spence","id":"24e140e9-7335-4de2-a0f9-b75bd1294879","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"203","node_id":"20","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:73","maintenances":[],"modification_date":"2025-01-27T13:47:29.068530+00:00","name":"tf-srv-brave-spence","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.826917+00:00","export_uri":null,"id":"76be47fc-1e77-4664-8491-2a6f15154775","modification_date":"2025-01-27T13:47:03.826917+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"24e140e9-7335-4de2-a0f9-b75bd1294879","name":"tf-srv-brave-spence"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2225"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:47:34 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - bb452b82-2e3a-4b22-a991-cc24e2ca49d9
-        status: 200 OK
-        code: 200
-        duration: 195.885416ms
+        duration: 254.177625ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1877,8 +1877,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b906fc7a-351f-444a-95a8-b9bf5a20d698
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/302bc2c7-f834-4620-84e2-2346024e4485
         method: GET
       response:
         proto: HTTP/2.0
@@ -1886,20 +1886,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2250
+        content_length: 2131
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:29.417332+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-naughty-chaplygin","id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"1101","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:8f","maintenances":[],"modification_date":"2025-01-27T13:47:30.089678+00:00","name":"tf-srv-naughty-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:29.417332+00:00","export_uri":null,"id":"0f0d9856-afcb-497e-89a9-c9a720cc1336","modification_date":"2025-01-27T13:47:29.417332+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","name":"tf-srv-naughty-chaplygin"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:42.727591+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-yalow","id":"302bc2c7-f834-4620-84e2-2346024e4485","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:f7","maintenances":[],"modification_date":"2025-02-11T14:23:44.141941+00:00","name":"tf-srv-loving-yalow","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:23:42.727591+00:00","export_uri":null,"id":"5fc5d78d-c7d6-4a0d-9e48-705850306658","modification_date":"2025-02-11T14:23:42.727591+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"302bc2c7-f834-4620-84e2-2346024e4485","name":"tf-srv-loving-yalow"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2250"
+                - "2131"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:35 GMT
+                - Tue, 11 Feb 2025 14:23:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1907,10 +1907,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9376d1a0-507a-46b4-8e3b-7a8007fe8203
+                - 21514c65-d41a-41fb-8529-b3d6bc376e0e
         status: 200 OK
         code: 200
-        duration: 200.215792ms
+        duration: 288.19125ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1926,8 +1926,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/24e140e9-7335-4de2-a0f9-b75bd1294879
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ef84c3b8-4d79-420d-a41e-228336800626
         method: GET
       response:
         proto: HTTP/2.0
@@ -1935,20 +1935,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2225
+        content_length: 1789
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.826917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-brave-spence","id":"24e140e9-7335-4de2-a0f9-b75bd1294879","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"203","node_id":"20","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:73","maintenances":[],"modification_date":"2025-01-27T13:47:29.068530+00:00","name":"tf-srv-brave-spence","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.826917+00:00","export_uri":null,"id":"76be47fc-1e77-4664-8491-2a6f15154775","modification_date":"2025-01-27T13:47:03.826917+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"24e140e9-7335-4de2-a0f9-b75bd1294879","name":"tf-srv-brave-spence"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:33.047208+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-romantic-kalam","id":"ef84c3b8-4d79-420d-a41e-228336800626","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1301","node_id":"16","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f3","maintenances":[],"modification_date":"2025-02-11T14:23:42.536612+00:00","name":"tf-srv-romantic-kalam","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"af78f552-6ef0-49a2-bd07-0b3032ed6a83","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2225"
+                - "1789"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:39 GMT
+                - Tue, 11 Feb 2025 14:23:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1956,10 +1956,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a715607e-398e-46cc-9f2d-240556e7e173
+                - f128cc97-01d5-4e1d-9e70-38bca376f604
         status: 200 OK
         code: 200
-        duration: 165.242791ms
+        duration: 408.486292ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1975,8 +1975,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b906fc7a-351f-444a-95a8-b9bf5a20d698
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/302bc2c7-f834-4620-84e2-2346024e4485
         method: GET
       response:
         proto: HTTP/2.0
@@ -1984,20 +1984,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2250
+        content_length: 2233
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:29.417332+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-naughty-chaplygin","id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"1101","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:8f","maintenances":[],"modification_date":"2025-01-27T13:47:30.089678+00:00","name":"tf-srv-naughty-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:29.417332+00:00","export_uri":null,"id":"0f0d9856-afcb-497e-89a9-c9a720cc1336","modification_date":"2025-01-27T13:47:29.417332+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","name":"tf-srv-naughty-chaplygin"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:42.727591+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-yalow","id":"302bc2c7-f834-4620-84e2-2346024e4485","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"202","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f7","maintenances":[],"modification_date":"2025-02-11T14:23:44.141941+00:00","name":"tf-srv-loving-yalow","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:23:42.727591+00:00","export_uri":null,"id":"5fc5d78d-c7d6-4a0d-9e48-705850306658","modification_date":"2025-02-11T14:23:42.727591+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"302bc2c7-f834-4620-84e2-2346024e4485","name":"tf-srv-loving-yalow"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2250"
+                - "2233"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:40 GMT
+                - Tue, 11 Feb 2025 14:23:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2005,10 +2005,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 929eaf9a-4284-44ad-a34f-bf346ae0d56d
+                - 3913f8b6-2b57-4f13-a18d-47d488fa8f5d
         status: 200 OK
         code: 200
-        duration: 172.440791ms
+        duration: 152.617917ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2024,8 +2024,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/24e140e9-7335-4de2-a0f9-b75bd1294879
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ef84c3b8-4d79-420d-a41e-228336800626
         method: GET
       response:
         proto: HTTP/2.0
@@ -2033,20 +2033,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2225
+        content_length: 1789
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.826917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-brave-spence","id":"24e140e9-7335-4de2-a0f9-b75bd1294879","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"203","node_id":"20","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:73","maintenances":[],"modification_date":"2025-01-27T13:47:29.068530+00:00","name":"tf-srv-brave-spence","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.826917+00:00","export_uri":null,"id":"76be47fc-1e77-4664-8491-2a6f15154775","modification_date":"2025-01-27T13:47:03.826917+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"24e140e9-7335-4de2-a0f9-b75bd1294879","name":"tf-srv-brave-spence"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:33.047208+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-romantic-kalam","id":"ef84c3b8-4d79-420d-a41e-228336800626","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1301","node_id":"16","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f3","maintenances":[],"modification_date":"2025-02-11T14:23:42.536612+00:00","name":"tf-srv-romantic-kalam","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"af78f552-6ef0-49a2-bd07-0b3032ed6a83","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2225"
+                - "1789"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:44 GMT
+                - Tue, 11 Feb 2025 14:23:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2054,10 +2054,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ba04a961-75b1-4571-a45b-a2eab47ff55f
+                - 2c68c203-7a7b-421a-8999-b066be4fa1fb
         status: 200 OK
         code: 200
-        duration: 149.078125ms
+        duration: 176.639375ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2073,8 +2073,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b906fc7a-351f-444a-95a8-b9bf5a20d698
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/302bc2c7-f834-4620-84e2-2346024e4485
         method: GET
       response:
         proto: HTTP/2.0
@@ -2082,20 +2082,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2281
+        content_length: 2233
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:29.417332+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-naughty-chaplygin","id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"1101","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:8f","maintenances":[],"modification_date":"2025-01-27T13:47:43.131146+00:00","name":"tf-srv-naughty-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:29.417332+00:00","export_uri":null,"id":"0f0d9856-afcb-497e-89a9-c9a720cc1336","modification_date":"2025-01-27T13:47:29.417332+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","name":"tf-srv-naughty-chaplygin"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:42.727591+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-yalow","id":"302bc2c7-f834-4620-84e2-2346024e4485","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"202","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f7","maintenances":[],"modification_date":"2025-02-11T14:23:44.141941+00:00","name":"tf-srv-loving-yalow","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:23:42.727591+00:00","export_uri":null,"id":"5fc5d78d-c7d6-4a0d-9e48-705850306658","modification_date":"2025-02-11T14:23:42.727591+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"302bc2c7-f834-4620-84e2-2346024e4485","name":"tf-srv-loving-yalow"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2281"
+                - "2233"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:45 GMT
+                - Tue, 11 Feb 2025 14:23:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2103,10 +2103,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 11811d71-ee4b-4dca-9ecf-9cedd8a7c6e7
+                - e41a006c-d5d3-4b2d-9a06-dbb867aeef42
         status: 200 OK
         code: 200
-        duration: 159.171542ms
+        duration: 149.161584ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2122,8 +2122,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b906fc7a-351f-444a-95a8-b9bf5a20d698
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ef84c3b8-4d79-420d-a41e-228336800626
         method: GET
       response:
         proto: HTTP/2.0
@@ -2131,20 +2131,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2281
+        content_length: 1789
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:29.417332+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-naughty-chaplygin","id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"1101","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:8f","maintenances":[],"modification_date":"2025-01-27T13:47:43.131146+00:00","name":"tf-srv-naughty-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:29.417332+00:00","export_uri":null,"id":"0f0d9856-afcb-497e-89a9-c9a720cc1336","modification_date":"2025-01-27T13:47:29.417332+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","name":"tf-srv-naughty-chaplygin"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:33.047208+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-romantic-kalam","id":"ef84c3b8-4d79-420d-a41e-228336800626","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1301","node_id":"16","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f3","maintenances":[],"modification_date":"2025-02-11T14:23:42.536612+00:00","name":"tf-srv-romantic-kalam","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"af78f552-6ef0-49a2-bd07-0b3032ed6a83","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2281"
+                - "1789"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:46 GMT
+                - Tue, 11 Feb 2025 14:23:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2152,10 +2152,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a08eac9e-56e1-4b7d-8984-0082fea62725
+                - 42925203-2aa6-42ae-9840-55cbe78f2f90
         status: 200 OK
         code: 200
-        duration: 162.104875ms
+        duration: 219.739375ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2171,8 +2171,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0f0d9856-afcb-497e-89a9-c9a720cc1336
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/302bc2c7-f834-4620-84e2-2346024e4485
         method: GET
       response:
         proto: HTTP/2.0
@@ -2180,20 +2180,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 524
+        content_length: 2264
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:47:29.417332+00:00","export_uri":null,"id":"0f0d9856-afcb-497e-89a9-c9a720cc1336","modification_date":"2025-01-27T13:47:29.417332+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","name":"tf-srv-naughty-chaplygin"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:42.727591+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-yalow","id":"302bc2c7-f834-4620-84e2-2346024e4485","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"202","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f7","maintenances":[],"modification_date":"2025-02-11T14:23:59.958910+00:00","name":"tf-srv-loving-yalow","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:23:42.727591+00:00","export_uri":null,"id":"5fc5d78d-c7d6-4a0d-9e48-705850306658","modification_date":"2025-02-11T14:23:42.727591+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"302bc2c7-f834-4620-84e2-2346024e4485","name":"tf-srv-loving-yalow"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "524"
+                - "2264"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:46 GMT
+                - Tue, 11 Feb 2025 14:23:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2201,10 +2201,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9348dc7a-e003-4df7-8e9c-6112be3a8683
+                - 8d37cba3-2131-4017-9c1b-5e8225825e1e
         status: 200 OK
         code: 200
-        duration: 124.234209ms
+        duration: 210.103542ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2220,8 +2220,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b906fc7a-351f-444a-95a8-b9bf5a20d698/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/302bc2c7-f834-4620-84e2-2346024e4485
         method: GET
       response:
         proto: HTTP/2.0
@@ -2229,20 +2229,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 2264
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:42.727591+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-yalow","id":"302bc2c7-f834-4620-84e2-2346024e4485","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"202","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f7","maintenances":[],"modification_date":"2025-02-11T14:23:59.958910+00:00","name":"tf-srv-loving-yalow","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:23:42.727591+00:00","export_uri":null,"id":"5fc5d78d-c7d6-4a0d-9e48-705850306658","modification_date":"2025-02-11T14:23:42.727591+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"302bc2c7-f834-4620-84e2-2346024e4485","name":"tf-srv-loving-yalow"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "17"
+                - "2264"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:46 GMT
+                - Tue, 11 Feb 2025 14:23:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2250,10 +2250,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6aaab2f5-ffee-43ca-bfff-a3be58e5d571
+                - 914a208f-276e-4ff0-95ad-bd068f1f968a
         status: 200 OK
         code: 200
-        duration: 80.543375ms
+        duration: 259.801167ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2269,8 +2269,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b906fc7a-351f-444a-95a8-b9bf5a20d698/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/5fc5d78d-c7d6-4a0d-9e48-705850306658
         method: GET
       response:
         proto: HTTP/2.0
@@ -2278,22 +2278,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 519
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:23:42.727591+00:00","export_uri":null,"id":"5fc5d78d-c7d6-4a0d-9e48-705850306658","modification_date":"2025-02-11T14:23:42.727591+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"302bc2c7-f834-4620-84e2-2346024e4485","name":"tf-srv-loving-yalow"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "20"
+                - "519"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:46 GMT
-            Link:
-                - </servers/b906fc7a-351f-444a-95a8-b9bf5a20d698/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:24:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2301,12 +2299,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e0760458-cc18-4b78-ab06-17247a013846
-            X-Total-Count:
-                - "0"
+                - 2a3955c6-ec24-494f-9b1d-64df22d106ae
         status: 200 OK
         code: 200
-        duration: 84.140542ms
+        duration: 96.285375ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2322,8 +2318,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/24e140e9-7335-4de2-a0f9-b75bd1294879
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/302bc2c7-f834-4620-84e2-2346024e4485/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -2331,20 +2327,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2225
+        content_length: 17
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.826917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-brave-spence","id":"24e140e9-7335-4de2-a0f9-b75bd1294879","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"203","node_id":"20","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:73","maintenances":[],"modification_date":"2025-01-27T13:47:29.068530+00:00","name":"tf-srv-brave-spence","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.826917+00:00","export_uri":null,"id":"76be47fc-1e77-4664-8491-2a6f15154775","modification_date":"2025-01-27T13:47:03.826917+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"24e140e9-7335-4de2-a0f9-b75bd1294879","name":"tf-srv-brave-spence"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "2225"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:49 GMT
+                - Tue, 11 Feb 2025 14:24:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2352,10 +2348,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 59d76b7a-b5a7-4c05-95a7-ec15086e53c6
+                - 2b6d248f-973c-4e9f-b647-17183d742c6c
         status: 200 OK
         code: 200
-        duration: 182.972458ms
+        duration: 113.548083ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2371,8 +2367,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/24e140e9-7335-4de2-a0f9-b75bd1294879
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/302bc2c7-f834-4620-84e2-2346024e4485/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -2380,20 +2376,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2225
+        content_length: 20
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.826917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-brave-spence","id":"24e140e9-7335-4de2-a0f9-b75bd1294879","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"203","node_id":"20","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:73","maintenances":[],"modification_date":"2025-01-27T13:47:29.068530+00:00","name":"tf-srv-brave-spence","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.826917+00:00","export_uri":null,"id":"76be47fc-1e77-4664-8491-2a6f15154775","modification_date":"2025-01-27T13:47:03.826917+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"24e140e9-7335-4de2-a0f9-b75bd1294879","name":"tf-srv-brave-spence"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "2225"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:55 GMT
+                - Tue, 11 Feb 2025 14:24:00 GMT
+            Link:
+                - </servers/302bc2c7-f834-4620-84e2-2346024e4485/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2401,10 +2399,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 39200486-aa38-4a12-a494-4f01cffe3ae2
+                - d8a5c482-01d0-40c8-90f0-1cadfaf70979
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 169.096ms
+        duration: 98.688125ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2420,8 +2420,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/24e140e9-7335-4de2-a0f9-b75bd1294879
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ef84c3b8-4d79-420d-a41e-228336800626
         method: GET
       response:
         proto: HTTP/2.0
@@ -2429,20 +2429,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2225
+        content_length: 1789
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.826917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-brave-spence","id":"24e140e9-7335-4de2-a0f9-b75bd1294879","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"203","node_id":"20","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:73","maintenances":[],"modification_date":"2025-01-27T13:47:29.068530+00:00","name":"tf-srv-brave-spence","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.826917+00:00","export_uri":null,"id":"76be47fc-1e77-4664-8491-2a6f15154775","modification_date":"2025-01-27T13:47:03.826917+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"24e140e9-7335-4de2-a0f9-b75bd1294879","name":"tf-srv-brave-spence"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:33.047208+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-romantic-kalam","id":"ef84c3b8-4d79-420d-a41e-228336800626","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1301","node_id":"16","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f3","maintenances":[],"modification_date":"2025-02-11T14:23:42.536612+00:00","name":"tf-srv-romantic-kalam","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"af78f552-6ef0-49a2-bd07-0b3032ed6a83","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2225"
+                - "1789"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:00 GMT
+                - Tue, 11 Feb 2025 14:24:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2450,10 +2450,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e781a53d-e524-4877-a3f4-36c3aa704861
+                - 86168e03-9419-4c64-afa2-2f01bde426f3
         status: 200 OK
         code: 200
-        duration: 163.105667ms
+        duration: 206.265625ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2469,8 +2469,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/24e140e9-7335-4de2-a0f9-b75bd1294879
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ef84c3b8-4d79-420d-a41e-228336800626
         method: GET
       response:
         proto: HTTP/2.0
@@ -2478,20 +2478,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2225
+        content_length: 1789
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.826917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-brave-spence","id":"24e140e9-7335-4de2-a0f9-b75bd1294879","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"203","node_id":"20","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:73","maintenances":[],"modification_date":"2025-01-27T13:47:29.068530+00:00","name":"tf-srv-brave-spence","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.826917+00:00","export_uri":null,"id":"76be47fc-1e77-4664-8491-2a6f15154775","modification_date":"2025-01-27T13:47:03.826917+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"24e140e9-7335-4de2-a0f9-b75bd1294879","name":"tf-srv-brave-spence"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:33.047208+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-romantic-kalam","id":"ef84c3b8-4d79-420d-a41e-228336800626","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1301","node_id":"16","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f3","maintenances":[],"modification_date":"2025-02-11T14:23:42.536612+00:00","name":"tf-srv-romantic-kalam","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"af78f552-6ef0-49a2-bd07-0b3032ed6a83","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2225"
+                - "1789"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:05 GMT
+                - Tue, 11 Feb 2025 14:24:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2499,10 +2499,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ba0da2fc-9fa3-4c85-86dd-ec4d16573012
+                - 7f1b008f-3c0f-4bb2-a6f9-9324dfe0b53f
         status: 200 OK
         code: 200
-        duration: 141.020833ms
+        duration: 185.480584ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -2518,8 +2518,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/24e140e9-7335-4de2-a0f9-b75bd1294879
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ef84c3b8-4d79-420d-a41e-228336800626
         method: GET
       response:
         proto: HTTP/2.0
@@ -2527,20 +2527,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2225
+        content_length: 1789
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.826917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-brave-spence","id":"24e140e9-7335-4de2-a0f9-b75bd1294879","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"203","node_id":"20","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:73","maintenances":[],"modification_date":"2025-01-27T13:47:29.068530+00:00","name":"tf-srv-brave-spence","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.826917+00:00","export_uri":null,"id":"76be47fc-1e77-4664-8491-2a6f15154775","modification_date":"2025-01-27T13:47:03.826917+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"24e140e9-7335-4de2-a0f9-b75bd1294879","name":"tf-srv-brave-spence"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:33.047208+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-romantic-kalam","id":"ef84c3b8-4d79-420d-a41e-228336800626","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1301","node_id":"16","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f3","maintenances":[],"modification_date":"2025-02-11T14:23:42.536612+00:00","name":"tf-srv-romantic-kalam","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"af78f552-6ef0-49a2-bd07-0b3032ed6a83","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2225"
+                - "1789"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:10 GMT
+                - Tue, 11 Feb 2025 14:24:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2548,10 +2548,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b9e7c8cd-61f3-4b50-9ef3-076a61f3ff6d
+                - c04e7f68-db26-4776-8c10-c990d3b14298
         status: 200 OK
         code: 200
-        duration: 166.212125ms
+        duration: 188.347833ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2567,8 +2567,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/24e140e9-7335-4de2-a0f9-b75bd1294879
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ef84c3b8-4d79-420d-a41e-228336800626
         method: GET
       response:
         proto: HTTP/2.0
@@ -2576,20 +2576,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2109
+        content_length: 1672
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.826917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-brave-spence","id":"24e140e9-7335-4de2-a0f9-b75bd1294879","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:73","maintenances":[],"modification_date":"2025-01-27T13:48:11.374450+00:00","name":"tf-srv-brave-spence","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.826917+00:00","export_uri":null,"id":"76be47fc-1e77-4664-8491-2a6f15154775","modification_date":"2025-01-27T13:47:03.826917+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"24e140e9-7335-4de2-a0f9-b75bd1294879","name":"tf-srv-brave-spence"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:33.047208+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-romantic-kalam","id":"ef84c3b8-4d79-420d-a41e-228336800626","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:f3","maintenances":[],"modification_date":"2025-02-11T14:24:15.972941+00:00","name":"tf-srv-romantic-kalam","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"af78f552-6ef0-49a2-bd07-0b3032ed6a83","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2109"
+                - "1672"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:15 GMT
+                - Tue, 11 Feb 2025 14:24:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2597,10 +2597,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9503699e-d81c-4f67-909c-1376a05bbcb8
+                - c5c178b5-4949-4089-ae14-258264252884
         status: 200 OK
         code: 200
-        duration: 174.088167ms
+        duration: 187.719375ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -2616,8 +2616,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/24e140e9-7335-4de2-a0f9-b75bd1294879
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ef84c3b8-4d79-420d-a41e-228336800626
         method: GET
       response:
         proto: HTTP/2.0
@@ -2625,20 +2625,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2109
+        content_length: 1672
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:03.826917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-brave-spence","id":"24e140e9-7335-4de2-a0f9-b75bd1294879","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:73","maintenances":[],"modification_date":"2025-01-27T13:48:11.374450+00:00","name":"tf-srv-brave-spence","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:03.826917+00:00","export_uri":null,"id":"76be47fc-1e77-4664-8491-2a6f15154775","modification_date":"2025-01-27T13:47:03.826917+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"24e140e9-7335-4de2-a0f9-b75bd1294879","name":"tf-srv-brave-spence"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:33.047208+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-romantic-kalam","id":"ef84c3b8-4d79-420d-a41e-228336800626","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:f3","maintenances":[],"modification_date":"2025-02-11T14:24:15.972941+00:00","name":"tf-srv-romantic-kalam","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"af78f552-6ef0-49a2-bd07-0b3032ed6a83","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2109"
+                - "1672"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:15 GMT
+                - Tue, 11 Feb 2025 14:24:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2646,10 +2646,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - db48e449-4b77-4df2-bc9e-d07dc554f4d2
+                - 838127c9-0dae-4be3-9806-cb4ccc61e539
         status: 200 OK
         code: 200
-        duration: 177.826459ms
+        duration: 147.783959ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -2665,8 +2665,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/24e140e9-7335-4de2-a0f9-b75bd1294879
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ef84c3b8-4d79-420d-a41e-228336800626
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2683,9 +2683,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:15 GMT
+                - Tue, 11 Feb 2025 14:24:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2693,10 +2693,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a929bf19-0e1e-4cf4-b50e-f57611c642d0
+                - cacad23c-609c-4733-8719-8ee3819eec3b
         status: 204 No Content
         code: 204
-        duration: 141.525667ms
+        duration: 319.250666ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -2712,8 +2712,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/24e140e9-7335-4de2-a0f9-b75bd1294879
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ef84c3b8-4d79-420d-a41e-228336800626
         method: GET
       response:
         proto: HTTP/2.0
@@ -2723,7 +2723,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"24e140e9-7335-4de2-a0f9-b75bd1294879","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"ef84c3b8-4d79-420d-a41e-228336800626","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -2732,9 +2732,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:15 GMT
+                - Tue, 11 Feb 2025 14:24:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2742,10 +2742,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 386974ff-8dee-48dd-8133-d8d9aef201ec
+                - 713f4d35-eaa2-4667-9176-b794e8e0e2cf
         status: 404 Not Found
         code: 404
-        duration: 96.650542ms
+        duration: 82.708417ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -2761,8 +2761,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/76be47fc-1e77-4664-8491-2a6f15154775
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/af78f552-6ef0-49a2-bd07-0b3032ed6a83
         method: GET
       response:
         proto: HTTP/2.0
@@ -2770,20 +2770,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 446
+        content_length: 143
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:47:03.826917+00:00","export_uri":null,"id":"76be47fc-1e77-4664-8491-2a6f15154775","modification_date":"2025-01-27T13:48:16.184347+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"af78f552-6ef0-49a2-bd07-0b3032ed6a83","type":"not_found"}'
         headers:
             Content-Length:
-                - "446"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:16 GMT
+                - Tue, 11 Feb 2025 14:24:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2791,10 +2791,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0e06bbe3-e0c4-419d-ae6c-426618ae10e6
-        status: 200 OK
-        code: 200
-        duration: 82.164333ms
+                - d7cde000-8b53-4e81-833d-ea9744e9071d
+        status: 404 Not Found
+        code: 404
+        duration: 29.452875ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2810,8 +2810,57 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/76be47fc-1e77-4664-8491-2a6f15154775
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/af78f552-6ef0-49a2-bd07-0b3032ed6a83
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 494
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:23:33.297370Z","id":"af78f552-6ef0-49a2-bd07-0b3032ed6a83","last_detached_at":"2025-02-11T14:24:20.140420Z","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:24:20.140420Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "494"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:20 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d1213c48-63f7-4d09-92b0-f5df2cc4c098
+        status: 200 OK
+        code: 200
+        duration: 72.499708ms
+    - id: 57
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/af78f552-6ef0-49a2-bd07-0b3032ed6a83
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2828,9 +2877,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:16 GMT
+                - Tue, 11 Feb 2025 14:24:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2838,59 +2887,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a34ee8eb-dd08-4b17-99aa-bf0628a5b918
+                - b1b2e6e7-d533-4b18-a4cf-6c28d9a9e9c8
         status: 204 No Content
         code: 204
-        duration: 144.644208ms
-    - id: 57
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b906fc7a-351f-444a-95a8-b9bf5a20d698
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2281
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:29.417332+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-naughty-chaplygin","id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"1101","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:8f","maintenances":[],"modification_date":"2025-01-27T13:47:43.131146+00:00","name":"tf-srv-naughty-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:29.417332+00:00","export_uri":null,"id":"0f0d9856-afcb-497e-89a9-c9a720cc1336","modification_date":"2025-01-27T13:47:29.417332+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","name":"tf-srv-naughty-chaplygin"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2281"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:48:16 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 62d0200e-fd43-4330-96e1-8fbb304e720e
-        status: 200 OK
-        code: 200
-        duration: 152.662166ms
+        duration: 148.428375ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -2906,8 +2906,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b906fc7a-351f-444a-95a8-b9bf5a20d698
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/302bc2c7-f834-4620-84e2-2346024e4485
         method: GET
       response:
         proto: HTTP/2.0
@@ -2915,20 +2915,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2281
+        content_length: 2264
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:29.417332+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-naughty-chaplygin","id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"1101","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:8f","maintenances":[],"modification_date":"2025-01-27T13:47:43.131146+00:00","name":"tf-srv-naughty-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:29.417332+00:00","export_uri":null,"id":"0f0d9856-afcb-497e-89a9-c9a720cc1336","modification_date":"2025-01-27T13:47:29.417332+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","name":"tf-srv-naughty-chaplygin"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:42.727591+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-yalow","id":"302bc2c7-f834-4620-84e2-2346024e4485","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"202","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f7","maintenances":[],"modification_date":"2025-02-11T14:23:59.958910+00:00","name":"tf-srv-loving-yalow","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:23:42.727591+00:00","export_uri":null,"id":"5fc5d78d-c7d6-4a0d-9e48-705850306658","modification_date":"2025-02-11T14:23:42.727591+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"302bc2c7-f834-4620-84e2-2346024e4485","name":"tf-srv-loving-yalow"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2281"
+                - "2264"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:16 GMT
+                - Tue, 11 Feb 2025 14:24:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2936,10 +2936,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 93f2521d-ce71-42b3-a28e-722fca01363c
+                - 89d7cde1-8aea-4445-a020-2228f1725c62
         status: 200 OK
         code: 200
-        duration: 171.857ms
+        duration: 181.392292ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -2955,8 +2955,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0f0d9856-afcb-497e-89a9-c9a720cc1336
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/302bc2c7-f834-4620-84e2-2346024e4485
         method: GET
       response:
         proto: HTTP/2.0
@@ -2964,20 +2964,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 524
+        content_length: 2264
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:47:29.417332+00:00","export_uri":null,"id":"0f0d9856-afcb-497e-89a9-c9a720cc1336","modification_date":"2025-01-27T13:47:29.417332+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","name":"tf-srv-naughty-chaplygin"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:42.727591+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-yalow","id":"302bc2c7-f834-4620-84e2-2346024e4485","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"202","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f7","maintenances":[],"modification_date":"2025-02-11T14:23:59.958910+00:00","name":"tf-srv-loving-yalow","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:23:42.727591+00:00","export_uri":null,"id":"5fc5d78d-c7d6-4a0d-9e48-705850306658","modification_date":"2025-02-11T14:23:42.727591+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"302bc2c7-f834-4620-84e2-2346024e4485","name":"tf-srv-loving-yalow"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "524"
+                - "2264"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:17 GMT
+                - Tue, 11 Feb 2025 14:24:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2985,10 +2985,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - df539822-5ae6-4c1d-86ad-6fe7d3002ace
+                - 52b75ed5-db4f-4f17-a70a-e351231c9276
         status: 200 OK
         code: 200
-        duration: 81.638583ms
+        duration: 137.956125ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -3004,8 +3004,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b906fc7a-351f-444a-95a8-b9bf5a20d698/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/5fc5d78d-c7d6-4a0d-9e48-705850306658
         method: GET
       response:
         proto: HTTP/2.0
@@ -3013,20 +3013,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 519
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:23:42.727591+00:00","export_uri":null,"id":"5fc5d78d-c7d6-4a0d-9e48-705850306658","modification_date":"2025-02-11T14:23:42.727591+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"302bc2c7-f834-4620-84e2-2346024e4485","name":"tf-srv-loving-yalow"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "17"
+                - "519"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:17 GMT
+                - Tue, 11 Feb 2025 14:24:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3034,10 +3034,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2f794b7a-f09c-462a-be70-ba39a323512b
+                - c2ea9063-0721-48b0-8593-dba9f509a673
         status: 200 OK
         code: 200
-        duration: 84.433833ms
+        duration: 97.271833ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -3053,159 +3053,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b906fc7a-351f-444a-95a8-b9bf5a20d698/private_nics
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 20
-        uncompressed: false
-        body: '{"private_nics":[]}'
-        headers:
-            Content-Length:
-                - "20"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:48:16 GMT
-            Link:
-                - </servers/b906fc7a-351f-444a-95a8-b9bf5a20d698/private_nics?page=0&per_page=50&>; rel="last"
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - db78d2d5-7a6c-4ebf-89b8-29df5fe2ec9f
-            X-Total-Count:
-                - "0"
-        status: 200 OK
-        code: 200
-        duration: 93.634708ms
-    - id: 62
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b906fc7a-351f-444a-95a8-b9bf5a20d698
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2281
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:29.417332+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-naughty-chaplygin","id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"1101","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:8f","maintenances":[],"modification_date":"2025-01-27T13:47:43.131146+00:00","name":"tf-srv-naughty-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:29.417332+00:00","export_uri":null,"id":"0f0d9856-afcb-497e-89a9-c9a720cc1336","modification_date":"2025-01-27T13:47:29.417332+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","name":"tf-srv-naughty-chaplygin"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2281"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:48:17 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - afb8529a-8385-48be-bafe-1b4b07074030
-        status: 200 OK
-        code: 200
-        duration: 177.1255ms
-    - id: 63
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0f0d9856-afcb-497e-89a9-c9a720cc1336
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 524
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:47:29.417332+00:00","export_uri":null,"id":"0f0d9856-afcb-497e-89a9-c9a720cc1336","modification_date":"2025-01-27T13:47:29.417332+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","name":"tf-srv-naughty-chaplygin"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "524"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:48:17 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 26689e25-7f1a-4815-97cf-7a101fe22273
-        status: 200 OK
-        code: 200
-        duration: 103.838667ms
-    - id: 64
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b906fc7a-351f-444a-95a8-b9bf5a20d698/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/302bc2c7-f834-4620-84e2-2346024e4485/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -3224,9 +3073,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:17 GMT
+                - Tue, 11 Feb 2025 14:24:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3234,11 +3083,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 687cef0a-85f5-4db0-a3d4-bd146603f74e
+                - 2ec976b5-304b-423d-940f-175aab206732
         status: 200 OK
         code: 200
-        duration: 94.986042ms
-    - id: 65
+        duration: 83.653666ms
+    - id: 62
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3253,8 +3102,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b906fc7a-351f-444a-95a8-b9bf5a20d698/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/302bc2c7-f834-4620-84e2-2346024e4485/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -3273,11 +3122,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:17 GMT
+                - Tue, 11 Feb 2025 14:24:21 GMT
             Link:
-                - </servers/b906fc7a-351f-444a-95a8-b9bf5a20d698/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/302bc2c7-f834-4620-84e2-2346024e4485/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3285,12 +3134,159 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4b17d26e-e653-4292-8e1b-0c0d78be1863
+                - ea811129-d64b-4bcd-8857-cd06b121244c
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 90.944292ms
+        duration: 104.35175ms
+    - id: 63
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/302bc2c7-f834-4620-84e2-2346024e4485
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2264
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:42.727591+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-yalow","id":"302bc2c7-f834-4620-84e2-2346024e4485","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"202","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f7","maintenances":[],"modification_date":"2025-02-11T14:23:59.958910+00:00","name":"tf-srv-loving-yalow","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:23:42.727591+00:00","export_uri":null,"id":"5fc5d78d-c7d6-4a0d-9e48-705850306658","modification_date":"2025-02-11T14:23:42.727591+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"302bc2c7-f834-4620-84e2-2346024e4485","name":"tf-srv-loving-yalow"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2264"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:21 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 59a55368-8725-4068-9eb8-85c3fda81152
+        status: 200 OK
+        code: 200
+        duration: 151.719125ms
+    - id: 64
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/5fc5d78d-c7d6-4a0d-9e48-705850306658
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 519
+        uncompressed: false
+        body: '{"volume":{"creation_date":"2025-02-11T14:23:42.727591+00:00","export_uri":null,"id":"5fc5d78d-c7d6-4a0d-9e48-705850306658","modification_date":"2025-02-11T14:23:42.727591+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"302bc2c7-f834-4620-84e2-2346024e4485","name":"tf-srv-loving-yalow"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "519"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:21 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - adb8555f-3a22-4830-bca1-7f68aab0c89b
+        status: 200 OK
+        code: 200
+        duration: 110.301125ms
+    - id: 65
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/302bc2c7-f834-4620-84e2-2346024e4485/user_data
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 17
+        uncompressed: false
+        body: '{"user_data":[]}'
+        headers:
+            Content-Length:
+                - "17"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:21 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 744b7836-cdf4-43cf-9f74-580c448b15f4
+        status: 200 OK
+        code: 200
+        duration: 199.783791ms
     - id: 66
       request:
         proto: HTTP/1.1
@@ -3306,8 +3302,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/302bc2c7-f834-4620-84e2-2346024e4485/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -3315,22 +3311,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 38539
+        content_length: 20
         uncompressed: false
-        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "38539"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:18 GMT
+                - Tue, 11 Feb 2025 14:24:21 GMT
             Link:
-                - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
+                - </servers/302bc2c7-f834-4620-84e2-2346024e4485/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3338,12 +3334,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e9b780aa-f7c1-4b26-a7e3-ea405bff29d4
+                - 4532a730-93aa-4675-8c98-b98f2fad4a2c
             X-Total-Count:
-                - "68"
+                - "0"
         status: 200 OK
         code: 200
-        duration: 47.530875ms
+        duration: 71.634333ms
     - id: 67
       request:
         proto: HTTP/1.1
@@ -3359,8 +3355,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -3368,22 +3364,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 14208
+        content_length: 35639
         uncompressed: false
-        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
         headers:
             Content-Length:
-                - "14208"
+                - "35639"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:18 GMT
+                - Tue, 11 Feb 2025 14:24:21 GMT
             Link:
-                - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
+                - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3391,12 +3387,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 633738af-4c7a-4b99-87db-a8c1f5f9e6fc
+                - 6ddf85cb-2c9c-436e-bf02-58f6bc55e038
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 49.938542ms
+        duration: 53.631958ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -3412,8 +3408,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b906fc7a-351f-444a-95a8-b9bf5a20d698
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
         method: GET
       response:
         proto: HTTP/2.0
@@ -3421,20 +3417,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2281
+        content_length: 13164
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:29.417332+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-naughty-chaplygin","id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"1101","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:8f","maintenances":[],"modification_date":"2025-01-27T13:47:43.131146+00:00","name":"tf-srv-naughty-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:29.417332+00:00","export_uri":null,"id":"0f0d9856-afcb-497e-89a9-c9a720cc1336","modification_date":"2025-01-27T13:47:29.417332+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","name":"tf-srv-naughty-chaplygin"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
         headers:
             Content-Length:
-                - "2281"
+                - "13164"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:18 GMT
+                - Tue, 11 Feb 2025 14:24:22 GMT
+            Link:
+                - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3442,10 +3440,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1647cbab-7fe3-43d2-ac56-a190e5ab97c8
+                - 434e61a2-930d-4ac9-9fd5-6e1debfce0a3
+            X-Total-Count:
+                - "68"
         status: 200 OK
         code: 200
-        duration: 183.704334ms
+        duration: 32.261959ms
     - id: 69
       request:
         proto: HTTP/1.1
@@ -3461,7 +3461,56 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/302bc2c7-f834-4620-84e2-2346024e4485
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2264
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:42.727591+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-yalow","id":"302bc2c7-f834-4620-84e2-2346024e4485","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"202","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f7","maintenances":[],"modification_date":"2025-02-11T14:23:59.958910+00:00","name":"tf-srv-loving-yalow","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:23:42.727591+00:00","export_uri":null,"id":"5fc5d78d-c7d6-4a0d-9e48-705850306658","modification_date":"2025-02-11T14:23:42.727591+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"302bc2c7-f834-4620-84e2-2346024e4485","name":"tf-srv-loving-yalow"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2264"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 568202f7-4224-4c55-8686-0dbd42a1fdbf
+        status: 200 OK
+        code: 200
+        duration: 144.550542ms
+    - id: 70
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_local&zone=fr-par-1
         method: GET
       response:
@@ -3481,9 +3530,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:18 GMT
+                - Tue, 11 Feb 2025 14:24:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3491,11 +3540,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 891c65ae-684b-4970-8950-97fd84c83f69
+                - 2a16ec93-664a-4e3b-b16a-af6cdc22ca8f
         status: 200 OK
         code: 200
-        duration: 106.780041ms
-    - id: 70
+        duration: 92.474416ms
+    - id: 71
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3512,8 +3561,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b906fc7a-351f-444a-95a8-b9bf5a20d698/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/302bc2c7-f834-4620-84e2-2346024e4485/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -3523,7 +3572,7 @@ interactions:
         trailer: {}
         content_length: 352
         uncompressed: false
-        body: '{"task":{"description":"server_poweroff","href_from":"/servers/b906fc7a-351f-444a-95a8-b9bf5a20d698/action","href_result":"/servers/b906fc7a-351f-444a-95a8-b9bf5a20d698","id":"b63a4025-ce56-40b1-a41d-6ee9cc2aec07","progress":0,"started_at":"2025-01-27T13:48:18.813813+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_poweroff","href_from":"/servers/302bc2c7-f834-4620-84e2-2346024e4485/action","href_result":"/servers/302bc2c7-f834-4620-84e2-2346024e4485","id":"3ad82784-9b62-45f9-8124-1e871d7f93e6","progress":0,"started_at":"2025-02-11T14:24:22.647283+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "352"
@@ -3532,11 +3581,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:18 GMT
+                - Tue, 11 Feb 2025 14:24:22 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/b63a4025-ce56-40b1-a41d-6ee9cc2aec07
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/3ad82784-9b62-45f9-8124-1e871d7f93e6
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3544,11 +3593,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4336691b-c8d3-467f-a1c4-d996c7db3b0b
+                - ac6c834b-6b5c-4d72-a63f-2e02ed5501a6
         status: 202 Accepted
         code: 202
-        duration: 256.161209ms
-    - id: 71
+        duration: 275.325541ms
+    - id: 72
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3563,8 +3612,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b906fc7a-351f-444a-95a8-b9bf5a20d698
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/302bc2c7-f834-4620-84e2-2346024e4485
         method: GET
       response:
         proto: HTTP/2.0
@@ -3572,20 +3621,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2241
+        content_length: 2224
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:29.417332+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-naughty-chaplygin","id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"1101","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:8f","maintenances":[],"modification_date":"2025-01-27T13:48:18.608272+00:00","name":"tf-srv-naughty-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:29.417332+00:00","export_uri":null,"id":"0f0d9856-afcb-497e-89a9-c9a720cc1336","modification_date":"2025-01-27T13:47:29.417332+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","name":"tf-srv-naughty-chaplygin"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:42.727591+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-yalow","id":"302bc2c7-f834-4620-84e2-2346024e4485","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"202","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f7","maintenances":[],"modification_date":"2025-02-11T14:24:22.434119+00:00","name":"tf-srv-loving-yalow","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:23:42.727591+00:00","export_uri":null,"id":"5fc5d78d-c7d6-4a0d-9e48-705850306658","modification_date":"2025-02-11T14:23:42.727591+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"302bc2c7-f834-4620-84e2-2346024e4485","name":"tf-srv-loving-yalow"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2241"
+                - "2224"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:18 GMT
+                - Tue, 11 Feb 2025 14:24:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3593,28 +3642,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4a5bc2cc-528f-4963-998a-56929fba3baa
+                - 8b613475-7114-4a17-8836-dadf1a1f7100
         status: 200 OK
         code: 200
-        duration: 193.184792ms
-    - id: 72
+        duration: 134.077584ms
+    - id: 73
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 274
+        content_length: 277
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-srv-clever-shtern","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+        body: '{"name":"tf-srv-optimistic-brown","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
         method: POST
       response:
@@ -3623,22 +3672,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2112
+        content_length: 2121
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:19.235319+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-shtern","id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:d1","maintenances":[],"modification_date":"2025-01-27T13:48:19.235319+00:00","name":"tf-srv-clever-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:19.235319+00:00","export_uri":null,"id":"28d60469-69b9-4011-9c8d-68a765545d4b","modification_date":"2025-01-27T13:48:19.235319+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","name":"tf-srv-clever-shtern"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:22.658242+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-optimistic-brown","id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:07","maintenances":[],"modification_date":"2025-02-11T14:24:22.658242+00:00","name":"tf-srv-optimistic-brown","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:24:22.658242+00:00","export_uri":null,"id":"fbf3171b-e864-4820-879a-b290faa7aab4","modification_date":"2025-02-11T14:24:22.658242+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","name":"tf-srv-optimistic-brown"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2112"
+                - "2121"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:18 GMT
+                - Tue, 11 Feb 2025 14:24:22 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d0ba4c0f-51f2-449f-8709-82c253e0518f
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72706a50-fe4b-4b5e-b79f-20237b938dcf
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3646,59 +3695,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3981bbf7-175a-472b-ad75-df87c443a62a
+                - f2116d31-bd1f-4e8d-b88e-b56118b85563
         status: 201 Created
         code: 201
-        duration: 860.439125ms
-    - id: 73
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d0ba4c0f-51f2-449f-8709-82c253e0518f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2112
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:19.235319+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-shtern","id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:d1","maintenances":[],"modification_date":"2025-01-27T13:48:19.235319+00:00","name":"tf-srv-clever-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:19.235319+00:00","export_uri":null,"id":"28d60469-69b9-4011-9c8d-68a765545d4b","modification_date":"2025-01-27T13:48:19.235319+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","name":"tf-srv-clever-shtern"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2112"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:48:19 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 7ad82f6b-134d-4070-a2fa-9c60c52299a8
-        status: 200 OK
-        code: 200
-        duration: 123.069458ms
+        duration: 482.39975ms
     - id: 74
       request:
         proto: HTTP/1.1
@@ -3714,8 +3714,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d0ba4c0f-51f2-449f-8709-82c253e0518f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72706a50-fe4b-4b5e-b79f-20237b938dcf
         method: GET
       response:
         proto: HTTP/2.0
@@ -3723,20 +3723,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2112
+        content_length: 2121
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:19.235319+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-shtern","id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:d1","maintenances":[],"modification_date":"2025-01-27T13:48:19.235319+00:00","name":"tf-srv-clever-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:19.235319+00:00","export_uri":null,"id":"28d60469-69b9-4011-9c8d-68a765545d4b","modification_date":"2025-01-27T13:48:19.235319+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","name":"tf-srv-clever-shtern"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:22.658242+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-optimistic-brown","id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:07","maintenances":[],"modification_date":"2025-02-11T14:24:22.658242+00:00","name":"tf-srv-optimistic-brown","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:24:22.658242+00:00","export_uri":null,"id":"fbf3171b-e864-4820-879a-b290faa7aab4","modification_date":"2025-02-11T14:24:22.658242+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","name":"tf-srv-optimistic-brown"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2112"
+                - "2121"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:19 GMT
+                - Tue, 11 Feb 2025 14:24:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3744,11 +3744,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d6453942-a812-4c74-9e29-e281aa15ac6f
+                - 56c5e4cf-5d31-417a-a648-e49187944ca1
         status: 200 OK
         code: 200
-        duration: 129.598375ms
+        duration: 125.831167ms
     - id: 75
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72706a50-fe4b-4b5e-b79f-20237b938dcf
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2121
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:22.658242+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-optimistic-brown","id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:07","maintenances":[],"modification_date":"2025-02-11T14:24:22.658242+00:00","name":"tf-srv-optimistic-brown","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:24:22.658242+00:00","export_uri":null,"id":"fbf3171b-e864-4820-879a-b290faa7aab4","modification_date":"2025-02-11T14:24:22.658242+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","name":"tf-srv-optimistic-brown"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2121"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 078bfbd2-d2e0-4b69-a749-ac2da071424e
+        status: 200 OK
+        code: 200
+        duration: 154.74675ms
+    - id: 76
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3765,8 +3814,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d0ba4c0f-51f2-449f-8709-82c253e0518f/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72706a50-fe4b-4b5e-b79f-20237b938dcf/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -3776,7 +3825,7 @@ interactions:
         trailer: {}
         content_length: 357
         uncompressed: false
-        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/d0ba4c0f-51f2-449f-8709-82c253e0518f/action","href_result":"/servers/d0ba4c0f-51f2-449f-8709-82c253e0518f","id":"f698664c-50f5-4a3d-9ceb-542fac2251f0","progress":0,"started_at":"2025-01-27T13:48:19.944519+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/72706a50-fe4b-4b5e-b79f-20237b938dcf/action","href_result":"/servers/72706a50-fe4b-4b5e-b79f-20237b938dcf","id":"28ce2bba-3dee-4173-8a01-67680c71ba63","progress":0,"started_at":"2025-02-11T14:24:23.624232+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -3785,11 +3834,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:19 GMT
+                - Tue, 11 Feb 2025 14:24:23 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/f698664c-50f5-4a3d-9ceb-542fac2251f0
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/28ce2bba-3dee-4173-8a01-67680c71ba63
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3797,59 +3846,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ca4cef53-ea3d-43b9-90cc-7529df630fc6
+                - 03d206f8-75f3-4e4f-b296-4764500e547e
         status: 202 Accepted
         code: 202
-        duration: 245.863417ms
-    - id: 76
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d0ba4c0f-51f2-449f-8709-82c253e0518f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2134
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:19.235319+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-shtern","id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:d1","maintenances":[],"modification_date":"2025-01-27T13:48:19.756082+00:00","name":"tf-srv-clever-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:19.235319+00:00","export_uri":null,"id":"28d60469-69b9-4011-9c8d-68a765545d4b","modification_date":"2025-01-27T13:48:19.235319+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","name":"tf-srv-clever-shtern"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2134"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:48:19 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - f71bae35-f2d8-4841-9e8a-59585ab44873
-        status: 200 OK
-        code: 200
-        duration: 186.860792ms
+        duration: 426.56275ms
     - id: 77
       request:
         proto: HTTP/1.1
@@ -3865,8 +3865,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d0ba4c0f-51f2-449f-8709-82c253e0518f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72706a50-fe4b-4b5e-b79f-20237b938dcf
         method: GET
       response:
         proto: HTTP/2.0
@@ -3874,20 +3874,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2267
+        content_length: 2143
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:19.235319+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-shtern","id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"901","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:d1","maintenances":[],"modification_date":"2025-01-27T13:48:30.184936+00:00","name":"tf-srv-clever-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:19.235319+00:00","export_uri":null,"id":"28d60469-69b9-4011-9c8d-68a765545d4b","modification_date":"2025-01-27T13:48:19.235319+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","name":"tf-srv-clever-shtern"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:22.658242+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-optimistic-brown","id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:07","maintenances":[],"modification_date":"2025-02-11T14:24:23.242451+00:00","name":"tf-srv-optimistic-brown","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:24:22.658242+00:00","export_uri":null,"id":"fbf3171b-e864-4820-879a-b290faa7aab4","modification_date":"2025-02-11T14:24:22.658242+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","name":"tf-srv-optimistic-brown"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2267"
+                - "2143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:37 GMT
+                - Tue, 11 Feb 2025 14:24:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3895,10 +3895,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f5046a96-9b8f-4c82-8e9e-4af351013208
+                - fcb57650-9682-4fcc-91b9-f5c85d95ef63
         status: 200 OK
         code: 200
-        duration: 14.663110958s
+        duration: 509.400125ms
     - id: 78
       request:
         proto: HTTP/1.1
@@ -3914,8 +3914,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b906fc7a-351f-444a-95a8-b9bf5a20d698
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/302bc2c7-f834-4620-84e2-2346024e4485
         method: GET
       response:
         proto: HTTP/2.0
@@ -3923,20 +3923,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2241
+        content_length: 2224
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:29.417332+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-naughty-chaplygin","id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"1101","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:8f","maintenances":[],"modification_date":"2025-01-27T13:48:18.608272+00:00","name":"tf-srv-naughty-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:29.417332+00:00","export_uri":null,"id":"0f0d9856-afcb-497e-89a9-c9a720cc1336","modification_date":"2025-01-27T13:47:29.417332+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","name":"tf-srv-naughty-chaplygin"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:42.727591+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-yalow","id":"302bc2c7-f834-4620-84e2-2346024e4485","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"202","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f7","maintenances":[],"modification_date":"2025-02-11T14:24:22.434119+00:00","name":"tf-srv-loving-yalow","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:23:42.727591+00:00","export_uri":null,"id":"5fc5d78d-c7d6-4a0d-9e48-705850306658","modification_date":"2025-02-11T14:23:42.727591+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"302bc2c7-f834-4620-84e2-2346024e4485","name":"tf-srv-loving-yalow"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2241"
+                - "2224"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:37 GMT
+                - Tue, 11 Feb 2025 14:24:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3944,10 +3944,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f993c2e4-4685-439e-9a3a-bcf9f1997daa
+                - d9adc4c8-9703-48c3-ae71-056a5194749a
         status: 200 OK
         code: 200
-        duration: 15.790091208s
+        duration: 151.994083ms
     - id: 79
       request:
         proto: HTTP/1.1
@@ -3963,8 +3963,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d0ba4c0f-51f2-449f-8709-82c253e0518f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72706a50-fe4b-4b5e-b79f-20237b938dcf
         method: GET
       response:
         proto: HTTP/2.0
@@ -3972,20 +3972,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2267
+        content_length: 2246
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:19.235319+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-shtern","id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"901","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:d1","maintenances":[],"modification_date":"2025-01-27T13:48:30.184936+00:00","name":"tf-srv-clever-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:19.235319+00:00","export_uri":null,"id":"28d60469-69b9-4011-9c8d-68a765545d4b","modification_date":"2025-01-27T13:48:19.235319+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","name":"tf-srv-clever-shtern"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:22.658242+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-optimistic-brown","id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"104","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:07","maintenances":[],"modification_date":"2025-02-11T14:24:23.242451+00:00","name":"tf-srv-optimistic-brown","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:24:22.658242+00:00","export_uri":null,"id":"fbf3171b-e864-4820-879a-b290faa7aab4","modification_date":"2025-02-11T14:24:22.658242+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","name":"tf-srv-optimistic-brown"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2267"
+                - "2246"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:39 GMT
+                - Tue, 11 Feb 2025 14:24:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3993,10 +3993,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cdeb19d7-f1cb-4172-b69c-9be97e425924
+                - 7e03b59c-5e8a-4965-9c1a-ff3b951a2677
         status: 200 OK
         code: 200
-        duration: 1.273017875s
+        duration: 150.315583ms
     - id: 80
       request:
         proto: HTTP/1.1
@@ -4012,8 +4012,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/28d60469-69b9-4011-9c8d-68a765545d4b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/302bc2c7-f834-4620-84e2-2346024e4485
         method: GET
       response:
         proto: HTTP/2.0
@@ -4021,20 +4021,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 520
+        content_length: 2224
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:19.235319+00:00","export_uri":null,"id":"28d60469-69b9-4011-9c8d-68a765545d4b","modification_date":"2025-01-27T13:48:19.235319+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","name":"tf-srv-clever-shtern"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:42.727591+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-yalow","id":"302bc2c7-f834-4620-84e2-2346024e4485","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"202","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f7","maintenances":[],"modification_date":"2025-02-11T14:24:22.434119+00:00","name":"tf-srv-loving-yalow","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:23:42.727591+00:00","export_uri":null,"id":"5fc5d78d-c7d6-4a0d-9e48-705850306658","modification_date":"2025-02-11T14:23:42.727591+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"302bc2c7-f834-4620-84e2-2346024e4485","name":"tf-srv-loving-yalow"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "520"
+                - "2224"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:41 GMT
+                - Tue, 11 Feb 2025 14:24:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4042,10 +4042,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b767d3d7-075a-46f3-9916-5e8db0970ec1
+                - 3e0546fc-005b-4cb1-a30f-203cabb6a984
         status: 200 OK
         code: 200
-        duration: 113.205041ms
+        duration: 287.78325ms
     - id: 81
       request:
         proto: HTTP/1.1
@@ -4061,8 +4061,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d0ba4c0f-51f2-449f-8709-82c253e0518f/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72706a50-fe4b-4b5e-b79f-20237b938dcf
         method: GET
       response:
         proto: HTTP/2.0
@@ -4070,20 +4070,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 2277
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:22.658242+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-optimistic-brown","id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"104","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:07","maintenances":[],"modification_date":"2025-02-11T14:24:31.647238+00:00","name":"tf-srv-optimistic-brown","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:24:22.658242+00:00","export_uri":null,"id":"fbf3171b-e864-4820-879a-b290faa7aab4","modification_date":"2025-02-11T14:24:22.658242+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","name":"tf-srv-optimistic-brown"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "17"
+                - "2277"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:41 GMT
+                - Tue, 11 Feb 2025 14:24:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4091,10 +4091,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a7e205b3-eaf6-4c2c-8b10-c77657f0fade
+                - 52061972-5374-4bae-95d8-00e5db41c39f
         status: 200 OK
         code: 200
-        duration: 74.603541ms
+        duration: 156.580417ms
     - id: 82
       request:
         proto: HTTP/1.1
@@ -4110,8 +4110,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d0ba4c0f-51f2-449f-8709-82c253e0518f/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72706a50-fe4b-4b5e-b79f-20237b938dcf
         method: GET
       response:
         proto: HTTP/2.0
@@ -4119,22 +4119,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 2277
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:22.658242+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-optimistic-brown","id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"104","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:07","maintenances":[],"modification_date":"2025-02-11T14:24:31.647238+00:00","name":"tf-srv-optimistic-brown","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:24:22.658242+00:00","export_uri":null,"id":"fbf3171b-e864-4820-879a-b290faa7aab4","modification_date":"2025-02-11T14:24:22.658242+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","name":"tf-srv-optimistic-brown"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "20"
+                - "2277"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:40 GMT
-            Link:
-                - </servers/d0ba4c0f-51f2-449f-8709-82c253e0518f/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:24:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4142,12 +4140,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a8b764c3-8673-4d04-b06a-29c446c753b1
-            X-Total-Count:
-                - "0"
+                - e55ed00f-6001-48a2-9bb1-e366f27d3b7b
         status: 200 OK
         code: 200
-        duration: 91.820083ms
+        duration: 174.438334ms
     - id: 83
       request:
         proto: HTTP/1.1
@@ -4163,8 +4159,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b906fc7a-351f-444a-95a8-b9bf5a20d698
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/fbf3171b-e864-4820-879a-b290faa7aab4
         method: GET
       response:
         proto: HTTP/2.0
@@ -4172,20 +4168,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2241
+        content_length: 523
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:29.417332+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-naughty-chaplygin","id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"1101","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:8f","maintenances":[],"modification_date":"2025-01-27T13:48:18.608272+00:00","name":"tf-srv-naughty-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:29.417332+00:00","export_uri":null,"id":"0f0d9856-afcb-497e-89a9-c9a720cc1336","modification_date":"2025-01-27T13:47:29.417332+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","name":"tf-srv-naughty-chaplygin"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:24:22.658242+00:00","export_uri":null,"id":"fbf3171b-e864-4820-879a-b290faa7aab4","modification_date":"2025-02-11T14:24:22.658242+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","name":"tf-srv-optimistic-brown"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2241"
+                - "523"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:44 GMT
+                - Tue, 11 Feb 2025 14:24:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4193,10 +4189,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1ec594c2-daf4-4d93-996d-471b06d93b33
+                - 3dab3746-90ea-4c27-b719-66f3acd05619
         status: 200 OK
         code: 200
-        duration: 156.282167ms
+        duration: 97.838542ms
     - id: 84
       request:
         proto: HTTP/1.1
@@ -4212,543 +4208,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b906fc7a-351f-444a-95a8-b9bf5a20d698
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2241
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:29.417332+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-naughty-chaplygin","id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"1101","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:8f","maintenances":[],"modification_date":"2025-01-27T13:48:18.608272+00:00","name":"tf-srv-naughty-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:29.417332+00:00","export_uri":null,"id":"0f0d9856-afcb-497e-89a9-c9a720cc1336","modification_date":"2025-01-27T13:47:29.417332+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","name":"tf-srv-naughty-chaplygin"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2241"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:48:49 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 1ba12cf6-db5f-4f53-894b-024a5effab6e
-        status: 200 OK
-        code: 200
-        duration: 142.425708ms
-    - id: 85
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b906fc7a-351f-444a-95a8-b9bf5a20d698
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2241
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:29.417332+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-naughty-chaplygin","id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"1101","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:8f","maintenances":[],"modification_date":"2025-01-27T13:48:18.608272+00:00","name":"tf-srv-naughty-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:29.417332+00:00","export_uri":null,"id":"0f0d9856-afcb-497e-89a9-c9a720cc1336","modification_date":"2025-01-27T13:47:29.417332+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","name":"tf-srv-naughty-chaplygin"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2241"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:48:55 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 6ab527d3-14f8-416b-8312-861ff5384c8c
-        status: 200 OK
-        code: 200
-        duration: 207.959208ms
-    - id: 86
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b906fc7a-351f-444a-95a8-b9bf5a20d698
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2124
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:29.417332+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-naughty-chaplygin","id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:8f","maintenances":[],"modification_date":"2025-01-27T13:49:00.167902+00:00","name":"tf-srv-naughty-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:29.417332+00:00","export_uri":null,"id":"0f0d9856-afcb-497e-89a9-c9a720cc1336","modification_date":"2025-01-27T13:47:29.417332+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","name":"tf-srv-naughty-chaplygin"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2124"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:49:00 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 011e277e-7e48-4345-ac81-7c05cda8a6ad
-        status: 200 OK
-        code: 200
-        duration: 274.47675ms
-    - id: 87
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b906fc7a-351f-444a-95a8-b9bf5a20d698
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2124
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:29.417332+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-naughty-chaplygin","id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:8f","maintenances":[],"modification_date":"2025-01-27T13:49:00.167902+00:00","name":"tf-srv-naughty-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:29.417332+00:00","export_uri":null,"id":"0f0d9856-afcb-497e-89a9-c9a720cc1336","modification_date":"2025-01-27T13:47:29.417332+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","name":"tf-srv-naughty-chaplygin"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2124"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:49:00 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - dbf62619-7fa9-4900-b357-0f2088ea8325
-        status: 200 OK
-        code: 200
-        duration: 260.487209ms
-    - id: 88
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b906fc7a-351f-444a-95a8-b9bf5a20d698
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:49:00 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 7b7170cf-b420-4d1d-a26e-450359f108ff
-        status: 204 No Content
-        code: 204
-        duration: 164.30475ms
-    - id: 89
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b906fc7a-351f-444a-95a8-b9bf5a20d698
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 143
-        uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"b906fc7a-351f-444a-95a8-b9bf5a20d698","type":"not_found"}'
-        headers:
-            Content-Length:
-                - "143"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:49:01 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - a3f98a54-eab3-4628-9a30-f5afeb8fb5fe
-        status: 404 Not Found
-        code: 404
-        duration: 162.338ms
-    - id: 90
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0f0d9856-afcb-497e-89a9-c9a720cc1336
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 446
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:47:29.417332+00:00","export_uri":null,"id":"0f0d9856-afcb-497e-89a9-c9a720cc1336","modification_date":"2025-01-27T13:49:00.899632+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "446"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:49:01 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - a921670f-a168-4cd9-b320-429d6a5fd552
-        status: 200 OK
-        code: 200
-        duration: 103.633208ms
-    - id: 91
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0f0d9856-afcb-497e-89a9-c9a720cc1336
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:49:01 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - c59832ee-b9dc-430b-b228-87aadbb42100
-        status: 204 No Content
-        code: 204
-        duration: 178.43075ms
-    - id: 92
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d0ba4c0f-51f2-449f-8709-82c253e0518f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2267
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:19.235319+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-shtern","id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"901","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:d1","maintenances":[],"modification_date":"2025-01-27T13:48:30.184936+00:00","name":"tf-srv-clever-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:19.235319+00:00","export_uri":null,"id":"28d60469-69b9-4011-9c8d-68a765545d4b","modification_date":"2025-01-27T13:48:19.235319+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","name":"tf-srv-clever-shtern"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2267"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:49:01 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 5ecfd47b-6e90-4593-a619-8d765af48be4
-        status: 200 OK
-        code: 200
-        duration: 294.265875ms
-    - id: 93
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d0ba4c0f-51f2-449f-8709-82c253e0518f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2267
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:19.235319+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-shtern","id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"901","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:d1","maintenances":[],"modification_date":"2025-01-27T13:48:30.184936+00:00","name":"tf-srv-clever-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:19.235319+00:00","export_uri":null,"id":"28d60469-69b9-4011-9c8d-68a765545d4b","modification_date":"2025-01-27T13:48:19.235319+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","name":"tf-srv-clever-shtern"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2267"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:49:02 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - d1d90a12-e62d-4c25-bb53-6b2c49d1a440
-        status: 200 OK
-        code: 200
-        duration: 180.791167ms
-    - id: 94
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/28d60469-69b9-4011-9c8d-68a765545d4b
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 520
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:19.235319+00:00","export_uri":null,"id":"28d60469-69b9-4011-9c8d-68a765545d4b","modification_date":"2025-01-27T13:48:19.235319+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","name":"tf-srv-clever-shtern"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "520"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:49:01 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - ef4327b0-9958-4869-b8a1-4184eb636122
-        status: 200 OK
-        code: 200
-        duration: 74.81625ms
-    - id: 95
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d0ba4c0f-51f2-449f-8709-82c253e0518f/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72706a50-fe4b-4b5e-b79f-20237b938dcf/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -4767,9 +4228,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:01 GMT
+                - Tue, 11 Feb 2025 14:24:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4777,11 +4238,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5b75f476-4f3f-41ee-9673-34647b66d537
+                - 3666be04-6cfb-4e6e-b63f-991bb1abb1f1
         status: 200 OK
         code: 200
-        duration: 112.366834ms
-    - id: 96
+        duration: 98.707583ms
+    - id: 85
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4796,8 +4257,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d0ba4c0f-51f2-449f-8709-82c253e0518f/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72706a50-fe4b-4b5e-b79f-20237b938dcf/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -4816,11 +4277,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:02 GMT
+                - Tue, 11 Feb 2025 14:24:34 GMT
             Link:
-                - </servers/d0ba4c0f-51f2-449f-8709-82c253e0518f/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/72706a50-fe4b-4b5e-b79f-20237b938dcf/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4828,12 +4289,547 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c2735353-f4b6-42f9-aea1-97803f216e34
+                - fe58aeee-716e-4453-822c-8fd17ccb0a3e
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 113.927042ms
+        duration: 90.584959ms
+    - id: 86
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/302bc2c7-f834-4620-84e2-2346024e4485
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2224
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:42.727591+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-yalow","id":"302bc2c7-f834-4620-84e2-2346024e4485","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"202","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f7","maintenances":[],"modification_date":"2025-02-11T14:24:22.434119+00:00","name":"tf-srv-loving-yalow","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:23:42.727591+00:00","export_uri":null,"id":"5fc5d78d-c7d6-4a0d-9e48-705850306658","modification_date":"2025-02-11T14:23:42.727591+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"302bc2c7-f834-4620-84e2-2346024e4485","name":"tf-srv-loving-yalow"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2224"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:38 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 27f734db-c3e4-4440-8296-72ce15aa6604
+        status: 200 OK
+        code: 200
+        duration: 175.93525ms
+    - id: 87
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/302bc2c7-f834-4620-84e2-2346024e4485
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2224
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:42.727591+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-yalow","id":"302bc2c7-f834-4620-84e2-2346024e4485","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"202","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f7","maintenances":[],"modification_date":"2025-02-11T14:24:22.434119+00:00","name":"tf-srv-loving-yalow","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:23:42.727591+00:00","export_uri":null,"id":"5fc5d78d-c7d6-4a0d-9e48-705850306658","modification_date":"2025-02-11T14:23:42.727591+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"302bc2c7-f834-4620-84e2-2346024e4485","name":"tf-srv-loving-yalow"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2224"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:43 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8adb021a-5c35-4235-90b1-2db3c7f7904f
+        status: 200 OK
+        code: 200
+        duration: 185.564667ms
+    - id: 88
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/302bc2c7-f834-4620-84e2-2346024e4485
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2224
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:42.727591+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-yalow","id":"302bc2c7-f834-4620-84e2-2346024e4485","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"202","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f7","maintenances":[],"modification_date":"2025-02-11T14:24:22.434119+00:00","name":"tf-srv-loving-yalow","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:23:42.727591+00:00","export_uri":null,"id":"5fc5d78d-c7d6-4a0d-9e48-705850306658","modification_date":"2025-02-11T14:23:42.727591+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"302bc2c7-f834-4620-84e2-2346024e4485","name":"tf-srv-loving-yalow"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2224"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 15fd1178-5ef5-4555-bfeb-cd6022a78c19
+        status: 200 OK
+        code: 200
+        duration: 134.366708ms
+    - id: 89
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/302bc2c7-f834-4620-84e2-2346024e4485
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2109
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:42.727591+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-yalow","id":"302bc2c7-f834-4620-84e2-2346024e4485","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:f7","maintenances":[],"modification_date":"2025-02-11T14:24:51.523908+00:00","name":"tf-srv-loving-yalow","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:23:42.727591+00:00","export_uri":null,"id":"5fc5d78d-c7d6-4a0d-9e48-705850306658","modification_date":"2025-02-11T14:23:42.727591+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"302bc2c7-f834-4620-84e2-2346024e4485","name":"tf-srv-loving-yalow"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2109"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 31103632-2350-410e-8452-cd4d1e1e0427
+        status: 200 OK
+        code: 200
+        duration: 125.18375ms
+    - id: 90
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/302bc2c7-f834-4620-84e2-2346024e4485
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2109
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:42.727591+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-yalow","id":"302bc2c7-f834-4620-84e2-2346024e4485","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:f7","maintenances":[],"modification_date":"2025-02-11T14:24:51.523908+00:00","name":"tf-srv-loving-yalow","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:23:42.727591+00:00","export_uri":null,"id":"5fc5d78d-c7d6-4a0d-9e48-705850306658","modification_date":"2025-02-11T14:23:42.727591+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"302bc2c7-f834-4620-84e2-2346024e4485","name":"tf-srv-loving-yalow"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2109"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 932f1502-e38f-4fc1-ba1e-ec993a658650
+        status: 200 OK
+        code: 200
+        duration: 158.01125ms
+    - id: 91
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/302bc2c7-f834-4620-84e2-2346024e4485
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 81e663ae-2438-4585-b93b-5f4dce2a24e6
+        status: 204 No Content
+        code: 204
+        duration: 204.613041ms
+    - id: 92
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/302bc2c7-f834-4620-84e2-2346024e4485
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"302bc2c7-f834-4620-84e2-2346024e4485","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4323a0ca-c9c5-4e7f-b9c8-4bd27ee4f092
+        status: 404 Not Found
+        code: 404
+        duration: 74.391584ms
+    - id: 93
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/5fc5d78d-c7d6-4a0d-9e48-705850306658
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 446
+        uncompressed: false
+        body: '{"volume":{"creation_date":"2025-02-11T14:23:42.727591+00:00","export_uri":null,"id":"5fc5d78d-c7d6-4a0d-9e48-705850306658","modification_date":"2025-02-11T14:24:54.077356+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "446"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e7458295-903a-4e5b-9648-e28629b2a56c
+        status: 200 OK
+        code: 200
+        duration: 76.783292ms
+    - id: 94
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/5fc5d78d-c7d6-4a0d-9e48-705850306658
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - cb5f7e95-cfa9-4574-ac8c-65a371d98b45
+        status: 204 No Content
+        code: 204
+        duration: 142.355792ms
+    - id: 95
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72706a50-fe4b-4b5e-b79f-20237b938dcf
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2277
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:22.658242+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-optimistic-brown","id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"104","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:07","maintenances":[],"modification_date":"2025-02-11T14:24:31.647238+00:00","name":"tf-srv-optimistic-brown","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:24:22.658242+00:00","export_uri":null,"id":"fbf3171b-e864-4820-879a-b290faa7aab4","modification_date":"2025-02-11T14:24:22.658242+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","name":"tf-srv-optimistic-brown"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2277"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e66db8b3-881f-4268-94d0-f2e11a2ff0c9
+        status: 200 OK
+        code: 200
+        duration: 145.680416ms
+    - id: 96
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72706a50-fe4b-4b5e-b79f-20237b938dcf
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2277
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:22.658242+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-optimistic-brown","id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"104","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:07","maintenances":[],"modification_date":"2025-02-11T14:24:31.647238+00:00","name":"tf-srv-optimistic-brown","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:24:22.658242+00:00","export_uri":null,"id":"fbf3171b-e864-4820-879a-b290faa7aab4","modification_date":"2025-02-11T14:24:22.658242+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","name":"tf-srv-optimistic-brown"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2277"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - dd36153a-d8bc-474e-8cce-24f2219a8f87
+        status: 200 OK
+        code: 200
+        duration: 149.122667ms
     - id: 97
       request:
         proto: HTTP/1.1
@@ -4849,8 +4845,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d0ba4c0f-51f2-449f-8709-82c253e0518f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/fbf3171b-e864-4820-879a-b290faa7aab4
         method: GET
       response:
         proto: HTTP/2.0
@@ -4858,20 +4854,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2267
+        content_length: 523
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:19.235319+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-shtern","id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"901","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:d1","maintenances":[],"modification_date":"2025-01-27T13:48:30.184936+00:00","name":"tf-srv-clever-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:19.235319+00:00","export_uri":null,"id":"28d60469-69b9-4011-9c8d-68a765545d4b","modification_date":"2025-01-27T13:48:19.235319+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","name":"tf-srv-clever-shtern"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:24:22.658242+00:00","export_uri":null,"id":"fbf3171b-e864-4820-879a-b290faa7aab4","modification_date":"2025-02-11T14:24:22.658242+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","name":"tf-srv-optimistic-brown"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2267"
+                - "523"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:02 GMT
+                - Tue, 11 Feb 2025 14:24:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4879,11 +4875,162 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6a34902f-1283-4c0d-b65c-6a3db9e1d9e2
+                - 294d6009-3225-4091-acd8-3ebd6ef788ba
         status: 200 OK
         code: 200
-        duration: 166.619541ms
+        duration: 76.794042ms
     - id: 98
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72706a50-fe4b-4b5e-b79f-20237b938dcf/user_data
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 17
+        uncompressed: false
+        body: '{"user_data":[]}'
+        headers:
+            Content-Length:
+                - "17"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 04c51d8f-5f6f-4065-a515-6caa27d2c9c7
+        status: 200 OK
+        code: 200
+        duration: 72.775166ms
+    - id: 99
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72706a50-fe4b-4b5e-b79f-20237b938dcf/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 20
+        uncompressed: false
+        body: '{"private_nics":[]}'
+        headers:
+            Content-Length:
+                - "20"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:54 GMT
+            Link:
+                - </servers/72706a50-fe4b-4b5e-b79f-20237b938dcf/private_nics?page=0&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - af24b43c-aa65-4314-98a4-75167bbe5180
+            X-Total-Count:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 92.449083ms
+    - id: 100
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72706a50-fe4b-4b5e-b79f-20237b938dcf
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2277
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:22.658242+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-optimistic-brown","id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"104","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:07","maintenances":[],"modification_date":"2025-02-11T14:24:31.647238+00:00","name":"tf-srv-optimistic-brown","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:24:22.658242+00:00","export_uri":null,"id":"fbf3171b-e864-4820-879a-b290faa7aab4","modification_date":"2025-02-11T14:24:22.658242+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","name":"tf-srv-optimistic-brown"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2277"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fcb42c5e-ab97-4740-8248-7bc1512ee9dd
+        status: 200 OK
+        code: 200
+        duration: 303.096ms
+    - id: 101
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4900,8 +5047,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d0ba4c0f-51f2-449f-8709-82c253e0518f/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72706a50-fe4b-4b5e-b79f-20237b938dcf/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -4911,7 +5058,7 @@ interactions:
         trailer: {}
         content_length: 352
         uncompressed: false
-        body: '{"task":{"description":"server_poweroff","href_from":"/servers/d0ba4c0f-51f2-449f-8709-82c253e0518f/action","href_result":"/servers/d0ba4c0f-51f2-449f-8709-82c253e0518f","id":"3b399d2e-59c4-41a4-ab83-8ec727565592","progress":0,"started_at":"2025-01-27T13:49:03.147232+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_poweroff","href_from":"/servers/72706a50-fe4b-4b5e-b79f-20237b938dcf/action","href_result":"/servers/72706a50-fe4b-4b5e-b79f-20237b938dcf","id":"752c78ee-8d51-44de-9993-9b02850bb9f7","progress":0,"started_at":"2025-02-11T14:24:56.119953+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "352"
@@ -4920,11 +5067,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:03 GMT
+                - Tue, 11 Feb 2025 14:24:56 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/3b399d2e-59c4-41a4-ab83-8ec727565592
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/752c78ee-8d51-44de-9993-9b02850bb9f7
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4932,157 +5079,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3a67a5e8-7bf4-470a-b54c-10f9f034a998
+                - 6a4c626a-8aea-4c8a-9611-b9d86f56a6e2
         status: 202 Accepted
         code: 202
-        duration: 241.891834ms
-    - id: 99
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d0ba4c0f-51f2-449f-8709-82c253e0518f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2227
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:19.235319+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-shtern","id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"901","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:d1","maintenances":[],"modification_date":"2025-01-27T13:49:02.956589+00:00","name":"tf-srv-clever-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:19.235319+00:00","export_uri":null,"id":"28d60469-69b9-4011-9c8d-68a765545d4b","modification_date":"2025-01-27T13:48:19.235319+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","name":"tf-srv-clever-shtern"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2227"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:49:03 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 979fb059-eef5-4b57-8ee4-5f39ec02d5ae
-        status: 200 OK
-        code: 200
-        duration: 198.022834ms
-    - id: 100
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d0ba4c0f-51f2-449f-8709-82c253e0518f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2227
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:19.235319+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-shtern","id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"901","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:d1","maintenances":[],"modification_date":"2025-01-27T13:49:02.956589+00:00","name":"tf-srv-clever-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:19.235319+00:00","export_uri":null,"id":"28d60469-69b9-4011-9c8d-68a765545d4b","modification_date":"2025-01-27T13:48:19.235319+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","name":"tf-srv-clever-shtern"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2227"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:49:08 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 9a5f595d-45a1-4f35-83f2-bd7e80643546
-        status: 200 OK
-        code: 200
-        duration: 247.867583ms
-    - id: 101
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d0ba4c0f-51f2-449f-8709-82c253e0518f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2227
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:19.235319+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-shtern","id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"901","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:d1","maintenances":[],"modification_date":"2025-01-27T13:49:02.956589+00:00","name":"tf-srv-clever-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:19.235319+00:00","export_uri":null,"id":"28d60469-69b9-4011-9c8d-68a765545d4b","modification_date":"2025-01-27T13:48:19.235319+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","name":"tf-srv-clever-shtern"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2227"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:49:13 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 016a0491-2705-4ade-a500-4a644eab79b1
-        status: 200 OK
-        code: 200
-        duration: 178.597375ms
+        duration: 233.804375ms
     - id: 102
       request:
         proto: HTTP/1.1
@@ -5098,8 +5098,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d0ba4c0f-51f2-449f-8709-82c253e0518f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72706a50-fe4b-4b5e-b79f-20237b938dcf
         method: GET
       response:
         proto: HTTP/2.0
@@ -5107,20 +5107,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2227
+        content_length: 2237
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:19.235319+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-shtern","id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"901","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:d1","maintenances":[],"modification_date":"2025-01-27T13:49:02.956589+00:00","name":"tf-srv-clever-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:19.235319+00:00","export_uri":null,"id":"28d60469-69b9-4011-9c8d-68a765545d4b","modification_date":"2025-01-27T13:48:19.235319+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","name":"tf-srv-clever-shtern"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:22.658242+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-optimistic-brown","id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"104","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:07","maintenances":[],"modification_date":"2025-02-11T14:24:55.937812+00:00","name":"tf-srv-optimistic-brown","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:24:22.658242+00:00","export_uri":null,"id":"fbf3171b-e864-4820-879a-b290faa7aab4","modification_date":"2025-02-11T14:24:22.658242+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","name":"tf-srv-optimistic-brown"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2227"
+                - "2237"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:18 GMT
+                - Tue, 11 Feb 2025 14:24:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5128,10 +5128,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0945feb0-94ea-4b98-b0ea-a81dd3eeffe5
+                - cb20c204-5af3-498b-aa91-0584d2cc732c
         status: 200 OK
         code: 200
-        duration: 133.714667ms
+        duration: 163.664417ms
     - id: 103
       request:
         proto: HTTP/1.1
@@ -5147,8 +5147,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d0ba4c0f-51f2-449f-8709-82c253e0518f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72706a50-fe4b-4b5e-b79f-20237b938dcf
         method: GET
       response:
         proto: HTTP/2.0
@@ -5156,20 +5156,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2227
+        content_length: 2237
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:19.235319+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-shtern","id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"901","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:d1","maintenances":[],"modification_date":"2025-01-27T13:49:02.956589+00:00","name":"tf-srv-clever-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:19.235319+00:00","export_uri":null,"id":"28d60469-69b9-4011-9c8d-68a765545d4b","modification_date":"2025-01-27T13:48:19.235319+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","name":"tf-srv-clever-shtern"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:22.658242+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-optimistic-brown","id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"104","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:07","maintenances":[],"modification_date":"2025-02-11T14:24:55.937812+00:00","name":"tf-srv-optimistic-brown","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:24:22.658242+00:00","export_uri":null,"id":"fbf3171b-e864-4820-879a-b290faa7aab4","modification_date":"2025-02-11T14:24:22.658242+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","name":"tf-srv-optimistic-brown"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2227"
+                - "2237"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:24 GMT
+                - Tue, 11 Feb 2025 14:25:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5177,10 +5177,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ed2b05dd-dde2-47e1-b638-6337ce8d6459
+                - 23a5b59b-b2c8-4f72-ba9b-56cf4ab0d5e4
         status: 200 OK
         code: 200
-        duration: 143.065084ms
+        duration: 164.004083ms
     - id: 104
       request:
         proto: HTTP/1.1
@@ -5196,8 +5196,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d0ba4c0f-51f2-449f-8709-82c253e0518f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72706a50-fe4b-4b5e-b79f-20237b938dcf
         method: GET
       response:
         proto: HTTP/2.0
@@ -5205,20 +5205,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2227
+        content_length: 2237
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:19.235319+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-shtern","id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"901","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:d1","maintenances":[],"modification_date":"2025-01-27T13:49:02.956589+00:00","name":"tf-srv-clever-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:19.235319+00:00","export_uri":null,"id":"28d60469-69b9-4011-9c8d-68a765545d4b","modification_date":"2025-01-27T13:48:19.235319+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","name":"tf-srv-clever-shtern"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:22.658242+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-optimistic-brown","id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"104","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:07","maintenances":[],"modification_date":"2025-02-11T14:24:55.937812+00:00","name":"tf-srv-optimistic-brown","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:24:22.658242+00:00","export_uri":null,"id":"fbf3171b-e864-4820-879a-b290faa7aab4","modification_date":"2025-02-11T14:24:22.658242+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","name":"tf-srv-optimistic-brown"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2227"
+                - "2237"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:29 GMT
+                - Tue, 11 Feb 2025 14:25:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5226,10 +5226,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 643c3981-95fb-4fbd-b86c-cf96f46117f0
+                - 215f068b-4099-4e54-b134-f0dd8a7fd979
         status: 200 OK
         code: 200
-        duration: 151.8345ms
+        duration: 149.848166ms
     - id: 105
       request:
         proto: HTTP/1.1
@@ -5245,8 +5245,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d0ba4c0f-51f2-449f-8709-82c253e0518f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72706a50-fe4b-4b5e-b79f-20237b938dcf
         method: GET
       response:
         proto: HTTP/2.0
@@ -5254,20 +5254,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2227
+        content_length: 2237
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:19.235319+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-shtern","id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"901","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:d1","maintenances":[],"modification_date":"2025-01-27T13:49:02.956589+00:00","name":"tf-srv-clever-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:19.235319+00:00","export_uri":null,"id":"28d60469-69b9-4011-9c8d-68a765545d4b","modification_date":"2025-01-27T13:48:19.235319+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","name":"tf-srv-clever-shtern"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:22.658242+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-optimistic-brown","id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"104","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:07","maintenances":[],"modification_date":"2025-02-11T14:24:55.937812+00:00","name":"tf-srv-optimistic-brown","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:24:22.658242+00:00","export_uri":null,"id":"fbf3171b-e864-4820-879a-b290faa7aab4","modification_date":"2025-02-11T14:24:22.658242+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","name":"tf-srv-optimistic-brown"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2227"
+                - "2237"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:34 GMT
+                - Tue, 11 Feb 2025 14:25:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5275,10 +5275,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6cda55d8-c007-4047-b3ef-8f49b78e8711
+                - 11a01a0a-5aed-4ef5-b709-54b313292329
         status: 200 OK
         code: 200
-        duration: 193.993583ms
+        duration: 153.684292ms
     - id: 106
       request:
         proto: HTTP/1.1
@@ -5294,8 +5294,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d0ba4c0f-51f2-449f-8709-82c253e0518f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72706a50-fe4b-4b5e-b79f-20237b938dcf
         method: GET
       response:
         proto: HTTP/2.0
@@ -5303,20 +5303,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2227
+        content_length: 2237
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:19.235319+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-shtern","id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"901","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:d1","maintenances":[],"modification_date":"2025-01-27T13:49:02.956589+00:00","name":"tf-srv-clever-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:19.235319+00:00","export_uri":null,"id":"28d60469-69b9-4011-9c8d-68a765545d4b","modification_date":"2025-01-27T13:48:19.235319+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","name":"tf-srv-clever-shtern"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:22.658242+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-optimistic-brown","id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"104","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:07","maintenances":[],"modification_date":"2025-02-11T14:24:55.937812+00:00","name":"tf-srv-optimistic-brown","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:24:22.658242+00:00","export_uri":null,"id":"fbf3171b-e864-4820-879a-b290faa7aab4","modification_date":"2025-02-11T14:24:22.658242+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","name":"tf-srv-optimistic-brown"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2227"
+                - "2237"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:39 GMT
+                - Tue, 11 Feb 2025 14:25:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5324,10 +5324,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ba5da069-4946-4125-8ccc-3048d9ab3126
+                - 506046c3-a077-4538-a28f-b155c8baa256
         status: 200 OK
         code: 200
-        duration: 175.885667ms
+        duration: 152.49625ms
     - id: 107
       request:
         proto: HTTP/1.1
@@ -5343,8 +5343,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d0ba4c0f-51f2-449f-8709-82c253e0518f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72706a50-fe4b-4b5e-b79f-20237b938dcf
         method: GET
       response:
         proto: HTTP/2.0
@@ -5352,20 +5352,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2112
+        content_length: 2237
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:19.235319+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-shtern","id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:d1","maintenances":[],"modification_date":"2025-01-27T13:49:42.289910+00:00","name":"tf-srv-clever-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:19.235319+00:00","export_uri":null,"id":"28d60469-69b9-4011-9c8d-68a765545d4b","modification_date":"2025-01-27T13:48:19.235319+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","name":"tf-srv-clever-shtern"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:22.658242+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-optimistic-brown","id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"104","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:07","maintenances":[],"modification_date":"2025-02-11T14:24:55.937812+00:00","name":"tf-srv-optimistic-brown","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:24:22.658242+00:00","export_uri":null,"id":"fbf3171b-e864-4820-879a-b290faa7aab4","modification_date":"2025-02-11T14:24:22.658242+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","name":"tf-srv-optimistic-brown"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2112"
+                - "2237"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:44 GMT
+                - Tue, 11 Feb 2025 14:25:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5373,10 +5373,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 30a9440a-fcad-45ec-bb98-5112dfa0892a
+                - 23a2b720-0247-4861-91a3-8ad4c588f3ca
         status: 200 OK
         code: 200
-        duration: 145.252333ms
+        duration: 203.417541ms
     - id: 108
       request:
         proto: HTTP/1.1
@@ -5392,8 +5392,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d0ba4c0f-51f2-449f-8709-82c253e0518f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72706a50-fe4b-4b5e-b79f-20237b938dcf
         method: GET
       response:
         proto: HTTP/2.0
@@ -5401,20 +5401,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2112
+        content_length: 2237
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:19.235319+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-shtern","id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:d1","maintenances":[],"modification_date":"2025-01-27T13:49:42.289910+00:00","name":"tf-srv-clever-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:19.235319+00:00","export_uri":null,"id":"28d60469-69b9-4011-9c8d-68a765545d4b","modification_date":"2025-01-27T13:48:19.235319+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","name":"tf-srv-clever-shtern"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:22.658242+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-optimistic-brown","id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"104","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:07","maintenances":[],"modification_date":"2025-02-11T14:24:55.937812+00:00","name":"tf-srv-optimistic-brown","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:24:22.658242+00:00","export_uri":null,"id":"fbf3171b-e864-4820-879a-b290faa7aab4","modification_date":"2025-02-11T14:24:22.658242+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","name":"tf-srv-optimistic-brown"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2112"
+                - "2237"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:44 GMT
+                - Tue, 11 Feb 2025 14:25:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5422,10 +5422,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 632c41a1-756c-4775-86ab-bd57c25148ee
+                - d39e1e4f-6f8f-4477-b7c1-5dcfaca8fc3b
         status: 200 OK
         code: 200
-        duration: 163.434209ms
+        duration: 134.063792ms
     - id: 109
       request:
         proto: HTTP/1.1
@@ -5441,27 +5441,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d0ba4c0f-51f2-449f-8709-82c253e0518f
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72706a50-fe4b-4b5e-b79f-20237b938dcf
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 2237
         uncompressed: false
-        body: ""
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:22.658242+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-optimistic-brown","id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"104","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:07","maintenances":[],"modification_date":"2025-02-11T14:24:55.937812+00:00","name":"tf-srv-optimistic-brown","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:24:22.658242+00:00","export_uri":null,"id":"fbf3171b-e864-4820-879a-b290faa7aab4","modification_date":"2025-02-11T14:24:22.658242+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","name":"tf-srv-optimistic-brown"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
+            Content-Length:
+                - "2237"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:44 GMT
+                - Tue, 11 Feb 2025 14:25:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5469,10 +5471,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cbe2eba2-96b8-4926-a36a-ff660e104ac1
-        status: 204 No Content
-        code: 204
-        duration: 155.571209ms
+                - d58af06a-b07a-4882-825f-568fb12e9911
+        status: 200 OK
+        code: 200
+        duration: 202.352542ms
     - id: 110
       request:
         proto: HTTP/1.1
@@ -5488,8 +5490,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d0ba4c0f-51f2-449f-8709-82c253e0518f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72706a50-fe4b-4b5e-b79f-20237b938dcf
         method: GET
       response:
         proto: HTTP/2.0
@@ -5497,20 +5499,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 143
+        content_length: 2237
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","type":"not_found"}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:22.658242+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-optimistic-brown","id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"104","node_id":"19","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:07","maintenances":[],"modification_date":"2025-02-11T14:24:55.937812+00:00","name":"tf-srv-optimistic-brown","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:24:22.658242+00:00","export_uri":null,"id":"fbf3171b-e864-4820-879a-b290faa7aab4","modification_date":"2025-02-11T14:24:22.658242+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","name":"tf-srv-optimistic-brown"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "143"
+                - "2237"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:45 GMT
+                - Tue, 11 Feb 2025 14:25:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5518,10 +5520,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 518fc6aa-05f8-4c5a-9a1d-9cb4842887b3
-        status: 404 Not Found
-        code: 404
-        duration: 136.834833ms
+                - 266c619c-9241-406d-8dfc-cae9976aa8ad
+        status: 200 OK
+        code: 200
+        duration: 144.503625ms
     - id: 111
       request:
         proto: HTTP/1.1
@@ -5537,8 +5539,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/28d60469-69b9-4011-9c8d-68a765545d4b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72706a50-fe4b-4b5e-b79f-20237b938dcf
         method: GET
       response:
         proto: HTTP/2.0
@@ -5546,20 +5548,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 446
+        content_length: 2121
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:19.235319+00:00","export_uri":null,"id":"28d60469-69b9-4011-9c8d-68a765545d4b","modification_date":"2025-01-27T13:49:44.944812+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:22.658242+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-optimistic-brown","id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:07","maintenances":[],"modification_date":"2025-02-11T14:25:38.011000+00:00","name":"tf-srv-optimistic-brown","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:24:22.658242+00:00","export_uri":null,"id":"fbf3171b-e864-4820-879a-b290faa7aab4","modification_date":"2025-02-11T14:24:22.658242+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","name":"tf-srv-optimistic-brown"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "446"
+                - "2121"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:44 GMT
+                - Tue, 11 Feb 2025 14:25:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5567,10 +5569,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 97d9fad0-f05c-4baf-911c-7b4162c4d5cf
+                - 792fc4fd-0307-47a7-bdd3-004018d8692e
         status: 200 OK
         code: 200
-        duration: 96.976292ms
+        duration: 146.22425ms
     - id: 112
       request:
         proto: HTTP/1.1
@@ -5586,8 +5588,57 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/28d60469-69b9-4011-9c8d-68a765545d4b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72706a50-fe4b-4b5e-b79f-20237b938dcf
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2121
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:22.658242+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-optimistic-brown","id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:07","maintenances":[],"modification_date":"2025-02-11T14:25:38.011000+00:00","name":"tf-srv-optimistic-brown","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:24:22.658242+00:00","export_uri":null,"id":"fbf3171b-e864-4820-879a-b290faa7aab4","modification_date":"2025-02-11T14:24:22.658242+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","name":"tf-srv-optimistic-brown"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2121"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e8708f51-64b3-479a-b923-dcda70d2613d
+        status: 200 OK
+        code: 200
+        duration: 128.29475ms
+    - id: 113
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72706a50-fe4b-4b5e-b79f-20237b938dcf
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5604,9 +5655,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:45 GMT
+                - Tue, 11 Feb 2025 14:25:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5614,11 +5665,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a0da0a37-3a71-4453-9c9f-41445cdfb6e6
+                - 789d8f06-50af-491b-8f69-f2e73aa1bf52
         status: 204 No Content
         code: 204
-        duration: 209.572458ms
-    - id: 113
+        duration: 184.961625ms
+    - id: 114
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -5633,8 +5684,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d0ba4c0f-51f2-449f-8709-82c253e0518f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72706a50-fe4b-4b5e-b79f-20237b938dcf
         method: GET
       response:
         proto: HTTP/2.0
@@ -5644,7 +5695,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"d0ba4c0f-51f2-449f-8709-82c253e0518f","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -5653,9 +5704,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:45 GMT
+                - Tue, 11 Feb 2025 14:25:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5663,7 +5714,152 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 891cfd8f-55d3-456a-af02-9cb00fbaf583
+                - 67c67424-3583-4277-a96e-0de65b43e407
         status: 404 Not Found
         code: 404
-        duration: 77.130458ms
+        duration: 116.849416ms
+    - id: 115
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/fbf3171b-e864-4820-879a-b290faa7aab4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 446
+        uncompressed: false
+        body: '{"volume":{"creation_date":"2025-02-11T14:24:22.658242+00:00","export_uri":null,"id":"fbf3171b-e864-4820-879a-b290faa7aab4","modification_date":"2025-02-11T14:25:42.928632+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "446"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7094413c-28c9-4946-b31d-8c12477cc4af
+        status: 200 OK
+        code: 200
+        duration: 73.526084ms
+    - id: 116
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/fbf3171b-e864-4820-879a-b290faa7aab4
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:43 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 55ede462-5a84-4895-9f3a-120355ac1729
+        status: 204 No Content
+        code: 204
+        duration: 196.188333ms
+    - id: 117
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/72706a50-fe4b-4b5e-b79f-20237b938dcf
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"72706a50-fe4b-4b5e-b79f-20237b938dcf","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:43 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 40d5b5cb-d5c3-4ccd-bb73-6cf00020c2f1
+        status: 404 Not Found
+        code: 404
+        duration: 102.96675ms

--- a/internal/services/instance/testdata/server-private-network-missing-pnic.cassette.yaml
+++ b/internal/services/instance/testdata/server-private-network-missing-pnic.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 105
+        content_length: 108
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-pn-sad-almeida","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"subnets":null}'
+        body: '{"name":"tf-pn-vibrant-hoover","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"subnets":null}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1044
+        content_length: 1047
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:48:49.242784Z","dhcp_enabled":true,"id":"03e7480d-cb49-43d9-a418-9f410f1083ef","name":"tf-pn-sad-almeida","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:48:49.242784Z","id":"8cb282d3-7d82-4348-946b-11abc82151fd","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.20.0/22","updated_at":"2025-01-27T13:48:49.242784Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:48:49.242784Z","id":"18cba5f0-8632-4b35-ae9f-b97390ab1329","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:48fa::/64","updated_at":"2025-01-27T13:48:49.242784Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:48:49.242784Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"created_at":"2025-02-11T14:22:47.248262Z","dhcp_enabled":true,"id":"01911755-02f0-4fa2-b4ac-a997b37f0961","name":"tf-pn-vibrant-hoover","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-11T14:22:47.248262Z","id":"4acdfe92-d256-48d4-a67c-02bc29bc3108","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.12.0/22","updated_at":"2025-02-11T14:22:47.248262Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-11T14:22:47.248262Z","id":"aba8b3ed-b155-467f-8c38-e1d9c0f259d3","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:e93b::/64","updated_at":"2025-02-11T14:22:47.248262Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-11T14:22:47.248262Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "1044"
+                - "1047"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:49 GMT
+                - Tue, 11 Feb 2025 14:22:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1c6a6e37-3695-483e-9759-dc1578854347
+                - 8c2df8a3-ad0c-4123-99d3-6f739f8feafd
         status: 200 OK
         code: 200
-        duration: 519.190875ms
+        duration: 597.15825ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/03e7480d-cb49-43d9-a418-9f410f1083ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/01911755-02f0-4fa2-b4ac-a997b37f0961
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1044
+        content_length: 1047
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:48:49.242784Z","dhcp_enabled":true,"id":"03e7480d-cb49-43d9-a418-9f410f1083ef","name":"tf-pn-sad-almeida","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:48:49.242784Z","id":"8cb282d3-7d82-4348-946b-11abc82151fd","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.20.0/22","updated_at":"2025-01-27T13:48:49.242784Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:48:49.242784Z","id":"18cba5f0-8632-4b35-ae9f-b97390ab1329","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:48fa::/64","updated_at":"2025-01-27T13:48:49.242784Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:48:49.242784Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"created_at":"2025-02-11T14:22:47.248262Z","dhcp_enabled":true,"id":"01911755-02f0-4fa2-b4ac-a997b37f0961","name":"tf-pn-vibrant-hoover","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-11T14:22:47.248262Z","id":"4acdfe92-d256-48d4-a67c-02bc29bc3108","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.12.0/22","updated_at":"2025-02-11T14:22:47.248262Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-11T14:22:47.248262Z","id":"aba8b3ed-b155-467f-8c38-e1d9c0f259d3","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:e93b::/64","updated_at":"2025-02-11T14:22:47.248262Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-11T14:22:47.248262Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "1044"
+                - "1047"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:49 GMT
+                - Tue, 11 Feb 2025 14:22:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 39d6d77a-90a5-4777-a896-8ac0f114c011
+                - 4abb98a6-2f00-440c-a1f5-e484c14c36aa
         status: 200 OK
         code: 200
-        duration: 32.674709ms
+        duration: 32.0025ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,7 +116,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
         method: GET
       response:
@@ -125,22 +125,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 38539
+        content_length: 35639
         uncompressed: false
-        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
+        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
         headers:
             Content-Length:
-                - "38539"
+                - "35639"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:49 GMT
+                - Tue, 11 Feb 2025 14:22:47 GMT
             Link:
                 - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -148,12 +148,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e3ed9c86-4c26-4c5a-b611-a0c2456fc837
+                - 165d5bbb-819d-4da2-9e58-dd03c09232b3
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 51.92825ms
+        duration: 54.562708ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -169,7 +169,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
         method: GET
       response:
@@ -178,22 +178,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 14208
+        content_length: 13164
         uncompressed: false
-        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
         headers:
             Content-Length:
-                - "14208"
+                - "13164"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:49 GMT
+                - Tue, 11 Feb 2025 14:22:47 GMT
             Link:
                 - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -201,12 +201,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 94698b06-fbc4-4f11-8721-694554dfe775
+                - a377ef52-f0fc-4b6c-8ce5-0cd14b19cb18
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 50.355917ms
+        duration: 41.037792ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -222,7 +222,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=type_asc&type=instance_sbs&zone=fr-par-1
         method: GET
       response:
@@ -242,9 +242,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:49 GMT
+                - Tue, 11 Feb 2025 14:22:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -252,28 +252,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7426f637-70df-4292-b760-336c5ffc5c7b
+                - 7ba56cbf-d47c-4892-8d63-0ce6266f2c0f
         status: 200 OK
         code: 200
-        duration: 78.459375ms
+        duration: 78.788875ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 272
+        content_length: 246
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-srv-intelligent-engelbart","dynamic_ip_required":false,"commercial_type":"PLAY2-PICO","image":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","volumes":{"0":{"boot":false,"volume_type":"sbs_volume"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+        body: '{"name":"tf-srv-flamboyant-nightingale","dynamic_ip_required":false,"commercial_type":"PLAY2-PICO","image":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","volumes":{"0":{"boot":false}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
         method: POST
       response:
@@ -282,22 +282,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1694
+        content_length: 1696
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-01-27T13:48:50.285107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-engelbart","id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f7","maintenances":[],"modification_date":"2025-01-27T13:48:50.285107+00:00","name":"tf-srv-intelligent-engelbart","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-11T14:22:48.329567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-flamboyant-nightingale","id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e3","maintenances":[],"modification_date":"2025-02-11T14:22:48.329567+00:00","name":"tf-srv-flamboyant-nightingale","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"96fac504-4e66-47f0-bdcf-b05159266ac7","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1694"
+                - "1696"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:50 GMT
+                - Tue, 11 Feb 2025 14:22:49 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -305,10 +305,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3bc4887f-da23-4c4a-937e-f01d5d125190
+                - 878cb256-3f2c-435a-97eb-2772d4f326dd
         status: 201 Created
         code: 201
-        duration: 998.681292ms
+        duration: 1.585571792s
     - id: 6
       request:
         proto: HTTP/1.1
@@ -324,8 +324,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d
         method: GET
       response:
         proto: HTTP/2.0
@@ -333,20 +333,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1694
+        content_length: 1696
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-01-27T13:48:50.285107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-engelbart","id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f7","maintenances":[],"modification_date":"2025-01-27T13:48:50.285107+00:00","name":"tf-srv-intelligent-engelbart","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-11T14:22:48.329567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-flamboyant-nightingale","id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e3","maintenances":[],"modification_date":"2025-02-11T14:22:48.329567+00:00","name":"tf-srv-flamboyant-nightingale","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"96fac504-4e66-47f0-bdcf-b05159266ac7","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1694"
+                - "1696"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:50 GMT
+                - Tue, 11 Feb 2025 14:22:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -354,10 +354,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c35252b6-9cb9-4ce0-bc93-fe5f6861f9fa
+                - 45e43e27-a2d8-40a9-b348-b529c42126ed
         status: 200 OK
         code: 200
-        duration: 165.313458ms
+        duration: 174.995667ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -373,8 +373,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d
         method: GET
       response:
         proto: HTTP/2.0
@@ -382,20 +382,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1694
+        content_length: 1696
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-01-27T13:48:50.285107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-engelbart","id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f7","maintenances":[],"modification_date":"2025-01-27T13:48:50.285107+00:00","name":"tf-srv-intelligent-engelbart","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-11T14:22:48.329567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-flamboyant-nightingale","id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e3","maintenances":[],"modification_date":"2025-02-11T14:22:48.329567+00:00","name":"tf-srv-flamboyant-nightingale","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"96fac504-4e66-47f0-bdcf-b05159266ac7","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1694"
+                - "1696"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:51 GMT
+                - Tue, 11 Feb 2025 14:22:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -403,10 +403,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - eda80581-7087-4038-bfc4-da76650ccbd8
+                - 4fda86f0-5dff-46f5-9b60-c670129acb9f
         status: 200 OK
         code: 200
-        duration: 173.935333ms
+        duration: 153.664709ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -422,8 +422,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/bfb7435e-0766-4a84-9a8f-3a0726cac1a8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/96fac504-4e66-47f0-bdcf-b05159266ac7
         method: GET
       response:
         proto: HTTP/2.0
@@ -433,7 +433,7 @@ interactions:
         trailer: {}
         content_length: 705
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:48:50.498860Z","id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","last_detached_at":null,"name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-01-27T13:48:50.498860Z","id":"80c5dbf4-310b-4454-986c-c92cdb8483ab","product_resource_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-01-27T13:48:50.498860Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-11T14:22:48.568538Z","id":"96fac504-4e66-47f0-bdcf-b05159266ac7","last_detached_at":null,"name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:48.568538Z","id":"7ab2f9dd-8159-47ca-9247-ad5b487af566","product_resource_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:48.568538Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "705"
@@ -442,9 +442,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:51 GMT
+                - Tue, 11 Feb 2025 14:22:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -452,10 +452,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cc0b3e0f-44fb-4d6f-a2d9-000c0e0df138
+                - 24119369-92f7-4d24-9ef1-0fa44d8dc228
         status: 200 OK
         code: 200
-        duration: 79.794708ms
+        duration: 91.2985ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -473,8 +473,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -484,7 +484,7 @@ interactions:
         trailer: {}
         content_length: 357
         uncompressed: false
-        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/action","href_result":"/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5","id":"43d04546-0674-4861-8d4d-24ec437bb6f4","progress":0,"started_at":"2025-01-27T13:48:51.606841+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/action","href_result":"/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d","id":"9c2b3173-375f-4ba7-98f0-45b995166c45","progress":0,"started_at":"2025-02-11T14:22:50.217240+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -493,11 +493,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:51 GMT
+                - Tue, 11 Feb 2025 14:22:50 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/43d04546-0674-4861-8d4d-24ec437bb6f4
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/9c2b3173-375f-4ba7-98f0-45b995166c45
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -505,10 +505,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 21723a3b-0c9b-464d-819f-327a516138a7
+                - e065d837-46f4-4a15-80a1-55724e01e366
         status: 202 Accepted
         code: 202
-        duration: 286.940667ms
+        duration: 242.422875ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -524,8 +524,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d
         method: GET
       response:
         proto: HTTP/2.0
@@ -533,20 +533,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1716
+        content_length: 1718
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-01-27T13:48:50.285107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-engelbart","id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f7","maintenances":[],"modification_date":"2025-01-27T13:48:51.398254+00:00","name":"tf-srv-intelligent-engelbart","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-11T14:22:48.329567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-flamboyant-nightingale","id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e3","maintenances":[],"modification_date":"2025-02-11T14:22:50.025332+00:00","name":"tf-srv-flamboyant-nightingale","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"id":"96fac504-4e66-47f0-bdcf-b05159266ac7","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1716"
+                - "1718"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:51 GMT
+                - Tue, 11 Feb 2025 14:22:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -554,10 +554,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 20baa0f1-2b87-40c6-bbb2-240309d1ff69
+                - 237f0b3b-4e42-449d-804b-d6cc0428ff4d
         status: 200 OK
         code: 200
-        duration: 165.884875ms
+        duration: 146.238375ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -573,8 +573,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d
         method: GET
       response:
         proto: HTTP/2.0
@@ -582,20 +582,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1850
+        content_length: 1852
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-01-27T13:48:50.285107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-engelbart","id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"30","hypervisor_id":"601","node_id":"48","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:f7","maintenances":[],"modification_date":"2025-01-27T13:48:55.729736+00:00","name":"tf-srv-intelligent-engelbart","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-11T14:22:48.329567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-flamboyant-nightingale","id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"701","node_id":"90","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:e3","maintenances":[],"modification_date":"2025-02-11T14:22:53.854750+00:00","name":"tf-srv-flamboyant-nightingale","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"96fac504-4e66-47f0-bdcf-b05159266ac7","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1850"
+                - "1852"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:56 GMT
+                - Tue, 11 Feb 2025 14:22:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -603,10 +603,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f79bb974-c2ce-43fa-b32a-e5ea786af07f
+                - 34c18cf0-3ac6-48c9-b62d-7912c3cab11a
         status: 200 OK
         code: 200
-        duration: 212.523208ms
+        duration: 185.41675ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -622,8 +622,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/03e7480d-cb49-43d9-a418-9f410f1083ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/01911755-02f0-4fa2-b4ac-a997b37f0961
         method: GET
       response:
         proto: HTTP/2.0
@@ -631,20 +631,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1044
+        content_length: 1047
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:48:49.242784Z","dhcp_enabled":true,"id":"03e7480d-cb49-43d9-a418-9f410f1083ef","name":"tf-pn-sad-almeida","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:48:49.242784Z","id":"8cb282d3-7d82-4348-946b-11abc82151fd","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.20.0/22","updated_at":"2025-01-27T13:48:49.242784Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:48:49.242784Z","id":"18cba5f0-8632-4b35-ae9f-b97390ab1329","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:48fa::/64","updated_at":"2025-01-27T13:48:49.242784Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:48:49.242784Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"created_at":"2025-02-11T14:22:47.248262Z","dhcp_enabled":true,"id":"01911755-02f0-4fa2-b4ac-a997b37f0961","name":"tf-pn-vibrant-hoover","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-11T14:22:47.248262Z","id":"4acdfe92-d256-48d4-a67c-02bc29bc3108","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.12.0/22","updated_at":"2025-02-11T14:22:47.248262Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-11T14:22:47.248262Z","id":"aba8b3ed-b155-467f-8c38-e1d9c0f259d3","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:e93b::/64","updated_at":"2025-02-11T14:22:47.248262Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-11T14:22:47.248262Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "1044"
+                - "1047"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:57 GMT
+                - Tue, 11 Feb 2025 14:22:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -652,10 +652,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ff428c92-6542-4340-b9ce-84bb7a67422d
+                - a80f63db-5730-458c-a809-4e5f6441d215
         status: 200 OK
         code: 200
-        duration: 45.200458ms
+        duration: 61.644291ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -671,8 +671,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d
         method: GET
       response:
         proto: HTTP/2.0
@@ -680,20 +680,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1850
+        content_length: 1852
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-01-27T13:48:50.285107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-engelbart","id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"30","hypervisor_id":"601","node_id":"48","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:f7","maintenances":[],"modification_date":"2025-01-27T13:48:55.729736+00:00","name":"tf-srv-intelligent-engelbart","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-11T14:22:48.329567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-flamboyant-nightingale","id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"701","node_id":"90","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:e3","maintenances":[],"modification_date":"2025-02-11T14:22:53.854750+00:00","name":"tf-srv-flamboyant-nightingale","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"96fac504-4e66-47f0-bdcf-b05159266ac7","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1850"
+                - "1852"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:57 GMT
+                - Tue, 11 Feb 2025 14:22:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -701,10 +701,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5b13ca56-b3c5-4986-831b-906be0c559ed
+                - fa2b16b0-8d17-4172-9d24-ce2a27bdf8bf
         status: 200 OK
         code: 200
-        duration: 298.574167ms
+        duration: 192.429541ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -716,14 +716,14 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef"}'
+        body: '{"private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics
         method: POST
       response:
         proto: HTTP/2.0
@@ -733,7 +733,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:48:57.410571+00:00","id":"3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c","ipam_ip_ids":["1a7a3db2-ab00-4d25-af9d-26591734da40","d298eee2-d9b7-4605-b689-7be4cb5c5585"],"mac_address":"02:00:00:1f:f3:c5","modification_date":"2025-01-27T13:48:57.605694+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:22:55.856602+00:00","id":"78ad0d7f-2111-43ae-a43c-85e6167820a8","ipam_ip_ids":["a19c3013-1f37-4c86-b5fb-507415ce9f05","ca73fae0-0eb8-41d1-840b-5ae52ccd61ec"],"mac_address":"02:00:00:1f:3e:fc","modification_date":"2025-02-11T14:22:56.336306+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -742,9 +742,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:58 GMT
+                - Tue, 11 Feb 2025 14:22:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -752,10 +752,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 57f2a24b-b561-4d57-98ca-e0c3c38ddee2
+                - 3837fc87-c8e1-4394-b4da-e1b60e4c2da3
         status: 201 Created
         code: 201
-        duration: 1.179791875s
+        duration: 1.400045292s
     - id: 15
       request:
         proto: HTTP/1.1
@@ -771,8 +771,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics/3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics/78ad0d7f-2111-43ae-a43c-85e6167820a8
         method: GET
       response:
         proto: HTTP/2.0
@@ -782,7 +782,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:48:57.410571+00:00","id":"3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c","ipam_ip_ids":["1a7a3db2-ab00-4d25-af9d-26591734da40","d298eee2-d9b7-4605-b689-7be4cb5c5585"],"mac_address":"02:00:00:1f:f3:c5","modification_date":"2025-01-27T13:48:57.605694+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:22:55.856602+00:00","id":"78ad0d7f-2111-43ae-a43c-85e6167820a8","ipam_ip_ids":["a19c3013-1f37-4c86-b5fb-507415ce9f05","ca73fae0-0eb8-41d1-840b-5ae52ccd61ec"],"mac_address":"02:00:00:1f:3e:fc","modification_date":"2025-02-11T14:22:56.336306+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -791,9 +791,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:58 GMT
+                - Tue, 11 Feb 2025 14:22:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -801,10 +801,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 16bf05e8-bbda-44ad-955f-807acdc4b578
+                - 55752cff-62a7-4519-b23d-c8d3736aee3d
         status: 200 OK
         code: 200
-        duration: 163.707791ms
+        duration: 97.153666ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -820,8 +820,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics/3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics/78ad0d7f-2111-43ae-a43c-85e6167820a8
         method: GET
       response:
         proto: HTTP/2.0
@@ -831,7 +831,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:48:57.410571+00:00","id":"3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c","ipam_ip_ids":["1a7a3db2-ab00-4d25-af9d-26591734da40","d298eee2-d9b7-4605-b689-7be4cb5c5585"],"mac_address":"02:00:00:1f:f3:c5","modification_date":"2025-01-27T13:48:57.605694+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:22:55.856602+00:00","id":"78ad0d7f-2111-43ae-a43c-85e6167820a8","ipam_ip_ids":["a19c3013-1f37-4c86-b5fb-507415ce9f05","ca73fae0-0eb8-41d1-840b-5ae52ccd61ec"],"mac_address":"02:00:00:1f:3e:fc","modification_date":"2025-02-11T14:22:56.336306+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -840,9 +840,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:03 GMT
+                - Tue, 11 Feb 2025 14:23:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -850,10 +850,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 98206fe8-fd6d-4876-b74c-aaa9427e135d
+                - d7720e35-ed8e-4054-9947-8e4db33acaf5
         status: 200 OK
         code: 200
-        duration: 85.68175ms
+        duration: 80.044916ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -869,8 +869,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics/3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics/78ad0d7f-2111-43ae-a43c-85e6167820a8
         method: GET
       response:
         proto: HTTP/2.0
@@ -880,7 +880,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:48:57.410571+00:00","id":"3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c","ipam_ip_ids":["1a7a3db2-ab00-4d25-af9d-26591734da40","d298eee2-d9b7-4605-b689-7be4cb5c5585"],"mac_address":"02:00:00:1f:f3:c5","modification_date":"2025-01-27T13:48:57.605694+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:22:55.856602+00:00","id":"78ad0d7f-2111-43ae-a43c-85e6167820a8","ipam_ip_ids":["a19c3013-1f37-4c86-b5fb-507415ce9f05","ca73fae0-0eb8-41d1-840b-5ae52ccd61ec"],"mac_address":"02:00:00:1f:3e:fc","modification_date":"2025-02-11T14:22:56.336306+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -889,9 +889,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:08 GMT
+                - Tue, 11 Feb 2025 14:23:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -899,10 +899,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9cf6eebc-24b8-420a-b382-5fa2f65033d5
+                - 76c3023d-f472-4c83-ba3e-e9f6d53c90e3
         status: 200 OK
         code: 200
-        duration: 124.196916ms
+        duration: 82.747917ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -918,8 +918,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics/3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics/78ad0d7f-2111-43ae-a43c-85e6167820a8
         method: GET
       response:
         proto: HTTP/2.0
@@ -929,7 +929,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:48:57.410571+00:00","id":"3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c","ipam_ip_ids":["1a7a3db2-ab00-4d25-af9d-26591734da40","d298eee2-d9b7-4605-b689-7be4cb5c5585"],"mac_address":"02:00:00:1f:f3:c5","modification_date":"2025-01-27T13:48:57.605694+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:22:55.856602+00:00","id":"78ad0d7f-2111-43ae-a43c-85e6167820a8","ipam_ip_ids":["a19c3013-1f37-4c86-b5fb-507415ce9f05","ca73fae0-0eb8-41d1-840b-5ae52ccd61ec"],"mac_address":"02:00:00:1f:3e:fc","modification_date":"2025-02-11T14:22:56.336306+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -938,9 +938,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:13 GMT
+                - Tue, 11 Feb 2025 14:23:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -948,10 +948,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 15ed398c-b97f-4c65-b0fe-831477fddfa4
+                - 0783ad9f-b8cd-42bc-aa9d-df9ea7f113d7
         status: 200 OK
         code: 200
-        duration: 84.097833ms
+        duration: 131.737708ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -967,8 +967,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics/3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics/78ad0d7f-2111-43ae-a43c-85e6167820a8
         method: GET
       response:
         proto: HTTP/2.0
@@ -978,7 +978,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:48:57.410571+00:00","id":"3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c","ipam_ip_ids":["1a7a3db2-ab00-4d25-af9d-26591734da40","d298eee2-d9b7-4605-b689-7be4cb5c5585"],"mac_address":"02:00:00:1f:f3:c5","modification_date":"2025-01-27T13:48:57.605694+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:22:55.856602+00:00","id":"78ad0d7f-2111-43ae-a43c-85e6167820a8","ipam_ip_ids":["a19c3013-1f37-4c86-b5fb-507415ce9f05","ca73fae0-0eb8-41d1-840b-5ae52ccd61ec"],"mac_address":"02:00:00:1f:3e:fc","modification_date":"2025-02-11T14:22:56.336306+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -987,9 +987,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:19 GMT
+                - Tue, 11 Feb 2025 14:23:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -997,10 +997,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5fb68ef8-8caa-4ddf-9fef-d8f7b879655b
+                - d3b0d0cc-b6fb-4051-bb40-93758f7bfe5e
         status: 200 OK
         code: 200
-        duration: 76.653959ms
+        duration: 111.425208ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1016,8 +1016,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics/3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics/78ad0d7f-2111-43ae-a43c-85e6167820a8
         method: GET
       response:
         proto: HTTP/2.0
@@ -1027,7 +1027,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:48:57.410571+00:00","id":"3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c","ipam_ip_ids":["1a7a3db2-ab00-4d25-af9d-26591734da40","d298eee2-d9b7-4605-b689-7be4cb5c5585"],"mac_address":"02:00:00:1f:f3:c5","modification_date":"2025-01-27T13:48:57.605694+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:22:55.856602+00:00","id":"78ad0d7f-2111-43ae-a43c-85e6167820a8","ipam_ip_ids":["a19c3013-1f37-4c86-b5fb-507415ce9f05","ca73fae0-0eb8-41d1-840b-5ae52ccd61ec"],"mac_address":"02:00:00:1f:3e:fc","modification_date":"2025-02-11T14:22:56.336306+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -1036,9 +1036,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:23 GMT
+                - Tue, 11 Feb 2025 14:23:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1046,10 +1046,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6e5ce4c3-02c4-4686-b228-89789c3c89a2
+                - 1744de9c-e798-4d3b-8a94-bc91a125fbf4
         status: 200 OK
         code: 200
-        duration: 83.714375ms
+        duration: 82.350208ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1065,8 +1065,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics/3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics/78ad0d7f-2111-43ae-a43c-85e6167820a8
         method: GET
       response:
         proto: HTTP/2.0
@@ -1076,7 +1076,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:48:57.410571+00:00","id":"3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c","ipam_ip_ids":["1a7a3db2-ab00-4d25-af9d-26591734da40","d298eee2-d9b7-4605-b689-7be4cb5c5585"],"mac_address":"02:00:00:1f:f3:c5","modification_date":"2025-01-27T13:48:57.605694+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:22:55.856602+00:00","id":"78ad0d7f-2111-43ae-a43c-85e6167820a8","ipam_ip_ids":["a19c3013-1f37-4c86-b5fb-507415ce9f05","ca73fae0-0eb8-41d1-840b-5ae52ccd61ec"],"mac_address":"02:00:00:1f:3e:fc","modification_date":"2025-02-11T14:22:56.336306+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -1085,9 +1085,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:29 GMT
+                - Tue, 11 Feb 2025 14:23:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1095,10 +1095,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6d0162e2-f9d7-4727-81fd-b7c58ecfbee9
+                - 0722d6fc-90f7-45a1-9b24-1c21495d79cd
         status: 200 OK
         code: 200
-        duration: 91.114209ms
+        duration: 81.779417ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1114,8 +1114,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics/3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics/78ad0d7f-2111-43ae-a43c-85e6167820a8
         method: GET
       response:
         proto: HTTP/2.0
@@ -1125,7 +1125,7 @@ interactions:
         trailer: {}
         content_length: 475
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:48:57.410571+00:00","id":"3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c","ipam_ip_ids":["1a7a3db2-ab00-4d25-af9d-26591734da40","d298eee2-d9b7-4605-b689-7be4cb5c5585"],"mac_address":"02:00:00:1f:f3:c5","modification_date":"2025-01-27T13:49:29.329290+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:22:55.856602+00:00","id":"78ad0d7f-2111-43ae-a43c-85e6167820a8","ipam_ip_ids":["a19c3013-1f37-4c86-b5fb-507415ce9f05","ca73fae0-0eb8-41d1-840b-5ae52ccd61ec"],"mac_address":"02:00:00:1f:3e:fc","modification_date":"2025-02-11T14:23:28.014855+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "475"
@@ -1134,9 +1134,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:34 GMT
+                - Tue, 11 Feb 2025 14:23:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1144,10 +1144,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 24ba3a80-5fd3-47a9-b993-7f0108de98d1
+                - 33af519a-a407-4d6c-bc1e-1f2443461361
         status: 200 OK
         code: 200
-        duration: 80.828042ms
+        duration: 79.377959ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1163,8 +1163,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics/3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics/78ad0d7f-2111-43ae-a43c-85e6167820a8
         method: GET
       response:
         proto: HTTP/2.0
@@ -1174,7 +1174,7 @@ interactions:
         trailer: {}
         content_length: 475
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:48:57.410571+00:00","id":"3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c","ipam_ip_ids":["1a7a3db2-ab00-4d25-af9d-26591734da40","d298eee2-d9b7-4605-b689-7be4cb5c5585"],"mac_address":"02:00:00:1f:f3:c5","modification_date":"2025-01-27T13:49:29.329290+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:22:55.856602+00:00","id":"78ad0d7f-2111-43ae-a43c-85e6167820a8","ipam_ip_ids":["a19c3013-1f37-4c86-b5fb-507415ce9f05","ca73fae0-0eb8-41d1-840b-5ae52ccd61ec"],"mac_address":"02:00:00:1f:3e:fc","modification_date":"2025-02-11T14:23:28.014855+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "475"
@@ -1183,9 +1183,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:34 GMT
+                - Tue, 11 Feb 2025 14:23:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1193,10 +1193,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 51bed609-a97f-44a3-b37f-8221396189a9
+                - 2ef1a215-3604-47e3-b85e-016c749dbe92
         status: 200 OK
         code: 200
-        duration: 91.261ms
+        duration: 97.270417ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1212,8 +1212,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1221,20 +1221,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2308
+        content_length: 2310
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-01-27T13:48:50.285107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-engelbart","id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"30","hypervisor_id":"601","node_id":"48","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:f7","maintenances":[],"modification_date":"2025-01-27T13:48:55.729736+00:00","name":"tf-srv-intelligent-engelbart","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:48:57.410571+00:00","id":"3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c","ipam_ip_ids":["1a7a3db2-ab00-4d25-af9d-26591734da40","d298eee2-d9b7-4605-b689-7be4cb5c5585"],"mac_address":"02:00:00:1f:f3:c5","modification_date":"2025-01-27T13:49:29.329290+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-11T14:22:48.329567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-flamboyant-nightingale","id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"701","node_id":"90","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:e3","maintenances":[],"modification_date":"2025-02-11T14:22:53.854750+00:00","name":"tf-srv-flamboyant-nightingale","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:22:55.856602+00:00","id":"78ad0d7f-2111-43ae-a43c-85e6167820a8","ipam_ip_ids":["a19c3013-1f37-4c86-b5fb-507415ce9f05","ca73fae0-0eb8-41d1-840b-5ae52ccd61ec"],"mac_address":"02:00:00:1f:3e:fc","modification_date":"2025-02-11T14:23:28.014855+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"96fac504-4e66-47f0-bdcf-b05159266ac7","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2308"
+                - "2310"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:34 GMT
+                - Tue, 11 Feb 2025 14:23:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1242,10 +1242,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a561c70d-6747-44b1-9c3f-ca5224a368f0
+                - e90b422c-21c1-4511-94a4-800c2d75ce33
         status: 200 OK
         code: 200
-        duration: 181.565ms
+        duration: 194.610292ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1261,8 +1261,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/bfb7435e-0766-4a84-9a8f-3a0726cac1a8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/96fac504-4e66-47f0-bdcf-b05159266ac7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1272,7 +1272,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"96fac504-4e66-47f0-bdcf-b05159266ac7","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -1281,9 +1281,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:34 GMT
+                - Tue, 11 Feb 2025 14:23:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1291,10 +1291,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3a03d4f0-82fa-44cd-af2a-d58ac9fe01af
+                - 45c70640-25f5-429a-8cd9-5be55da583b5
         status: 404 Not Found
         code: 404
-        duration: 31.123333ms
+        duration: 30.189ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1310,8 +1310,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/bfb7435e-0766-4a84-9a8f-3a0726cac1a8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/96fac504-4e66-47f0-bdcf-b05159266ac7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1321,7 +1321,7 @@ interactions:
         trailer: {}
         content_length: 705
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:48:50.498860Z","id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","last_detached_at":null,"name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-01-27T13:48:50.498860Z","id":"80c5dbf4-310b-4454-986c-c92cdb8483ab","product_resource_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-01-27T13:48:50.498860Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-11T14:22:48.568538Z","id":"96fac504-4e66-47f0-bdcf-b05159266ac7","last_detached_at":null,"name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:48.568538Z","id":"7ab2f9dd-8159-47ca-9247-ad5b487af566","product_resource_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:48.568538Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "705"
@@ -1330,9 +1330,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:34 GMT
+                - Tue, 11 Feb 2025 14:23:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1340,10 +1340,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1000da9d-4ade-460b-952f-aa943a7e4ce7
+                - 5f27ea19-973d-4ffe-b358-10f35b92f542
         status: 200 OK
         code: 200
-        duration: 81.024ms
+        duration: 64.258083ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1359,8 +1359,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1379,9 +1379,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:34 GMT
+                - Tue, 11 Feb 2025 14:23:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1389,10 +1389,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 454b28ea-4b08-403e-b795-bd5a7fbdba42
+                - f650fd62-dad5-40f1-b42c-80794d4a3421
         status: 200 OK
         code: 200
-        duration: 82.122833ms
+        duration: 90.028584ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1408,8 +1408,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1419,7 +1419,7 @@ interactions:
         trailer: {}
         content_length: 478
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:48:57.410571+00:00","id":"3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c","ipam_ip_ids":["1a7a3db2-ab00-4d25-af9d-26591734da40","d298eee2-d9b7-4605-b689-7be4cb5c5585"],"mac_address":"02:00:00:1f:f3:c5","modification_date":"2025-01-27T13:49:29.329290+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"private_nics":[{"creation_date":"2025-02-11T14:22:55.856602+00:00","id":"78ad0d7f-2111-43ae-a43c-85e6167820a8","ipam_ip_ids":["a19c3013-1f37-4c86-b5fb-507415ce9f05","ca73fae0-0eb8-41d1-840b-5ae52ccd61ec"],"mac_address":"02:00:00:1f:3e:fc","modification_date":"2025-02-11T14:23:28.014855+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
                 - "478"
@@ -1428,11 +1428,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:34 GMT
+                - Tue, 11 Feb 2025 14:23:33 GMT
             Link:
-                - </servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics?page=1&per_page=50&>; rel="last"
+                - </servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics?page=1&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1440,12 +1440,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 68af3873-ea48-4f07-817d-ac08461c4a84
+                - 245899d9-afbc-40a8-a155-5cc1cb93878d
             X-Total-Count:
                 - "1"
         status: 200 OK
         code: 200
-        duration: 96.631833ms
+        duration: 71.308625ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1461,8 +1461,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/03e7480d-cb49-43d9-a418-9f410f1083ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/01911755-02f0-4fa2-b4ac-a997b37f0961
         method: GET
       response:
         proto: HTTP/2.0
@@ -1470,20 +1470,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1044
+        content_length: 1047
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:48:49.242784Z","dhcp_enabled":true,"id":"03e7480d-cb49-43d9-a418-9f410f1083ef","name":"tf-pn-sad-almeida","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:48:49.242784Z","id":"8cb282d3-7d82-4348-946b-11abc82151fd","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.20.0/22","updated_at":"2025-01-27T13:48:49.242784Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:48:49.242784Z","id":"18cba5f0-8632-4b35-ae9f-b97390ab1329","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:48fa::/64","updated_at":"2025-01-27T13:48:49.242784Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:48:49.242784Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"created_at":"2025-02-11T14:22:47.248262Z","dhcp_enabled":true,"id":"01911755-02f0-4fa2-b4ac-a997b37f0961","name":"tf-pn-vibrant-hoover","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-11T14:22:47.248262Z","id":"4acdfe92-d256-48d4-a67c-02bc29bc3108","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.12.0/22","updated_at":"2025-02-11T14:22:47.248262Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-11T14:22:47.248262Z","id":"aba8b3ed-b155-467f-8c38-e1d9c0f259d3","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:e93b::/64","updated_at":"2025-02-11T14:22:47.248262Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-11T14:22:47.248262Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "1044"
+                - "1047"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:35 GMT
+                - Tue, 11 Feb 2025 14:23:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1491,10 +1491,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3e624e70-cb67-4ee2-b7f0-44c1213cf972
+                - ccbe66b7-1cc7-4f43-9e9d-79f23e268579
         status: 200 OK
         code: 200
-        duration: 25.314916ms
+        duration: 73.662084ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1510,8 +1510,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1519,20 +1519,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2308
+        content_length: 2310
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-01-27T13:48:50.285107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-engelbart","id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"30","hypervisor_id":"601","node_id":"48","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:f7","maintenances":[],"modification_date":"2025-01-27T13:48:55.729736+00:00","name":"tf-srv-intelligent-engelbart","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:48:57.410571+00:00","id":"3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c","ipam_ip_ids":["1a7a3db2-ab00-4d25-af9d-26591734da40","d298eee2-d9b7-4605-b689-7be4cb5c5585"],"mac_address":"02:00:00:1f:f3:c5","modification_date":"2025-01-27T13:49:29.329290+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-11T14:22:48.329567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-flamboyant-nightingale","id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"701","node_id":"90","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:e3","maintenances":[],"modification_date":"2025-02-11T14:22:53.854750+00:00","name":"tf-srv-flamboyant-nightingale","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:22:55.856602+00:00","id":"78ad0d7f-2111-43ae-a43c-85e6167820a8","ipam_ip_ids":["a19c3013-1f37-4c86-b5fb-507415ce9f05","ca73fae0-0eb8-41d1-840b-5ae52ccd61ec"],"mac_address":"02:00:00:1f:3e:fc","modification_date":"2025-02-11T14:23:28.014855+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"96fac504-4e66-47f0-bdcf-b05159266ac7","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2308"
+                - "2310"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:35 GMT
+                - Tue, 11 Feb 2025 14:23:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1540,10 +1540,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 95a2814b-d648-41db-976e-1a3f008a429f
+                - 515e4ade-bb8e-4d2c-adc6-5aa85240f62d
         status: 200 OK
         code: 200
-        duration: 170.200083ms
+        duration: 179.197208ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1559,8 +1559,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/bfb7435e-0766-4a84-9a8f-3a0726cac1a8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/96fac504-4e66-47f0-bdcf-b05159266ac7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1570,7 +1570,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"96fac504-4e66-47f0-bdcf-b05159266ac7","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -1579,9 +1579,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:34 GMT
+                - Tue, 11 Feb 2025 14:23:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1589,10 +1589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5404ebd2-36a2-4ac0-86bd-d5560da2cbc1
+                - 20028d59-02b9-4e48-80dc-4d64d749a22c
         status: 404 Not Found
         code: 404
-        duration: 44.671084ms
+        duration: 33.888959ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1608,8 +1608,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/bfb7435e-0766-4a84-9a8f-3a0726cac1a8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/96fac504-4e66-47f0-bdcf-b05159266ac7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1619,7 +1619,7 @@ interactions:
         trailer: {}
         content_length: 705
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:48:50.498860Z","id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","last_detached_at":null,"name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-01-27T13:48:50.498860Z","id":"80c5dbf4-310b-4454-986c-c92cdb8483ab","product_resource_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-01-27T13:48:50.498860Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-11T14:22:48.568538Z","id":"96fac504-4e66-47f0-bdcf-b05159266ac7","last_detached_at":null,"name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:48.568538Z","id":"7ab2f9dd-8159-47ca-9247-ad5b487af566","product_resource_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:48.568538Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "705"
@@ -1628,9 +1628,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:35 GMT
+                - Tue, 11 Feb 2025 14:23:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1638,10 +1638,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ca0f12f9-2174-4eee-b4ec-071fd2fd6bd5
+                - b28d7452-82c3-4be4-9c5c-c1739f4c4e32
         status: 200 OK
         code: 200
-        duration: 87.661542ms
+        duration: 68.747333ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1657,8 +1657,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1677,9 +1677,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:35 GMT
+                - Tue, 11 Feb 2025 14:23:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1687,10 +1687,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e20aece8-af1c-471c-8420-e3d0b799d884
+                - 188c0411-df8b-468e-bce9-5b91d1b5b687
         status: 200 OK
         code: 200
-        duration: 94.024292ms
+        duration: 97.62475ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1706,8 +1706,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1717,7 +1717,7 @@ interactions:
         trailer: {}
         content_length: 478
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:48:57.410571+00:00","id":"3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c","ipam_ip_ids":["1a7a3db2-ab00-4d25-af9d-26591734da40","d298eee2-d9b7-4605-b689-7be4cb5c5585"],"mac_address":"02:00:00:1f:f3:c5","modification_date":"2025-01-27T13:49:29.329290+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"private_nics":[{"creation_date":"2025-02-11T14:22:55.856602+00:00","id":"78ad0d7f-2111-43ae-a43c-85e6167820a8","ipam_ip_ids":["a19c3013-1f37-4c86-b5fb-507415ce9f05","ca73fae0-0eb8-41d1-840b-5ae52ccd61ec"],"mac_address":"02:00:00:1f:3e:fc","modification_date":"2025-02-11T14:23:28.014855+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
                 - "478"
@@ -1726,11 +1726,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:35 GMT
+                - Tue, 11 Feb 2025 14:23:34 GMT
             Link:
-                - </servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics?page=1&per_page=50&>; rel="last"
+                - </servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics?page=1&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1738,12 +1738,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 50af6159-8efa-49c7-bdb8-492efd7a4944
+                - c25abcd5-851e-4001-9e51-92ae7ea057db
             X-Total-Count:
                 - "1"
         status: 200 OK
         code: 200
-        duration: 92.871375ms
+        duration: 64.48825ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1759,8 +1759,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics/3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics/78ad0d7f-2111-43ae-a43c-85e6167820a8
         method: GET
       response:
         proto: HTTP/2.0
@@ -1770,7 +1770,7 @@ interactions:
         trailer: {}
         content_length: 475
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:48:57.410571+00:00","id":"3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c","ipam_ip_ids":["1a7a3db2-ab00-4d25-af9d-26591734da40","d298eee2-d9b7-4605-b689-7be4cb5c5585"],"mac_address":"02:00:00:1f:f3:c5","modification_date":"2025-01-27T13:49:29.329290+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:22:55.856602+00:00","id":"78ad0d7f-2111-43ae-a43c-85e6167820a8","ipam_ip_ids":["a19c3013-1f37-4c86-b5fb-507415ce9f05","ca73fae0-0eb8-41d1-840b-5ae52ccd61ec"],"mac_address":"02:00:00:1f:3e:fc","modification_date":"2025-02-11T14:23:28.014855+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "475"
@@ -1779,9 +1779,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:35 GMT
+                - Tue, 11 Feb 2025 14:23:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1789,10 +1789,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d5135e96-2e3a-4d48-98e7-ad76f010cdaa
+                - c7dbd84d-f4e3-4151-9371-760ca4589320
         status: 200 OK
         code: 200
-        duration: 79.635333ms
+        duration: 73.914166ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1808,8 +1808,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/03e7480d-cb49-43d9-a418-9f410f1083ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/01911755-02f0-4fa2-b4ac-a997b37f0961
         method: GET
       response:
         proto: HTTP/2.0
@@ -1817,20 +1817,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1044
+        content_length: 1047
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:48:49.242784Z","dhcp_enabled":true,"id":"03e7480d-cb49-43d9-a418-9f410f1083ef","name":"tf-pn-sad-almeida","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:48:49.242784Z","id":"8cb282d3-7d82-4348-946b-11abc82151fd","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.20.0/22","updated_at":"2025-01-27T13:48:49.242784Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:48:49.242784Z","id":"18cba5f0-8632-4b35-ae9f-b97390ab1329","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:48fa::/64","updated_at":"2025-01-27T13:48:49.242784Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:48:49.242784Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"created_at":"2025-02-11T14:22:47.248262Z","dhcp_enabled":true,"id":"01911755-02f0-4fa2-b4ac-a997b37f0961","name":"tf-pn-vibrant-hoover","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-11T14:22:47.248262Z","id":"4acdfe92-d256-48d4-a67c-02bc29bc3108","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.12.0/22","updated_at":"2025-02-11T14:22:47.248262Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-11T14:22:47.248262Z","id":"aba8b3ed-b155-467f-8c38-e1d9c0f259d3","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:e93b::/64","updated_at":"2025-02-11T14:22:47.248262Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-11T14:22:47.248262Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "1044"
+                - "1047"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:36 GMT
+                - Tue, 11 Feb 2025 14:23:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1838,10 +1838,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6c40b95f-fad8-4dfc-aa3d-c27096139a9d
+                - b713876f-0dac-484f-8848-dcce5fd7dd83
         status: 200 OK
         code: 200
-        duration: 31.033625ms
+        duration: 28.78725ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1857,8 +1857,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1866,20 +1866,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2308
+        content_length: 2310
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-01-27T13:48:50.285107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-engelbart","id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"30","hypervisor_id":"601","node_id":"48","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:f7","maintenances":[],"modification_date":"2025-01-27T13:48:55.729736+00:00","name":"tf-srv-intelligent-engelbart","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:48:57.410571+00:00","id":"3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c","ipam_ip_ids":["1a7a3db2-ab00-4d25-af9d-26591734da40","d298eee2-d9b7-4605-b689-7be4cb5c5585"],"mac_address":"02:00:00:1f:f3:c5","modification_date":"2025-01-27T13:49:29.329290+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-11T14:22:48.329567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-flamboyant-nightingale","id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"701","node_id":"90","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:e3","maintenances":[],"modification_date":"2025-02-11T14:22:53.854750+00:00","name":"tf-srv-flamboyant-nightingale","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:22:55.856602+00:00","id":"78ad0d7f-2111-43ae-a43c-85e6167820a8","ipam_ip_ids":["a19c3013-1f37-4c86-b5fb-507415ce9f05","ca73fae0-0eb8-41d1-840b-5ae52ccd61ec"],"mac_address":"02:00:00:1f:3e:fc","modification_date":"2025-02-11T14:23:28.014855+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"96fac504-4e66-47f0-bdcf-b05159266ac7","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2308"
+                - "2310"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:35 GMT
+                - Tue, 11 Feb 2025 14:23:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1887,10 +1887,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b834c89a-a671-4f47-a27e-499473f1733b
+                - 45985066-6466-467f-9a0a-a2deb2ccbc87
         status: 200 OK
         code: 200
-        duration: 187.738666ms
+        duration: 158.840709ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1906,8 +1906,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/bfb7435e-0766-4a84-9a8f-3a0726cac1a8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/96fac504-4e66-47f0-bdcf-b05159266ac7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1917,7 +1917,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"96fac504-4e66-47f0-bdcf-b05159266ac7","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -1926,9 +1926,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:36 GMT
+                - Tue, 11 Feb 2025 14:23:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1936,10 +1936,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 27e206f4-7532-47dd-b90d-5cf27560d876
+                - 7cbf5839-6eb6-4952-8056-3010319236b9
         status: 404 Not Found
         code: 404
-        duration: 35.125375ms
+        duration: 33.172208ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1955,8 +1955,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/bfb7435e-0766-4a84-9a8f-3a0726cac1a8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/96fac504-4e66-47f0-bdcf-b05159266ac7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1966,7 +1966,7 @@ interactions:
         trailer: {}
         content_length: 705
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:48:50.498860Z","id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","last_detached_at":null,"name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-01-27T13:48:50.498860Z","id":"80c5dbf4-310b-4454-986c-c92cdb8483ab","product_resource_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-01-27T13:48:50.498860Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-11T14:22:48.568538Z","id":"96fac504-4e66-47f0-bdcf-b05159266ac7","last_detached_at":null,"name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:48.568538Z","id":"7ab2f9dd-8159-47ca-9247-ad5b487af566","product_resource_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:48.568538Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "705"
@@ -1975,9 +1975,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:36 GMT
+                - Tue, 11 Feb 2025 14:23:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1985,10 +1985,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b0093bac-6807-4f02-89d7-e80fd3ecd9f0
+                - 89e084d1-b6be-4d9b-86a9-0b480b9eafa2
         status: 200 OK
         code: 200
-        duration: 74.739291ms
+        duration: 63.503417ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2004,8 +2004,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -2024,9 +2024,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:36 GMT
+                - Tue, 11 Feb 2025 14:23:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2034,10 +2034,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 87545cd1-b612-4b8d-9b7a-0a4d1fd74a26
+                - 5f691448-39f2-4075-907e-65e6deff2962
         status: 200 OK
         code: 200
-        duration: 89.21575ms
+        duration: 79.630833ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2053,8 +2053,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -2064,7 +2064,7 @@ interactions:
         trailer: {}
         content_length: 478
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:48:57.410571+00:00","id":"3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c","ipam_ip_ids":["1a7a3db2-ab00-4d25-af9d-26591734da40","d298eee2-d9b7-4605-b689-7be4cb5c5585"],"mac_address":"02:00:00:1f:f3:c5","modification_date":"2025-01-27T13:49:29.329290+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"private_nics":[{"creation_date":"2025-02-11T14:22:55.856602+00:00","id":"78ad0d7f-2111-43ae-a43c-85e6167820a8","ipam_ip_ids":["a19c3013-1f37-4c86-b5fb-507415ce9f05","ca73fae0-0eb8-41d1-840b-5ae52ccd61ec"],"mac_address":"02:00:00:1f:3e:fc","modification_date":"2025-02-11T14:23:28.014855+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
                 - "478"
@@ -2073,11 +2073,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:36 GMT
+                - Tue, 11 Feb 2025 14:23:35 GMT
             Link:
-                - </servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics?page=1&per_page=50&>; rel="last"
+                - </servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics?page=1&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2085,12 +2085,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ed817060-4d62-4bb4-bf72-0c4ff50e4a93
+                - 1a9a40be-9cc1-4ca6-8393-abc2f6c6040a
             X-Total-Count:
                 - "1"
         status: 200 OK
         code: 200
-        duration: 91.206708ms
+        duration: 70.888167ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2106,8 +2106,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics/3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics/78ad0d7f-2111-43ae-a43c-85e6167820a8
         method: GET
       response:
         proto: HTTP/2.0
@@ -2117,7 +2117,7 @@ interactions:
         trailer: {}
         content_length: 475
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:48:57.410571+00:00","id":"3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c","ipam_ip_ids":["1a7a3db2-ab00-4d25-af9d-26591734da40","d298eee2-d9b7-4605-b689-7be4cb5c5585"],"mac_address":"02:00:00:1f:f3:c5","modification_date":"2025-01-27T13:49:29.329290+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:22:55.856602+00:00","id":"78ad0d7f-2111-43ae-a43c-85e6167820a8","ipam_ip_ids":["a19c3013-1f37-4c86-b5fb-507415ce9f05","ca73fae0-0eb8-41d1-840b-5ae52ccd61ec"],"mac_address":"02:00:00:1f:3e:fc","modification_date":"2025-02-11T14:23:28.014855+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "475"
@@ -2126,9 +2126,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:36 GMT
+                - Tue, 11 Feb 2025 14:23:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2136,10 +2136,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 30441ad3-ac77-417c-b0ae-8e2538dc7ce3
+                - 15bad51c-9915-4b7d-b858-d24ec15e5695
         status: 200 OK
         code: 200
-        duration: 89.686208ms
+        duration: 73.485333ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2155,8 +2155,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/03e7480d-cb49-43d9-a418-9f410f1083ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/01911755-02f0-4fa2-b4ac-a997b37f0961
         method: GET
       response:
         proto: HTTP/2.0
@@ -2164,20 +2164,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1044
+        content_length: 1047
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:48:49.242784Z","dhcp_enabled":true,"id":"03e7480d-cb49-43d9-a418-9f410f1083ef","name":"tf-pn-sad-almeida","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:48:49.242784Z","id":"8cb282d3-7d82-4348-946b-11abc82151fd","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.20.0/22","updated_at":"2025-01-27T13:48:49.242784Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:48:49.242784Z","id":"18cba5f0-8632-4b35-ae9f-b97390ab1329","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:48fa::/64","updated_at":"2025-01-27T13:48:49.242784Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:48:49.242784Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"created_at":"2025-02-11T14:22:47.248262Z","dhcp_enabled":true,"id":"01911755-02f0-4fa2-b4ac-a997b37f0961","name":"tf-pn-vibrant-hoover","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-11T14:22:47.248262Z","id":"4acdfe92-d256-48d4-a67c-02bc29bc3108","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.12.0/22","updated_at":"2025-02-11T14:22:47.248262Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-11T14:22:47.248262Z","id":"aba8b3ed-b155-467f-8c38-e1d9c0f259d3","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:e93b::/64","updated_at":"2025-02-11T14:22:47.248262Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-11T14:22:47.248262Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "1044"
+                - "1047"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:37 GMT
+                - Tue, 11 Feb 2025 14:23:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2185,10 +2185,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b5f69bd6-f54a-47f4-8b08-983519dd46d5
+                - 49526b04-7de0-4db5-a32b-0b1ab84f8453
         status: 200 OK
         code: 200
-        duration: 30.095ms
+        duration: 41.278791ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2204,8 +2204,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d
         method: GET
       response:
         proto: HTTP/2.0
@@ -2213,20 +2213,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2308
+        content_length: 2310
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-01-27T13:48:50.285107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-engelbart","id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"30","hypervisor_id":"601","node_id":"48","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:f7","maintenances":[],"modification_date":"2025-01-27T13:48:55.729736+00:00","name":"tf-srv-intelligent-engelbart","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:48:57.410571+00:00","id":"3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c","ipam_ip_ids":["1a7a3db2-ab00-4d25-af9d-26591734da40","d298eee2-d9b7-4605-b689-7be4cb5c5585"],"mac_address":"02:00:00:1f:f3:c5","modification_date":"2025-01-27T13:49:29.329290+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-11T14:22:48.329567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-flamboyant-nightingale","id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"701","node_id":"90","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:e3","maintenances":[],"modification_date":"2025-02-11T14:22:53.854750+00:00","name":"tf-srv-flamboyant-nightingale","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:22:55.856602+00:00","id":"78ad0d7f-2111-43ae-a43c-85e6167820a8","ipam_ip_ids":["a19c3013-1f37-4c86-b5fb-507415ce9f05","ca73fae0-0eb8-41d1-840b-5ae52ccd61ec"],"mac_address":"02:00:00:1f:3e:fc","modification_date":"2025-02-11T14:23:28.014855+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"96fac504-4e66-47f0-bdcf-b05159266ac7","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2308"
+                - "2310"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:37 GMT
+                - Tue, 11 Feb 2025 14:23:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2234,10 +2234,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - de0d803d-5d6f-492a-a99d-0ebf162e1562
+                - 1ab9740a-3ca4-4406-a701-57c8608b9447
         status: 200 OK
         code: 200
-        duration: 212.477916ms
+        duration: 198.46925ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2253,8 +2253,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/bfb7435e-0766-4a84-9a8f-3a0726cac1a8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/96fac504-4e66-47f0-bdcf-b05159266ac7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2264,7 +2264,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"96fac504-4e66-47f0-bdcf-b05159266ac7","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -2273,9 +2273,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:37 GMT
+                - Tue, 11 Feb 2025 14:23:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2283,10 +2283,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 91b10a37-3705-4d64-a965-739459dbd893
+                - 5482a11e-550e-451e-848f-ad191876fc2b
         status: 404 Not Found
         code: 404
-        duration: 28.880209ms
+        duration: 33.597917ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2302,8 +2302,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/bfb7435e-0766-4a84-9a8f-3a0726cac1a8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/96fac504-4e66-47f0-bdcf-b05159266ac7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2313,7 +2313,7 @@ interactions:
         trailer: {}
         content_length: 705
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:48:50.498860Z","id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","last_detached_at":null,"name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-01-27T13:48:50.498860Z","id":"80c5dbf4-310b-4454-986c-c92cdb8483ab","product_resource_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-01-27T13:48:50.498860Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-11T14:22:48.568538Z","id":"96fac504-4e66-47f0-bdcf-b05159266ac7","last_detached_at":null,"name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:48.568538Z","id":"7ab2f9dd-8159-47ca-9247-ad5b487af566","product_resource_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:48.568538Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "705"
@@ -2322,9 +2322,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:37 GMT
+                - Tue, 11 Feb 2025 14:23:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2332,10 +2332,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c8f3e30c-3130-40c6-a093-cf5a33fc07be
+                - af71a20b-575f-4820-9e1f-a2015d90511c
         status: 200 OK
         code: 200
-        duration: 74.770875ms
+        duration: 73.776625ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2351,8 +2351,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -2371,9 +2371,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:37 GMT
+                - Tue, 11 Feb 2025 14:23:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2381,10 +2381,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6fb8d99c-5b62-4795-b422-73e211d93747
+                - c00fa501-f5b9-4ebe-b122-f97a37b6f118
         status: 200 OK
         code: 200
-        duration: 81.706667ms
+        duration: 79.706167ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2400,8 +2400,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -2411,7 +2411,7 @@ interactions:
         trailer: {}
         content_length: 478
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:48:57.410571+00:00","id":"3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c","ipam_ip_ids":["1a7a3db2-ab00-4d25-af9d-26591734da40","d298eee2-d9b7-4605-b689-7be4cb5c5585"],"mac_address":"02:00:00:1f:f3:c5","modification_date":"2025-01-27T13:49:29.329290+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"private_nics":[{"creation_date":"2025-02-11T14:22:55.856602+00:00","id":"78ad0d7f-2111-43ae-a43c-85e6167820a8","ipam_ip_ids":["a19c3013-1f37-4c86-b5fb-507415ce9f05","ca73fae0-0eb8-41d1-840b-5ae52ccd61ec"],"mac_address":"02:00:00:1f:3e:fc","modification_date":"2025-02-11T14:23:28.014855+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
                 - "478"
@@ -2420,11 +2420,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:37 GMT
+                - Tue, 11 Feb 2025 14:23:36 GMT
             Link:
-                - </servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics?page=1&per_page=50&>; rel="last"
+                - </servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics?page=1&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2432,12 +2432,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9a31ae55-22ac-4ae3-b1c7-323a6c7d6a3a
+                - ef850018-5226-4728-a818-6a39220f37f2
             X-Total-Count:
                 - "1"
         status: 200 OK
         code: 200
-        duration: 118.408959ms
+        duration: 101.418208ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2453,8 +2453,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics/3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics/78ad0d7f-2111-43ae-a43c-85e6167820a8
         method: GET
       response:
         proto: HTTP/2.0
@@ -2464,7 +2464,7 @@ interactions:
         trailer: {}
         content_length: 475
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:48:57.410571+00:00","id":"3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c","ipam_ip_ids":["1a7a3db2-ab00-4d25-af9d-26591734da40","d298eee2-d9b7-4605-b689-7be4cb5c5585"],"mac_address":"02:00:00:1f:f3:c5","modification_date":"2025-01-27T13:49:29.329290+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:22:55.856602+00:00","id":"78ad0d7f-2111-43ae-a43c-85e6167820a8","ipam_ip_ids":["a19c3013-1f37-4c86-b5fb-507415ce9f05","ca73fae0-0eb8-41d1-840b-5ae52ccd61ec"],"mac_address":"02:00:00:1f:3e:fc","modification_date":"2025-02-11T14:23:28.014855+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "475"
@@ -2473,9 +2473,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:37 GMT
+                - Tue, 11 Feb 2025 14:23:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2483,10 +2483,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dc16ee98-b7d8-4795-8c6d-917110f46ae6
+                - f9341a0a-bc7e-4442-8a25-071eb40696ac
         status: 200 OK
         code: 200
-        duration: 98.687583ms
+        duration: 102.5315ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -2502,8 +2502,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/03e7480d-cb49-43d9-a418-9f410f1083ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/01911755-02f0-4fa2-b4ac-a997b37f0961
         method: GET
       response:
         proto: HTTP/2.0
@@ -2511,20 +2511,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1044
+        content_length: 1047
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:48:49.242784Z","dhcp_enabled":true,"id":"03e7480d-cb49-43d9-a418-9f410f1083ef","name":"tf-pn-sad-almeida","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:48:49.242784Z","id":"8cb282d3-7d82-4348-946b-11abc82151fd","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.20.0/22","updated_at":"2025-01-27T13:48:49.242784Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:48:49.242784Z","id":"18cba5f0-8632-4b35-ae9f-b97390ab1329","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:48fa::/64","updated_at":"2025-01-27T13:48:49.242784Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:48:49.242784Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"created_at":"2025-02-11T14:22:47.248262Z","dhcp_enabled":true,"id":"01911755-02f0-4fa2-b4ac-a997b37f0961","name":"tf-pn-vibrant-hoover","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-11T14:22:47.248262Z","id":"4acdfe92-d256-48d4-a67c-02bc29bc3108","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.12.0/22","updated_at":"2025-02-11T14:22:47.248262Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-11T14:22:47.248262Z","id":"aba8b3ed-b155-467f-8c38-e1d9c0f259d3","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:e93b::/64","updated_at":"2025-02-11T14:22:47.248262Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-11T14:22:47.248262Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "1044"
+                - "1047"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:38 GMT
+                - Tue, 11 Feb 2025 14:23:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2532,10 +2532,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4a9459ee-dafe-45ad-937f-0bb07deb205d
+                - 7dade246-9050-4134-816d-4797581deee3
         status: 200 OK
         code: 200
-        duration: 71.0805ms
+        duration: 62.5165ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2551,8 +2551,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics/3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics/78ad0d7f-2111-43ae-a43c-85e6167820a8
         method: GET
       response:
         proto: HTTP/2.0
@@ -2562,7 +2562,7 @@ interactions:
         trailer: {}
         content_length: 475
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:48:57.410571+00:00","id":"3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c","ipam_ip_ids":["1a7a3db2-ab00-4d25-af9d-26591734da40","d298eee2-d9b7-4605-b689-7be4cb5c5585"],"mac_address":"02:00:00:1f:f3:c5","modification_date":"2025-01-27T13:49:29.329290+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:22:55.856602+00:00","id":"78ad0d7f-2111-43ae-a43c-85e6167820a8","ipam_ip_ids":["a19c3013-1f37-4c86-b5fb-507415ce9f05","ca73fae0-0eb8-41d1-840b-5ae52ccd61ec"],"mac_address":"02:00:00:1f:3e:fc","modification_date":"2025-02-11T14:23:28.014855+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "475"
@@ -2571,9 +2571,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:38 GMT
+                - Tue, 11 Feb 2025 14:23:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2581,10 +2581,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 171f7b63-f254-4bf2-8abf-e7637eaed207
+                - 32dc1590-64c2-4b61-8415-7f1d2844d59d
         status: 200 OK
         code: 200
-        duration: 117.716833ms
+        duration: 82.514167ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -2600,8 +2600,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d
         method: GET
       response:
         proto: HTTP/2.0
@@ -2609,20 +2609,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2308
+        content_length: 2310
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-01-27T13:48:50.285107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-engelbart","id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"30","hypervisor_id":"601","node_id":"48","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:f7","maintenances":[],"modification_date":"2025-01-27T13:48:55.729736+00:00","name":"tf-srv-intelligent-engelbart","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:48:57.410571+00:00","id":"3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c","ipam_ip_ids":["1a7a3db2-ab00-4d25-af9d-26591734da40","d298eee2-d9b7-4605-b689-7be4cb5c5585"],"mac_address":"02:00:00:1f:f3:c5","modification_date":"2025-01-27T13:49:29.329290+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-11T14:22:48.329567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-flamboyant-nightingale","id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"701","node_id":"90","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:e3","maintenances":[],"modification_date":"2025-02-11T14:22:53.854750+00:00","name":"tf-srv-flamboyant-nightingale","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:22:55.856602+00:00","id":"78ad0d7f-2111-43ae-a43c-85e6167820a8","ipam_ip_ids":["a19c3013-1f37-4c86-b5fb-507415ce9f05","ca73fae0-0eb8-41d1-840b-5ae52ccd61ec"],"mac_address":"02:00:00:1f:3e:fc","modification_date":"2025-02-11T14:23:28.014855+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"96fac504-4e66-47f0-bdcf-b05159266ac7","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2308"
+                - "2310"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:37 GMT
+                - Tue, 11 Feb 2025 14:23:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2630,10 +2630,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e1e6e75b-e5e3-4647-9d31-7d67648483ac
+                - 758c61d0-bbbd-408c-a388-9680dbd8d9dc
         status: 200 OK
         code: 200
-        duration: 259.77725ms
+        duration: 144.441ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -2649,8 +2649,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/bfb7435e-0766-4a84-9a8f-3a0726cac1a8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/96fac504-4e66-47f0-bdcf-b05159266ac7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2660,7 +2660,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"96fac504-4e66-47f0-bdcf-b05159266ac7","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -2669,9 +2669,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:38 GMT
+                - Tue, 11 Feb 2025 14:23:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2679,10 +2679,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - be585b73-3a00-4f4a-9a9e-b233f81754e7
+                - 9661c33d-2bd0-4544-b3b2-a6302e4e41f9
         status: 404 Not Found
         code: 404
-        duration: 32.849042ms
+        duration: 29.218ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -2698,8 +2698,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/bfb7435e-0766-4a84-9a8f-3a0726cac1a8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/96fac504-4e66-47f0-bdcf-b05159266ac7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2709,7 +2709,7 @@ interactions:
         trailer: {}
         content_length: 705
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:48:50.498860Z","id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","last_detached_at":null,"name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-01-27T13:48:50.498860Z","id":"80c5dbf4-310b-4454-986c-c92cdb8483ab","product_resource_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-01-27T13:48:50.498860Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-11T14:22:48.568538Z","id":"96fac504-4e66-47f0-bdcf-b05159266ac7","last_detached_at":null,"name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:48.568538Z","id":"7ab2f9dd-8159-47ca-9247-ad5b487af566","product_resource_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:48.568538Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "705"
@@ -2718,9 +2718,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:38 GMT
+                - Tue, 11 Feb 2025 14:23:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2728,10 +2728,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3f1b0e3e-6191-4208-af45-56e673a7b4d9
+                - 084dc9d0-ed47-4859-b78e-295318713664
         status: 200 OK
         code: 200
-        duration: 68.714917ms
+        duration: 64.990708ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -2747,8 +2747,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -2767,9 +2767,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:38 GMT
+                - Tue, 11 Feb 2025 14:23:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2777,10 +2777,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b1e394ae-d63b-452f-b963-2633bbfed6e3
+                - 72d15d1d-c458-4edf-9a92-f2c7f8b081c8
         status: 200 OK
         code: 200
-        duration: 77.416458ms
+        duration: 77.259917ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2796,8 +2796,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -2807,7 +2807,7 @@ interactions:
         trailer: {}
         content_length: 478
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:48:57.410571+00:00","id":"3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c","ipam_ip_ids":["1a7a3db2-ab00-4d25-af9d-26591734da40","d298eee2-d9b7-4605-b689-7be4cb5c5585"],"mac_address":"02:00:00:1f:f3:c5","modification_date":"2025-01-27T13:49:29.329290+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"private_nics":[{"creation_date":"2025-02-11T14:22:55.856602+00:00","id":"78ad0d7f-2111-43ae-a43c-85e6167820a8","ipam_ip_ids":["a19c3013-1f37-4c86-b5fb-507415ce9f05","ca73fae0-0eb8-41d1-840b-5ae52ccd61ec"],"mac_address":"02:00:00:1f:3e:fc","modification_date":"2025-02-11T14:23:28.014855+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
                 - "478"
@@ -2816,11 +2816,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:38 GMT
+                - Tue, 11 Feb 2025 14:23:36 GMT
             Link:
-                - </servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics?page=1&per_page=50&>; rel="last"
+                - </servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics?page=1&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2828,12 +2828,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - eab11e8e-229b-4fde-95c7-39c205e8eec4
+                - 531b6afd-9fb2-4afe-bcce-fca8c2fa475b
             X-Total-Count:
                 - "1"
         status: 200 OK
         code: 200
-        duration: 78.335958ms
+        duration: 77.826291ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2849,8 +2849,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics/3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics/78ad0d7f-2111-43ae-a43c-85e6167820a8
         method: GET
       response:
         proto: HTTP/2.0
@@ -2860,7 +2860,7 @@ interactions:
         trailer: {}
         content_length: 475
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:48:57.410571+00:00","id":"3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c","ipam_ip_ids":["1a7a3db2-ab00-4d25-af9d-26591734da40","d298eee2-d9b7-4605-b689-7be4cb5c5585"],"mac_address":"02:00:00:1f:f3:c5","modification_date":"2025-01-27T13:49:29.329290+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:22:55.856602+00:00","id":"78ad0d7f-2111-43ae-a43c-85e6167820a8","ipam_ip_ids":["a19c3013-1f37-4c86-b5fb-507415ce9f05","ca73fae0-0eb8-41d1-840b-5ae52ccd61ec"],"mac_address":"02:00:00:1f:3e:fc","modification_date":"2025-02-11T14:23:28.014855+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "475"
@@ -2869,9 +2869,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:38 GMT
+                - Tue, 11 Feb 2025 14:23:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2879,10 +2879,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 49b351a7-b841-478a-bf67-e851c110a1ec
+                - 1f13ce74-f9ac-497f-abd7-fb1cec9a0dcc
         status: 200 OK
         code: 200
-        duration: 94.531959ms
+        duration: 77.693666ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -2898,8 +2898,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics/3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics/78ad0d7f-2111-43ae-a43c-85e6167820a8
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2916,9 +2916,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:39 GMT
+                - Tue, 11 Feb 2025 14:23:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2926,10 +2926,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c9da02cd-8fc9-45c4-8776-77b5373aa159
+                - 1fff4e91-eda6-4462-adf4-3ced7badc753
         status: 204 No Content
         code: 204
-        duration: 401.971792ms
+        duration: 458.21225ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -2945,8 +2945,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics/3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics/78ad0d7f-2111-43ae-a43c-85e6167820a8
         method: GET
       response:
         proto: HTTP/2.0
@@ -2956,7 +2956,7 @@ interactions:
         trailer: {}
         content_length: 148
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"3a46bbd8-70b9-4d37-89f9-59fdd8da8d2c","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"78ad0d7f-2111-43ae-a43c-85e6167820a8","type":"not_found"}'
         headers:
             Content-Length:
                 - "148"
@@ -2965,9 +2965,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:39 GMT
+                - Tue, 11 Feb 2025 14:23:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2975,10 +2975,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a205088b-fb76-42d9-9e96-e3577ef36439
+                - abfae52a-c67c-445b-9ac4-1459e6381565
         status: 404 Not Found
         code: 404
-        duration: 79.080791ms
+        duration: 99.044ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -2994,8 +2994,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/03e7480d-cb49-43d9-a418-9f410f1083ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/01911755-02f0-4fa2-b4ac-a997b37f0961
         method: GET
       response:
         proto: HTTP/2.0
@@ -3003,20 +3003,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1044
+        content_length: 1047
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:48:49.242784Z","dhcp_enabled":true,"id":"03e7480d-cb49-43d9-a418-9f410f1083ef","name":"tf-pn-sad-almeida","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:48:49.242784Z","id":"8cb282d3-7d82-4348-946b-11abc82151fd","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.20.0/22","updated_at":"2025-01-27T13:48:49.242784Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:48:49.242784Z","id":"18cba5f0-8632-4b35-ae9f-b97390ab1329","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:48fa::/64","updated_at":"2025-01-27T13:48:49.242784Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:48:49.242784Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"created_at":"2025-02-11T14:22:47.248262Z","dhcp_enabled":true,"id":"01911755-02f0-4fa2-b4ac-a997b37f0961","name":"tf-pn-vibrant-hoover","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-11T14:22:47.248262Z","id":"4acdfe92-d256-48d4-a67c-02bc29bc3108","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.12.0/22","updated_at":"2025-02-11T14:22:47.248262Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-11T14:22:47.248262Z","id":"aba8b3ed-b155-467f-8c38-e1d9c0f259d3","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:e93b::/64","updated_at":"2025-02-11T14:22:47.248262Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-11T14:22:47.248262Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "1044"
+                - "1047"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:39 GMT
+                - Tue, 11 Feb 2025 14:23:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3024,10 +3024,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 58f7ee36-0f38-4ac1-a514-6edd4ccd10ba
+                - c7a0886c-be5f-49eb-be2d-7aea1542f559
         status: 200 OK
         code: 200
-        duration: 26.311333ms
+        duration: 67.419042ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -3043,8 +3043,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d
         method: GET
       response:
         proto: HTTP/2.0
@@ -3052,20 +3052,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1850
+        content_length: 1852
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-01-27T13:48:50.285107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-engelbart","id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"30","hypervisor_id":"601","node_id":"48","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:f7","maintenances":[],"modification_date":"2025-01-27T13:48:55.729736+00:00","name":"tf-srv-intelligent-engelbart","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-11T14:22:48.329567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-flamboyant-nightingale","id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"701","node_id":"90","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:e3","maintenances":[],"modification_date":"2025-02-11T14:22:53.854750+00:00","name":"tf-srv-flamboyant-nightingale","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"96fac504-4e66-47f0-bdcf-b05159266ac7","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1850"
+                - "1852"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:39 GMT
+                - Tue, 11 Feb 2025 14:23:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3073,10 +3073,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f7e55401-75a2-40c1-9c5b-0924c66abfcd
+                - b6b6edc0-20ba-4093-9048-e194f15dace6
         status: 200 OK
         code: 200
-        duration: 220.077084ms
+        duration: 189.350792ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -3092,8 +3092,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/bfb7435e-0766-4a84-9a8f-3a0726cac1a8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/96fac504-4e66-47f0-bdcf-b05159266ac7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3103,7 +3103,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"96fac504-4e66-47f0-bdcf-b05159266ac7","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -3112,9 +3112,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:39 GMT
+                - Tue, 11 Feb 2025 14:23:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3122,10 +3122,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f38b6094-56ab-47ec-ad59-338e2d6435ae
+                - c5a4c14e-71e2-4fea-9aa8-c77d6ab9e12e
         status: 404 Not Found
         code: 404
-        duration: 42.828167ms
+        duration: 38.972125ms
     - id: 63
       request:
         proto: HTTP/1.1
@@ -3141,8 +3141,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/bfb7435e-0766-4a84-9a8f-3a0726cac1a8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/96fac504-4e66-47f0-bdcf-b05159266ac7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3152,7 +3152,7 @@ interactions:
         trailer: {}
         content_length: 705
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:48:50.498860Z","id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","last_detached_at":null,"name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-01-27T13:48:50.498860Z","id":"80c5dbf4-310b-4454-986c-c92cdb8483ab","product_resource_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-01-27T13:48:50.498860Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-11T14:22:48.568538Z","id":"96fac504-4e66-47f0-bdcf-b05159266ac7","last_detached_at":null,"name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:48.568538Z","id":"7ab2f9dd-8159-47ca-9247-ad5b487af566","product_resource_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:48.568538Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "705"
@@ -3161,9 +3161,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:40 GMT
+                - Tue, 11 Feb 2025 14:23:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3171,10 +3171,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8edb0ff8-02ce-4031-a98f-dbf350b5c437
+                - 46e20abf-421e-4e2e-86c1-a736d032652d
         status: 200 OK
         code: 200
-        duration: 82.415583ms
+        duration: 76.676792ms
     - id: 64
       request:
         proto: HTTP/1.1
@@ -3190,8 +3190,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -3210,9 +3210,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:40 GMT
+                - Tue, 11 Feb 2025 14:23:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3220,10 +3220,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6badf0fb-62bb-426e-a4bd-65a2ef8d006b
+                - 742688e8-cf0a-4c76-a24f-f66a72904b44
         status: 200 OK
         code: 200
-        duration: 87.517875ms
+        duration: 96.544583ms
     - id: 65
       request:
         proto: HTTP/1.1
@@ -3239,8 +3239,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -3259,11 +3259,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:40 GMT
+                - Tue, 11 Feb 2025 14:23:38 GMT
             Link:
-                - </servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3271,12 +3271,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d4b151f2-a234-4993-acd2-aaa117d4022e
+                - 0d5b266c-2cb9-45d0-ad69-0eea7c22f36f
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 87.828917ms
+        duration: 102.270084ms
     - id: 66
       request:
         proto: HTTP/1.1
@@ -3292,8 +3292,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/03e7480d-cb49-43d9-a418-9f410f1083ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/01911755-02f0-4fa2-b4ac-a997b37f0961
         method: GET
       response:
         proto: HTTP/2.0
@@ -3301,20 +3301,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1044
+        content_length: 1047
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:48:49.242784Z","dhcp_enabled":true,"id":"03e7480d-cb49-43d9-a418-9f410f1083ef","name":"tf-pn-sad-almeida","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:48:49.242784Z","id":"8cb282d3-7d82-4348-946b-11abc82151fd","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.20.0/22","updated_at":"2025-01-27T13:48:49.242784Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:48:49.242784Z","id":"18cba5f0-8632-4b35-ae9f-b97390ab1329","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:48fa::/64","updated_at":"2025-01-27T13:48:49.242784Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:48:49.242784Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"created_at":"2025-02-11T14:22:47.248262Z","dhcp_enabled":true,"id":"01911755-02f0-4fa2-b4ac-a997b37f0961","name":"tf-pn-vibrant-hoover","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-11T14:22:47.248262Z","id":"4acdfe92-d256-48d4-a67c-02bc29bc3108","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.12.0/22","updated_at":"2025-02-11T14:22:47.248262Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-11T14:22:47.248262Z","id":"aba8b3ed-b155-467f-8c38-e1d9c0f259d3","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:e93b::/64","updated_at":"2025-02-11T14:22:47.248262Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-11T14:22:47.248262Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "1044"
+                - "1047"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:40 GMT
+                - Tue, 11 Feb 2025 14:23:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3322,10 +3322,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 38e4c818-4356-4778-8bdb-ae9c13ba4209
+                - ede2666c-cc22-4f8f-8656-d7c81c67db6a
         status: 200 OK
         code: 200
-        duration: 29.226708ms
+        duration: 37.075416ms
     - id: 67
       request:
         proto: HTTP/1.1
@@ -3341,8 +3341,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d
         method: GET
       response:
         proto: HTTP/2.0
@@ -3350,20 +3350,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1850
+        content_length: 1852
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-01-27T13:48:50.285107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-engelbart","id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"30","hypervisor_id":"601","node_id":"48","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:f7","maintenances":[],"modification_date":"2025-01-27T13:48:55.729736+00:00","name":"tf-srv-intelligent-engelbart","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-11T14:22:48.329567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-flamboyant-nightingale","id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"701","node_id":"90","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:e3","maintenances":[],"modification_date":"2025-02-11T14:22:53.854750+00:00","name":"tf-srv-flamboyant-nightingale","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"96fac504-4e66-47f0-bdcf-b05159266ac7","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1850"
+                - "1852"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:40 GMT
+                - Tue, 11 Feb 2025 14:23:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3371,10 +3371,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a59c5942-fe9f-4c05-9387-608346bd5c60
+                - bae0051a-cfe1-4a1f-8cf3-14bf39be61c2
         status: 200 OK
         code: 200
-        duration: 186.072875ms
+        duration: 169.750667ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -3390,8 +3390,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/bfb7435e-0766-4a84-9a8f-3a0726cac1a8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/96fac504-4e66-47f0-bdcf-b05159266ac7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3401,7 +3401,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"96fac504-4e66-47f0-bdcf-b05159266ac7","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -3410,9 +3410,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:40 GMT
+                - Tue, 11 Feb 2025 14:23:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3420,10 +3420,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e0e2dc1e-4e0b-4444-9a29-97a6d8cea424
+                - 8697fd34-eb4d-4e07-883a-0ef9e869773d
         status: 404 Not Found
         code: 404
-        duration: 32.485042ms
+        duration: 30.4035ms
     - id: 69
       request:
         proto: HTTP/1.1
@@ -3439,8 +3439,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/bfb7435e-0766-4a84-9a8f-3a0726cac1a8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/96fac504-4e66-47f0-bdcf-b05159266ac7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3450,7 +3450,7 @@ interactions:
         trailer: {}
         content_length: 705
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:48:50.498860Z","id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","last_detached_at":null,"name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-01-27T13:48:50.498860Z","id":"80c5dbf4-310b-4454-986c-c92cdb8483ab","product_resource_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-01-27T13:48:50.498860Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-11T14:22:48.568538Z","id":"96fac504-4e66-47f0-bdcf-b05159266ac7","last_detached_at":null,"name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:48.568538Z","id":"7ab2f9dd-8159-47ca-9247-ad5b487af566","product_resource_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:48.568538Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "705"
@@ -3459,9 +3459,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:40 GMT
+                - Tue, 11 Feb 2025 14:23:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3469,10 +3469,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 01355191-c2a4-496d-9c3d-2cf6f800189f
+                - 005c053b-08e5-49c8-895e-831c7c0d234c
         status: 200 OK
         code: 200
-        duration: 80.548833ms
+        duration: 73.73275ms
     - id: 70
       request:
         proto: HTTP/1.1
@@ -3488,8 +3488,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -3508,9 +3508,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:40 GMT
+                - Tue, 11 Feb 2025 14:23:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3518,10 +3518,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dae9efd3-b475-4fe6-8245-0f1e3e2cc746
+                - f0293d46-0ba8-4001-98bf-6b1a052cfe63
         status: 200 OK
         code: 200
-        duration: 91.973583ms
+        duration: 93.68875ms
     - id: 71
       request:
         proto: HTTP/1.1
@@ -3537,8 +3537,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -3557,11 +3557,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:40 GMT
+                - Tue, 11 Feb 2025 14:23:39 GMT
             Link:
-                - </servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3569,12 +3569,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b979e0e8-7fd3-44eb-8b15-591f0c5b9fbd
+                - af2417b1-2f40-42de-bff9-67471d01a9cc
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 94.319959ms
+        duration: 82.474416ms
     - id: 72
       request:
         proto: HTTP/1.1
@@ -3590,8 +3590,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d
         method: GET
       response:
         proto: HTTP/2.0
@@ -3599,20 +3599,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1850
+        content_length: 1852
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-01-27T13:48:50.285107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-engelbart","id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"30","hypervisor_id":"601","node_id":"48","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:f7","maintenances":[],"modification_date":"2025-01-27T13:48:55.729736+00:00","name":"tf-srv-intelligent-engelbart","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-11T14:22:48.329567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-flamboyant-nightingale","id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"701","node_id":"90","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:e3","maintenances":[],"modification_date":"2025-02-11T14:22:53.854750+00:00","name":"tf-srv-flamboyant-nightingale","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"96fac504-4e66-47f0-bdcf-b05159266ac7","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1850"
+                - "1852"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:41 GMT
+                - Tue, 11 Feb 2025 14:23:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3620,10 +3620,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7ace84f8-28c9-4fb1-95a4-1106a4dd0c9d
+                - 91d048cc-6d84-4461-b114-b8d0ce6b130a
         status: 200 OK
         code: 200
-        duration: 188.341584ms
+        duration: 199.534833ms
     - id: 73
       request:
         proto: HTTP/1.1
@@ -3639,8 +3639,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -3659,11 +3659,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:41 GMT
+                - Tue, 11 Feb 2025 14:23:40 GMT
             Link:
-                - </servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3671,12 +3671,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f2925914-163b-46d2-b9bb-a526c41f7ce0
+                - 66bd6e9d-4ba9-42ab-bf38-ae5b747c1e7f
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 87.502625ms
+        duration: 104.053708ms
     - id: 74
       request:
         proto: HTTP/1.1
@@ -3692,8 +3692,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d
         method: GET
       response:
         proto: HTTP/2.0
@@ -3701,20 +3701,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1850
+        content_length: 1852
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-01-27T13:48:50.285107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-engelbart","id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"30","hypervisor_id":"601","node_id":"48","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:f7","maintenances":[],"modification_date":"2025-01-27T13:48:55.729736+00:00","name":"tf-srv-intelligent-engelbart","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-11T14:22:48.329567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-flamboyant-nightingale","id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"701","node_id":"90","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:e3","maintenances":[],"modification_date":"2025-02-11T14:22:53.854750+00:00","name":"tf-srv-flamboyant-nightingale","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"96fac504-4e66-47f0-bdcf-b05159266ac7","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1850"
+                - "1852"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:41 GMT
+                - Tue, 11 Feb 2025 14:23:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3722,10 +3722,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ce33064c-9a00-4075-87a2-c4f873c29919
+                - a401720a-785f-4616-8057-c26fd0bc0ee7
         status: 200 OK
         code: 200
-        duration: 273.948459ms
+        duration: 174.408292ms
     - id: 75
       request:
         proto: HTTP/1.1
@@ -3737,14 +3737,14 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef"}'
+        body: '{"private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics
         method: POST
       response:
         proto: HTTP/2.0
@@ -3754,7 +3754,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:49:41.824411+00:00","id":"885cff18-19ee-4884-8565-bfa3374d440f","ipam_ip_ids":["a779dbf7-75a9-4edd-9608-d5ad091545e6","f520090f-935c-479b-8820-49dacd0af6d3"],"mac_address":"02:00:00:10:8d:e7","modification_date":"2025-01-27T13:49:42.059927+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:23:40.484372+00:00","id":"622de415-1432-4794-9c84-ca313285179b","ipam_ip_ids":["d55299ea-dbdb-4e9d-baff-82782d62e323","9b55df26-6a5f-4080-b17c-21f9a1ad1418"],"mac_address":"02:00:00:11:a8:d2","modification_date":"2025-02-11T14:23:40.696511+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -3763,9 +3763,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:42 GMT
+                - Tue, 11 Feb 2025 14:23:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3773,10 +3773,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 029d1d7f-fbd0-4744-bdec-79a07f97ee1f
+                - b997c92a-e6f8-4e8a-9915-086f26e83604
         status: 201 Created
         code: 201
-        duration: 1.158527167s
+        duration: 1.039512125s
     - id: 76
       request:
         proto: HTTP/1.1
@@ -3792,8 +3792,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics/885cff18-19ee-4884-8565-bfa3374d440f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics/622de415-1432-4794-9c84-ca313285179b
         method: GET
       response:
         proto: HTTP/2.0
@@ -3803,7 +3803,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:49:41.824411+00:00","id":"885cff18-19ee-4884-8565-bfa3374d440f","ipam_ip_ids":["a779dbf7-75a9-4edd-9608-d5ad091545e6","f520090f-935c-479b-8820-49dacd0af6d3"],"mac_address":"02:00:00:10:8d:e7","modification_date":"2025-01-27T13:49:42.059927+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:23:40.484372+00:00","id":"622de415-1432-4794-9c84-ca313285179b","ipam_ip_ids":["d55299ea-dbdb-4e9d-baff-82782d62e323","9b55df26-6a5f-4080-b17c-21f9a1ad1418"],"mac_address":"02:00:00:11:a8:d2","modification_date":"2025-02-11T14:23:40.696511+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -3812,9 +3812,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:42 GMT
+                - Tue, 11 Feb 2025 14:23:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3822,10 +3822,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2df6be51-beef-4fb4-a5b1-8332d591e5fb
+                - d1838fc2-da83-4d6e-b8c4-3803423108c9
         status: 200 OK
         code: 200
-        duration: 90.847083ms
+        duration: 85.375417ms
     - id: 77
       request:
         proto: HTTP/1.1
@@ -3841,8 +3841,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics/885cff18-19ee-4884-8565-bfa3374d440f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics/622de415-1432-4794-9c84-ca313285179b
         method: GET
       response:
         proto: HTTP/2.0
@@ -3852,7 +3852,7 @@ interactions:
         trailer: {}
         content_length: 475
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:49:41.824411+00:00","id":"885cff18-19ee-4884-8565-bfa3374d440f","ipam_ip_ids":["a779dbf7-75a9-4edd-9608-d5ad091545e6","f520090f-935c-479b-8820-49dacd0af6d3"],"mac_address":"02:00:00:10:8d:e7","modification_date":"2025-01-27T13:49:43.524812+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:23:40.484372+00:00","id":"622de415-1432-4794-9c84-ca313285179b","ipam_ip_ids":["d55299ea-dbdb-4e9d-baff-82782d62e323","9b55df26-6a5f-4080-b17c-21f9a1ad1418"],"mac_address":"02:00:00:11:a8:d2","modification_date":"2025-02-11T14:23:42.209127+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "475"
@@ -3861,9 +3861,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:47 GMT
+                - Tue, 11 Feb 2025 14:23:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3871,10 +3871,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7948681a-749a-4e7b-86b5-49694c9a57e1
+                - 8d93adda-7d98-4e77-afe9-ab10da314678
         status: 200 OK
         code: 200
-        duration: 83.767042ms
+        duration: 95.046459ms
     - id: 78
       request:
         proto: HTTP/1.1
@@ -3890,8 +3890,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics/885cff18-19ee-4884-8565-bfa3374d440f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics/622de415-1432-4794-9c84-ca313285179b
         method: GET
       response:
         proto: HTTP/2.0
@@ -3901,7 +3901,7 @@ interactions:
         trailer: {}
         content_length: 475
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:49:41.824411+00:00","id":"885cff18-19ee-4884-8565-bfa3374d440f","ipam_ip_ids":["a779dbf7-75a9-4edd-9608-d5ad091545e6","f520090f-935c-479b-8820-49dacd0af6d3"],"mac_address":"02:00:00:10:8d:e7","modification_date":"2025-01-27T13:49:43.524812+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:23:40.484372+00:00","id":"622de415-1432-4794-9c84-ca313285179b","ipam_ip_ids":["d55299ea-dbdb-4e9d-baff-82782d62e323","9b55df26-6a5f-4080-b17c-21f9a1ad1418"],"mac_address":"02:00:00:11:a8:d2","modification_date":"2025-02-11T14:23:42.209127+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "475"
@@ -3910,9 +3910,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:48 GMT
+                - Tue, 11 Feb 2025 14:23:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3920,10 +3920,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 62fa29e9-be28-4dc8-8bde-ac6813d48a0b
+                - 7c022d48-9f1d-433d-8e54-cfc45e75760c
         status: 200 OK
         code: 200
-        duration: 73.321875ms
+        duration: 109.80375ms
     - id: 79
       request:
         proto: HTTP/1.1
@@ -3939,8 +3939,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d
         method: GET
       response:
         proto: HTTP/2.0
@@ -3948,20 +3948,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2308
+        content_length: 2310
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-01-27T13:48:50.285107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-engelbart","id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"30","hypervisor_id":"601","node_id":"48","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:f7","maintenances":[],"modification_date":"2025-01-27T13:48:55.729736+00:00","name":"tf-srv-intelligent-engelbart","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:49:41.824411+00:00","id":"885cff18-19ee-4884-8565-bfa3374d440f","ipam_ip_ids":["a779dbf7-75a9-4edd-9608-d5ad091545e6","f520090f-935c-479b-8820-49dacd0af6d3"],"mac_address":"02:00:00:10:8d:e7","modification_date":"2025-01-27T13:49:43.524812+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-11T14:22:48.329567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-flamboyant-nightingale","id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"701","node_id":"90","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:e3","maintenances":[],"modification_date":"2025-02-11T14:22:53.854750+00:00","name":"tf-srv-flamboyant-nightingale","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:23:40.484372+00:00","id":"622de415-1432-4794-9c84-ca313285179b","ipam_ip_ids":["d55299ea-dbdb-4e9d-baff-82782d62e323","9b55df26-6a5f-4080-b17c-21f9a1ad1418"],"mac_address":"02:00:00:11:a8:d2","modification_date":"2025-02-11T14:23:42.209127+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"96fac504-4e66-47f0-bdcf-b05159266ac7","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2308"
+                - "2310"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:48 GMT
+                - Tue, 11 Feb 2025 14:23:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3969,10 +3969,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8424a75e-3bde-4f98-9448-cd90fd0b8e33
+                - 9fb2b897-245d-42b2-8111-8c509a76ca04
         status: 200 OK
         code: 200
-        duration: 189.709875ms
+        duration: 189.235292ms
     - id: 80
       request:
         proto: HTTP/1.1
@@ -3988,8 +3988,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d
         method: GET
       response:
         proto: HTTP/2.0
@@ -3997,20 +3997,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2308
+        content_length: 2310
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-01-27T13:48:50.285107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-engelbart","id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"30","hypervisor_id":"601","node_id":"48","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:f7","maintenances":[],"modification_date":"2025-01-27T13:48:55.729736+00:00","name":"tf-srv-intelligent-engelbart","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:49:41.824411+00:00","id":"885cff18-19ee-4884-8565-bfa3374d440f","ipam_ip_ids":["a779dbf7-75a9-4edd-9608-d5ad091545e6","f520090f-935c-479b-8820-49dacd0af6d3"],"mac_address":"02:00:00:10:8d:e7","modification_date":"2025-01-27T13:49:43.524812+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-11T14:22:48.329567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-flamboyant-nightingale","id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"701","node_id":"90","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:e3","maintenances":[],"modification_date":"2025-02-11T14:22:53.854750+00:00","name":"tf-srv-flamboyant-nightingale","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:23:40.484372+00:00","id":"622de415-1432-4794-9c84-ca313285179b","ipam_ip_ids":["d55299ea-dbdb-4e9d-baff-82782d62e323","9b55df26-6a5f-4080-b17c-21f9a1ad1418"],"mac_address":"02:00:00:11:a8:d2","modification_date":"2025-02-11T14:23:42.209127+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"96fac504-4e66-47f0-bdcf-b05159266ac7","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2308"
+                - "2310"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:48 GMT
+                - Tue, 11 Feb 2025 14:23:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4018,10 +4018,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 858e40ec-273e-4cd0-8cef-2f247d7edda5
+                - 5a39c420-f22c-4fe9-a59d-735546ccf9c3
         status: 200 OK
         code: 200
-        duration: 190.072958ms
+        duration: 207.506167ms
     - id: 81
       request:
         proto: HTTP/1.1
@@ -4037,8 +4037,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/bfb7435e-0766-4a84-9a8f-3a0726cac1a8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/96fac504-4e66-47f0-bdcf-b05159266ac7
         method: GET
       response:
         proto: HTTP/2.0
@@ -4048,7 +4048,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"96fac504-4e66-47f0-bdcf-b05159266ac7","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -4057,9 +4057,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:48 GMT
+                - Tue, 11 Feb 2025 14:23:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4067,10 +4067,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5bbd75a7-93a7-4d21-9701-b7e31f9a7486
+                - d25c0b92-033b-409c-9d65-fedad823d334
         status: 404 Not Found
         code: 404
-        duration: 46.18175ms
+        duration: 34.051708ms
     - id: 82
       request:
         proto: HTTP/1.1
@@ -4086,8 +4086,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/bfb7435e-0766-4a84-9a8f-3a0726cac1a8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/96fac504-4e66-47f0-bdcf-b05159266ac7
         method: GET
       response:
         proto: HTTP/2.0
@@ -4097,7 +4097,7 @@ interactions:
         trailer: {}
         content_length: 705
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:48:50.498860Z","id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","last_detached_at":null,"name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-01-27T13:48:50.498860Z","id":"80c5dbf4-310b-4454-986c-c92cdb8483ab","product_resource_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-01-27T13:48:50.498860Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-11T14:22:48.568538Z","id":"96fac504-4e66-47f0-bdcf-b05159266ac7","last_detached_at":null,"name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:48.568538Z","id":"7ab2f9dd-8159-47ca-9247-ad5b487af566","product_resource_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:48.568538Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "705"
@@ -4106,9 +4106,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:48 GMT
+                - Tue, 11 Feb 2025 14:23:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4116,10 +4116,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 90e2bb01-d110-4358-b56b-7ec644cdfe0a
+                - 516dbe4b-8b31-4e40-8dd2-7c8fa57c70e8
         status: 200 OK
         code: 200
-        duration: 78.757208ms
+        duration: 127.509041ms
     - id: 83
       request:
         proto: HTTP/1.1
@@ -4135,8 +4135,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -4155,9 +4155,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:48 GMT
+                - Tue, 11 Feb 2025 14:23:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4165,10 +4165,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 333f674b-4197-419e-94a2-da1935ac24a1
+                - b0be2a66-dc4f-4fc6-9be3-cad74cd48019
         status: 200 OK
         code: 200
-        duration: 79.175167ms
+        duration: 106.015208ms
     - id: 84
       request:
         proto: HTTP/1.1
@@ -4184,8 +4184,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -4195,7 +4195,7 @@ interactions:
         trailer: {}
         content_length: 478
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:49:41.824411+00:00","id":"885cff18-19ee-4884-8565-bfa3374d440f","ipam_ip_ids":["a779dbf7-75a9-4edd-9608-d5ad091545e6","f520090f-935c-479b-8820-49dacd0af6d3"],"mac_address":"02:00:00:10:8d:e7","modification_date":"2025-01-27T13:49:43.524812+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"private_nics":[{"creation_date":"2025-02-11T14:23:40.484372+00:00","id":"622de415-1432-4794-9c84-ca313285179b","ipam_ip_ids":["d55299ea-dbdb-4e9d-baff-82782d62e323","9b55df26-6a5f-4080-b17c-21f9a1ad1418"],"mac_address":"02:00:00:11:a8:d2","modification_date":"2025-02-11T14:23:42.209127+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
                 - "478"
@@ -4204,11 +4204,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:48 GMT
+                - Tue, 11 Feb 2025 14:23:47 GMT
             Link:
-                - </servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics?page=1&per_page=50&>; rel="last"
+                - </servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics?page=1&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4216,12 +4216,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6a1ec751-01db-464d-b8c7-74a38630bf34
+                - 1349693b-11af-447b-83d8-a32e57c14495
             X-Total-Count:
                 - "1"
         status: 200 OK
         code: 200
-        duration: 75.202875ms
+        duration: 164.579125ms
     - id: 85
       request:
         proto: HTTP/1.1
@@ -4237,8 +4237,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/03e7480d-cb49-43d9-a418-9f410f1083ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/01911755-02f0-4fa2-b4ac-a997b37f0961
         method: GET
       response:
         proto: HTTP/2.0
@@ -4246,20 +4246,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1044
+        content_length: 1047
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:48:49.242784Z","dhcp_enabled":true,"id":"03e7480d-cb49-43d9-a418-9f410f1083ef","name":"tf-pn-sad-almeida","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:48:49.242784Z","id":"8cb282d3-7d82-4348-946b-11abc82151fd","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.20.0/22","updated_at":"2025-01-27T13:48:49.242784Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:48:49.242784Z","id":"18cba5f0-8632-4b35-ae9f-b97390ab1329","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:48fa::/64","updated_at":"2025-01-27T13:48:49.242784Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:48:49.242784Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"created_at":"2025-02-11T14:22:47.248262Z","dhcp_enabled":true,"id":"01911755-02f0-4fa2-b4ac-a997b37f0961","name":"tf-pn-vibrant-hoover","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-11T14:22:47.248262Z","id":"4acdfe92-d256-48d4-a67c-02bc29bc3108","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.12.0/22","updated_at":"2025-02-11T14:22:47.248262Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-11T14:22:47.248262Z","id":"aba8b3ed-b155-467f-8c38-e1d9c0f259d3","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:e93b::/64","updated_at":"2025-02-11T14:22:47.248262Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-11T14:22:47.248262Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "1044"
+                - "1047"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:49 GMT
+                - Tue, 11 Feb 2025 14:23:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4267,10 +4267,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 664329f2-f010-449c-9cc0-e7fbe24c620c
+                - 0305c9cb-1d45-4b67-8a0c-62f2a2eb31ab
         status: 200 OK
         code: 200
-        duration: 33.630167ms
+        duration: 275.221167ms
     - id: 86
       request:
         proto: HTTP/1.1
@@ -4286,8 +4286,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d
         method: GET
       response:
         proto: HTTP/2.0
@@ -4295,20 +4295,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2308
+        content_length: 2310
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-01-27T13:48:50.285107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-engelbart","id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"30","hypervisor_id":"601","node_id":"48","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:f7","maintenances":[],"modification_date":"2025-01-27T13:48:55.729736+00:00","name":"tf-srv-intelligent-engelbart","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:49:41.824411+00:00","id":"885cff18-19ee-4884-8565-bfa3374d440f","ipam_ip_ids":["a779dbf7-75a9-4edd-9608-d5ad091545e6","f520090f-935c-479b-8820-49dacd0af6d3"],"mac_address":"02:00:00:10:8d:e7","modification_date":"2025-01-27T13:49:43.524812+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-11T14:22:48.329567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-flamboyant-nightingale","id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"701","node_id":"90","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:e3","maintenances":[],"modification_date":"2025-02-11T14:22:53.854750+00:00","name":"tf-srv-flamboyant-nightingale","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:23:40.484372+00:00","id":"622de415-1432-4794-9c84-ca313285179b","ipam_ip_ids":["d55299ea-dbdb-4e9d-baff-82782d62e323","9b55df26-6a5f-4080-b17c-21f9a1ad1418"],"mac_address":"02:00:00:11:a8:d2","modification_date":"2025-02-11T14:23:42.209127+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"96fac504-4e66-47f0-bdcf-b05159266ac7","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2308"
+                - "2310"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:49 GMT
+                - Tue, 11 Feb 2025 14:23:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4316,10 +4316,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bfd26668-8779-4ed1-bc4c-6c2c652c8323
+                - dc3bb426-c688-42d0-a82f-8e1bb51f5896
         status: 200 OK
         code: 200
-        duration: 170.68475ms
+        duration: 206.358375ms
     - id: 87
       request:
         proto: HTTP/1.1
@@ -4335,8 +4335,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/bfb7435e-0766-4a84-9a8f-3a0726cac1a8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/96fac504-4e66-47f0-bdcf-b05159266ac7
         method: GET
       response:
         proto: HTTP/2.0
@@ -4346,7 +4346,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"96fac504-4e66-47f0-bdcf-b05159266ac7","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -4355,9 +4355,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:49 GMT
+                - Tue, 11 Feb 2025 14:23:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4365,10 +4365,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7cea7259-8f52-449c-b0d7-3a1750467630
+                - 276b9997-a1cf-4056-9957-0248d7ecee22
         status: 404 Not Found
         code: 404
-        duration: 33.0925ms
+        duration: 26.953958ms
     - id: 88
       request:
         proto: HTTP/1.1
@@ -4384,8 +4384,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/bfb7435e-0766-4a84-9a8f-3a0726cac1a8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/96fac504-4e66-47f0-bdcf-b05159266ac7
         method: GET
       response:
         proto: HTTP/2.0
@@ -4395,7 +4395,7 @@ interactions:
         trailer: {}
         content_length: 705
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:48:50.498860Z","id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","last_detached_at":null,"name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-01-27T13:48:50.498860Z","id":"80c5dbf4-310b-4454-986c-c92cdb8483ab","product_resource_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-01-27T13:48:50.498860Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-11T14:22:48.568538Z","id":"96fac504-4e66-47f0-bdcf-b05159266ac7","last_detached_at":null,"name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:48.568538Z","id":"7ab2f9dd-8159-47ca-9247-ad5b487af566","product_resource_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:48.568538Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "705"
@@ -4404,9 +4404,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:49 GMT
+                - Tue, 11 Feb 2025 14:23:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4414,10 +4414,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f159d79a-8101-46de-8a6b-86da6870398b
+                - 6da1c33d-38f3-4ec1-8887-bc9a609d85a3
         status: 200 OK
         code: 200
-        duration: 95.777584ms
+        duration: 71.025584ms
     - id: 89
       request:
         proto: HTTP/1.1
@@ -4433,8 +4433,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -4453,9 +4453,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:49 GMT
+                - Tue, 11 Feb 2025 14:23:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4463,10 +4463,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 31caa198-3479-4afd-8ab1-f70038ec4e9b
+                - b375b315-ad94-44a5-acd8-16238d88162c
         status: 200 OK
         code: 200
-        duration: 98.934792ms
+        duration: 73.586792ms
     - id: 90
       request:
         proto: HTTP/1.1
@@ -4482,8 +4482,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -4493,7 +4493,7 @@ interactions:
         trailer: {}
         content_length: 478
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:49:41.824411+00:00","id":"885cff18-19ee-4884-8565-bfa3374d440f","ipam_ip_ids":["a779dbf7-75a9-4edd-9608-d5ad091545e6","f520090f-935c-479b-8820-49dacd0af6d3"],"mac_address":"02:00:00:10:8d:e7","modification_date":"2025-01-27T13:49:43.524812+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"private_nics":[{"creation_date":"2025-02-11T14:23:40.484372+00:00","id":"622de415-1432-4794-9c84-ca313285179b","ipam_ip_ids":["d55299ea-dbdb-4e9d-baff-82782d62e323","9b55df26-6a5f-4080-b17c-21f9a1ad1418"],"mac_address":"02:00:00:11:a8:d2","modification_date":"2025-02-11T14:23:42.209127+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
                 - "478"
@@ -4502,11 +4502,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:49 GMT
+                - Tue, 11 Feb 2025 14:23:48 GMT
             Link:
-                - </servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics?page=1&per_page=50&>; rel="last"
+                - </servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics?page=1&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4514,12 +4514,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b5bb1bb0-e252-4df3-811e-02a119d2140f
+                - d1e208fc-9a93-4659-891c-617154ce4c77
             X-Total-Count:
                 - "1"
         status: 200 OK
         code: 200
-        duration: 109.036875ms
+        duration: 86.810667ms
     - id: 91
       request:
         proto: HTTP/1.1
@@ -4535,8 +4535,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d
         method: GET
       response:
         proto: HTTP/2.0
@@ -4544,20 +4544,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2308
+        content_length: 2310
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-01-27T13:48:50.285107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-engelbart","id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"30","hypervisor_id":"601","node_id":"48","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:f7","maintenances":[],"modification_date":"2025-01-27T13:48:55.729736+00:00","name":"tf-srv-intelligent-engelbart","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:49:41.824411+00:00","id":"885cff18-19ee-4884-8565-bfa3374d440f","ipam_ip_ids":["a779dbf7-75a9-4edd-9608-d5ad091545e6","f520090f-935c-479b-8820-49dacd0af6d3"],"mac_address":"02:00:00:10:8d:e7","modification_date":"2025-01-27T13:49:43.524812+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-11T14:22:48.329567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-flamboyant-nightingale","id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"701","node_id":"90","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:e3","maintenances":[],"modification_date":"2025-02-11T14:22:53.854750+00:00","name":"tf-srv-flamboyant-nightingale","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:23:40.484372+00:00","id":"622de415-1432-4794-9c84-ca313285179b","ipam_ip_ids":["d55299ea-dbdb-4e9d-baff-82782d62e323","9b55df26-6a5f-4080-b17c-21f9a1ad1418"],"mac_address":"02:00:00:11:a8:d2","modification_date":"2025-02-11T14:23:42.209127+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"96fac504-4e66-47f0-bdcf-b05159266ac7","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2308"
+                - "2310"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:49 GMT
+                - Tue, 11 Feb 2025 14:23:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4565,10 +4565,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 918b74dd-b98b-47a7-879c-f5c83c272d92
+                - 4932cbbe-ab77-4a77-88e1-4533ff06ec0d
         status: 200 OK
         code: 200
-        duration: 198.508875ms
+        duration: 204.566417ms
     - id: 92
       request:
         proto: HTTP/1.1
@@ -4584,8 +4584,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/bfb7435e-0766-4a84-9a8f-3a0726cac1a8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/96fac504-4e66-47f0-bdcf-b05159266ac7
         method: GET
       response:
         proto: HTTP/2.0
@@ -4595,7 +4595,7 @@ interactions:
         trailer: {}
         content_length: 705
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:48:50.498860Z","id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","last_detached_at":null,"name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-01-27T13:48:50.498860Z","id":"80c5dbf4-310b-4454-986c-c92cdb8483ab","product_resource_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-01-27T13:48:50.498860Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-11T14:22:48.568538Z","id":"96fac504-4e66-47f0-bdcf-b05159266ac7","last_detached_at":null,"name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:48.568538Z","id":"7ab2f9dd-8159-47ca-9247-ad5b487af566","product_resource_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:48.568538Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "705"
@@ -4604,9 +4604,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:50 GMT
+                - Tue, 11 Feb 2025 14:23:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4614,10 +4614,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0da0d66b-bb3d-4982-bd8d-7027ede15305
+                - 358c06ba-5761-4142-bbb4-e4617b924ce3
         status: 200 OK
         code: 200
-        duration: 73.042333ms
+        duration: 74.306542ms
     - id: 93
       request:
         proto: HTTP/1.1
@@ -4635,8 +4635,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -4646,7 +4646,7 @@ interactions:
         trailer: {}
         content_length: 352
         uncompressed: false
-        body: '{"task":{"description":"server_poweroff","href_from":"/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/action","href_result":"/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5","id":"bfcaa71e-27e6-48fa-afd2-c28dff547f06","progress":0,"started_at":"2025-01-27T13:49:50.481723+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_poweroff","href_from":"/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/action","href_result":"/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d","id":"df7d3b6c-245a-4cd3-9ae2-681ecc29d241","progress":0,"started_at":"2025-02-11T14:23:49.465844+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "352"
@@ -4655,11 +4655,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:50 GMT
+                - Tue, 11 Feb 2025 14:23:49 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/bfcaa71e-27e6-48fa-afd2-c28dff547f06
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/df7d3b6c-245a-4cd3-9ae2-681ecc29d241
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4667,10 +4667,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 726cc390-de40-4701-8998-288acd4777f8
+                - 081412cf-4573-4eb8-9294-a9b911a973ac
         status: 202 Accepted
         code: 202
-        duration: 254.537125ms
+        duration: 251.313917ms
     - id: 94
       request:
         proto: HTTP/1.1
@@ -4686,8 +4686,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d
         method: GET
       response:
         proto: HTTP/2.0
@@ -4695,20 +4695,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2268
+        content_length: 2270
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-01-27T13:48:50.285107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-engelbart","id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"30","hypervisor_id":"601","node_id":"48","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:f7","maintenances":[],"modification_date":"2025-01-27T13:49:50.287939+00:00","name":"tf-srv-intelligent-engelbart","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:49:41.824411+00:00","id":"885cff18-19ee-4884-8565-bfa3374d440f","ipam_ip_ids":["a779dbf7-75a9-4edd-9608-d5ad091545e6","f520090f-935c-479b-8820-49dacd0af6d3"],"mac_address":"02:00:00:10:8d:e7","modification_date":"2025-01-27T13:49:43.524812+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-11T14:22:48.329567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-flamboyant-nightingale","id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"701","node_id":"90","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:e3","maintenances":[],"modification_date":"2025-02-11T14:23:49.274964+00:00","name":"tf-srv-flamboyant-nightingale","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:23:40.484372+00:00","id":"622de415-1432-4794-9c84-ca313285179b","ipam_ip_ids":["d55299ea-dbdb-4e9d-baff-82782d62e323","9b55df26-6a5f-4080-b17c-21f9a1ad1418"],"mac_address":"02:00:00:11:a8:d2","modification_date":"2025-02-11T14:23:42.209127+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"96fac504-4e66-47f0-bdcf-b05159266ac7","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2268"
+                - "2270"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:50 GMT
+                - Tue, 11 Feb 2025 14:23:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4716,10 +4716,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6726cce7-7f8c-430d-a937-8d469b4ba1c8
+                - 512e258a-6fe2-4607-b2fc-60eebe75d042
         status: 200 OK
         code: 200
-        duration: 202.164916ms
+        duration: 160.841209ms
     - id: 95
       request:
         proto: HTTP/1.1
@@ -4735,8 +4735,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d
         method: GET
       response:
         proto: HTTP/2.0
@@ -4744,20 +4744,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2268
+        content_length: 2270
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-01-27T13:48:50.285107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-engelbart","id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"30","hypervisor_id":"601","node_id":"48","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:f7","maintenances":[],"modification_date":"2025-01-27T13:49:50.287939+00:00","name":"tf-srv-intelligent-engelbart","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:49:41.824411+00:00","id":"885cff18-19ee-4884-8565-bfa3374d440f","ipam_ip_ids":["a779dbf7-75a9-4edd-9608-d5ad091545e6","f520090f-935c-479b-8820-49dacd0af6d3"],"mac_address":"02:00:00:10:8d:e7","modification_date":"2025-01-27T13:49:43.524812+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-11T14:22:48.329567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-flamboyant-nightingale","id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"701","node_id":"90","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:e3","maintenances":[],"modification_date":"2025-02-11T14:23:49.274964+00:00","name":"tf-srv-flamboyant-nightingale","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:23:40.484372+00:00","id":"622de415-1432-4794-9c84-ca313285179b","ipam_ip_ids":["d55299ea-dbdb-4e9d-baff-82782d62e323","9b55df26-6a5f-4080-b17c-21f9a1ad1418"],"mac_address":"02:00:00:11:a8:d2","modification_date":"2025-02-11T14:23:42.209127+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"96fac504-4e66-47f0-bdcf-b05159266ac7","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2268"
+                - "2270"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:55 GMT
+                - Tue, 11 Feb 2025 14:23:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4765,10 +4765,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 290425c1-227c-44d2-ae1f-d59dc18333f3
+                - a95d130b-487e-4fa0-a2bd-167923b4ef03
         status: 200 OK
         code: 200
-        duration: 186.65375ms
+        duration: 180.107458ms
     - id: 96
       request:
         proto: HTTP/1.1
@@ -4784,8 +4784,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d
         method: GET
       response:
         proto: HTTP/2.0
@@ -4793,20 +4793,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2268
+        content_length: 2270
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-01-27T13:48:50.285107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-engelbart","id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"30","hypervisor_id":"601","node_id":"48","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:f7","maintenances":[],"modification_date":"2025-01-27T13:49:50.287939+00:00","name":"tf-srv-intelligent-engelbart","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:49:41.824411+00:00","id":"885cff18-19ee-4884-8565-bfa3374d440f","ipam_ip_ids":["a779dbf7-75a9-4edd-9608-d5ad091545e6","f520090f-935c-479b-8820-49dacd0af6d3"],"mac_address":"02:00:00:10:8d:e7","modification_date":"2025-01-27T13:49:43.524812+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-11T14:22:48.329567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-flamboyant-nightingale","id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"701","node_id":"90","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:e3","maintenances":[],"modification_date":"2025-02-11T14:23:49.274964+00:00","name":"tf-srv-flamboyant-nightingale","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:23:40.484372+00:00","id":"622de415-1432-4794-9c84-ca313285179b","ipam_ip_ids":["d55299ea-dbdb-4e9d-baff-82782d62e323","9b55df26-6a5f-4080-b17c-21f9a1ad1418"],"mac_address":"02:00:00:11:a8:d2","modification_date":"2025-02-11T14:23:42.209127+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"96fac504-4e66-47f0-bdcf-b05159266ac7","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2268"
+                - "2270"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:01 GMT
+                - Tue, 11 Feb 2025 14:23:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4814,10 +4814,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d51a9906-b64d-49cc-ae39-4944a3088503
+                - 48d148a2-717c-4780-acda-b80917e2227e
         status: 200 OK
         code: 200
-        duration: 187.567416ms
+        duration: 178.778542ms
     - id: 97
       request:
         proto: HTTP/1.1
@@ -4833,8 +4833,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d
         method: GET
       response:
         proto: HTTP/2.0
@@ -4842,20 +4842,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2268
+        content_length: 2270
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-01-27T13:48:50.285107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-engelbart","id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"30","hypervisor_id":"601","node_id":"48","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:f7","maintenances":[],"modification_date":"2025-01-27T13:49:50.287939+00:00","name":"tf-srv-intelligent-engelbart","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:49:41.824411+00:00","id":"885cff18-19ee-4884-8565-bfa3374d440f","ipam_ip_ids":["a779dbf7-75a9-4edd-9608-d5ad091545e6","f520090f-935c-479b-8820-49dacd0af6d3"],"mac_address":"02:00:00:10:8d:e7","modification_date":"2025-01-27T13:49:43.524812+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-11T14:22:48.329567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-flamboyant-nightingale","id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"701","node_id":"90","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:e3","maintenances":[],"modification_date":"2025-02-11T14:23:49.274964+00:00","name":"tf-srv-flamboyant-nightingale","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:23:40.484372+00:00","id":"622de415-1432-4794-9c84-ca313285179b","ipam_ip_ids":["d55299ea-dbdb-4e9d-baff-82782d62e323","9b55df26-6a5f-4080-b17c-21f9a1ad1418"],"mac_address":"02:00:00:11:a8:d2","modification_date":"2025-02-11T14:23:42.209127+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"96fac504-4e66-47f0-bdcf-b05159266ac7","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2268"
+                - "2270"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:05 GMT
+                - Tue, 11 Feb 2025 14:24:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4863,10 +4863,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 102ea02f-75b4-4fa4-883a-7d0deb292883
+                - 88154d64-b3d4-486f-aca3-7103af394125
         status: 200 OK
         code: 200
-        duration: 210.4715ms
+        duration: 191.191209ms
     - id: 98
       request:
         proto: HTTP/1.1
@@ -4882,8 +4882,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d
         method: GET
       response:
         proto: HTTP/2.0
@@ -4891,20 +4891,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2152
+        content_length: 2154
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-01-27T13:48:50.285107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-engelbart","id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f7","maintenances":[],"modification_date":"2025-01-27T13:50:08.643449+00:00","name":"tf-srv-intelligent-engelbart","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:49:41.824411+00:00","id":"885cff18-19ee-4884-8565-bfa3374d440f","ipam_ip_ids":["a779dbf7-75a9-4edd-9608-d5ad091545e6","f520090f-935c-479b-8820-49dacd0af6d3"],"mac_address":"02:00:00:10:8d:e7","modification_date":"2025-01-27T13:49:43.524812+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-11T14:22:48.329567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-flamboyant-nightingale","id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e3","maintenances":[],"modification_date":"2025-02-11T14:24:05.276073+00:00","name":"tf-srv-flamboyant-nightingale","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:23:40.484372+00:00","id":"622de415-1432-4794-9c84-ca313285179b","ipam_ip_ids":["d55299ea-dbdb-4e9d-baff-82782d62e323","9b55df26-6a5f-4080-b17c-21f9a1ad1418"],"mac_address":"02:00:00:11:a8:d2","modification_date":"2025-02-11T14:23:42.209127+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"96fac504-4e66-47f0-bdcf-b05159266ac7","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2152"
+                - "2154"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:11 GMT
+                - Tue, 11 Feb 2025 14:24:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4912,10 +4912,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3981c03a-13e3-4900-8c38-b099a2dc89ce
+                - 2a5978c0-be4c-40e9-bea8-14dfcee805e9
         status: 200 OK
         code: 200
-        duration: 231.858458ms
+        duration: 165.968916ms
     - id: 99
       request:
         proto: HTTP/1.1
@@ -4931,8 +4931,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -4942,7 +4942,7 @@ interactions:
         trailer: {}
         content_length: 478
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:49:41.824411+00:00","id":"885cff18-19ee-4884-8565-bfa3374d440f","ipam_ip_ids":["a779dbf7-75a9-4edd-9608-d5ad091545e6","f520090f-935c-479b-8820-49dacd0af6d3"],"mac_address":"02:00:00:10:8d:e7","modification_date":"2025-01-27T13:49:43.524812+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"private_nics":[{"creation_date":"2025-02-11T14:23:40.484372+00:00","id":"622de415-1432-4794-9c84-ca313285179b","ipam_ip_ids":["d55299ea-dbdb-4e9d-baff-82782d62e323","9b55df26-6a5f-4080-b17c-21f9a1ad1418"],"mac_address":"02:00:00:11:a8:d2","modification_date":"2025-02-11T14:23:42.209127+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
                 - "478"
@@ -4951,11 +4951,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:11 GMT
+                - Tue, 11 Feb 2025 14:24:10 GMT
             Link:
-                - </servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics?page=1&per_page=50&>; rel="last"
+                - </servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics?page=1&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4963,12 +4963,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7324e9bf-c316-4206-9ee9-9d740fab25b0
+                - ec54cc93-8fa1-422e-bbdf-f5fd0480c047
             X-Total-Count:
                 - "1"
         status: 200 OK
         code: 200
-        duration: 93.841042ms
+        duration: 85.412916ms
     - id: 100
       request:
         proto: HTTP/1.1
@@ -4984,8 +4984,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics/885cff18-19ee-4884-8565-bfa3374d440f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics/622de415-1432-4794-9c84-ca313285179b
         method: GET
       response:
         proto: HTTP/2.0
@@ -4995,7 +4995,7 @@ interactions:
         trailer: {}
         content_length: 475
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:49:41.824411+00:00","id":"885cff18-19ee-4884-8565-bfa3374d440f","ipam_ip_ids":["a779dbf7-75a9-4edd-9608-d5ad091545e6","f520090f-935c-479b-8820-49dacd0af6d3"],"mac_address":"02:00:00:10:8d:e7","modification_date":"2025-01-27T13:49:43.524812+00:00","private_network_id":"03e7480d-cb49-43d9-a418-9f410f1083ef","server_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:23:40.484372+00:00","id":"622de415-1432-4794-9c84-ca313285179b","ipam_ip_ids":["d55299ea-dbdb-4e9d-baff-82782d62e323","9b55df26-6a5f-4080-b17c-21f9a1ad1418"],"mac_address":"02:00:00:11:a8:d2","modification_date":"2025-02-11T14:23:42.209127+00:00","private_network_id":"01911755-02f0-4fa2-b4ac-a997b37f0961","server_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "475"
@@ -5004,9 +5004,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:11 GMT
+                - Tue, 11 Feb 2025 14:24:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5014,10 +5014,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d40dfdeb-82bc-4733-9ed2-0745fbb46598
+                - 8ade01ee-9536-49f9-94c1-d3e4ff64466e
         status: 200 OK
         code: 200
-        duration: 151.115583ms
+        duration: 86.271334ms
     - id: 101
       request:
         proto: HTTP/1.1
@@ -5033,8 +5033,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics/885cff18-19ee-4884-8565-bfa3374d440f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics/622de415-1432-4794-9c84-ca313285179b
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5051,9 +5051,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:11 GMT
+                - Tue, 11 Feb 2025 14:24:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5061,10 +5061,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2ce6d017-aae0-4b4f-9569-6b12fe9c9b83
+                - 58ec59bb-ce63-4bb7-9fe3-87abc07c8acb
         status: 204 No Content
         code: 204
-        duration: 254.719666ms
+        duration: 333.119583ms
     - id: 102
       request:
         proto: HTTP/1.1
@@ -5080,8 +5080,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5/private_nics/885cff18-19ee-4884-8565-bfa3374d440f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d/private_nics/622de415-1432-4794-9c84-ca313285179b
         method: GET
       response:
         proto: HTTP/2.0
@@ -5091,7 +5091,7 @@ interactions:
         trailer: {}
         content_length: 148
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"885cff18-19ee-4884-8565-bfa3374d440f","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"622de415-1432-4794-9c84-ca313285179b","type":"not_found"}'
         headers:
             Content-Length:
                 - "148"
@@ -5100,9 +5100,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:11 GMT
+                - Tue, 11 Feb 2025 14:24:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5110,10 +5110,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 75e0fc08-43fb-4690-9142-1d52ef661ea6
+                - f7b6865c-d7fb-41dd-af5e-bff2bc44ef09
         status: 404 Not Found
         code: 404
-        duration: 113.721709ms
+        duration: 109.529834ms
     - id: 103
       request:
         proto: HTTP/1.1
@@ -5129,8 +5129,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d
         method: GET
       response:
         proto: HTTP/2.0
@@ -5138,20 +5138,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1694
+        content_length: 1696
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-01-27T13:48:50.285107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-intelligent-engelbart","id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:f7","maintenances":[],"modification_date":"2025-01-27T13:50:08.643449+00:00","name":"tf-srv-intelligent-engelbart","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"PLAY2-PICO","creation_date":"2025-02-11T14:22:48.329567+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-flamboyant-nightingale","id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:e3","maintenances":[],"modification_date":"2025-02-11T14:24:05.276073+00:00","name":"tf-srv-flamboyant-nightingale","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"96fac504-4e66-47f0-bdcf-b05159266ac7","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1694"
+                - "1696"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:11 GMT
+                - Tue, 11 Feb 2025 14:24:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5159,10 +5159,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1124696d-8ec0-4989-a8c1-d8ae60ba1cd3
+                - d932735c-eb24-4b13-a064-43bc7c58ceb3
         status: 200 OK
         code: 200
-        duration: 170.575375ms
+        duration: 138.685ms
     - id: 104
       request:
         proto: HTTP/1.1
@@ -5178,8 +5178,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5196,9 +5196,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:12 GMT
+                - Tue, 11 Feb 2025 14:24:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5206,10 +5206,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 56c97304-2d61-4e5e-b0c2-5eb534fd17ce
+                - 26977be3-3a42-4b2e-b7c9-6a2df62de850
         status: 204 No Content
         code: 204
-        duration: 256.831541ms
+        duration: 230.635292ms
     - id: 105
       request:
         proto: HTTP/1.1
@@ -5225,8 +5225,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d
         method: GET
       response:
         proto: HTTP/2.0
@@ -5236,7 +5236,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -5245,9 +5245,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:12 GMT
+                - Tue, 11 Feb 2025 14:24:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5255,10 +5255,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8ac75477-e7bd-4123-826f-24b17b0d0d05
+                - 78330ea0-a305-4ff0-bc7a-8179790db8ff
         status: 404 Not Found
         code: 404
-        duration: 170.802042ms
+        duration: 109.922542ms
     - id: 106
       request:
         proto: HTTP/1.1
@@ -5274,8 +5274,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/bfb7435e-0766-4a84-9a8f-3a0726cac1a8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/96fac504-4e66-47f0-bdcf-b05159266ac7
         method: GET
       response:
         proto: HTTP/2.0
@@ -5285,7 +5285,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"96fac504-4e66-47f0-bdcf-b05159266ac7","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -5294,9 +5294,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:12 GMT
+                - Tue, 11 Feb 2025 14:24:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5304,10 +5304,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dd94da5f-b520-4289-ad05-bf5e5cb2e250
+                - dad8136c-5678-403d-8c95-fe1f77e93e43
         status: 404 Not Found
         code: 404
-        duration: 41.46375ms
+        duration: 35.563666ms
     - id: 107
       request:
         proto: HTTP/1.1
@@ -5323,8 +5323,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/bfb7435e-0766-4a84-9a8f-3a0726cac1a8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/96fac504-4e66-47f0-bdcf-b05159266ac7
         method: GET
       response:
         proto: HTTP/2.0
@@ -5334,7 +5334,7 @@ interactions:
         trailer: {}
         content_length: 498
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:48:50.498860Z","id":"bfb7435e-0766-4a84-9a8f-3a0726cac1a8","last_detached_at":"2025-01-27T13:50:12.651910Z","name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-01-27T13:50:12.651910Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-11T14:22:48.568538Z","id":"96fac504-4e66-47f0-bdcf-b05159266ac7","last_detached_at":"2025-02-11T14:24:11.463634Z","name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:24:11.463634Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "498"
@@ -5343,9 +5343,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:12 GMT
+                - Tue, 11 Feb 2025 14:24:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5353,10 +5353,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 15f1882e-50af-4031-9329-50ee78e1830c
+                - 43c040db-7796-472f-8b34-155e3a416112
         status: 200 OK
         code: 200
-        duration: 71.991042ms
+        duration: 69.930083ms
     - id: 108
       request:
         proto: HTTP/1.1
@@ -5372,8 +5372,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/bfb7435e-0766-4a84-9a8f-3a0726cac1a8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/96fac504-4e66-47f0-bdcf-b05159266ac7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5390,9 +5390,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:13 GMT
+                - Tue, 11 Feb 2025 14:24:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5400,10 +5400,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a0518ea7-5d93-4729-b36a-7420d5be7be5
+                - 8842b2b0-8b32-493a-b75b-29ce18da33e6
         status: 204 No Content
         code: 204
-        duration: 132.145417ms
+        duration: 109.511375ms
     - id: 109
       request:
         proto: HTTP/1.1
@@ -5419,8 +5419,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/03e7480d-cb49-43d9-a418-9f410f1083ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/01911755-02f0-4fa2-b4ac-a997b37f0961
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5437,9 +5437,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:14 GMT
+                - Tue, 11 Feb 2025 14:24:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5447,10 +5447,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a6f8f097-37f5-4320-b030-80840c70196f
+                - 58ceb241-6739-43da-864e-f0cbb7bb4a4d
         status: 204 No Content
         code: 204
-        duration: 1.232640375s
+        duration: 999.987292ms
     - id: 110
       request:
         proto: HTTP/1.1
@@ -5466,8 +5466,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1e48453-aa93-48e8-9838-22bfc19b27d5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44ec4832-cd95-4716-b1e9-69cee8eae97d
         method: GET
       response:
         proto: HTTP/2.0
@@ -5477,7 +5477,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"d1e48453-aa93-48e8-9838-22bfc19b27d5","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"44ec4832-cd95-4716-b1e9-69cee8eae97d","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -5486,9 +5486,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:14 GMT
+                - Tue, 11 Feb 2025 14:24:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5496,7 +5496,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 535c2d4b-7829-455c-aae6-031a6d518aae
+                - b3756026-529c-4163-9e0d-e50d55d69ea1
         status: 404 Not Found
         code: 404
-        duration: 100.764667ms
+        duration: 96.895916ms

--- a/internal/services/instance/testdata/server-private-network.cassette.yaml
+++ b/internal/services/instance/testdata/server-private-network.cassette.yaml
@@ -18,7 +18,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1050
+        content_length: 1051
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:51:59.584261Z","dhcp_enabled":true,"id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:51:59.584261Z","id":"7effac1e-03c4-473b-99ff-5259a5d3cc41","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.8.0/22","updated_at":"2025-01-27T13:51:59.584261Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:51:59.584261Z","id":"c06b449d-e2da-4e6c-a951-0db8d17df196","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:b07a::/64","updated_at":"2025-01-27T13:51:59.584261Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:51:59.584261Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"created_at":"2025-02-11T14:22:36.064186Z","dhcp_enabled":true,"id":"838071ad-2943-4cd4-87e0-15285d88c11b","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-11T14:22:36.064186Z","id":"40e28a62-f6cf-4cf9-9c29-2964e8d97d16","private_network_id":"838071ad-2943-4cd4-87e0-15285d88c11b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.20.0/22","updated_at":"2025-02-11T14:22:36.064186Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-11T14:22:36.064186Z","id":"ab4f087f-1a81-4623-aabb-393b531352ed","private_network_id":"838071ad-2943-4cd4-87e0-15285d88c11b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:58e0::/64","updated_at":"2025-02-11T14:22:36.064186Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-11T14:22:36.064186Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "1050"
+                - "1051"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:00 GMT
+                - Tue, 11 Feb 2025 14:22:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fb820cab-24bb-49c3-bf97-2cc1e7e2da78
+                - 73ad53b0-fa25-4d6a-9a93-50f27d3c33dd
         status: 200 OK
         code: 200
-        duration: 579.297375ms
+        duration: 1.055995917s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/201b8529-612e-4452-93f5-c7b9a38ee2c7
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/838071ad-2943-4cd4-87e0-15285d88c11b
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1050
+        content_length: 1051
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:51:59.584261Z","dhcp_enabled":true,"id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:51:59.584261Z","id":"7effac1e-03c4-473b-99ff-5259a5d3cc41","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.8.0/22","updated_at":"2025-01-27T13:51:59.584261Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:51:59.584261Z","id":"c06b449d-e2da-4e6c-a951-0db8d17df196","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:b07a::/64","updated_at":"2025-01-27T13:51:59.584261Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:51:59.584261Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"created_at":"2025-02-11T14:22:36.064186Z","dhcp_enabled":true,"id":"838071ad-2943-4cd4-87e0-15285d88c11b","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-11T14:22:36.064186Z","id":"40e28a62-f6cf-4cf9-9c29-2964e8d97d16","private_network_id":"838071ad-2943-4cd4-87e0-15285d88c11b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.20.0/22","updated_at":"2025-02-11T14:22:36.064186Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-11T14:22:36.064186Z","id":"ab4f087f-1a81-4623-aabb-393b531352ed","private_network_id":"838071ad-2943-4cd4-87e0-15285d88c11b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:58e0::/64","updated_at":"2025-02-11T14:22:36.064186Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-11T14:22:36.064186Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "1050"
+                - "1051"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:00 GMT
+                - Tue, 11 Feb 2025 14:22:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 457394c8-bd0d-4d3d-943e-baaa67eda18e
+                - 531d721a-4860-495b-ad88-564cd5f7b253
         status: 200 OK
         code: 200
-        duration: 26.226083ms
+        duration: 90.569125ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -116,7 +116,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-2/products/servers?page=1
         method: GET
       response:
@@ -125,22 +125,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 38575
+        content_length: 35675
         uncompressed: false
-        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"GPU-3070-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":0.98,"mig_profile":null,"monthly_price":715.4,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":2500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2500000000}],"ipv6_support":true,"sum_internal_bandwidth":2500000000,"sum_internet_bandwidth":2500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"H100-1-80G":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":2.73,"mig_profile":null,"monthly_price":1992.9,"ncpus":24,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":257698037760,"scratch_storage_max_size":3000000000000,"volumes_constraint":{"max_size":0,"min_size":0}},"H100-1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":4.2,"mig_profile":null,"monthly_price":3066,"ncpus":24,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":257698037760,"scratch_storage_max_size":3000000000000,"volumes_constraint":{"max_size":0,"min_size":0}},"H100-2-80G":{"alt_names":[],"arch":"x86_64","block_bandwidth":4194304000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":2,"hourly_price":5.46,"mig_profile":null,"monthly_price":3985.8,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":515396075520,"scratch_storage_max_size":6000000000000,"volumes_constraint":{"max_size":0,"min_size":0}},"H100-2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":4194304000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":2,"hourly_price":8.4,"mig_profile":null,"monthly_price":6132,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":515396075520,"scratch_storage_max_size":6000000000000,"volumes_constraint":{"max_size":0,"min_size":0}},"L4-1-24G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":0.75,"mig_profile":null,"monthly_price":547.5,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":2500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2500000000}],"ipv6_support":true,"sum_internal_bandwidth":2500000000,"sum_internet_bandwidth":2500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":51539607552,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"L4-2-24G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1572864000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":2,"hourly_price":1.5,"mig_profile":null,"monthly_price":1095,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":103079215104,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"L4-4-24G":{"alt_names":[],"arch":"x86_64","block_bandwidth":2621440000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":4,"hourly_price":3,"mig_profile":null,"monthly_price":2190,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":206158430208,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"L4-8-24G":{"alt_names":[],"arch":"x86_64","block_bandwidth":5242880000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":8,"hourly_price":6,"mig_profile":null,"monthly_price":4380,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"L40S-1-48G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.4,"mig_profile":null,"monthly_price":1022,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":2500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2500000000}],"ipv6_support":true,"sum_internal_bandwidth":2500000000,"sum_internet_bandwidth":2500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":103079215104,"scratch_storage_max_size":1600000000000,"volumes_constraint":{"max_size":0,"min_size":0}},"L40S-2-48G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1572864000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":2,"hourly_price":2.8,"mig_profile":null,"monthly_price":2044,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":206158430208,"scratch_storage_max_size":3200000000000,"volumes_constraint":{"max_size":0,"min_size":0}},"L40S-4-48G":{"alt_names":[],"arch":"x86_64","block_bandwidth":2621440000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":4,"hourly_price":5.6,"mig_profile":null,"monthly_price":4088,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":6400000000000,"volumes_constraint":{"max_size":0,"min_size":0}},"L40S-8-48G":{"alt_names":[],"arch":"x86_64","block_bandwidth":5242880000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":8,"hourly_price":11.2,"mig_profile":null,"monthly_price":8176,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":824633720832,"scratch_storage_max_size":12800000000000,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
+        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"GPU-3070-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":0.98,"mig_profile":null,"monthly_price":715.4,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":2500000000,"internet_bandwidth":2500000000}],"ipv6_support":true,"sum_internal_bandwidth":2500000000,"sum_internet_bandwidth":2500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"H100-1-80G":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":2.73,"mig_profile":null,"monthly_price":1992.9,"ncpus":24,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":257698037760,"scratch_storage_max_size":3000000000000,"volumes_constraint":{"max_size":0,"min_size":0}},"H100-1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":4.2,"mig_profile":null,"monthly_price":3066,"ncpus":24,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":257698037760,"scratch_storage_max_size":3000000000000,"volumes_constraint":{"max_size":0,"min_size":0}},"H100-2-80G":{"alt_names":[],"arch":"x86_64","block_bandwidth":4194304000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":2,"hourly_price":5.46,"mig_profile":null,"monthly_price":3985.8,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":515396075520,"scratch_storage_max_size":6000000000000,"volumes_constraint":{"max_size":0,"min_size":0}},"H100-2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":4194304000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":2,"hourly_price":8.4,"mig_profile":null,"monthly_price":6132,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":515396075520,"scratch_storage_max_size":6000000000000,"volumes_constraint":{"max_size":0,"min_size":0}},"L4-1-24G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":0.75,"mig_profile":null,"monthly_price":547.5,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":2500000000,"internet_bandwidth":2500000000}],"ipv6_support":true,"sum_internal_bandwidth":2500000000,"sum_internet_bandwidth":2500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":51539607552,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"L4-2-24G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1572864000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":2,"hourly_price":1.5,"mig_profile":null,"monthly_price":1095,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":103079215104,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"L4-4-24G":{"alt_names":[],"arch":"x86_64","block_bandwidth":2621440000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":4,"hourly_price":3,"mig_profile":null,"monthly_price":2190,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":206158430208,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"L4-8-24G":{"alt_names":[],"arch":"x86_64","block_bandwidth":5242880000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":8,"hourly_price":6,"mig_profile":null,"monthly_price":4380,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"L40S-1-48G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.4,"mig_profile":null,"monthly_price":1022,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":2500000000,"internet_bandwidth":2500000000}],"ipv6_support":true,"sum_internal_bandwidth":2500000000,"sum_internet_bandwidth":2500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":103079215104,"scratch_storage_max_size":1600000000000,"volumes_constraint":{"max_size":0,"min_size":0}},"L40S-2-48G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1572864000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":2,"hourly_price":2.8,"mig_profile":null,"monthly_price":2044,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":206158430208,"scratch_storage_max_size":3200000000000,"volumes_constraint":{"max_size":0,"min_size":0}},"L40S-4-48G":{"alt_names":[],"arch":"x86_64","block_bandwidth":2621440000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":4,"hourly_price":5.6,"mig_profile":null,"monthly_price":4088,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":6400000000000,"volumes_constraint":{"max_size":0,"min_size":0}},"L40S-8-48G":{"alt_names":[],"arch":"x86_64","block_bandwidth":5242880000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":8,"hourly_price":11.2,"mig_profile":null,"monthly_price":8176,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":824633720832,"scratch_storage_max_size":12800000000000,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
         headers:
             Content-Length:
-                - "38575"
+                - "35675"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:00 GMT
+                - Tue, 11 Feb 2025 14:22:36 GMT
             Link:
                 - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -148,12 +148,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0e265cbe-95a6-411d-aaab-a237f54019c8
+                - 64ce3a4a-ed8e-41dc-be79-dd074c4f1e20
             X-Total-Count:
                 - "69"
         status: 200 OK
         code: 200
-        duration: 43.196416ms
+        duration: 36.176709ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -169,7 +169,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-2/products/servers?page=2
         method: GET
       response:
@@ -178,22 +178,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 14604
+        content_length: 13502
         uncompressed: false
-        body: '{"servers":{"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}}}}'
+        body: '{"servers":{"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}}}}'
         headers:
             Content-Length:
-                - "14604"
+                - "13502"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:00 GMT
+                - Tue, 11 Feb 2025 14:22:36 GMT
             Link:
                 - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -201,12 +201,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a0547d0c-b9e7-48a2-8fd5-c26409e8b21e
+                - ae1bf68d-293f-4ffd-8cce-32a8bdeab6ab
             X-Total-Count:
                 - "69"
         status: 200 OK
         code: 200
-        duration: 52.868125ms
+        duration: 48.538458ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -222,8 +222,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_local&zone=fr-par-2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_sbs&zone=fr-par-2
         method: GET
       response:
         proto: HTTP/2.0
@@ -231,20 +231,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1285
+        content_length: 1281
         uncompressed: false
-        body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"887bb4d9-1487-42c3-81fe-5ddda627b115","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-2"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"a52aee59-c5cf-44d0-915e-6bf8da8e87f7","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-2"}],"total_count":2}'
+        body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"458bd724-e3e9-4c9a-8e05-f21fb365ff7a","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-2"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"a4a91637-cfbf-4a45-be29-9795d04c4f98","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-2"}],"total_count":2}'
         headers:
             Content-Length:
-                - "1285"
+                - "1281"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:00 GMT
+                - Tue, 11 Feb 2025 14:22:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -252,28 +252,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 50d8647b-0deb-4276-bbe8-2b0bd7658da0
+                - c1bbd0af-331a-4c01-92f4-bd04dcea020d
         status: 200 OK
         code: 200
-        duration: 67.613083ms
+        duration: 85.081ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 280
+        content_length: 232
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-srv-serene-grothendieck","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"a52aee59-c5cf-44d0-915e-6bf8da8e87f7","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+        body: '{"name":"tf-srv-keen-swirles","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"a4a91637-cfbf-4a45-be29-9795d04c4f98","volumes":{"0":{"boot":false}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers
         method: POST
       response:
@@ -282,22 +282,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2130
+        content_length: 1668
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:00.725315+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-serene-grothendieck","id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.713123+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a52aee59-c5cf-44d0-915e-6bf8da8e87f7","modification_date":"2024-10-14T09:05:23.713123+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"9490ba87-565a-4ba4-998f-b8cf2b7b3b6f","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":null,"mac_address":"de:00:00:68:de:5f","maintenances":[],"modification_date":"2025-01-27T13:52:00.725315+00:00","name":"tf-srv-serene-grothendieck","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:00.725315+00:00","export_uri":null,"id":"6e5d5152-3105-42ab-a4f9-00e41036aeb8","modification_date":"2025-01-27T13:52:00.725315+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","name":"tf-srv-serene-grothendieck"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.318589+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-keen-swirles","id":"1774b008-62b8-473c-bffd-8b29b9d852c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.426391+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a4a91637-cfbf-4a45-be29-9795d04c4f98","modification_date":"2024-10-14T09:05:23.426391+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4658bc98-1c87-4dfe-8dae-fa0dc563a43e","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":null,"mac_address":"de:00:00:6b:08:f9","maintenances":[],"modification_date":"2025-02-11T14:22:37.318589+00:00","name":"tf-srv-keen-swirles","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"2953faa1-9cf4-4f7a-a33f-21ce47364692","volume_type":"sbs_volume","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
         headers:
             Content-Length:
-                - "2130"
+                - "1668"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:01 GMT
+                - Tue, 11 Feb 2025 14:22:37 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2
+                - https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -305,10 +305,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d4591876-a51c-463a-801e-70dc5ca3a0a4
+                - be39f0e2-47f7-42cd-a3ba-f6a46b797304
         status: 201 Created
         code: 201
-        duration: 797.676833ms
+        duration: 918.214416ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -324,8 +324,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -333,20 +333,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2130
+        content_length: 1668
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:00.725315+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-serene-grothendieck","id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.713123+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a52aee59-c5cf-44d0-915e-6bf8da8e87f7","modification_date":"2024-10-14T09:05:23.713123+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"9490ba87-565a-4ba4-998f-b8cf2b7b3b6f","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":null,"mac_address":"de:00:00:68:de:5f","maintenances":[],"modification_date":"2025-01-27T13:52:00.725315+00:00","name":"tf-srv-serene-grothendieck","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:00.725315+00:00","export_uri":null,"id":"6e5d5152-3105-42ab-a4f9-00e41036aeb8","modification_date":"2025-01-27T13:52:00.725315+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","name":"tf-srv-serene-grothendieck"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.318589+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-keen-swirles","id":"1774b008-62b8-473c-bffd-8b29b9d852c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.426391+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a4a91637-cfbf-4a45-be29-9795d04c4f98","modification_date":"2024-10-14T09:05:23.426391+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4658bc98-1c87-4dfe-8dae-fa0dc563a43e","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":null,"mac_address":"de:00:00:6b:08:f9","maintenances":[],"modification_date":"2025-02-11T14:22:37.318589+00:00","name":"tf-srv-keen-swirles","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"2953faa1-9cf4-4f7a-a33f-21ce47364692","volume_type":"sbs_volume","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
         headers:
             Content-Length:
-                - "2130"
+                - "1668"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:01 GMT
+                - Tue, 11 Feb 2025 14:22:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -354,10 +354,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e7960758-f83f-4721-8dbd-5f998fa8a2b9
+                - fa9f14c9-eeb2-42b2-9aa1-39e9d824f6bd
         status: 200 OK
         code: 200
-        duration: 113.047833ms
+        duration: 179.418708ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -373,8 +373,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -382,20 +382,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2130
+        content_length: 1668
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:00.725315+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-serene-grothendieck","id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.713123+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a52aee59-c5cf-44d0-915e-6bf8da8e87f7","modification_date":"2024-10-14T09:05:23.713123+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"9490ba87-565a-4ba4-998f-b8cf2b7b3b6f","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":null,"mac_address":"de:00:00:68:de:5f","maintenances":[],"modification_date":"2025-01-27T13:52:00.725315+00:00","name":"tf-srv-serene-grothendieck","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:00.725315+00:00","export_uri":null,"id":"6e5d5152-3105-42ab-a4f9-00e41036aeb8","modification_date":"2025-01-27T13:52:00.725315+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","name":"tf-srv-serene-grothendieck"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.318589+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-keen-swirles","id":"1774b008-62b8-473c-bffd-8b29b9d852c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.426391+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a4a91637-cfbf-4a45-be29-9795d04c4f98","modification_date":"2024-10-14T09:05:23.426391+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4658bc98-1c87-4dfe-8dae-fa0dc563a43e","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":null,"mac_address":"de:00:00:6b:08:f9","maintenances":[],"modification_date":"2025-02-11T14:22:37.318589+00:00","name":"tf-srv-keen-swirles","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"2953faa1-9cf4-4f7a-a33f-21ce47364692","volume_type":"sbs_volume","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
         headers:
             Content-Length:
-                - "2130"
+                - "1668"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:01 GMT
+                - Tue, 11 Feb 2025 14:22:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -403,11 +403,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fad46659-ddb0-4301-a4a4-f3347ee8df01
+                - d555748d-7bf8-45f3-b68c-df221e2614e5
         status: 200 OK
         code: 200
-        duration: 115.941375ms
+        duration: 162.607333ms
     - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-2/volumes/2953faa1-9cf4-4f7a-a33f-21ce47364692
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:22:37.488569Z","id":"2953faa1-9cf4-4f7a-a33f-21ce47364692","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"4658bc98-1c87-4dfe-8dae-fa0dc563a43e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:37.488569Z","id":"b8892b98-fb2e-4e39-897e-86e866ebb1f1","product_resource_id":"1774b008-62b8-473c-bffd-8b29b9d852c8","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:37.488569Z","zone":"fr-par-2"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:22:38 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 04983b0f-1996-4968-88c1-0e4e78562f8e
+        status: 200 OK
+        code: 200
+        duration: 91.814667ms
+    - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -424,8 +473,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -435,7 +484,7 @@ interactions:
         trailer: {}
         content_length: 357
         uncompressed: false
-        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2/action","href_result":"/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2","id":"636105a7-02a4-474e-87a1-95b00faa012b","progress":0,"started_at":"2025-01-27T13:52:01.799835+00:00","status":"pending","terminated_at":null,"zone":"fr-par-2"}}'
+        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/1774b008-62b8-473c-bffd-8b29b9d852c8/action","href_result":"/servers/1774b008-62b8-473c-bffd-8b29b9d852c8","id":"aeab5d71-8fa6-4060-b884-6deb71c8fae2","progress":0,"started_at":"2025-02-11T14:22:38.442670+00:00","status":"pending","terminated_at":null,"zone":"fr-par-2"}}'
         headers:
             Content-Length:
                 - "357"
@@ -444,11 +493,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:01 GMT
+                - Tue, 11 Feb 2025 14:22:38 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-2/tasks/636105a7-02a4-474e-87a1-95b00faa012b
+                - https://api.scaleway.com/instance/v1/zones/fr-par-2/tasks/aeab5d71-8fa6-4060-b884-6deb71c8fae2
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -456,59 +505,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 253ce558-207b-4160-88d8-9a6712311ed6
+                - dac1dc9c-e856-454a-8acc-106ebf77264d
         status: 202 Accepted
         code: 202
-        duration: 467.728375ms
-    - id: 9
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2152
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:00.725315+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-serene-grothendieck","id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.713123+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a52aee59-c5cf-44d0-915e-6bf8da8e87f7","modification_date":"2024-10-14T09:05:23.713123+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"9490ba87-565a-4ba4-998f-b8cf2b7b3b6f","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":null,"mac_address":"de:00:00:68:de:5f","maintenances":[],"modification_date":"2025-01-27T13:52:01.380845+00:00","name":"tf-srv-serene-grothendieck","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:00.725315+00:00","export_uri":null,"id":"6e5d5152-3105-42ab-a4f9-00e41036aeb8","modification_date":"2025-01-27T13:52:00.725315+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","name":"tf-srv-serene-grothendieck"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
-        headers:
-            Content-Length:
-                - "2152"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:52:01 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 2ef0b07d-b87e-41e0-8a02-14dd588890d3
-        status: 200 OK
-        code: 200
-        duration: 112.093667ms
+        duration: 233.699ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -524,8 +524,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -533,20 +533,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2255
+        content_length: 1690
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:00.725315+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-serene-grothendieck","id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.713123+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a52aee59-c5cf-44d0-915e-6bf8da8e87f7","modification_date":"2024-10-14T09:05:23.713123+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"9490ba87-565a-4ba4-998f-b8cf2b7b3b6f","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"14","hypervisor_id":"302","node_id":"46","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:68:de:5f","maintenances":[],"modification_date":"2025-01-27T13:52:01.380845+00:00","name":"tf-srv-serene-grothendieck","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:00.725315+00:00","export_uri":null,"id":"6e5d5152-3105-42ab-a4f9-00e41036aeb8","modification_date":"2025-01-27T13:52:00.725315+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","name":"tf-srv-serene-grothendieck"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.318589+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-keen-swirles","id":"1774b008-62b8-473c-bffd-8b29b9d852c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.426391+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a4a91637-cfbf-4a45-be29-9795d04c4f98","modification_date":"2024-10-14T09:05:23.426391+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4658bc98-1c87-4dfe-8dae-fa0dc563a43e","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":null,"mac_address":"de:00:00:6b:08:f9","maintenances":[],"modification_date":"2025-02-11T14:22:38.256724+00:00","name":"tf-srv-keen-swirles","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"id":"2953faa1-9cf4-4f7a-a33f-21ce47364692","volume_type":"sbs_volume","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
         headers:
             Content-Length:
-                - "2255"
+                - "1690"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:07 GMT
+                - Tue, 11 Feb 2025 14:22:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -554,10 +554,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 86418632-aaf4-45db-88ea-2142ece9b18b
+                - 1b1fc74f-3e53-4083-ab8d-6a0e398f9828
         status: 200 OK
         code: 200
-        duration: 118.073917ms
+        duration: 194.747166ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -573,8 +573,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -582,20 +582,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2255
+        content_length: 1824
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:00.725315+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-serene-grothendieck","id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.713123+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a52aee59-c5cf-44d0-915e-6bf8da8e87f7","modification_date":"2024-10-14T09:05:23.713123+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"9490ba87-565a-4ba4-998f-b8cf2b7b3b6f","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"14","hypervisor_id":"302","node_id":"46","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:68:de:5f","maintenances":[],"modification_date":"2025-01-27T13:52:01.380845+00:00","name":"tf-srv-serene-grothendieck","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:00.725315+00:00","export_uri":null,"id":"6e5d5152-3105-42ab-a4f9-00e41036aeb8","modification_date":"2025-01-27T13:52:00.725315+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","name":"tf-srv-serene-grothendieck"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.318589+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-keen-swirles","id":"1774b008-62b8-473c-bffd-8b29b9d852c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.426391+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a4a91637-cfbf-4a45-be29-9795d04c4f98","modification_date":"2024-10-14T09:05:23.426391+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4658bc98-1c87-4dfe-8dae-fa0dc563a43e","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"103","node_id":"12","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:6b:08:f9","maintenances":[],"modification_date":"2025-02-11T14:22:40.995024+00:00","name":"tf-srv-keen-swirles","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"2953faa1-9cf4-4f7a-a33f-21ce47364692","volume_type":"sbs_volume","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
         headers:
             Content-Length:
-                - "2255"
+                - "1824"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:12 GMT
+                - Tue, 11 Feb 2025 14:22:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -603,10 +603,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3476e4b6-98fb-48ec-8c10-9badb4a2c681
+                - a9550f17-3e9d-4e07-b157-aaf4bc18afd8
         status: 200 OK
         code: 200
-        duration: 150.755667ms
+        duration: 231.725375ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -622,8 +622,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/838071ad-2943-4cd4-87e0-15285d88c11b
         method: GET
       response:
         proto: HTTP/2.0
@@ -631,20 +631,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2286
+        content_length: 1051
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:00.725315+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-serene-grothendieck","id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.713123+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a52aee59-c5cf-44d0-915e-6bf8da8e87f7","modification_date":"2024-10-14T09:05:23.713123+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"9490ba87-565a-4ba4-998f-b8cf2b7b3b6f","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"14","hypervisor_id":"302","node_id":"46","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:68:de:5f","maintenances":[],"modification_date":"2025-01-27T13:52:13.414764+00:00","name":"tf-srv-serene-grothendieck","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:00.725315+00:00","export_uri":null,"id":"6e5d5152-3105-42ab-a4f9-00e41036aeb8","modification_date":"2025-01-27T13:52:00.725315+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","name":"tf-srv-serene-grothendieck"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+        body: '{"created_at":"2025-02-11T14:22:36.064186Z","dhcp_enabled":true,"id":"838071ad-2943-4cd4-87e0-15285d88c11b","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-11T14:22:36.064186Z","id":"40e28a62-f6cf-4cf9-9c29-2964e8d97d16","private_network_id":"838071ad-2943-4cd4-87e0-15285d88c11b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.20.0/22","updated_at":"2025-02-11T14:22:36.064186Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-11T14:22:36.064186Z","id":"ab4f087f-1a81-4623-aabb-393b531352ed","private_network_id":"838071ad-2943-4cd4-87e0-15285d88c11b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:58e0::/64","updated_at":"2025-02-11T14:22:36.064186Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-11T14:22:36.064186Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "2286"
+                - "1051"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:17 GMT
+                - Tue, 11 Feb 2025 14:22:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -652,10 +652,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a21ec8d9-9cfc-497c-9075-3e76bd819c8f
+                - dee53a19-7013-4317-a860-c6b46a9fb30f
         status: 200 OK
         code: 200
-        duration: 150.872917ms
+        duration: 64.780167ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -671,8 +671,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/201b8529-612e-4452-93f5-c7b9a38ee2c7
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -680,20 +680,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1050
+        content_length: 1824
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:51:59.584261Z","dhcp_enabled":true,"id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:51:59.584261Z","id":"7effac1e-03c4-473b-99ff-5259a5d3cc41","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.8.0/22","updated_at":"2025-01-27T13:51:59.584261Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:51:59.584261Z","id":"c06b449d-e2da-4e6c-a951-0db8d17df196","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:b07a::/64","updated_at":"2025-01-27T13:51:59.584261Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:51:59.584261Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.318589+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-keen-swirles","id":"1774b008-62b8-473c-bffd-8b29b9d852c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.426391+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a4a91637-cfbf-4a45-be29-9795d04c4f98","modification_date":"2024-10-14T09:05:23.426391+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4658bc98-1c87-4dfe-8dae-fa0dc563a43e","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"103","node_id":"12","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:6b:08:f9","maintenances":[],"modification_date":"2025-02-11T14:22:40.995024+00:00","name":"tf-srv-keen-swirles","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"2953faa1-9cf4-4f7a-a33f-21ce47364692","volume_type":"sbs_volume","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
         headers:
             Content-Length:
-                - "1050"
+                - "1824"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:17 GMT
+                - Tue, 11 Feb 2025 14:22:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -701,11 +701,62 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 87318114-d20b-40f9-993c-7913554fc1d5
+                - a42c25d1-fb50-491f-99c0-cc3ed22d9c2a
         status: 200 OK
         code: 200
-        duration: 33.797917ms
+        duration: 174.204875ms
     - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 61
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"private_network_id":"838071ad-2943-4cd4-87e0-15285d88c11b"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8/private_nics
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 473
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:22:44.190547+00:00","id":"ab5c7c79-153c-4397-9e3f-9e0fb2157d8d","ipam_ip_ids":["bc7752ab-7438-40bd-acf4-0164fffc59dc","c8b212eb-69d8-4f7e-9819-02bcbc9781ce"],"mac_address":"02:00:00:2c:82:98","modification_date":"2025-02-11T14:22:44.391653+00:00","private_network_id":"838071ad-2943-4cd4-87e0-15285d88c11b","server_id":"1774b008-62b8-473c-bffd-8b29b9d852c8","state":"syncing","tags":[],"zone":"fr-par-2"}}'
+        headers:
+            Content-Length:
+                - "473"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:22:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3da40058-7678-43cc-8f9d-537cfbb38cbf
+        status: 201 Created
+        code: 201
+        duration: 1.0781165s
+    - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -720,60 +771,9 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8/private_nics/ab5c7c79-153c-4397-9e3f-9e0fb2157d8d
         method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2286
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:00.725315+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-serene-grothendieck","id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.713123+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a52aee59-c5cf-44d0-915e-6bf8da8e87f7","modification_date":"2024-10-14T09:05:23.713123+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"9490ba87-565a-4ba4-998f-b8cf2b7b3b6f","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"14","hypervisor_id":"302","node_id":"46","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:68:de:5f","maintenances":[],"modification_date":"2025-01-27T13:52:13.414764+00:00","name":"tf-srv-serene-grothendieck","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:00.725315+00:00","export_uri":null,"id":"6e5d5152-3105-42ab-a4f9-00e41036aeb8","modification_date":"2025-01-27T13:52:00.725315+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","name":"tf-srv-serene-grothendieck"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
-        headers:
-            Content-Length:
-                - "2286"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:52:17 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - d214f7ce-478e-40c9-9d0e-02dd1be56728
-        status: 200 OK
-        code: 200
-        duration: 153.775667ms
-    - id: 15
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 61
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2/private_nics
-        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -782,7 +782,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:52:17.573967+00:00","id":"785c0b9e-c76a-4849-a3e4-2dea16be3ecd","ipam_ip_ids":["099de162-3f1a-4dd3-af86-b8a45e88322f","4281722f-26bc-4ba6-b5d3-eecbb8d6c411"],"mac_address":"02:00:00:2c:d9:85","modification_date":"2025-01-27T13:52:17.840984+00:00","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","server_id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","state":"syncing","tags":[],"zone":"fr-par-2"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:22:44.190547+00:00","id":"ab5c7c79-153c-4397-9e3f-9e0fb2157d8d","ipam_ip_ids":["bc7752ab-7438-40bd-acf4-0164fffc59dc","c8b212eb-69d8-4f7e-9819-02bcbc9781ce"],"mac_address":"02:00:00:2c:82:98","modification_date":"2025-02-11T14:22:44.391653+00:00","private_network_id":"838071ad-2943-4cd4-87e0-15285d88c11b","server_id":"1774b008-62b8-473c-bffd-8b29b9d852c8","state":"syncing","tags":[],"zone":"fr-par-2"}}'
         headers:
             Content-Length:
                 - "473"
@@ -791,9 +791,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:18 GMT
+                - Tue, 11 Feb 2025 14:22:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -801,10 +801,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6bdc3057-d5d5-4fb0-a6f2-37d427551792
-        status: 201 Created
-        code: 201
-        duration: 1.562845667s
+                - 9c486664-6bb0-431f-97ae-836dc4084426
+        status: 200 OK
+        code: 200
+        duration: 92.141958ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -820,8 +820,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2/private_nics/785c0b9e-c76a-4849-a3e4-2dea16be3ecd
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8/private_nics/ab5c7c79-153c-4397-9e3f-9e0fb2157d8d
         method: GET
       response:
         proto: HTTP/2.0
@@ -831,7 +831,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:52:17.573967+00:00","id":"785c0b9e-c76a-4849-a3e4-2dea16be3ecd","ipam_ip_ids":["099de162-3f1a-4dd3-af86-b8a45e88322f","4281722f-26bc-4ba6-b5d3-eecbb8d6c411"],"mac_address":"02:00:00:2c:d9:85","modification_date":"2025-01-27T13:52:17.840984+00:00","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","server_id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","state":"syncing","tags":[],"zone":"fr-par-2"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:22:44.190547+00:00","id":"ab5c7c79-153c-4397-9e3f-9e0fb2157d8d","ipam_ip_ids":["bc7752ab-7438-40bd-acf4-0164fffc59dc","c8b212eb-69d8-4f7e-9819-02bcbc9781ce"],"mac_address":"02:00:00:2c:82:98","modification_date":"2025-02-11T14:22:44.391653+00:00","private_network_id":"838071ad-2943-4cd4-87e0-15285d88c11b","server_id":"1774b008-62b8-473c-bffd-8b29b9d852c8","state":"syncing","tags":[],"zone":"fr-par-2"}}'
         headers:
             Content-Length:
                 - "473"
@@ -840,9 +840,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:19 GMT
+                - Tue, 11 Feb 2025 14:22:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -850,10 +850,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fea2778e-c97f-4a06-832e-134645521959
+                - ca0d39db-6248-4d17-bdfe-53c67d3014ee
         status: 200 OK
         code: 200
-        duration: 85.42175ms
+        duration: 112.007458ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -869,8 +869,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2/private_nics/785c0b9e-c76a-4849-a3e4-2dea16be3ecd
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8/private_nics/ab5c7c79-153c-4397-9e3f-9e0fb2157d8d
         method: GET
       response:
         proto: HTTP/2.0
@@ -880,7 +880,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:52:17.573967+00:00","id":"785c0b9e-c76a-4849-a3e4-2dea16be3ecd","ipam_ip_ids":["099de162-3f1a-4dd3-af86-b8a45e88322f","4281722f-26bc-4ba6-b5d3-eecbb8d6c411"],"mac_address":"02:00:00:2c:d9:85","modification_date":"2025-01-27T13:52:17.840984+00:00","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","server_id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","state":"syncing","tags":[],"zone":"fr-par-2"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:22:44.190547+00:00","id":"ab5c7c79-153c-4397-9e3f-9e0fb2157d8d","ipam_ip_ids":["bc7752ab-7438-40bd-acf4-0164fffc59dc","c8b212eb-69d8-4f7e-9819-02bcbc9781ce"],"mac_address":"02:00:00:2c:82:98","modification_date":"2025-02-11T14:22:44.391653+00:00","private_network_id":"838071ad-2943-4cd4-87e0-15285d88c11b","server_id":"1774b008-62b8-473c-bffd-8b29b9d852c8","state":"syncing","tags":[],"zone":"fr-par-2"}}'
         headers:
             Content-Length:
                 - "473"
@@ -889,9 +889,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:24 GMT
+                - Tue, 11 Feb 2025 14:22:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -899,10 +899,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 634fc0b4-e9fc-4bc8-98f3-056c1ab41ed4
+                - 5df7801a-427f-469a-a0e6-7dca04193d2f
         status: 200 OK
         code: 200
-        duration: 81.405166ms
+        duration: 98.078292ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -918,8 +918,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2/private_nics/785c0b9e-c76a-4849-a3e4-2dea16be3ecd
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8/private_nics/ab5c7c79-153c-4397-9e3f-9e0fb2157d8d
         method: GET
       response:
         proto: HTTP/2.0
@@ -929,7 +929,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:52:17.573967+00:00","id":"785c0b9e-c76a-4849-a3e4-2dea16be3ecd","ipam_ip_ids":["099de162-3f1a-4dd3-af86-b8a45e88322f","4281722f-26bc-4ba6-b5d3-eecbb8d6c411"],"mac_address":"02:00:00:2c:d9:85","modification_date":"2025-01-27T13:52:17.840984+00:00","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","server_id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","state":"syncing","tags":[],"zone":"fr-par-2"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:22:44.190547+00:00","id":"ab5c7c79-153c-4397-9e3f-9e0fb2157d8d","ipam_ip_ids":["bc7752ab-7438-40bd-acf4-0164fffc59dc","c8b212eb-69d8-4f7e-9819-02bcbc9781ce"],"mac_address":"02:00:00:2c:82:98","modification_date":"2025-02-11T14:22:44.391653+00:00","private_network_id":"838071ad-2943-4cd4-87e0-15285d88c11b","server_id":"1774b008-62b8-473c-bffd-8b29b9d852c8","state":"syncing","tags":[],"zone":"fr-par-2"}}'
         headers:
             Content-Length:
                 - "473"
@@ -938,9 +938,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:29 GMT
+                - Tue, 11 Feb 2025 14:23:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -948,10 +948,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 63b9bd2d-1182-4642-a8ff-dbcb161509f2
+                - 76931097-c3e1-4b80-bed4-2966dffc0db0
         status: 200 OK
         code: 200
-        duration: 192.749959ms
+        duration: 96.682583ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -967,8 +967,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2/private_nics/785c0b9e-c76a-4849-a3e4-2dea16be3ecd
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8/private_nics/ab5c7c79-153c-4397-9e3f-9e0fb2157d8d
         method: GET
       response:
         proto: HTTP/2.0
@@ -978,7 +978,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:52:17.573967+00:00","id":"785c0b9e-c76a-4849-a3e4-2dea16be3ecd","ipam_ip_ids":["099de162-3f1a-4dd3-af86-b8a45e88322f","4281722f-26bc-4ba6-b5d3-eecbb8d6c411"],"mac_address":"02:00:00:2c:d9:85","modification_date":"2025-01-27T13:52:17.840984+00:00","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","server_id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","state":"syncing","tags":[],"zone":"fr-par-2"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:22:44.190547+00:00","id":"ab5c7c79-153c-4397-9e3f-9e0fb2157d8d","ipam_ip_ids":["bc7752ab-7438-40bd-acf4-0164fffc59dc","c8b212eb-69d8-4f7e-9819-02bcbc9781ce"],"mac_address":"02:00:00:2c:82:98","modification_date":"2025-02-11T14:22:44.391653+00:00","private_network_id":"838071ad-2943-4cd4-87e0-15285d88c11b","server_id":"1774b008-62b8-473c-bffd-8b29b9d852c8","state":"syncing","tags":[],"zone":"fr-par-2"}}'
         headers:
             Content-Length:
                 - "473"
@@ -987,9 +987,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:34 GMT
+                - Tue, 11 Feb 2025 14:23:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -997,10 +997,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 29fd0cc0-5a5b-4589-8e7f-7b61b223a129
+                - fe6fa28a-30df-4a4f-b00d-586c374934ce
         status: 200 OK
         code: 200
-        duration: 72.569291ms
+        duration: 100.8345ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1016,8 +1016,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2/private_nics/785c0b9e-c76a-4849-a3e4-2dea16be3ecd
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8/private_nics/ab5c7c79-153c-4397-9e3f-9e0fb2157d8d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1027,7 +1027,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:52:17.573967+00:00","id":"785c0b9e-c76a-4849-a3e4-2dea16be3ecd","ipam_ip_ids":["099de162-3f1a-4dd3-af86-b8a45e88322f","4281722f-26bc-4ba6-b5d3-eecbb8d6c411"],"mac_address":"02:00:00:2c:d9:85","modification_date":"2025-01-27T13:52:17.840984+00:00","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","server_id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","state":"syncing","tags":[],"zone":"fr-par-2"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:22:44.190547+00:00","id":"ab5c7c79-153c-4397-9e3f-9e0fb2157d8d","ipam_ip_ids":["bc7752ab-7438-40bd-acf4-0164fffc59dc","c8b212eb-69d8-4f7e-9819-02bcbc9781ce"],"mac_address":"02:00:00:2c:82:98","modification_date":"2025-02-11T14:22:44.391653+00:00","private_network_id":"838071ad-2943-4cd4-87e0-15285d88c11b","server_id":"1774b008-62b8-473c-bffd-8b29b9d852c8","state":"syncing","tags":[],"zone":"fr-par-2"}}'
         headers:
             Content-Length:
                 - "473"
@@ -1036,9 +1036,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:39 GMT
+                - Tue, 11 Feb 2025 14:23:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1046,10 +1046,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7ff1dcf5-3aaa-4e35-8788-6c2e27633ecf
+                - 099c44b4-7836-4391-807f-28ffb7cd05c0
         status: 200 OK
         code: 200
-        duration: 112.860375ms
+        duration: 89.109291ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1065,8 +1065,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2/private_nics/785c0b9e-c76a-4849-a3e4-2dea16be3ecd
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8/private_nics/ab5c7c79-153c-4397-9e3f-9e0fb2157d8d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1076,7 +1076,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:52:17.573967+00:00","id":"785c0b9e-c76a-4849-a3e4-2dea16be3ecd","ipam_ip_ids":["099de162-3f1a-4dd3-af86-b8a45e88322f","4281722f-26bc-4ba6-b5d3-eecbb8d6c411"],"mac_address":"02:00:00:2c:d9:85","modification_date":"2025-01-27T13:52:17.840984+00:00","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","server_id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","state":"syncing","tags":[],"zone":"fr-par-2"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:22:44.190547+00:00","id":"ab5c7c79-153c-4397-9e3f-9e0fb2157d8d","ipam_ip_ids":["bc7752ab-7438-40bd-acf4-0164fffc59dc","c8b212eb-69d8-4f7e-9819-02bcbc9781ce"],"mac_address":"02:00:00:2c:82:98","modification_date":"2025-02-11T14:22:44.391653+00:00","private_network_id":"838071ad-2943-4cd4-87e0-15285d88c11b","server_id":"1774b008-62b8-473c-bffd-8b29b9d852c8","state":"syncing","tags":[],"zone":"fr-par-2"}}'
         headers:
             Content-Length:
                 - "473"
@@ -1085,9 +1085,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:44 GMT
+                - Tue, 11 Feb 2025 14:23:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1095,10 +1095,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a7015896-e327-49fa-b37d-abd0a6111427
+                - 89097367-2d47-4dea-aad9-b26e8fd34033
         status: 200 OK
         code: 200
-        duration: 95.707125ms
+        duration: 75.041709ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1114,8 +1114,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2/private_nics/785c0b9e-c76a-4849-a3e4-2dea16be3ecd
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8/private_nics/ab5c7c79-153c-4397-9e3f-9e0fb2157d8d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1123,20 +1123,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 473
+        content_length: 475
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:52:17.573967+00:00","id":"785c0b9e-c76a-4849-a3e4-2dea16be3ecd","ipam_ip_ids":["099de162-3f1a-4dd3-af86-b8a45e88322f","4281722f-26bc-4ba6-b5d3-eecbb8d6c411"],"mac_address":"02:00:00:2c:d9:85","modification_date":"2025-01-27T13:52:17.840984+00:00","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","server_id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","state":"syncing","tags":[],"zone":"fr-par-2"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:22:44.190547+00:00","id":"ab5c7c79-153c-4397-9e3f-9e0fb2157d8d","ipam_ip_ids":["bc7752ab-7438-40bd-acf4-0164fffc59dc","c8b212eb-69d8-4f7e-9819-02bcbc9781ce"],"mac_address":"02:00:00:2c:82:98","modification_date":"2025-02-11T14:23:15.979265+00:00","private_network_id":"838071ad-2943-4cd4-87e0-15285d88c11b","server_id":"1774b008-62b8-473c-bffd-8b29b9d852c8","state":"available","tags":[],"zone":"fr-par-2"}}'
         headers:
             Content-Length:
-                - "473"
+                - "475"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:49 GMT
+                - Tue, 11 Feb 2025 14:23:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1144,10 +1144,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a2189eb4-e77e-474a-a86c-c3ab8a3e43f3
+                - 2b375448-0f75-49ef-9b9a-bb89bfdb289f
         status: 200 OK
         code: 200
-        duration: 79.544667ms
+        duration: 93.175333ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1163,8 +1163,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2/private_nics/785c0b9e-c76a-4849-a3e4-2dea16be3ecd
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8/private_nics/ab5c7c79-153c-4397-9e3f-9e0fb2157d8d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1174,7 +1174,7 @@ interactions:
         trailer: {}
         content_length: 475
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:52:17.573967+00:00","id":"785c0b9e-c76a-4849-a3e4-2dea16be3ecd","ipam_ip_ids":["099de162-3f1a-4dd3-af86-b8a45e88322f","4281722f-26bc-4ba6-b5d3-eecbb8d6c411"],"mac_address":"02:00:00:2c:d9:85","modification_date":"2025-01-27T13:52:50.004095+00:00","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","server_id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","state":"available","tags":[],"zone":"fr-par-2"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:22:44.190547+00:00","id":"ab5c7c79-153c-4397-9e3f-9e0fb2157d8d","ipam_ip_ids":["bc7752ab-7438-40bd-acf4-0164fffc59dc","c8b212eb-69d8-4f7e-9819-02bcbc9781ce"],"mac_address":"02:00:00:2c:82:98","modification_date":"2025-02-11T14:23:15.979265+00:00","private_network_id":"838071ad-2943-4cd4-87e0-15285d88c11b","server_id":"1774b008-62b8-473c-bffd-8b29b9d852c8","state":"available","tags":[],"zone":"fr-par-2"}}'
         headers:
             Content-Length:
                 - "475"
@@ -1183,9 +1183,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:54 GMT
+                - Tue, 11 Feb 2025 14:23:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1193,10 +1193,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 31f87a72-2b6c-43f2-8325-4bec0a359a56
+                - f9e674b8-0a2f-4ec2-aae4-1e3387f148c7
         status: 200 OK
         code: 200
-        duration: 93.517334ms
+        duration: 108.17175ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1212,8 +1212,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2/private_nics/785c0b9e-c76a-4849-a3e4-2dea16be3ecd
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -1221,20 +1221,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 475
+        content_length: 2282
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:52:17.573967+00:00","id":"785c0b9e-c76a-4849-a3e4-2dea16be3ecd","ipam_ip_ids":["099de162-3f1a-4dd3-af86-b8a45e88322f","4281722f-26bc-4ba6-b5d3-eecbb8d6c411"],"mac_address":"02:00:00:2c:d9:85","modification_date":"2025-01-27T13:52:50.004095+00:00","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","server_id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","state":"available","tags":[],"zone":"fr-par-2"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.318589+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-keen-swirles","id":"1774b008-62b8-473c-bffd-8b29b9d852c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.426391+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a4a91637-cfbf-4a45-be29-9795d04c4f98","modification_date":"2024-10-14T09:05:23.426391+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4658bc98-1c87-4dfe-8dae-fa0dc563a43e","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"103","node_id":"12","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:6b:08:f9","maintenances":[],"modification_date":"2025-02-11T14:22:40.995024+00:00","name":"tf-srv-keen-swirles","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:22:44.190547+00:00","id":"ab5c7c79-153c-4397-9e3f-9e0fb2157d8d","ipam_ip_ids":["bc7752ab-7438-40bd-acf4-0164fffc59dc","c8b212eb-69d8-4f7e-9819-02bcbc9781ce"],"mac_address":"02:00:00:2c:82:98","modification_date":"2025-02-11T14:23:15.979265+00:00","private_network_id":"838071ad-2943-4cd4-87e0-15285d88c11b","server_id":"1774b008-62b8-473c-bffd-8b29b9d852c8","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"2953faa1-9cf4-4f7a-a33f-21ce47364692","volume_type":"sbs_volume","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
         headers:
             Content-Length:
-                - "475"
+                - "2282"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:54 GMT
+                - Tue, 11 Feb 2025 14:23:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1242,10 +1242,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 94e6cca3-2fd8-48ff-84a6-c8f84b20607d
+                - b7fa666c-8a7d-4fd5-8297-99df78a73352
         status: 200 OK
         code: 200
-        duration: 79.021416ms
+        duration: 177.16275ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1261,8 +1261,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/volumes/2953faa1-9cf4-4f7a-a33f-21ce47364692
         method: GET
       response:
         proto: HTTP/2.0
@@ -1270,20 +1270,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2744
+        content_length: 143
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:00.725315+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-serene-grothendieck","id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.713123+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a52aee59-c5cf-44d0-915e-6bf8da8e87f7","modification_date":"2024-10-14T09:05:23.713123+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"9490ba87-565a-4ba4-998f-b8cf2b7b3b6f","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"14","hypervisor_id":"302","node_id":"46","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:68:de:5f","maintenances":[],"modification_date":"2025-01-27T13:52:13.414764+00:00","name":"tf-srv-serene-grothendieck","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:52:17.573967+00:00","id":"785c0b9e-c76a-4849-a3e4-2dea16be3ecd","ipam_ip_ids":["099de162-3f1a-4dd3-af86-b8a45e88322f","4281722f-26bc-4ba6-b5d3-eecbb8d6c411"],"mac_address":"02:00:00:2c:d9:85","modification_date":"2025-01-27T13:52:50.004095+00:00","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","server_id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:00.725315+00:00","export_uri":null,"id":"6e5d5152-3105-42ab-a4f9-00e41036aeb8","modification_date":"2025-01-27T13:52:00.725315+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","name":"tf-srv-serene-grothendieck"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"2953faa1-9cf4-4f7a-a33f-21ce47364692","type":"not_found"}'
         headers:
             Content-Length:
-                - "2744"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:54 GMT
+                - Tue, 11 Feb 2025 14:23:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1291,10 +1291,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 69702afd-bfa3-4b7a-8b0f-6dd6abb33a27
-        status: 200 OK
-        code: 200
-        duration: 118.422625ms
+                - 74c14d7e-d307-41db-b5c4-83da69658681
+        status: 404 Not Found
+        code: 404
+        duration: 68.611ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1310,8 +1310,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/volumes/6e5d5152-3105-42ab-a4f9-00e41036aeb8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-2/volumes/2953faa1-9cf4-4f7a-a33f-21ce47364692
         method: GET
       response:
         proto: HTTP/2.0
@@ -1319,20 +1319,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 526
+        content_length: 701
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:52:00.725315+00:00","export_uri":null,"id":"6e5d5152-3105-42ab-a4f9-00e41036aeb8","modification_date":"2025-01-27T13:52:00.725315+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","name":"tf-srv-serene-grothendieck"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}}'
+        body: '{"created_at":"2025-02-11T14:22:37.488569Z","id":"2953faa1-9cf4-4f7a-a33f-21ce47364692","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"4658bc98-1c87-4dfe-8dae-fa0dc563a43e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:37.488569Z","id":"b8892b98-fb2e-4e39-897e-86e866ebb1f1","product_resource_id":"1774b008-62b8-473c-bffd-8b29b9d852c8","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:37.488569Z","zone":"fr-par-2"}'
         headers:
             Content-Length:
-                - "526"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:54 GMT
+                - Tue, 11 Feb 2025 14:23:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1340,10 +1340,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 00653012-de06-41ed-a903-28c271660353
+                - 23fc026a-6512-4666-8c06-923d793129c0
         status: 200 OK
         code: 200
-        duration: 68.018375ms
+        duration: 70.637541ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1359,8 +1359,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1379,9 +1379,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:55 GMT
+                - Tue, 11 Feb 2025 14:23:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1389,10 +1389,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 268f5796-0d20-4d98-869e-b52193dca05a
+                - 55b6ec23-f330-4813-8a1a-490e0c0049af
         status: 200 OK
         code: 200
-        duration: 71.610042ms
+        duration: 90.759458ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1408,8 +1408,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1419,7 +1419,7 @@ interactions:
         trailer: {}
         content_length: 478
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:52:17.573967+00:00","id":"785c0b9e-c76a-4849-a3e4-2dea16be3ecd","ipam_ip_ids":["099de162-3f1a-4dd3-af86-b8a45e88322f","4281722f-26bc-4ba6-b5d3-eecbb8d6c411"],"mac_address":"02:00:00:2c:d9:85","modification_date":"2025-01-27T13:52:50.004095+00:00","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","server_id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","state":"available","tags":[],"zone":"fr-par-2"}]}'
+        body: '{"private_nics":[{"creation_date":"2025-02-11T14:22:44.190547+00:00","id":"ab5c7c79-153c-4397-9e3f-9e0fb2157d8d","ipam_ip_ids":["bc7752ab-7438-40bd-acf4-0164fffc59dc","c8b212eb-69d8-4f7e-9819-02bcbc9781ce"],"mac_address":"02:00:00:2c:82:98","modification_date":"2025-02-11T14:23:15.979265+00:00","private_network_id":"838071ad-2943-4cd4-87e0-15285d88c11b","server_id":"1774b008-62b8-473c-bffd-8b29b9d852c8","state":"available","tags":[],"zone":"fr-par-2"}]}'
         headers:
             Content-Length:
                 - "478"
@@ -1428,11 +1428,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:55 GMT
+                - Tue, 11 Feb 2025 14:23:21 GMT
             Link:
-                - </servers/53ff15f0-a93e-4c90-a468-faa33e738ff2/private_nics?page=1&per_page=50&>; rel="last"
+                - </servers/1774b008-62b8-473c-bffd-8b29b9d852c8/private_nics?page=1&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1440,12 +1440,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f1dc36be-72ea-4848-8f52-b0b421286ad6
+                - ea5b6394-66f5-470e-b110-ce31ecf4e356
             X-Total-Count:
                 - "1"
         status: 200 OK
         code: 200
-        duration: 77.83975ms
+        duration: 98.171583ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1461,8 +1461,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1472,7 +1472,7 @@ interactions:
         trailer: {}
         content_length: 478
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:52:17.573967+00:00","id":"785c0b9e-c76a-4849-a3e4-2dea16be3ecd","ipam_ip_ids":["099de162-3f1a-4dd3-af86-b8a45e88322f","4281722f-26bc-4ba6-b5d3-eecbb8d6c411"],"mac_address":"02:00:00:2c:d9:85","modification_date":"2025-01-27T13:52:50.004095+00:00","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","server_id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","state":"available","tags":[],"zone":"fr-par-2"}]}'
+        body: '{"private_nics":[{"creation_date":"2025-02-11T14:22:44.190547+00:00","id":"ab5c7c79-153c-4397-9e3f-9e0fb2157d8d","ipam_ip_ids":["bc7752ab-7438-40bd-acf4-0164fffc59dc","c8b212eb-69d8-4f7e-9819-02bcbc9781ce"],"mac_address":"02:00:00:2c:82:98","modification_date":"2025-02-11T14:23:15.979265+00:00","private_network_id":"838071ad-2943-4cd4-87e0-15285d88c11b","server_id":"1774b008-62b8-473c-bffd-8b29b9d852c8","state":"available","tags":[],"zone":"fr-par-2"}]}'
         headers:
             Content-Length:
                 - "478"
@@ -1481,11 +1481,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:55 GMT
+                - Tue, 11 Feb 2025 14:23:21 GMT
             Link:
-                - </servers/53ff15f0-a93e-4c90-a468-faa33e738ff2/private_nics?page=1&per_page=50&>; rel="last"
+                - </servers/1774b008-62b8-473c-bffd-8b29b9d852c8/private_nics?page=1&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1493,12 +1493,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 95044a16-f12f-4dab-a2e6-4b15ebdee462
+                - bec9c549-f645-42c4-bd47-891d786cb0c9
             X-Total-Count:
                 - "1"
         status: 200 OK
         code: 200
-        duration: 77.9ms
+        duration: 85.767292ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1514,8 +1514,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/201b8529-612e-4452-93f5-c7b9a38ee2c7
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/838071ad-2943-4cd4-87e0-15285d88c11b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1523,20 +1523,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1050
+        content_length: 1051
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:51:59.584261Z","dhcp_enabled":true,"id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:51:59.584261Z","id":"7effac1e-03c4-473b-99ff-5259a5d3cc41","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.8.0/22","updated_at":"2025-01-27T13:51:59.584261Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:51:59.584261Z","id":"c06b449d-e2da-4e6c-a951-0db8d17df196","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:b07a::/64","updated_at":"2025-01-27T13:51:59.584261Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:51:59.584261Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"created_at":"2025-02-11T14:22:36.064186Z","dhcp_enabled":true,"id":"838071ad-2943-4cd4-87e0-15285d88c11b","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-11T14:22:36.064186Z","id":"40e28a62-f6cf-4cf9-9c29-2964e8d97d16","private_network_id":"838071ad-2943-4cd4-87e0-15285d88c11b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.20.0/22","updated_at":"2025-02-11T14:22:36.064186Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-11T14:22:36.064186Z","id":"ab4f087f-1a81-4623-aabb-393b531352ed","private_network_id":"838071ad-2943-4cd4-87e0-15285d88c11b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:58e0::/64","updated_at":"2025-02-11T14:22:36.064186Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-11T14:22:36.064186Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "1050"
+                - "1051"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:55 GMT
+                - Tue, 11 Feb 2025 14:23:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1544,10 +1544,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 09ab9e54-26c7-4957-b4c9-676818f0087a
+                - 2418ad2f-b236-4d18-b89e-e0d1c6b1f2a1
         status: 200 OK
         code: 200
-        duration: 31.99825ms
+        duration: 32.579916ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1563,8 +1563,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -1572,20 +1572,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2744
+        content_length: 2282
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:00.725315+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-serene-grothendieck","id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.713123+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a52aee59-c5cf-44d0-915e-6bf8da8e87f7","modification_date":"2024-10-14T09:05:23.713123+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"9490ba87-565a-4ba4-998f-b8cf2b7b3b6f","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"14","hypervisor_id":"302","node_id":"46","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:68:de:5f","maintenances":[],"modification_date":"2025-01-27T13:52:13.414764+00:00","name":"tf-srv-serene-grothendieck","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:52:17.573967+00:00","id":"785c0b9e-c76a-4849-a3e4-2dea16be3ecd","ipam_ip_ids":["099de162-3f1a-4dd3-af86-b8a45e88322f","4281722f-26bc-4ba6-b5d3-eecbb8d6c411"],"mac_address":"02:00:00:2c:d9:85","modification_date":"2025-01-27T13:52:50.004095+00:00","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","server_id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:00.725315+00:00","export_uri":null,"id":"6e5d5152-3105-42ab-a4f9-00e41036aeb8","modification_date":"2025-01-27T13:52:00.725315+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","name":"tf-srv-serene-grothendieck"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.318589+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-keen-swirles","id":"1774b008-62b8-473c-bffd-8b29b9d852c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.426391+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a4a91637-cfbf-4a45-be29-9795d04c4f98","modification_date":"2024-10-14T09:05:23.426391+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4658bc98-1c87-4dfe-8dae-fa0dc563a43e","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"103","node_id":"12","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:6b:08:f9","maintenances":[],"modification_date":"2025-02-11T14:22:40.995024+00:00","name":"tf-srv-keen-swirles","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:22:44.190547+00:00","id":"ab5c7c79-153c-4397-9e3f-9e0fb2157d8d","ipam_ip_ids":["bc7752ab-7438-40bd-acf4-0164fffc59dc","c8b212eb-69d8-4f7e-9819-02bcbc9781ce"],"mac_address":"02:00:00:2c:82:98","modification_date":"2025-02-11T14:23:15.979265+00:00","private_network_id":"838071ad-2943-4cd4-87e0-15285d88c11b","server_id":"1774b008-62b8-473c-bffd-8b29b9d852c8","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"2953faa1-9cf4-4f7a-a33f-21ce47364692","volume_type":"sbs_volume","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
         headers:
             Content-Length:
-                - "2744"
+                - "2282"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:55 GMT
+                - Tue, 11 Feb 2025 14:23:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1593,10 +1593,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 21dfe1f1-5b0f-46d9-93be-866dd64a5802
+                - c47c3a72-2ee4-4bde-9ab5-6f5070375597
         status: 200 OK
         code: 200
-        duration: 109.132083ms
+        duration: 205.451042ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1612,8 +1612,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/volumes/6e5d5152-3105-42ab-a4f9-00e41036aeb8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/volumes/2953faa1-9cf4-4f7a-a33f-21ce47364692
         method: GET
       response:
         proto: HTTP/2.0
@@ -1621,20 +1621,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 526
+        content_length: 143
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:52:00.725315+00:00","export_uri":null,"id":"6e5d5152-3105-42ab-a4f9-00e41036aeb8","modification_date":"2025-01-27T13:52:00.725315+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","name":"tf-srv-serene-grothendieck"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"2953faa1-9cf4-4f7a-a33f-21ce47364692","type":"not_found"}'
         headers:
             Content-Length:
-                - "526"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:55 GMT
+                - Tue, 11 Feb 2025 14:23:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1642,10 +1642,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6f17a113-5c77-4a46-8473-eea6ca372fcc
-        status: 200 OK
-        code: 200
-        duration: 89.600292ms
+                - 4d181a15-9a47-440e-ac14-200afa01a530
+        status: 404 Not Found
+        code: 404
+        duration: 41.446042ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1661,8 +1661,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-2/volumes/2953faa1-9cf4-4f7a-a33f-21ce47364692
         method: GET
       response:
         proto: HTTP/2.0
@@ -1670,20 +1670,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 701
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"created_at":"2025-02-11T14:22:37.488569Z","id":"2953faa1-9cf4-4f7a-a33f-21ce47364692","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"4658bc98-1c87-4dfe-8dae-fa0dc563a43e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:37.488569Z","id":"b8892b98-fb2e-4e39-897e-86e866ebb1f1","product_resource_id":"1774b008-62b8-473c-bffd-8b29b9d852c8","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:37.488569Z","zone":"fr-par-2"}'
         headers:
             Content-Length:
-                - "17"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:55 GMT
+                - Tue, 11 Feb 2025 14:23:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1691,10 +1691,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4f622585-fdab-450e-adf2-6bfa6ae6dbcd
+                - 471f560d-a515-4340-81dd-996727eeca59
         status: 200 OK
         code: 200
-        duration: 78.818125ms
+        duration: 81.18025ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1710,208 +1710,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2/private_nics
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 478
-        uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:52:17.573967+00:00","id":"785c0b9e-c76a-4849-a3e4-2dea16be3ecd","ipam_ip_ids":["099de162-3f1a-4dd3-af86-b8a45e88322f","4281722f-26bc-4ba6-b5d3-eecbb8d6c411"],"mac_address":"02:00:00:2c:d9:85","modification_date":"2025-01-27T13:52:50.004095+00:00","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","server_id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","state":"available","tags":[],"zone":"fr-par-2"}]}'
-        headers:
-            Content-Length:
-                - "478"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:52:55 GMT
-            Link:
-                - </servers/53ff15f0-a93e-4c90-a468-faa33e738ff2/private_nics?page=1&per_page=50&>; rel="last"
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 8300e346-0339-41d6-929e-77f960f4d924
-            X-Total-Count:
-                - "1"
-        status: 200 OK
-        code: 200
-        duration: 86.466334ms
-    - id: 35
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/201b8529-612e-4452-93f5-c7b9a38ee2c7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1050
-        uncompressed: false
-        body: '{"created_at":"2025-01-27T13:51:59.584261Z","dhcp_enabled":true,"id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:51:59.584261Z","id":"7effac1e-03c4-473b-99ff-5259a5d3cc41","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.8.0/22","updated_at":"2025-01-27T13:51:59.584261Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:51:59.584261Z","id":"c06b449d-e2da-4e6c-a951-0db8d17df196","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:b07a::/64","updated_at":"2025-01-27T13:51:59.584261Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:51:59.584261Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
-        headers:
-            Content-Length:
-                - "1050"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:52:56 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - e7e174cb-8007-4b88-96bd-1d6c436e53c2
-        status: 200 OK
-        code: 200
-        duration: 30.089416ms
-    - id: 36
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2744
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:00.725315+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-serene-grothendieck","id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.713123+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a52aee59-c5cf-44d0-915e-6bf8da8e87f7","modification_date":"2024-10-14T09:05:23.713123+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"9490ba87-565a-4ba4-998f-b8cf2b7b3b6f","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"14","hypervisor_id":"302","node_id":"46","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:68:de:5f","maintenances":[],"modification_date":"2025-01-27T13:52:13.414764+00:00","name":"tf-srv-serene-grothendieck","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:52:17.573967+00:00","id":"785c0b9e-c76a-4849-a3e4-2dea16be3ecd","ipam_ip_ids":["099de162-3f1a-4dd3-af86-b8a45e88322f","4281722f-26bc-4ba6-b5d3-eecbb8d6c411"],"mac_address":"02:00:00:2c:d9:85","modification_date":"2025-01-27T13:52:50.004095+00:00","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","server_id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:00.725315+00:00","export_uri":null,"id":"6e5d5152-3105-42ab-a4f9-00e41036aeb8","modification_date":"2025-01-27T13:52:00.725315+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","name":"tf-srv-serene-grothendieck"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
-        headers:
-            Content-Length:
-                - "2744"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:52:56 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 2683284f-301c-46e2-86e8-5b0def744834
-        status: 200 OK
-        code: 200
-        duration: 147.237792ms
-    - id: 37
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/volumes/6e5d5152-3105-42ab-a4f9-00e41036aeb8
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 526
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:52:00.725315+00:00","export_uri":null,"id":"6e5d5152-3105-42ab-a4f9-00e41036aeb8","modification_date":"2025-01-27T13:52:00.725315+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","name":"tf-srv-serene-grothendieck"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}}'
-        headers:
-            Content-Length:
-                - "526"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:52:56 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - dde059a8-0513-4cec-8a0e-c8b046c16628
-        status: 200 OK
-        code: 200
-        duration: 85.02075ms
-    - id: 38
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1930,9 +1730,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:56 GMT
+                - Tue, 11 Feb 2025 14:23:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1940,10 +1740,210 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c2999b0d-a6d8-498b-a940-de7aaec128e1
+                - dfbcae81-c931-4b9b-9bd4-45c65815b9c6
         status: 200 OK
         code: 200
-        duration: 71.365042ms
+        duration: 76.415375ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 478
+        uncompressed: false
+        body: '{"private_nics":[{"creation_date":"2025-02-11T14:22:44.190547+00:00","id":"ab5c7c79-153c-4397-9e3f-9e0fb2157d8d","ipam_ip_ids":["bc7752ab-7438-40bd-acf4-0164fffc59dc","c8b212eb-69d8-4f7e-9819-02bcbc9781ce"],"mac_address":"02:00:00:2c:82:98","modification_date":"2025-02-11T14:23:15.979265+00:00","private_network_id":"838071ad-2943-4cd4-87e0-15285d88c11b","server_id":"1774b008-62b8-473c-bffd-8b29b9d852c8","state":"available","tags":[],"zone":"fr-par-2"}]}'
+        headers:
+            Content-Length:
+                - "478"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:22 GMT
+            Link:
+                - </servers/1774b008-62b8-473c-bffd-8b29b9d852c8/private_nics?page=1&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1cf09995-73c6-4cee-b2c4-70d7d65c81b0
+            X-Total-Count:
+                - "1"
+        status: 200 OK
+        code: 200
+        duration: 69.334916ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/838071ad-2943-4cd4-87e0-15285d88c11b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1051
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:22:36.064186Z","dhcp_enabled":true,"id":"838071ad-2943-4cd4-87e0-15285d88c11b","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-11T14:22:36.064186Z","id":"40e28a62-f6cf-4cf9-9c29-2964e8d97d16","private_network_id":"838071ad-2943-4cd4-87e0-15285d88c11b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.20.0/22","updated_at":"2025-02-11T14:22:36.064186Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-11T14:22:36.064186Z","id":"ab4f087f-1a81-4623-aabb-393b531352ed","private_network_id":"838071ad-2943-4cd4-87e0-15285d88c11b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:58e0::/64","updated_at":"2025-02-11T14:22:36.064186Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-11T14:22:36.064186Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        headers:
+            Content-Length:
+                - "1051"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - be8df042-d593-4cda-aa03-8680c703b2c5
+        status: 200 OK
+        code: 200
+        duration: 31.840583ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2282
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.318589+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-keen-swirles","id":"1774b008-62b8-473c-bffd-8b29b9d852c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.426391+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a4a91637-cfbf-4a45-be29-9795d04c4f98","modification_date":"2024-10-14T09:05:23.426391+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4658bc98-1c87-4dfe-8dae-fa0dc563a43e","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"103","node_id":"12","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:6b:08:f9","maintenances":[],"modification_date":"2025-02-11T14:22:40.995024+00:00","name":"tf-srv-keen-swirles","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:22:44.190547+00:00","id":"ab5c7c79-153c-4397-9e3f-9e0fb2157d8d","ipam_ip_ids":["bc7752ab-7438-40bd-acf4-0164fffc59dc","c8b212eb-69d8-4f7e-9819-02bcbc9781ce"],"mac_address":"02:00:00:2c:82:98","modification_date":"2025-02-11T14:23:15.979265+00:00","private_network_id":"838071ad-2943-4cd4-87e0-15285d88c11b","server_id":"1774b008-62b8-473c-bffd-8b29b9d852c8","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"2953faa1-9cf4-4f7a-a33f-21ce47364692","volume_type":"sbs_volume","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+        headers:
+            Content-Length:
+                - "2282"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a8042667-cef1-4d03-b14a-e10f2908dcc1
+        status: 200 OK
+        code: 200
+        duration: 176.683333ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/volumes/2953faa1-9cf4-4f7a-a33f-21ce47364692
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"2953faa1-9cf4-4f7a-a33f-21ce47364692","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0f8ed3a6-b358-4b33-9b5c-8bc8c8542cf1
+        status: 404 Not Found
+        code: 404
+        duration: 27.759291ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1959,8 +1959,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-2/volumes/2953faa1-9cf4-4f7a-a33f-21ce47364692
         method: GET
       response:
         proto: HTTP/2.0
@@ -1968,22 +1968,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 478
+        content_length: 701
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:52:17.573967+00:00","id":"785c0b9e-c76a-4849-a3e4-2dea16be3ecd","ipam_ip_ids":["099de162-3f1a-4dd3-af86-b8a45e88322f","4281722f-26bc-4ba6-b5d3-eecbb8d6c411"],"mac_address":"02:00:00:2c:d9:85","modification_date":"2025-01-27T13:52:50.004095+00:00","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","server_id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","state":"available","tags":[],"zone":"fr-par-2"}]}'
+        body: '{"created_at":"2025-02-11T14:22:37.488569Z","id":"2953faa1-9cf4-4f7a-a33f-21ce47364692","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"4658bc98-1c87-4dfe-8dae-fa0dc563a43e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:37.488569Z","id":"b8892b98-fb2e-4e39-897e-86e866ebb1f1","product_resource_id":"1774b008-62b8-473c-bffd-8b29b9d852c8","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:37.488569Z","zone":"fr-par-2"}'
         headers:
             Content-Length:
-                - "478"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:56 GMT
-            Link:
-                - </servers/53ff15f0-a93e-4c90-a468-faa33e738ff2/private_nics?page=1&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:23:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1991,12 +1989,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bf4ea130-d384-4680-82f1-774043c9c285
-            X-Total-Count:
-                - "1"
+                - 29100574-245a-40bc-bc72-09bf527fba14
         status: 200 OK
         code: 200
-        duration: 83.044959ms
+        duration: 79.759458ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2012,8 +2008,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -2021,20 +2017,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2744
+        content_length: 17
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:00.725315+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-serene-grothendieck","id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.713123+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a52aee59-c5cf-44d0-915e-6bf8da8e87f7","modification_date":"2024-10-14T09:05:23.713123+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"9490ba87-565a-4ba4-998f-b8cf2b7b3b6f","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"14","hypervisor_id":"302","node_id":"46","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:68:de:5f","maintenances":[],"modification_date":"2025-01-27T13:52:13.414764+00:00","name":"tf-srv-serene-grothendieck","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:52:17.573967+00:00","id":"785c0b9e-c76a-4849-a3e4-2dea16be3ecd","ipam_ip_ids":["099de162-3f1a-4dd3-af86-b8a45e88322f","4281722f-26bc-4ba6-b5d3-eecbb8d6c411"],"mac_address":"02:00:00:2c:d9:85","modification_date":"2025-01-27T13:52:50.004095+00:00","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","server_id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:00.725315+00:00","export_uri":null,"id":"6e5d5152-3105-42ab-a4f9-00e41036aeb8","modification_date":"2025-01-27T13:52:00.725315+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","name":"tf-srv-serene-grothendieck"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "2744"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:56 GMT
+                - Tue, 11 Feb 2025 14:23:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2042,11 +2038,162 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 97a705c2-3cf4-4cdf-9662-1a162819b2f4
+                - 58dada40-871b-449c-9cd9-444b87d5c6f9
         status: 200 OK
         code: 200
-        duration: 152.800791ms
+        duration: 78.647334ms
     - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 478
+        uncompressed: false
+        body: '{"private_nics":[{"creation_date":"2025-02-11T14:22:44.190547+00:00","id":"ab5c7c79-153c-4397-9e3f-9e0fb2157d8d","ipam_ip_ids":["bc7752ab-7438-40bd-acf4-0164fffc59dc","c8b212eb-69d8-4f7e-9819-02bcbc9781ce"],"mac_address":"02:00:00:2c:82:98","modification_date":"2025-02-11T14:23:15.979265+00:00","private_network_id":"838071ad-2943-4cd4-87e0-15285d88c11b","server_id":"1774b008-62b8-473c-bffd-8b29b9d852c8","state":"available","tags":[],"zone":"fr-par-2"}]}'
+        headers:
+            Content-Length:
+                - "478"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:22 GMT
+            Link:
+                - </servers/1774b008-62b8-473c-bffd-8b29b9d852c8/private_nics?page=1&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 350a8a35-d37c-4456-87f3-6758d5bcd680
+            X-Total-Count:
+                - "1"
+        status: 200 OK
+        code: 200
+        duration: 99.829375ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2282
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.318589+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-keen-swirles","id":"1774b008-62b8-473c-bffd-8b29b9d852c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.426391+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a4a91637-cfbf-4a45-be29-9795d04c4f98","modification_date":"2024-10-14T09:05:23.426391+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4658bc98-1c87-4dfe-8dae-fa0dc563a43e","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"103","node_id":"12","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:6b:08:f9","maintenances":[],"modification_date":"2025-02-11T14:22:40.995024+00:00","name":"tf-srv-keen-swirles","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:22:44.190547+00:00","id":"ab5c7c79-153c-4397-9e3f-9e0fb2157d8d","ipam_ip_ids":["bc7752ab-7438-40bd-acf4-0164fffc59dc","c8b212eb-69d8-4f7e-9819-02bcbc9781ce"],"mac_address":"02:00:00:2c:82:98","modification_date":"2025-02-11T14:23:15.979265+00:00","private_network_id":"838071ad-2943-4cd4-87e0-15285d88c11b","server_id":"1774b008-62b8-473c-bffd-8b29b9d852c8","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"2953faa1-9cf4-4f7a-a33f-21ce47364692","volume_type":"sbs_volume","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+        headers:
+            Content-Length:
+                - "2282"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3bae3d16-56a0-4f96-9672-5d493d13ce7d
+        status: 200 OK
+        code: 200
+        duration: 115.056792ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-2/volumes/2953faa1-9cf4-4f7a-a33f-21ce47364692
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:22:37.488569Z","id":"2953faa1-9cf4-4f7a-a33f-21ce47364692","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"4658bc98-1c87-4dfe-8dae-fa0dc563a43e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:37.488569Z","id":"b8892b98-fb2e-4e39-897e-86e866ebb1f1","product_resource_id":"1774b008-62b8-473c-bffd-8b29b9d852c8","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:37.488569Z","zone":"fr-par-2"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0aad2242-37e1-4b3d-8f84-4bfffc8e828c
+        status: 200 OK
+        code: 200
+        duration: 83.143834ms
+    - id: 44
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2063,8 +2210,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -2074,7 +2221,7 @@ interactions:
         trailer: {}
         content_length: 352
         uncompressed: false
-        body: '{"task":{"description":"server_poweroff","href_from":"/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2/action","href_result":"/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2","id":"17bdae67-28d1-4a52-b4f4-137371048d61","progress":0,"started_at":"2025-01-27T13:52:57.290465+00:00","status":"pending","terminated_at":null,"zone":"fr-par-2"}}'
+        body: '{"task":{"description":"server_poweroff","href_from":"/servers/1774b008-62b8-473c-bffd-8b29b9d852c8/action","href_result":"/servers/1774b008-62b8-473c-bffd-8b29b9d852c8","id":"2beaf49c-aa20-4ef8-89a6-5bce5f395b36","progress":0,"started_at":"2025-02-11T14:23:23.815637+00:00","status":"pending","terminated_at":null,"zone":"fr-par-2"}}'
         headers:
             Content-Length:
                 - "352"
@@ -2083,11 +2230,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:57 GMT
+                - Tue, 11 Feb 2025 14:23:23 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-2/tasks/17bdae67-28d1-4a52-b4f4-137371048d61
+                - https://api.scaleway.com/instance/v1/zones/fr-par-2/tasks/2beaf49c-aa20-4ef8-89a6-5bce5f395b36
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2095,157 +2242,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 998fd0af-b8d4-46af-9527-69332bb99b69
+                - 9309c7cc-bf03-40bb-ae04-db2b12bc6af6
         status: 202 Accepted
         code: 202
-        duration: 231.185834ms
-    - id: 42
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2704
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:00.725315+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-serene-grothendieck","id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.713123+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a52aee59-c5cf-44d0-915e-6bf8da8e87f7","modification_date":"2024-10-14T09:05:23.713123+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"9490ba87-565a-4ba4-998f-b8cf2b7b3b6f","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"14","hypervisor_id":"302","node_id":"46","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:68:de:5f","maintenances":[],"modification_date":"2025-01-27T13:52:57.121614+00:00","name":"tf-srv-serene-grothendieck","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:52:17.573967+00:00","id":"785c0b9e-c76a-4849-a3e4-2dea16be3ecd","ipam_ip_ids":["099de162-3f1a-4dd3-af86-b8a45e88322f","4281722f-26bc-4ba6-b5d3-eecbb8d6c411"],"mac_address":"02:00:00:2c:d9:85","modification_date":"2025-01-27T13:52:50.004095+00:00","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","server_id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:00.725315+00:00","export_uri":null,"id":"6e5d5152-3105-42ab-a4f9-00e41036aeb8","modification_date":"2025-01-27T13:52:00.725315+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","name":"tf-srv-serene-grothendieck"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
-        headers:
-            Content-Length:
-                - "2704"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:52:57 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - dea38d11-cf4e-40a0-900e-a3f805f48dab
-        status: 200 OK
-        code: 200
-        duration: 153.105417ms
-    - id: 43
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2704
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:00.725315+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-serene-grothendieck","id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.713123+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a52aee59-c5cf-44d0-915e-6bf8da8e87f7","modification_date":"2024-10-14T09:05:23.713123+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"9490ba87-565a-4ba4-998f-b8cf2b7b3b6f","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"14","hypervisor_id":"302","node_id":"46","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:68:de:5f","maintenances":[],"modification_date":"2025-01-27T13:52:57.121614+00:00","name":"tf-srv-serene-grothendieck","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:52:17.573967+00:00","id":"785c0b9e-c76a-4849-a3e4-2dea16be3ecd","ipam_ip_ids":["099de162-3f1a-4dd3-af86-b8a45e88322f","4281722f-26bc-4ba6-b5d3-eecbb8d6c411"],"mac_address":"02:00:00:2c:d9:85","modification_date":"2025-01-27T13:52:50.004095+00:00","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","server_id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:00.725315+00:00","export_uri":null,"id":"6e5d5152-3105-42ab-a4f9-00e41036aeb8","modification_date":"2025-01-27T13:52:00.725315+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","name":"tf-srv-serene-grothendieck"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
-        headers:
-            Content-Length:
-                - "2704"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:53:02 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 39e43b19-299e-4427-bb6e-96868df6786c
-        status: 200 OK
-        code: 200
-        duration: 157.002ms
-    - id: 44
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2704
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:00.725315+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-serene-grothendieck","id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.713123+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a52aee59-c5cf-44d0-915e-6bf8da8e87f7","modification_date":"2024-10-14T09:05:23.713123+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"9490ba87-565a-4ba4-998f-b8cf2b7b3b6f","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"14","hypervisor_id":"302","node_id":"46","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:68:de:5f","maintenances":[],"modification_date":"2025-01-27T13:52:57.121614+00:00","name":"tf-srv-serene-grothendieck","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:52:17.573967+00:00","id":"785c0b9e-c76a-4849-a3e4-2dea16be3ecd","ipam_ip_ids":["099de162-3f1a-4dd3-af86-b8a45e88322f","4281722f-26bc-4ba6-b5d3-eecbb8d6c411"],"mac_address":"02:00:00:2c:d9:85","modification_date":"2025-01-27T13:52:50.004095+00:00","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","server_id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:00.725315+00:00","export_uri":null,"id":"6e5d5152-3105-42ab-a4f9-00e41036aeb8","modification_date":"2025-01-27T13:52:00.725315+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","name":"tf-srv-serene-grothendieck"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
-        headers:
-            Content-Length:
-                - "2704"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:53:07 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - a7ebc814-a275-4ae9-af72-d6adfccc0fbe
-        status: 200 OK
-        code: 200
-        duration: 134.263708ms
+        duration: 242.298959ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2261,8 +2261,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -2270,20 +2270,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2704
+        content_length: 2242
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:00.725315+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-serene-grothendieck","id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.713123+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a52aee59-c5cf-44d0-915e-6bf8da8e87f7","modification_date":"2024-10-14T09:05:23.713123+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"9490ba87-565a-4ba4-998f-b8cf2b7b3b6f","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"14","hypervisor_id":"302","node_id":"46","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:68:de:5f","maintenances":[],"modification_date":"2025-01-27T13:52:57.121614+00:00","name":"tf-srv-serene-grothendieck","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:52:17.573967+00:00","id":"785c0b9e-c76a-4849-a3e4-2dea16be3ecd","ipam_ip_ids":["099de162-3f1a-4dd3-af86-b8a45e88322f","4281722f-26bc-4ba6-b5d3-eecbb8d6c411"],"mac_address":"02:00:00:2c:d9:85","modification_date":"2025-01-27T13:52:50.004095+00:00","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","server_id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:00.725315+00:00","export_uri":null,"id":"6e5d5152-3105-42ab-a4f9-00e41036aeb8","modification_date":"2025-01-27T13:52:00.725315+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","name":"tf-srv-serene-grothendieck"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.318589+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-keen-swirles","id":"1774b008-62b8-473c-bffd-8b29b9d852c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.426391+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a4a91637-cfbf-4a45-be29-9795d04c4f98","modification_date":"2024-10-14T09:05:23.426391+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4658bc98-1c87-4dfe-8dae-fa0dc563a43e","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"103","node_id":"12","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:6b:08:f9","maintenances":[],"modification_date":"2025-02-11T14:23:23.656612+00:00","name":"tf-srv-keen-swirles","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:22:44.190547+00:00","id":"ab5c7c79-153c-4397-9e3f-9e0fb2157d8d","ipam_ip_ids":["bc7752ab-7438-40bd-acf4-0164fffc59dc","c8b212eb-69d8-4f7e-9819-02bcbc9781ce"],"mac_address":"02:00:00:2c:82:98","modification_date":"2025-02-11T14:23:15.979265+00:00","private_network_id":"838071ad-2943-4cd4-87e0-15285d88c11b","server_id":"1774b008-62b8-473c-bffd-8b29b9d852c8","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"2953faa1-9cf4-4f7a-a33f-21ce47364692","volume_type":"sbs_volume","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
         headers:
             Content-Length:
-                - "2704"
+                - "2242"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:12 GMT
+                - Tue, 11 Feb 2025 14:23:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2291,10 +2291,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f157a09b-54dc-46a7-8566-997ebada3476
+                - 95eafcaa-6b4d-47fc-98e7-ffce1984e160
         status: 200 OK
         code: 200
-        duration: 124.74525ms
+        duration: 189.5315ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2310,8 +2310,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -2319,20 +2319,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2704
+        content_length: 2242
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:00.725315+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-serene-grothendieck","id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.713123+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a52aee59-c5cf-44d0-915e-6bf8da8e87f7","modification_date":"2024-10-14T09:05:23.713123+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"9490ba87-565a-4ba4-998f-b8cf2b7b3b6f","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"14","hypervisor_id":"302","node_id":"46","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:68:de:5f","maintenances":[],"modification_date":"2025-01-27T13:52:57.121614+00:00","name":"tf-srv-serene-grothendieck","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:52:17.573967+00:00","id":"785c0b9e-c76a-4849-a3e4-2dea16be3ecd","ipam_ip_ids":["099de162-3f1a-4dd3-af86-b8a45e88322f","4281722f-26bc-4ba6-b5d3-eecbb8d6c411"],"mac_address":"02:00:00:2c:d9:85","modification_date":"2025-01-27T13:52:50.004095+00:00","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","server_id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:00.725315+00:00","export_uri":null,"id":"6e5d5152-3105-42ab-a4f9-00e41036aeb8","modification_date":"2025-01-27T13:52:00.725315+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","name":"tf-srv-serene-grothendieck"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.318589+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-keen-swirles","id":"1774b008-62b8-473c-bffd-8b29b9d852c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.426391+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a4a91637-cfbf-4a45-be29-9795d04c4f98","modification_date":"2024-10-14T09:05:23.426391+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4658bc98-1c87-4dfe-8dae-fa0dc563a43e","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"103","node_id":"12","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:6b:08:f9","maintenances":[],"modification_date":"2025-02-11T14:23:23.656612+00:00","name":"tf-srv-keen-swirles","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:22:44.190547+00:00","id":"ab5c7c79-153c-4397-9e3f-9e0fb2157d8d","ipam_ip_ids":["bc7752ab-7438-40bd-acf4-0164fffc59dc","c8b212eb-69d8-4f7e-9819-02bcbc9781ce"],"mac_address":"02:00:00:2c:82:98","modification_date":"2025-02-11T14:23:15.979265+00:00","private_network_id":"838071ad-2943-4cd4-87e0-15285d88c11b","server_id":"1774b008-62b8-473c-bffd-8b29b9d852c8","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"2953faa1-9cf4-4f7a-a33f-21ce47364692","volume_type":"sbs_volume","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
         headers:
             Content-Length:
-                - "2704"
+                - "2242"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:17 GMT
+                - Tue, 11 Feb 2025 14:23:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2340,10 +2340,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 78498043-2697-416b-802e-a0fa68e97d7f
+                - 5839ec05-c3d2-4b78-a18c-53516a67870c
         status: 200 OK
         code: 200
-        duration: 126.530375ms
+        duration: 192.097875ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2359,8 +2359,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -2368,20 +2368,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2704
+        content_length: 2242
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:00.725315+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-serene-grothendieck","id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.713123+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a52aee59-c5cf-44d0-915e-6bf8da8e87f7","modification_date":"2024-10-14T09:05:23.713123+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"9490ba87-565a-4ba4-998f-b8cf2b7b3b6f","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"14","hypervisor_id":"302","node_id":"46","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:68:de:5f","maintenances":[],"modification_date":"2025-01-27T13:52:57.121614+00:00","name":"tf-srv-serene-grothendieck","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:52:17.573967+00:00","id":"785c0b9e-c76a-4849-a3e4-2dea16be3ecd","ipam_ip_ids":["099de162-3f1a-4dd3-af86-b8a45e88322f","4281722f-26bc-4ba6-b5d3-eecbb8d6c411"],"mac_address":"02:00:00:2c:d9:85","modification_date":"2025-01-27T13:52:50.004095+00:00","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","server_id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:00.725315+00:00","export_uri":null,"id":"6e5d5152-3105-42ab-a4f9-00e41036aeb8","modification_date":"2025-01-27T13:52:00.725315+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","name":"tf-srv-serene-grothendieck"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.318589+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-keen-swirles","id":"1774b008-62b8-473c-bffd-8b29b9d852c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.426391+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a4a91637-cfbf-4a45-be29-9795d04c4f98","modification_date":"2024-10-14T09:05:23.426391+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4658bc98-1c87-4dfe-8dae-fa0dc563a43e","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"103","node_id":"12","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:6b:08:f9","maintenances":[],"modification_date":"2025-02-11T14:23:23.656612+00:00","name":"tf-srv-keen-swirles","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:22:44.190547+00:00","id":"ab5c7c79-153c-4397-9e3f-9e0fb2157d8d","ipam_ip_ids":["bc7752ab-7438-40bd-acf4-0164fffc59dc","c8b212eb-69d8-4f7e-9819-02bcbc9781ce"],"mac_address":"02:00:00:2c:82:98","modification_date":"2025-02-11T14:23:15.979265+00:00","private_network_id":"838071ad-2943-4cd4-87e0-15285d88c11b","server_id":"1774b008-62b8-473c-bffd-8b29b9d852c8","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"2953faa1-9cf4-4f7a-a33f-21ce47364692","volume_type":"sbs_volume","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
         headers:
             Content-Length:
-                - "2704"
+                - "2242"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:23 GMT
+                - Tue, 11 Feb 2025 14:23:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2389,10 +2389,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7be0b153-bca9-481a-ad06-802632a307ca
+                - 26043785-e6b2-4c67-86a4-fcfa475a3a28
         status: 200 OK
         code: 200
-        duration: 160.959459ms
+        duration: 169.677708ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2408,8 +2408,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -2417,20 +2417,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2704
+        content_length: 2242
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:00.725315+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-serene-grothendieck","id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.713123+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a52aee59-c5cf-44d0-915e-6bf8da8e87f7","modification_date":"2024-10-14T09:05:23.713123+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"9490ba87-565a-4ba4-998f-b8cf2b7b3b6f","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"14","hypervisor_id":"302","node_id":"46","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:68:de:5f","maintenances":[],"modification_date":"2025-01-27T13:52:57.121614+00:00","name":"tf-srv-serene-grothendieck","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:52:17.573967+00:00","id":"785c0b9e-c76a-4849-a3e4-2dea16be3ecd","ipam_ip_ids":["099de162-3f1a-4dd3-af86-b8a45e88322f","4281722f-26bc-4ba6-b5d3-eecbb8d6c411"],"mac_address":"02:00:00:2c:d9:85","modification_date":"2025-01-27T13:52:50.004095+00:00","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","server_id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:00.725315+00:00","export_uri":null,"id":"6e5d5152-3105-42ab-a4f9-00e41036aeb8","modification_date":"2025-01-27T13:52:00.725315+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","name":"tf-srv-serene-grothendieck"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.318589+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-keen-swirles","id":"1774b008-62b8-473c-bffd-8b29b9d852c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.426391+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a4a91637-cfbf-4a45-be29-9795d04c4f98","modification_date":"2024-10-14T09:05:23.426391+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4658bc98-1c87-4dfe-8dae-fa0dc563a43e","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"103","node_id":"12","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:6b:08:f9","maintenances":[],"modification_date":"2025-02-11T14:23:23.656612+00:00","name":"tf-srv-keen-swirles","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:22:44.190547+00:00","id":"ab5c7c79-153c-4397-9e3f-9e0fb2157d8d","ipam_ip_ids":["bc7752ab-7438-40bd-acf4-0164fffc59dc","c8b212eb-69d8-4f7e-9819-02bcbc9781ce"],"mac_address":"02:00:00:2c:82:98","modification_date":"2025-02-11T14:23:15.979265+00:00","private_network_id":"838071ad-2943-4cd4-87e0-15285d88c11b","server_id":"1774b008-62b8-473c-bffd-8b29b9d852c8","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"2953faa1-9cf4-4f7a-a33f-21ce47364692","volume_type":"sbs_volume","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
         headers:
             Content-Length:
-                - "2704"
+                - "2242"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:27 GMT
+                - Tue, 11 Feb 2025 14:23:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2438,10 +2438,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 52be09c9-8067-4235-97d0-5d9555f65748
+                - 0fadd8cc-60ed-4eeb-9585-f0987c3c3d50
         status: 200 OK
         code: 200
-        duration: 148.358958ms
+        duration: 169.408083ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2457,8 +2457,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -2466,20 +2466,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2704
+        content_length: 2126
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:00.725315+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-serene-grothendieck","id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.713123+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a52aee59-c5cf-44d0-915e-6bf8da8e87f7","modification_date":"2024-10-14T09:05:23.713123+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"9490ba87-565a-4ba4-998f-b8cf2b7b3b6f","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"14","hypervisor_id":"302","node_id":"46","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:68:de:5f","maintenances":[],"modification_date":"2025-01-27T13:52:57.121614+00:00","name":"tf-srv-serene-grothendieck","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:52:17.573967+00:00","id":"785c0b9e-c76a-4849-a3e4-2dea16be3ecd","ipam_ip_ids":["099de162-3f1a-4dd3-af86-b8a45e88322f","4281722f-26bc-4ba6-b5d3-eecbb8d6c411"],"mac_address":"02:00:00:2c:d9:85","modification_date":"2025-01-27T13:52:50.004095+00:00","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","server_id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:00.725315+00:00","export_uri":null,"id":"6e5d5152-3105-42ab-a4f9-00e41036aeb8","modification_date":"2025-01-27T13:52:00.725315+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","name":"tf-srv-serene-grothendieck"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.318589+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-keen-swirles","id":"1774b008-62b8-473c-bffd-8b29b9d852c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.426391+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a4a91637-cfbf-4a45-be29-9795d04c4f98","modification_date":"2024-10-14T09:05:23.426391+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4658bc98-1c87-4dfe-8dae-fa0dc563a43e","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":null,"mac_address":"de:00:00:6b:08:f9","maintenances":[],"modification_date":"2025-02-11T14:23:43.305398+00:00","name":"tf-srv-keen-swirles","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:22:44.190547+00:00","id":"ab5c7c79-153c-4397-9e3f-9e0fb2157d8d","ipam_ip_ids":["bc7752ab-7438-40bd-acf4-0164fffc59dc","c8b212eb-69d8-4f7e-9819-02bcbc9781ce"],"mac_address":"02:00:00:2c:82:98","modification_date":"2025-02-11T14:23:15.979265+00:00","private_network_id":"838071ad-2943-4cd4-87e0-15285d88c11b","server_id":"1774b008-62b8-473c-bffd-8b29b9d852c8","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"2953faa1-9cf4-4f7a-a33f-21ce47364692","volume_type":"sbs_volume","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
         headers:
             Content-Length:
-                - "2704"
+                - "2126"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:33 GMT
+                - Tue, 11 Feb 2025 14:23:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2487,10 +2487,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9fa1717a-bf6e-4a15-bbac-f26757dae2cc
+                - 3482ed01-95f7-48d3-bd99-225869f24093
         status: 200 OK
         code: 200
-        duration: 177.08575ms
+        duration: 191.599625ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -2506,8 +2506,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -2515,20 +2515,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2588
+        content_length: 478
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:00.725315+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-serene-grothendieck","id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.713123+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a52aee59-c5cf-44d0-915e-6bf8da8e87f7","modification_date":"2024-10-14T09:05:23.713123+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"9490ba87-565a-4ba4-998f-b8cf2b7b3b6f","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":null,"mac_address":"de:00:00:68:de:5f","maintenances":[],"modification_date":"2025-01-27T13:53:37.634973+00:00","name":"tf-srv-serene-grothendieck","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:52:17.573967+00:00","id":"785c0b9e-c76a-4849-a3e4-2dea16be3ecd","ipam_ip_ids":["099de162-3f1a-4dd3-af86-b8a45e88322f","4281722f-26bc-4ba6-b5d3-eecbb8d6c411"],"mac_address":"02:00:00:2c:d9:85","modification_date":"2025-01-27T13:52:50.004095+00:00","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","server_id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:00.725315+00:00","export_uri":null,"id":"6e5d5152-3105-42ab-a4f9-00e41036aeb8","modification_date":"2025-01-27T13:52:00.725315+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","name":"tf-srv-serene-grothendieck"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+        body: '{"private_nics":[{"creation_date":"2025-02-11T14:22:44.190547+00:00","id":"ab5c7c79-153c-4397-9e3f-9e0fb2157d8d","ipam_ip_ids":["bc7752ab-7438-40bd-acf4-0164fffc59dc","c8b212eb-69d8-4f7e-9819-02bcbc9781ce"],"mac_address":"02:00:00:2c:82:98","modification_date":"2025-02-11T14:23:15.979265+00:00","private_network_id":"838071ad-2943-4cd4-87e0-15285d88c11b","server_id":"1774b008-62b8-473c-bffd-8b29b9d852c8","state":"available","tags":[],"zone":"fr-par-2"}]}'
         headers:
             Content-Length:
-                - "2588"
+                - "478"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:38 GMT
+                - Tue, 11 Feb 2025 14:23:44 GMT
+            Link:
+                - </servers/1774b008-62b8-473c-bffd-8b29b9d852c8/private_nics?page=1&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2536,10 +2538,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b2b5e72f-4be6-4417-b71f-8daca9db49de
+                - fb516cda-1e05-4f12-baf1-8b481256dcb1
+            X-Total-Count:
+                - "1"
         status: 200 OK
         code: 200
-        duration: 128.926125ms
+        duration: 70.632708ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2555,8 +2559,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8/private_nics/ab5c7c79-153c-4397-9e3f-9e0fb2157d8d
         method: GET
       response:
         proto: HTTP/2.0
@@ -2564,22 +2568,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 478
+        content_length: 475
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:52:17.573967+00:00","id":"785c0b9e-c76a-4849-a3e4-2dea16be3ecd","ipam_ip_ids":["099de162-3f1a-4dd3-af86-b8a45e88322f","4281722f-26bc-4ba6-b5d3-eecbb8d6c411"],"mac_address":"02:00:00:2c:d9:85","modification_date":"2025-01-27T13:52:50.004095+00:00","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","server_id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","state":"available","tags":[],"zone":"fr-par-2"}]}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:22:44.190547+00:00","id":"ab5c7c79-153c-4397-9e3f-9e0fb2157d8d","ipam_ip_ids":["bc7752ab-7438-40bd-acf4-0164fffc59dc","c8b212eb-69d8-4f7e-9819-02bcbc9781ce"],"mac_address":"02:00:00:2c:82:98","modification_date":"2025-02-11T14:23:15.979265+00:00","private_network_id":"838071ad-2943-4cd4-87e0-15285d88c11b","server_id":"1774b008-62b8-473c-bffd-8b29b9d852c8","state":"available","tags":[],"zone":"fr-par-2"}}'
         headers:
             Content-Length:
-                - "478"
+                - "475"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:38 GMT
-            Link:
-                - </servers/53ff15f0-a93e-4c90-a468-faa33e738ff2/private_nics?page=1&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:23:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2587,12 +2589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1c5dab45-1485-4475-a534-b59c87fc3370
-            X-Total-Count:
-                - "1"
+                - 2ae05fec-21d4-4fe7-abe7-8934a108b45d
         status: 200 OK
         code: 200
-        duration: 90.792458ms
+        duration: 86.069208ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -2608,29 +2608,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2/private_nics/785c0b9e-c76a-4849-a3e4-2dea16be3ecd
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8/private_nics/ab5c7c79-153c-4397-9e3f-9e0fb2157d8d
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 475
+        content_length: 0
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:52:17.573967+00:00","id":"785c0b9e-c76a-4849-a3e4-2dea16be3ecd","ipam_ip_ids":["099de162-3f1a-4dd3-af86-b8a45e88322f","4281722f-26bc-4ba6-b5d3-eecbb8d6c411"],"mac_address":"02:00:00:2c:d9:85","modification_date":"2025-01-27T13:52:50.004095+00:00","private_network_id":"201b8529-612e-4452-93f5-c7b9a38ee2c7","server_id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","state":"available","tags":[],"zone":"fr-par-2"}}'
+        body: ""
         headers:
-            Content-Length:
-                - "475"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:38 GMT
+                - Tue, 11 Feb 2025 14:23:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2638,10 +2636,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dc526421-51e4-4fd3-a1ad-efb7cad41111
-        status: 200 OK
-        code: 200
-        duration: 93.928333ms
+                - ddf8d47c-ef8a-426d-89fc-37249a772a3b
+        status: 204 No Content
+        code: 204
+        duration: 315.49225ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -2657,27 +2655,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2/private_nics/785c0b9e-c76a-4849-a3e4-2dea16be3ecd
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8/private_nics/ab5c7c79-153c-4397-9e3f-9e0fb2157d8d
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 148
         uncompressed: false
-        body: ""
+        body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"ab5c7c79-153c-4397-9e3f-9e0fb2157d8d","type":"not_found"}'
         headers:
+            Content-Length:
+                - "148"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:38 GMT
+                - Tue, 11 Feb 2025 14:23:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2685,10 +2685,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 913d3f1c-ffe2-4a0d-b1f5-effa766c0424
-        status: 204 No Content
-        code: 204
-        duration: 231.084042ms
+                - 11e0899a-3473-472d-bee6-8dc1cb197e40
+        status: 404 Not Found
+        code: 404
+        duration: 91.305958ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -2704,8 +2704,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2/private_nics/785c0b9e-c76a-4849-a3e4-2dea16be3ecd
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -2713,20 +2713,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 148
+        content_length: 1668
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"785c0b9e-c76a-4849-a3e4-2dea16be3ecd","type":"not_found"}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.318589+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-keen-swirles","id":"1774b008-62b8-473c-bffd-8b29b9d852c8","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.426391+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a4a91637-cfbf-4a45-be29-9795d04c4f98","modification_date":"2024-10-14T09:05:23.426391+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4658bc98-1c87-4dfe-8dae-fa0dc563a43e","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":null,"mac_address":"de:00:00:6b:08:f9","maintenances":[],"modification_date":"2025-02-11T14:23:43.305398+00:00","name":"tf-srv-keen-swirles","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"2953faa1-9cf4-4f7a-a33f-21ce47364692","volume_type":"sbs_volume","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
         headers:
             Content-Length:
-                - "148"
+                - "1668"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:38 GMT
+                - Tue, 11 Feb 2025 14:23:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2734,10 +2734,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 99a897b6-0b58-4611-b69e-75c0f5f6483d
-        status: 404 Not Found
-        code: 404
-        duration: 73.426167ms
+                - a07c33f8-15e9-4238-ac10-3f36508994ad
+        status: 200 OK
+        code: 200
+        duration: 164.128959ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -2753,29 +2753,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2130
+        content_length: 0
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:00.725315+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-serene-grothendieck","id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:23.713123+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a52aee59-c5cf-44d0-915e-6bf8da8e87f7","modification_date":"2024-10-14T09:05:23.713123+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"9490ba87-565a-4ba4-998f-b8cf2b7b3b6f","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":null,"mac_address":"de:00:00:68:de:5f","maintenances":[],"modification_date":"2025-01-27T13:53:37.634973+00:00","name":"tf-srv-serene-grothendieck","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:00.725315+00:00","export_uri":null,"id":"6e5d5152-3105-42ab-a4f9-00e41036aeb8","modification_date":"2025-01-27T13:52:00.725315+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","name":"tf-srv-serene-grothendieck"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+        body: ""
         headers:
-            Content-Length:
-                - "2130"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:38 GMT
+                - Tue, 11 Feb 2025 14:23:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2783,10 +2781,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0ed3dfb7-2bf1-47ea-834c-cb3412280792
-        status: 200 OK
-        code: 200
-        duration: 139.960666ms
+                - 3c821e88-573c-492d-a9e2-b8824ad1c275
+        status: 204 No Content
+        code: 204
+        duration: 246.527792ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2802,27 +2800,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/1774b008-62b8-473c-bffd-8b29b9d852c8
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 143
         uncompressed: false
-        body: ""
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"1774b008-62b8-473c-bffd-8b29b9d852c8","type":"not_found"}'
         headers:
+            Content-Length:
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:39 GMT
+                - Tue, 11 Feb 2025 14:23:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2830,10 +2830,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - db1b5ddb-38dc-44aa-8ea1-4678839633a8
-        status: 204 No Content
-        code: 204
-        duration: 189.733875ms
+                - 2fa6b4e9-7032-4a88-8005-3e42c13cad30
+        status: 404 Not Found
+        code: 404
+        duration: 63.144292ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2849,8 +2849,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/53ff15f0-a93e-4c90-a468-faa33e738ff2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/volumes/2953faa1-9cf4-4f7a-a33f-21ce47364692
         method: GET
       response:
         proto: HTTP/2.0
@@ -2860,7 +2860,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"53ff15f0-a93e-4c90-a468-faa33e738ff2","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"2953faa1-9cf4-4f7a-a33f-21ce47364692","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -2869,9 +2869,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:39 GMT
+                - Tue, 11 Feb 2025 14:23:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2879,10 +2879,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e5e1d448-f327-4d7e-b6ac-d1c5516efe4b
+                - c3f5b210-ac92-4fb4-bf63-1fb9f606791e
         status: 404 Not Found
         code: 404
-        duration: 84.360125ms
+        duration: 32.539125ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -2898,8 +2898,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/volumes/6e5d5152-3105-42ab-a4f9-00e41036aeb8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-2/volumes/2953faa1-9cf4-4f7a-a33f-21ce47364692
         method: GET
       response:
         proto: HTTP/2.0
@@ -2907,20 +2907,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 446
+        content_length: 494
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:52:00.725315+00:00","export_uri":null,"id":"6e5d5152-3105-42ab-a4f9-00e41036aeb8","modification_date":"2025-01-27T13:53:39.318473+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}}'
+        body: '{"created_at":"2025-02-11T14:22:37.488569Z","id":"2953faa1-9cf4-4f7a-a33f-21ce47364692","last_detached_at":"2025-02-11T14:23:45.844729Z","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"4658bc98-1c87-4dfe-8dae-fa0dc563a43e","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:45.844729Z","zone":"fr-par-2"}'
         headers:
             Content-Length:
-                - "446"
+                - "494"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:39 GMT
+                - Tue, 11 Feb 2025 14:23:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2928,10 +2928,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e06c780b-5dba-46bb-a005-332555374b0a
+                - d45c1a90-fb40-44e6-ad91-8e30ee650c6e
         status: 200 OK
         code: 200
-        duration: 69.175666ms
+        duration: 76.798333ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -2947,8 +2947,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/volumes/6e5d5152-3105-42ab-a4f9-00e41036aeb8
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-2/volumes/2953faa1-9cf4-4f7a-a33f-21ce47364692
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2965,9 +2965,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:39 GMT
+                - Tue, 11 Feb 2025 14:23:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2975,10 +2975,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9309eb03-ee15-4b1c-97b1-0791b8738f62
+                - c3f4c433-12f9-42db-8c95-324b21d06ff7
         status: 204 No Content
         code: 204
-        duration: 177.196875ms
+        duration: 134.996542ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -2996,7 +2996,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
         method: POST
       response:
@@ -3007,7 +3007,7 @@ interactions:
         trailer: {}
         content_length: 1051
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:53:39.867750Z","dhcp_enabled":true,"id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:53:39.867750Z","id":"3b4ac01d-048a-4077-a2b6-b5e344768fc3","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.20.0/22","updated_at":"2025-01-27T13:53:39.867750Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:53:39.867750Z","id":"32ddd6f5-f125-4418-b7c2-18de23d13498","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:e437::/64","updated_at":"2025-01-27T13:53:39.867750Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:53:39.867750Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"created_at":"2025-02-11T14:23:46.151993Z","dhcp_enabled":true,"id":"8e85576b-7702-4413-866b-4f684d7dcfb6","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-11T14:23:46.151993Z","id":"ae5ebb5e-3140-4c2a-aebb-7c2492695024","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.16.0/22","updated_at":"2025-02-11T14:23:46.151993Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-11T14:23:46.151993Z","id":"db3dfab7-aa89-48aa-90db-b0af2fbbe71b","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:819d::/64","updated_at":"2025-02-11T14:23:46.151993Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-11T14:23:46.151993Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
                 - "1051"
@@ -3016,9 +3016,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:40 GMT
+                - Tue, 11 Feb 2025 14:23:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3026,10 +3026,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ca485d9b-e1a8-4c9e-a5e6-870e7d14be2c
+                - 49064866-2709-4219-9258-924b56216e0c
         status: 200 OK
         code: 200
-        duration: 715.284375ms
+        duration: 662.064792ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -3045,8 +3045,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6e43bd7f-e7d5-4d93-999e-26abbc550834
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8e85576b-7702-4413-866b-4f684d7dcfb6
         method: GET
       response:
         proto: HTTP/2.0
@@ -3056,7 +3056,7 @@ interactions:
         trailer: {}
         content_length: 1051
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:53:39.867750Z","dhcp_enabled":true,"id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:53:39.867750Z","id":"3b4ac01d-048a-4077-a2b6-b5e344768fc3","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.20.0/22","updated_at":"2025-01-27T13:53:39.867750Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:53:39.867750Z","id":"32ddd6f5-f125-4418-b7c2-18de23d13498","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:e437::/64","updated_at":"2025-01-27T13:53:39.867750Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:53:39.867750Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"created_at":"2025-02-11T14:23:46.151993Z","dhcp_enabled":true,"id":"8e85576b-7702-4413-866b-4f684d7dcfb6","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-11T14:23:46.151993Z","id":"ae5ebb5e-3140-4c2a-aebb-7c2492695024","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.16.0/22","updated_at":"2025-02-11T14:23:46.151993Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-11T14:23:46.151993Z","id":"db3dfab7-aa89-48aa-90db-b0af2fbbe71b","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:819d::/64","updated_at":"2025-02-11T14:23:46.151993Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-11T14:23:46.151993Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
                 - "1051"
@@ -3065,9 +3065,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:40 GMT
+                - Tue, 11 Feb 2025 14:23:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3075,10 +3075,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d21ac195-1f5c-46d7-9fb3-9ec85e4200da
+                - f589b12c-b8b6-497e-b275-a0a56055ce20
         status: 200 OK
         code: 200
-        duration: 30.93425ms
+        duration: 42.924916ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -3094,8 +3094,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/201b8529-612e-4452-93f5-c7b9a38ee2c7
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/838071ad-2943-4cd4-87e0-15285d88c11b
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3112,9 +3112,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:40 GMT
+                - Tue, 11 Feb 2025 14:23:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3122,10 +3122,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bf39295a-b8ba-4ffe-bd41-98b7b222917d
+                - e89e5631-2349-4ff8-ae6b-968aacf7e476
         status: 204 No Content
         code: 204
-        duration: 1.100385625s
+        duration: 1.37538675s
     - id: 63
       request:
         proto: HTTP/1.1
@@ -3141,7 +3141,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
         method: GET
       response:
@@ -3150,22 +3150,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 38539
+        content_length: 35639
         uncompressed: false
-        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
+        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
         headers:
             Content-Length:
-                - "38539"
+                - "35639"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:40 GMT
+                - Tue, 11 Feb 2025 14:23:47 GMT
             Link:
                 - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3173,12 +3173,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fcc76247-ab47-4129-9f1f-e14be26632b3
+                - 807bcd6d-9d4f-4c45-b569-7762bf6fc41d
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 47.984292ms
+        duration: 107.192667ms
     - id: 64
       request:
         proto: HTTP/1.1
@@ -3194,7 +3194,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
         method: GET
       response:
@@ -3203,22 +3203,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 14208
+        content_length: 13164
         uncompressed: false
-        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
         headers:
             Content-Length:
-                - "14208"
+                - "13164"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:40 GMT
+                - Tue, 11 Feb 2025 14:23:47 GMT
             Link:
                 - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3226,12 +3226,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3c2653ca-311f-49c1-b5ae-33726a615b52
+                - 2a37ed39-9290-4400-8737-cf4e00eb5367
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 42.90075ms
+        duration: 64.077292ms
     - id: 65
       request:
         proto: HTTP/1.1
@@ -3247,8 +3247,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_local&zone=fr-par-1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_sbs&zone=fr-par-1
         method: GET
       response:
         proto: HTTP/2.0
@@ -3256,20 +3256,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1300
+        content_length: 1296
         uncompressed: false
-        body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"56d4019c-8305-467a-a3f2-70498ad799df","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
+        body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"57509e82-ac3b-49b7-9970-97b60f40ff72","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"9b647e1e-253a-41e7-8c15-911c622ee2dc","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"}],"total_count":2}'
         headers:
             Content-Length:
-                - "1300"
+                - "1296"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:41 GMT
+                - Tue, 11 Feb 2025 14:23:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3277,28 +3277,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 23a31edc-316a-4cc1-9947-05e73bc1f871
+                - f8c6ee58-2fdc-4bd5-b860-42905f6aea88
         status: 200 OK
         code: 200
-        duration: 89.318583ms
+        duration: 467.314084ms
     - id: 66
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 275
+        content_length: 233
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-srv-musing-johnson","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+        body: '{"name":"tf-srv-zealous-tesla","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"57509e82-ac3b-49b7-9970-97b60f40ff72","volumes":{"0":{"boot":false}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
         method: POST
       response:
@@ -3307,22 +3307,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2115
+        content_length: 1670
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:53:41.719194+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:48.517107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-zealous-tesla","id":"d6a4ef64-1630-4987-aabb-e733f3478c04","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:f9","maintenances":[],"modification_date":"2025-02-11T14:23:48.517107+00:00","name":"tf-srv-zealous-tesla","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"810a8a91-0c84-4910-9038-f757b08e6d92","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2115"
+                - "1670"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:41 GMT
+                - Tue, 11 Feb 2025 14:23:49 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3330,10 +3330,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 399d8559-f169-43ad-95e9-888d2b92eb99
+                - bc7c1943-ce6c-4ac8-a751-cc30daf832e1
         status: 201 Created
         code: 201
-        duration: 1.015169917s
+        duration: 1.12475525s
     - id: 67
       request:
         proto: HTTP/1.1
@@ -3349,8 +3349,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04
         method: GET
       response:
         proto: HTTP/2.0
@@ -3358,20 +3358,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2115
+        content_length: 1670
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:53:41.719194+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:48.517107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-zealous-tesla","id":"d6a4ef64-1630-4987-aabb-e733f3478c04","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:f9","maintenances":[],"modification_date":"2025-02-11T14:23:48.517107+00:00","name":"tf-srv-zealous-tesla","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"810a8a91-0c84-4910-9038-f757b08e6d92","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2115"
+                - "1670"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:42 GMT
+                - Tue, 11 Feb 2025 14:23:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3379,10 +3379,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 112d518c-7c32-4071-8907-2ab4735bf104
+                - a6afbd5d-f7b7-4aa0-a738-e03e2d75abe8
         status: 200 OK
         code: 200
-        duration: 169.247625ms
+        duration: 184.036291ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -3398,8 +3398,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04
         method: GET
       response:
         proto: HTTP/2.0
@@ -3407,20 +3407,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2115
+        content_length: 1670
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:53:41.719194+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:48.517107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-zealous-tesla","id":"d6a4ef64-1630-4987-aabb-e733f3478c04","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:f9","maintenances":[],"modification_date":"2025-02-11T14:23:48.517107+00:00","name":"tf-srv-zealous-tesla","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"810a8a91-0c84-4910-9038-f757b08e6d92","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2115"
+                - "1670"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:42 GMT
+                - Tue, 11 Feb 2025 14:23:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3428,11 +3428,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 73f1e62b-b414-43a6-883d-2a0bf0a146a0
+                - 48f4136d-86d9-4420-92bb-a4073f631844
         status: 200 OK
         code: 200
-        duration: 161.102625ms
+        duration: 167.767542ms
     - id: 69
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/810a8a91-0c84-4910-9038-f757b08e6d92
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:23:48.722794Z","id":"810a8a91-0c84-4910-9038-f757b08e6d92","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:48.722794Z","id":"5b696577-55c8-4230-9368-a29e9ea2b0e5","product_resource_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:48.722794Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4f8cc3cc-1e01-420b-84e7-a1ab9f17857a
+        status: 200 OK
+        code: 200
+        duration: 65.862125ms
+    - id: 70
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3449,8 +3498,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -3460,7 +3509,7 @@ interactions:
         trailer: {}
         content_length: 357
         uncompressed: false
-        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/action","href_result":"/servers/44be618c-4ff5-4b62-ac34-867025adcc7e","id":"32b9a34e-6923-4425-a6e0-078d4981813c","progress":0,"started_at":"2025-01-27T13:53:42.765854+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/action","href_result":"/servers/d6a4ef64-1630-4987-aabb-e733f3478c04","id":"323f02d6-fd8a-4418-8731-fc2984d46e64","progress":0,"started_at":"2025-02-11T14:23:49.934073+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -3469,11 +3518,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:42 GMT
+                - Tue, 11 Feb 2025 14:23:49 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/32b9a34e-6923-4425-a6e0-078d4981813c
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/323f02d6-fd8a-4418-8731-fc2984d46e64
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3481,59 +3530,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 72451479-48bf-42cc-94de-f3b6293e2357
+                - 8141f613-3dba-4f2f-8fd7-af98589eb86c
         status: 202 Accepted
         code: 202
-        duration: 326.483083ms
-    - id: 70
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2137
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:53:42.503529+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2137"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:53:42 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 12df946b-ce84-4427-bb13-cb680f22bf24
-        status: 200 OK
-        code: 200
-        duration: 165.539042ms
+        duration: 252.867041ms
     - id: 71
       request:
         proto: HTTP/1.1
@@ -3549,8 +3549,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04
         method: GET
       response:
         proto: HTTP/2.0
@@ -3558,20 +3558,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2240
+        content_length: 1692
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"102","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:53:42.503529+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:48.517107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-zealous-tesla","id":"d6a4ef64-1630-4987-aabb-e733f3478c04","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:f9","maintenances":[],"modification_date":"2025-02-11T14:23:49.738939+00:00","name":"tf-srv-zealous-tesla","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"id":"810a8a91-0c84-4910-9038-f757b08e6d92","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2240"
+                - "1692"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:48 GMT
+                - Tue, 11 Feb 2025 14:23:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3579,10 +3579,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 11234c48-873b-4572-8616-bc62a694f03c
+                - d6582fa7-019d-438f-97b1-ed1be1769197
         status: 200 OK
         code: 200
-        duration: 205.456584ms
+        duration: 186.809208ms
     - id: 72
       request:
         proto: HTTP/1.1
@@ -3598,8 +3598,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04
         method: GET
       response:
         proto: HTTP/2.0
@@ -3607,20 +3607,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2240
+        content_length: 1825
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"102","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:53:42.503529+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:48.517107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-zealous-tesla","id":"d6a4ef64-1630-4987-aabb-e733f3478c04","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"803","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f9","maintenances":[],"modification_date":"2025-02-11T14:23:53.803702+00:00","name":"tf-srv-zealous-tesla","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"810a8a91-0c84-4910-9038-f757b08e6d92","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2240"
+                - "1825"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:53 GMT
+                - Tue, 11 Feb 2025 14:23:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3628,10 +3628,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 02e6ff2f-837c-4067-9452-09dd177aad66
+                - 34d8f7e9-4d4b-42a4-a03f-cffae77661ef
         status: 200 OK
         code: 200
-        duration: 216.828666ms
+        duration: 158.061834ms
     - id: 73
       request:
         proto: HTTP/1.1
@@ -3647,8 +3647,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8e85576b-7702-4413-866b-4f684d7dcfb6
         method: GET
       response:
         proto: HTTP/2.0
@@ -3656,20 +3656,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2271
+        content_length: 1051
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"102","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:53:55.578717+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T14:23:46.151993Z","dhcp_enabled":true,"id":"8e85576b-7702-4413-866b-4f684d7dcfb6","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-11T14:23:46.151993Z","id":"ae5ebb5e-3140-4c2a-aebb-7c2492695024","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.16.0/22","updated_at":"2025-02-11T14:23:46.151993Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-11T14:23:46.151993Z","id":"db3dfab7-aa89-48aa-90db-b0af2fbbe71b","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:819d::/64","updated_at":"2025-02-11T14:23:46.151993Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-11T14:23:46.151993Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "2271"
+                - "1051"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:59 GMT
+                - Tue, 11 Feb 2025 14:23:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3677,10 +3677,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4bac9f5c-8502-46c3-94c3-d76bd3e51e47
+                - c1f08618-c9d5-447c-9a70-27638bb10c31
         status: 200 OK
         code: 200
-        duration: 141.103125ms
+        duration: 31.564625ms
     - id: 74
       request:
         proto: HTTP/1.1
@@ -3696,8 +3696,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6e43bd7f-e7d5-4d93-999e-26abbc550834
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04
         method: GET
       response:
         proto: HTTP/2.0
@@ -3705,20 +3705,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1051
+        content_length: 1825
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:53:39.867750Z","dhcp_enabled":true,"id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:53:39.867750Z","id":"3b4ac01d-048a-4077-a2b6-b5e344768fc3","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.20.0/22","updated_at":"2025-01-27T13:53:39.867750Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:53:39.867750Z","id":"32ddd6f5-f125-4418-b7c2-18de23d13498","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:e437::/64","updated_at":"2025-01-27T13:53:39.867750Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:53:39.867750Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:48.517107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-zealous-tesla","id":"d6a4ef64-1630-4987-aabb-e733f3478c04","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"803","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f9","maintenances":[],"modification_date":"2025-02-11T14:23:53.803702+00:00","name":"tf-srv-zealous-tesla","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"810a8a91-0c84-4910-9038-f757b08e6d92","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1051"
+                - "1825"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:59 GMT
+                - Tue, 11 Feb 2025 14:23:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3726,11 +3726,62 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c47d4841-2ca0-446d-8d09-a7daa1488806
+                - c0dc88c6-6465-4655-be0d-50349e098fe9
         status: 200 OK
         code: 200
-        duration: 26.326375ms
+        duration: 165.813333ms
     - id: 75
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 61
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 473
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:23:55.533598+00:00","id":"865cfe47-19b9-403a-9b38-6f30061479fc","ipam_ip_ids":["bb477641-af00-42e0-af75-9b6b1bfac443","b39378f6-3d8d-4588-a4d6-11cfa06a3d57"],"mac_address":"02:00:00:19:0c:9a","modification_date":"2025-02-11T14:23:55.739828+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "473"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b74061c2-4015-4711-85ae-ff03bc514c81
+        status: 201 Created
+        code: 201
+        duration: 2.060191958s
+    - id: 76
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3745,60 +3796,9 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics/865cfe47-19b9-403a-9b38-6f30061479fc
         method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2271
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"102","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:53:55.578717+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2271"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:53:59 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 0c955a1a-b687-424c-8dba-c5a3a7142701
-        status: 200 OK
-        code: 200
-        duration: 130.672417ms
-    - id: 76
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 61
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics
-        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -3807,7 +3807,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:53:59.732072+00:00","id":"d71bb31d-3a42-435d-81e7-f5a73ebbd51d","ipam_ip_ids":["a0ecce20-89f8-434e-a9fc-4db517b8bbef","1e815b98-7caf-45ab-8b49-87153e211cc7"],"mac_address":"02:00:00:13:4c:fd","modification_date":"2025-01-27T13:53:59.919555+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:23:55.533598+00:00","id":"865cfe47-19b9-403a-9b38-6f30061479fc","ipam_ip_ids":["bb477641-af00-42e0-af75-9b6b1bfac443","b39378f6-3d8d-4588-a4d6-11cfa06a3d57"],"mac_address":"02:00:00:19:0c:9a","modification_date":"2025-02-11T14:23:55.739828+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -3816,9 +3816,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:00 GMT
+                - Tue, 11 Feb 2025 14:23:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3826,10 +3826,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f8cc0b80-9377-4765-9695-dbb5f3b28fa0
-        status: 201 Created
-        code: 201
-        duration: 1.0723385s
+                - 3c407156-9f71-4e3b-9f83-94f1e67e6472
+        status: 200 OK
+        code: 200
+        duration: 84.298666ms
     - id: 77
       request:
         proto: HTTP/1.1
@@ -3845,8 +3845,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics/d71bb31d-3a42-435d-81e7-f5a73ebbd51d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics/865cfe47-19b9-403a-9b38-6f30061479fc
         method: GET
       response:
         proto: HTTP/2.0
@@ -3856,7 +3856,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:53:59.732072+00:00","id":"d71bb31d-3a42-435d-81e7-f5a73ebbd51d","ipam_ip_ids":["a0ecce20-89f8-434e-a9fc-4db517b8bbef","1e815b98-7caf-45ab-8b49-87153e211cc7"],"mac_address":"02:00:00:13:4c:fd","modification_date":"2025-01-27T13:53:59.919555+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:23:55.533598+00:00","id":"865cfe47-19b9-403a-9b38-6f30061479fc","ipam_ip_ids":["bb477641-af00-42e0-af75-9b6b1bfac443","b39378f6-3d8d-4588-a4d6-11cfa06a3d57"],"mac_address":"02:00:00:19:0c:9a","modification_date":"2025-02-11T14:23:55.739828+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -3865,9 +3865,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:00 GMT
+                - Tue, 11 Feb 2025 14:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3875,10 +3875,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6d136a7b-badd-4e4e-8d91-5ba5ff32fca1
+                - 0e3a1c8f-8e47-42d4-90f5-3ae6ae4e2452
         status: 200 OK
         code: 200
-        duration: 95.76275ms
+        duration: 83.3705ms
     - id: 78
       request:
         proto: HTTP/1.1
@@ -3894,8 +3894,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics/d71bb31d-3a42-435d-81e7-f5a73ebbd51d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics/865cfe47-19b9-403a-9b38-6f30061479fc
         method: GET
       response:
         proto: HTTP/2.0
@@ -3905,7 +3905,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:53:59.732072+00:00","id":"d71bb31d-3a42-435d-81e7-f5a73ebbd51d","ipam_ip_ids":["a0ecce20-89f8-434e-a9fc-4db517b8bbef","1e815b98-7caf-45ab-8b49-87153e211cc7"],"mac_address":"02:00:00:13:4c:fd","modification_date":"2025-01-27T13:53:59.919555+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:23:55.533598+00:00","id":"865cfe47-19b9-403a-9b38-6f30061479fc","ipam_ip_ids":["bb477641-af00-42e0-af75-9b6b1bfac443","b39378f6-3d8d-4588-a4d6-11cfa06a3d57"],"mac_address":"02:00:00:19:0c:9a","modification_date":"2025-02-11T14:23:55.739828+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -3914,9 +3914,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:05 GMT
+                - Tue, 11 Feb 2025 14:24:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3924,10 +3924,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cbd57732-d4fd-4142-8165-ff6a65fcfb3d
+                - b6163cc6-10da-4b5e-acf7-7119acc3358a
         status: 200 OK
         code: 200
-        duration: 88.970542ms
+        duration: 100.1735ms
     - id: 79
       request:
         proto: HTTP/1.1
@@ -3943,8 +3943,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics/d71bb31d-3a42-435d-81e7-f5a73ebbd51d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics/865cfe47-19b9-403a-9b38-6f30061479fc
         method: GET
       response:
         proto: HTTP/2.0
@@ -3954,7 +3954,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:53:59.732072+00:00","id":"d71bb31d-3a42-435d-81e7-f5a73ebbd51d","ipam_ip_ids":["a0ecce20-89f8-434e-a9fc-4db517b8bbef","1e815b98-7caf-45ab-8b49-87153e211cc7"],"mac_address":"02:00:00:13:4c:fd","modification_date":"2025-01-27T13:53:59.919555+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:23:55.533598+00:00","id":"865cfe47-19b9-403a-9b38-6f30061479fc","ipam_ip_ids":["bb477641-af00-42e0-af75-9b6b1bfac443","b39378f6-3d8d-4588-a4d6-11cfa06a3d57"],"mac_address":"02:00:00:19:0c:9a","modification_date":"2025-02-11T14:23:55.739828+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -3963,9 +3963,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:11 GMT
+                - Tue, 11 Feb 2025 14:24:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3973,10 +3973,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0c4841cb-66c2-443f-8037-c0dda9e286ce
+                - b08eafc6-a657-46a1-a4ef-b3c11559285a
         status: 200 OK
         code: 200
-        duration: 83.594708ms
+        duration: 98.387917ms
     - id: 80
       request:
         proto: HTTP/1.1
@@ -3992,8 +3992,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics/d71bb31d-3a42-435d-81e7-f5a73ebbd51d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics/865cfe47-19b9-403a-9b38-6f30061479fc
         method: GET
       response:
         proto: HTTP/2.0
@@ -4003,7 +4003,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:53:59.732072+00:00","id":"d71bb31d-3a42-435d-81e7-f5a73ebbd51d","ipam_ip_ids":["a0ecce20-89f8-434e-a9fc-4db517b8bbef","1e815b98-7caf-45ab-8b49-87153e211cc7"],"mac_address":"02:00:00:13:4c:fd","modification_date":"2025-01-27T13:53:59.919555+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:23:55.533598+00:00","id":"865cfe47-19b9-403a-9b38-6f30061479fc","ipam_ip_ids":["bb477641-af00-42e0-af75-9b6b1bfac443","b39378f6-3d8d-4588-a4d6-11cfa06a3d57"],"mac_address":"02:00:00:19:0c:9a","modification_date":"2025-02-11T14:23:55.739828+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -4012,9 +4012,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:15 GMT
+                - Tue, 11 Feb 2025 14:24:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4022,10 +4022,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6bf5c057-520f-4020-b728-197030ee8a7b
+                - 83a432ed-ba8b-4048-b448-e20bc883d719
         status: 200 OK
         code: 200
-        duration: 87.821875ms
+        duration: 102.892167ms
     - id: 81
       request:
         proto: HTTP/1.1
@@ -4041,8 +4041,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics/d71bb31d-3a42-435d-81e7-f5a73ebbd51d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics/865cfe47-19b9-403a-9b38-6f30061479fc
         method: GET
       response:
         proto: HTTP/2.0
@@ -4052,7 +4052,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:53:59.732072+00:00","id":"d71bb31d-3a42-435d-81e7-f5a73ebbd51d","ipam_ip_ids":["a0ecce20-89f8-434e-a9fc-4db517b8bbef","1e815b98-7caf-45ab-8b49-87153e211cc7"],"mac_address":"02:00:00:13:4c:fd","modification_date":"2025-01-27T13:53:59.919555+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:23:55.533598+00:00","id":"865cfe47-19b9-403a-9b38-6f30061479fc","ipam_ip_ids":["bb477641-af00-42e0-af75-9b6b1bfac443","b39378f6-3d8d-4588-a4d6-11cfa06a3d57"],"mac_address":"02:00:00:19:0c:9a","modification_date":"2025-02-11T14:23:55.739828+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -4061,9 +4061,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:21 GMT
+                - Tue, 11 Feb 2025 14:24:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4071,10 +4071,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a5081319-e44e-47a4-b1b2-97dc326ed174
+                - 9c9bcf89-be00-47e0-b25a-8874f8bc5f72
         status: 200 OK
         code: 200
-        duration: 85.864834ms
+        duration: 69.999834ms
     - id: 82
       request:
         proto: HTTP/1.1
@@ -4090,8 +4090,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics/d71bb31d-3a42-435d-81e7-f5a73ebbd51d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics/865cfe47-19b9-403a-9b38-6f30061479fc
         method: GET
       response:
         proto: HTTP/2.0
@@ -4101,7 +4101,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:53:59.732072+00:00","id":"d71bb31d-3a42-435d-81e7-f5a73ebbd51d","ipam_ip_ids":["a0ecce20-89f8-434e-a9fc-4db517b8bbef","1e815b98-7caf-45ab-8b49-87153e211cc7"],"mac_address":"02:00:00:13:4c:fd","modification_date":"2025-01-27T13:53:59.919555+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:23:55.533598+00:00","id":"865cfe47-19b9-403a-9b38-6f30061479fc","ipam_ip_ids":["bb477641-af00-42e0-af75-9b6b1bfac443","b39378f6-3d8d-4588-a4d6-11cfa06a3d57"],"mac_address":"02:00:00:19:0c:9a","modification_date":"2025-02-11T14:23:55.739828+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -4110,9 +4110,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:26 GMT
+                - Tue, 11 Feb 2025 14:24:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4120,10 +4120,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f62dc812-b823-4b58-b4b4-c42231e2516e
+                - 2a51bfa1-2f4e-4af5-a2c0-3ef45de6a294
         status: 200 OK
         code: 200
-        duration: 72.0445ms
+        duration: 101.712958ms
     - id: 83
       request:
         proto: HTTP/1.1
@@ -4139,8 +4139,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics/d71bb31d-3a42-435d-81e7-f5a73ebbd51d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics/865cfe47-19b9-403a-9b38-6f30061479fc
         method: GET
       response:
         proto: HTTP/2.0
@@ -4148,20 +4148,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 473
+        content_length: 475
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:53:59.732072+00:00","id":"d71bb31d-3a42-435d-81e7-f5a73ebbd51d","ipam_ip_ids":["a0ecce20-89f8-434e-a9fc-4db517b8bbef","1e815b98-7caf-45ab-8b49-87153e211cc7"],"mac_address":"02:00:00:13:4c:fd","modification_date":"2025-01-27T13:53:59.919555+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:23:55.533598+00:00","id":"865cfe47-19b9-403a-9b38-6f30061479fc","ipam_ip_ids":["bb477641-af00-42e0-af75-9b6b1bfac443","b39378f6-3d8d-4588-a4d6-11cfa06a3d57"],"mac_address":"02:00:00:19:0c:9a","modification_date":"2025-02-11T14:24:28.375342+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "473"
+                - "475"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:31 GMT
+                - Tue, 11 Feb 2025 14:24:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4169,10 +4169,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c293618c-457a-4dd4-970f-932440819596
+                - d308d441-4efa-45a3-92b3-eb744d356835
         status: 200 OK
         code: 200
-        duration: 97.693834ms
+        duration: 102.883458ms
     - id: 84
       request:
         proto: HTTP/1.1
@@ -4188,8 +4188,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics/d71bb31d-3a42-435d-81e7-f5a73ebbd51d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics/865cfe47-19b9-403a-9b38-6f30061479fc
         method: GET
       response:
         proto: HTTP/2.0
@@ -4199,7 +4199,7 @@ interactions:
         trailer: {}
         content_length: 475
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:53:59.732072+00:00","id":"d71bb31d-3a42-435d-81e7-f5a73ebbd51d","ipam_ip_ids":["a0ecce20-89f8-434e-a9fc-4db517b8bbef","1e815b98-7caf-45ab-8b49-87153e211cc7"],"mac_address":"02:00:00:13:4c:fd","modification_date":"2025-01-27T13:54:31.818980+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:23:55.533598+00:00","id":"865cfe47-19b9-403a-9b38-6f30061479fc","ipam_ip_ids":["bb477641-af00-42e0-af75-9b6b1bfac443","b39378f6-3d8d-4588-a4d6-11cfa06a3d57"],"mac_address":"02:00:00:19:0c:9a","modification_date":"2025-02-11T14:24:28.375342+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "475"
@@ -4208,9 +4208,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:36 GMT
+                - Tue, 11 Feb 2025 14:24:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4218,10 +4218,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 17161a73-4161-46bf-a032-1b5182858cb2
+                - d9925dc5-8d72-4f32-ab70-c79d4eaa89b3
         status: 200 OK
         code: 200
-        duration: 102.850584ms
+        duration: 89.706417ms
     - id: 85
       request:
         proto: HTTP/1.1
@@ -4237,8 +4237,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics/d71bb31d-3a42-435d-81e7-f5a73ebbd51d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04
         method: GET
       response:
         proto: HTTP/2.0
@@ -4246,20 +4246,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 475
+        content_length: 2283
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:53:59.732072+00:00","id":"d71bb31d-3a42-435d-81e7-f5a73ebbd51d","ipam_ip_ids":["a0ecce20-89f8-434e-a9fc-4db517b8bbef","1e815b98-7caf-45ab-8b49-87153e211cc7"],"mac_address":"02:00:00:13:4c:fd","modification_date":"2025-01-27T13:54:31.818980+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:48.517107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-zealous-tesla","id":"d6a4ef64-1630-4987-aabb-e733f3478c04","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"803","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f9","maintenances":[],"modification_date":"2025-02-11T14:23:53.803702+00:00","name":"tf-srv-zealous-tesla","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:23:55.533598+00:00","id":"865cfe47-19b9-403a-9b38-6f30061479fc","ipam_ip_ids":["bb477641-af00-42e0-af75-9b6b1bfac443","b39378f6-3d8d-4588-a4d6-11cfa06a3d57"],"mac_address":"02:00:00:19:0c:9a","modification_date":"2025-02-11T14:24:28.375342+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"810a8a91-0c84-4910-9038-f757b08e6d92","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "475"
+                - "2283"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:36 GMT
+                - Tue, 11 Feb 2025 14:24:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4267,10 +4267,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a3380593-726e-4a8b-b19c-d8f4ef0d179a
+                - 09354be1-5ef1-4b98-bcb4-0af944e3346e
         status: 200 OK
         code: 200
-        duration: 91.15875ms
+        duration: 176.033416ms
     - id: 86
       request:
         proto: HTTP/1.1
@@ -4286,8 +4286,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/810a8a91-0c84-4910-9038-f757b08e6d92
         method: GET
       response:
         proto: HTTP/2.0
@@ -4295,20 +4295,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2729
+        content_length: 143
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"102","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:53:55.578717+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:53:59.732072+00:00","id":"d71bb31d-3a42-435d-81e7-f5a73ebbd51d","ipam_ip_ids":["a0ecce20-89f8-434e-a9fc-4db517b8bbef","1e815b98-7caf-45ab-8b49-87153e211cc7"],"mac_address":"02:00:00:13:4c:fd","modification_date":"2025-01-27T13:54:31.818980+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"810a8a91-0c84-4910-9038-f757b08e6d92","type":"not_found"}'
         headers:
             Content-Length:
-                - "2729"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:36 GMT
+                - Tue, 11 Feb 2025 14:24:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4316,10 +4316,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 104e89e0-10e0-4f4b-bc52-5fbb81f70842
-        status: 200 OK
-        code: 200
-        duration: 160.869792ms
+                - 9d44b527-2bbd-4cb3-a79e-5d119182188f
+        status: 404 Not Found
+        code: 404
+        duration: 46.766083ms
     - id: 87
       request:
         proto: HTTP/1.1
@@ -4335,8 +4335,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/1197fc24-679a-40dc-9858-30c145bbfa4a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/810a8a91-0c84-4910-9038-f757b08e6d92
         method: GET
       response:
         proto: HTTP/2.0
@@ -4344,20 +4344,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 521
+        content_length: 701
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T14:23:48.722794Z","id":"810a8a91-0c84-4910-9038-f757b08e6d92","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:48.722794Z","id":"5b696577-55c8-4230-9368-a29e9ea2b0e5","product_resource_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:48.722794Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "521"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:36 GMT
+                - Tue, 11 Feb 2025 14:24:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4365,10 +4365,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e3d968f1-026e-4e31-b453-0520f2094167
+                - 1b3bedd4-1b2d-469f-856a-3b881197309a
         status: 200 OK
         code: 200
-        duration: 76.610958ms
+        duration: 78.657ms
     - id: 88
       request:
         proto: HTTP/1.1
@@ -4384,8 +4384,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -4404,9 +4404,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:36 GMT
+                - Tue, 11 Feb 2025 14:24:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4414,10 +4414,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7585594e-b703-4396-84dd-0a9f51606f54
+                - 11fca262-e4c7-4f58-9874-79b4b9667dde
         status: 200 OK
         code: 200
-        duration: 106.341375ms
+        duration: 96.734917ms
     - id: 89
       request:
         proto: HTTP/1.1
@@ -4433,8 +4433,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -4444,7 +4444,7 @@ interactions:
         trailer: {}
         content_length: 478
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:53:59.732072+00:00","id":"d71bb31d-3a42-435d-81e7-f5a73ebbd51d","ipam_ip_ids":["a0ecce20-89f8-434e-a9fc-4db517b8bbef","1e815b98-7caf-45ab-8b49-87153e211cc7"],"mac_address":"02:00:00:13:4c:fd","modification_date":"2025-01-27T13:54:31.818980+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"private_nics":[{"creation_date":"2025-02-11T14:23:55.533598+00:00","id":"865cfe47-19b9-403a-9b38-6f30061479fc","ipam_ip_ids":["bb477641-af00-42e0-af75-9b6b1bfac443","b39378f6-3d8d-4588-a4d6-11cfa06a3d57"],"mac_address":"02:00:00:19:0c:9a","modification_date":"2025-02-11T14:24:28.375342+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
                 - "478"
@@ -4453,11 +4453,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:37 GMT
+                - Tue, 11 Feb 2025 14:24:33 GMT
             Link:
-                - </servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics?page=1&per_page=50&>; rel="last"
+                - </servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics?page=1&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4465,12 +4465,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 50f3a82d-c92e-403f-a813-75959bf463d4
+                - f9af5d1a-2c75-4e38-bb71-c94f10304ed7
             X-Total-Count:
                 - "1"
         status: 200 OK
         code: 200
-        duration: 90.12925ms
+        duration: 93.753416ms
     - id: 90
       request:
         proto: HTTP/1.1
@@ -4486,8 +4486,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -4497,7 +4497,7 @@ interactions:
         trailer: {}
         content_length: 478
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:53:59.732072+00:00","id":"d71bb31d-3a42-435d-81e7-f5a73ebbd51d","ipam_ip_ids":["a0ecce20-89f8-434e-a9fc-4db517b8bbef","1e815b98-7caf-45ab-8b49-87153e211cc7"],"mac_address":"02:00:00:13:4c:fd","modification_date":"2025-01-27T13:54:31.818980+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"private_nics":[{"creation_date":"2025-02-11T14:23:55.533598+00:00","id":"865cfe47-19b9-403a-9b38-6f30061479fc","ipam_ip_ids":["bb477641-af00-42e0-af75-9b6b1bfac443","b39378f6-3d8d-4588-a4d6-11cfa06a3d57"],"mac_address":"02:00:00:19:0c:9a","modification_date":"2025-02-11T14:24:28.375342+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
                 - "478"
@@ -4506,11 +4506,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:37 GMT
+                - Tue, 11 Feb 2025 14:24:33 GMT
             Link:
-                - </servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics?page=1&per_page=50&>; rel="last"
+                - </servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics?page=1&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4518,12 +4518,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8c00789e-ff9f-4d52-bd56-1bf0fcf28d92
+                - c1f045a8-b604-4893-8b9f-2e4dba210d2b
             X-Total-Count:
                 - "1"
         status: 200 OK
         code: 200
-        duration: 87.539958ms
+        duration: 86.175625ms
     - id: 91
       request:
         proto: HTTP/1.1
@@ -4539,8 +4539,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6e43bd7f-e7d5-4d93-999e-26abbc550834
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8e85576b-7702-4413-866b-4f684d7dcfb6
         method: GET
       response:
         proto: HTTP/2.0
@@ -4550,7 +4550,7 @@ interactions:
         trailer: {}
         content_length: 1051
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:53:39.867750Z","dhcp_enabled":true,"id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:53:39.867750Z","id":"3b4ac01d-048a-4077-a2b6-b5e344768fc3","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.20.0/22","updated_at":"2025-01-27T13:53:39.867750Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:53:39.867750Z","id":"32ddd6f5-f125-4418-b7c2-18de23d13498","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:e437::/64","updated_at":"2025-01-27T13:53:39.867750Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:53:39.867750Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"created_at":"2025-02-11T14:23:46.151993Z","dhcp_enabled":true,"id":"8e85576b-7702-4413-866b-4f684d7dcfb6","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-11T14:23:46.151993Z","id":"ae5ebb5e-3140-4c2a-aebb-7c2492695024","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.16.0/22","updated_at":"2025-02-11T14:23:46.151993Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-11T14:23:46.151993Z","id":"db3dfab7-aa89-48aa-90db-b0af2fbbe71b","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:819d::/64","updated_at":"2025-02-11T14:23:46.151993Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-11T14:23:46.151993Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
                 - "1051"
@@ -4559,9 +4559,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:37 GMT
+                - Tue, 11 Feb 2025 14:24:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4569,10 +4569,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 130f0c05-4086-4b26-afe8-95e8c58ff1a5
+                - c2d89962-ffb0-4bbe-95d0-05049cb25723
         status: 200 OK
         code: 200
-        duration: 27.616125ms
+        duration: 49.244333ms
     - id: 92
       request:
         proto: HTTP/1.1
@@ -4588,8 +4588,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04
         method: GET
       response:
         proto: HTTP/2.0
@@ -4597,20 +4597,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2729
+        content_length: 2283
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"102","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:53:55.578717+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:53:59.732072+00:00","id":"d71bb31d-3a42-435d-81e7-f5a73ebbd51d","ipam_ip_ids":["a0ecce20-89f8-434e-a9fc-4db517b8bbef","1e815b98-7caf-45ab-8b49-87153e211cc7"],"mac_address":"02:00:00:13:4c:fd","modification_date":"2025-01-27T13:54:31.818980+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:48.517107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-zealous-tesla","id":"d6a4ef64-1630-4987-aabb-e733f3478c04","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"803","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f9","maintenances":[],"modification_date":"2025-02-11T14:23:53.803702+00:00","name":"tf-srv-zealous-tesla","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:23:55.533598+00:00","id":"865cfe47-19b9-403a-9b38-6f30061479fc","ipam_ip_ids":["bb477641-af00-42e0-af75-9b6b1bfac443","b39378f6-3d8d-4588-a4d6-11cfa06a3d57"],"mac_address":"02:00:00:19:0c:9a","modification_date":"2025-02-11T14:24:28.375342+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"810a8a91-0c84-4910-9038-f757b08e6d92","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2729"
+                - "2283"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:37 GMT
+                - Tue, 11 Feb 2025 14:24:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4618,10 +4618,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5a8f47f6-7470-429d-a470-7bd0e742cc7f
+                - 8de7a5ec-d1fb-42b7-aa1b-c9aa8951d478
         status: 200 OK
         code: 200
-        duration: 220.520542ms
+        duration: 228.491958ms
     - id: 93
       request:
         proto: HTTP/1.1
@@ -4637,8 +4637,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/1197fc24-679a-40dc-9858-30c145bbfa4a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/810a8a91-0c84-4910-9038-f757b08e6d92
         method: GET
       response:
         proto: HTTP/2.0
@@ -4646,20 +4646,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 521
+        content_length: 143
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"810a8a91-0c84-4910-9038-f757b08e6d92","type":"not_found"}'
         headers:
             Content-Length:
-                - "521"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:37 GMT
+                - Tue, 11 Feb 2025 14:24:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4667,10 +4667,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6032d739-a54b-4f19-a10f-77fff508b30f
-        status: 200 OK
-        code: 200
-        duration: 84.528583ms
+                - 9388e288-472c-47ae-b95b-d0909411fc1a
+        status: 404 Not Found
+        code: 404
+        duration: 34.712542ms
     - id: 94
       request:
         proto: HTTP/1.1
@@ -4686,8 +4686,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/810a8a91-0c84-4910-9038-f757b08e6d92
         method: GET
       response:
         proto: HTTP/2.0
@@ -4695,20 +4695,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 701
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"created_at":"2025-02-11T14:23:48.722794Z","id":"810a8a91-0c84-4910-9038-f757b08e6d92","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:48.722794Z","id":"5b696577-55c8-4230-9368-a29e9ea2b0e5","product_resource_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:48.722794Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "17"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:37 GMT
+                - Tue, 11 Feb 2025 14:24:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4716,10 +4716,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c0a766bd-a25a-4838-a3ae-19e579921e74
+                - e7a866d6-1a9d-475d-9a99-8d3dd61752fe
         status: 200 OK
         code: 200
-        duration: 113.506292ms
+        duration: 71.179291ms
     - id: 95
       request:
         proto: HTTP/1.1
@@ -4735,208 +4735,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 478
-        uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:53:59.732072+00:00","id":"d71bb31d-3a42-435d-81e7-f5a73ebbd51d","ipam_ip_ids":["a0ecce20-89f8-434e-a9fc-4db517b8bbef","1e815b98-7caf-45ab-8b49-87153e211cc7"],"mac_address":"02:00:00:13:4c:fd","modification_date":"2025-01-27T13:54:31.818980+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}]}'
-        headers:
-            Content-Length:
-                - "478"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:54:37 GMT
-            Link:
-                - </servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics?page=1&per_page=50&>; rel="last"
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - bfb39c55-e41a-47bf-a284-7db2485aa2ad
-            X-Total-Count:
-                - "1"
-        status: 200 OK
-        code: 200
-        duration: 94.393125ms
-    - id: 96
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6e43bd7f-e7d5-4d93-999e-26abbc550834
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1051
-        uncompressed: false
-        body: '{"created_at":"2025-01-27T13:53:39.867750Z","dhcp_enabled":true,"id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:53:39.867750Z","id":"3b4ac01d-048a-4077-a2b6-b5e344768fc3","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.20.0/22","updated_at":"2025-01-27T13:53:39.867750Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:53:39.867750Z","id":"32ddd6f5-f125-4418-b7c2-18de23d13498","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:e437::/64","updated_at":"2025-01-27T13:53:39.867750Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:53:39.867750Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
-        headers:
-            Content-Length:
-                - "1051"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:54:38 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - d981bf74-d3da-4695-8d3d-3bbeaefae9f7
-        status: 200 OK
-        code: 200
-        duration: 35.193625ms
-    - id: 97
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2729
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"102","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:53:55.578717+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:53:59.732072+00:00","id":"d71bb31d-3a42-435d-81e7-f5a73ebbd51d","ipam_ip_ids":["a0ecce20-89f8-434e-a9fc-4db517b8bbef","1e815b98-7caf-45ab-8b49-87153e211cc7"],"mac_address":"02:00:00:13:4c:fd","modification_date":"2025-01-27T13:54:31.818980+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2729"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:54:38 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - e3d5dbc1-b255-4cbd-8b05-8664014aef61
-        status: 200 OK
-        code: 200
-        duration: 153.57ms
-    - id: 98
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/1197fc24-679a-40dc-9858-30c145bbfa4a
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 521
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "521"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:54:38 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 863f02a7-9649-4a10-a289-c3f424f44545
-        status: 200 OK
-        code: 200
-        duration: 74.947292ms
-    - id: 99
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -4955,9 +4755,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:38 GMT
+                - Tue, 11 Feb 2025 14:24:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4965,10 +4765,210 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 43c80018-4386-4702-893b-ac5d075925ce
+                - e79c2d0f-1d0c-4f40-abd0-73222fafa45e
         status: 200 OK
         code: 200
-        duration: 87.757625ms
+        duration: 87.192542ms
+    - id: 96
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 478
+        uncompressed: false
+        body: '{"private_nics":[{"creation_date":"2025-02-11T14:23:55.533598+00:00","id":"865cfe47-19b9-403a-9b38-6f30061479fc","ipam_ip_ids":["bb477641-af00-42e0-af75-9b6b1bfac443","b39378f6-3d8d-4588-a4d6-11cfa06a3d57"],"mac_address":"02:00:00:19:0c:9a","modification_date":"2025-02-11T14:24:28.375342+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        headers:
+            Content-Length:
+                - "478"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:34 GMT
+            Link:
+                - </servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics?page=1&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - bee7346c-9c48-4cf7-981c-2839b8fc43de
+            X-Total-Count:
+                - "1"
+        status: 200 OK
+        code: 200
+        duration: 84.333708ms
+    - id: 97
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8e85576b-7702-4413-866b-4f684d7dcfb6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1051
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:23:46.151993Z","dhcp_enabled":true,"id":"8e85576b-7702-4413-866b-4f684d7dcfb6","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-11T14:23:46.151993Z","id":"ae5ebb5e-3140-4c2a-aebb-7c2492695024","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.16.0/22","updated_at":"2025-02-11T14:23:46.151993Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-11T14:23:46.151993Z","id":"db3dfab7-aa89-48aa-90db-b0af2fbbe71b","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:819d::/64","updated_at":"2025-02-11T14:23:46.151993Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-11T14:23:46.151993Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        headers:
+            Content-Length:
+                - "1051"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f54e9b55-e407-4a98-8abe-03c2682bc40b
+        status: 200 OK
+        code: 200
+        duration: 26.222417ms
+    - id: 98
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2283
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:48.517107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-zealous-tesla","id":"d6a4ef64-1630-4987-aabb-e733f3478c04","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"803","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f9","maintenances":[],"modification_date":"2025-02-11T14:23:53.803702+00:00","name":"tf-srv-zealous-tesla","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:23:55.533598+00:00","id":"865cfe47-19b9-403a-9b38-6f30061479fc","ipam_ip_ids":["bb477641-af00-42e0-af75-9b6b1bfac443","b39378f6-3d8d-4588-a4d6-11cfa06a3d57"],"mac_address":"02:00:00:19:0c:9a","modification_date":"2025-02-11T14:24:28.375342+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"810a8a91-0c84-4910-9038-f757b08e6d92","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2283"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3300c31d-8212-4b75-94b5-0d714eb6d636
+        status: 200 OK
+        code: 200
+        duration: 158.862125ms
+    - id: 99
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/810a8a91-0c84-4910-9038-f757b08e6d92
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"810a8a91-0c84-4910-9038-f757b08e6d92","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2cca7f10-64c9-4ef8-8a16-f7e9056bc156
+        status: 404 Not Found
+        code: 404
+        duration: 40.115292ms
     - id: 100
       request:
         proto: HTTP/1.1
@@ -4984,8 +4984,106 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/810a8a91-0c84-4910-9038-f757b08e6d92
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:23:48.722794Z","id":"810a8a91-0c84-4910-9038-f757b08e6d92","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:48.722794Z","id":"5b696577-55c8-4230-9368-a29e9ea2b0e5","product_resource_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:48.722794Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f0b314eb-7b84-430f-91c3-9d4008e3291e
+        status: 200 OK
+        code: 200
+        duration: 56.585791ms
+    - id: 101
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/user_data
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 17
+        uncompressed: false
+        body: '{"user_data":[]}'
+        headers:
+            Content-Length:
+                - "17"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1b4553f3-ec09-4efb-bec7-a54dae16b341
+        status: 200 OK
+        code: 200
+        duration: 91.665708ms
+    - id: 102
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -4995,7 +5093,7 @@ interactions:
         trailer: {}
         content_length: 478
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:53:59.732072+00:00","id":"d71bb31d-3a42-435d-81e7-f5a73ebbd51d","ipam_ip_ids":["a0ecce20-89f8-434e-a9fc-4db517b8bbef","1e815b98-7caf-45ab-8b49-87153e211cc7"],"mac_address":"02:00:00:13:4c:fd","modification_date":"2025-01-27T13:54:31.818980+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"private_nics":[{"creation_date":"2025-02-11T14:23:55.533598+00:00","id":"865cfe47-19b9-403a-9b38-6f30061479fc","ipam_ip_ids":["bb477641-af00-42e0-af75-9b6b1bfac443","b39378f6-3d8d-4588-a4d6-11cfa06a3d57"],"mac_address":"02:00:00:19:0c:9a","modification_date":"2025-02-11T14:24:28.375342+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
                 - "478"
@@ -5004,11 +5102,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:38 GMT
+                - Tue, 11 Feb 2025 14:24:35 GMT
             Link:
-                - </servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics?page=1&per_page=50&>; rel="last"
+                - </servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics?page=1&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5016,13 +5114,13 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bdaa0c0e-621c-49d9-9fe1-a89132f06050
+                - 7db4aa18-f6ce-4e32-a60e-0b7dc2c10d6e
             X-Total-Count:
                 - "1"
         status: 200 OK
         code: 200
-        duration: 82.759542ms
-    - id: 101
+        duration: 92.570083ms
+    - id: 103
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -5039,7 +5137,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
         method: POST
       response:
@@ -5050,7 +5148,7 @@ interactions:
         trailer: {}
         content_length: 1054
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:54:39.033868Z","dhcp_enabled":true,"id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","name":"private_network_instance_02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:54:39.033868Z","id":"5a031fb6-7da9-444c-be5e-0fc437f0c3d1","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.24.0/22","updated_at":"2025-01-27T13:54:39.033868Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:54:39.033868Z","id":"e3b82fe9-ecc2-4b25-af4f-169257e510e8","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:e3cd::/64","updated_at":"2025-01-27T13:54:39.033868Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:54:39.033868Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"created_at":"2025-02-11T14:24:35.842692Z","dhcp_enabled":true,"id":"a1de608c-4136-462d-875c-cc274949abe3","name":"private_network_instance_02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-11T14:24:35.842692Z","id":"72b9eafe-2e09-48d5-ae5d-9d63ebebc738","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.12.0/22","updated_at":"2025-02-11T14:24:35.842692Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-11T14:24:35.842692Z","id":"c37fba53-d26d-41b9-986a-cc71dcbca69e","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:cfb4::/64","updated_at":"2025-02-11T14:24:35.842692Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-11T14:24:35.842692Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
                 - "1054"
@@ -5059,9 +5157,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:39 GMT
+                - Tue, 11 Feb 2025 14:24:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5069,108 +5167,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8195eb44-f816-421c-8d06-18c678367155
+                - fed176da-8ba5-4104-8e71-41e72ee73b3e
         status: 200 OK
         code: 200
-        duration: 482.19775ms
-    - id: 102
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7e4f4db4-f983-4fad-ab8e-abb34f3b0292
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1054
-        uncompressed: false
-        body: '{"created_at":"2025-01-27T13:54:39.033868Z","dhcp_enabled":true,"id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","name":"private_network_instance_02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:54:39.033868Z","id":"5a031fb6-7da9-444c-be5e-0fc437f0c3d1","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.24.0/22","updated_at":"2025-01-27T13:54:39.033868Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:54:39.033868Z","id":"e3b82fe9-ecc2-4b25-af4f-169257e510e8","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:e3cd::/64","updated_at":"2025-01-27T13:54:39.033868Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:54:39.033868Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
-        headers:
-            Content-Length:
-                - "1054"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:54:39 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 5d650269-8ea1-4d99-9c8e-41e8e4dd4be8
-        status: 200 OK
-        code: 200
-        duration: 28.869083ms
-    - id: 103
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2729
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"102","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:53:55.578717+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:53:59.732072+00:00","id":"d71bb31d-3a42-435d-81e7-f5a73ebbd51d","ipam_ip_ids":["a0ecce20-89f8-434e-a9fc-4db517b8bbef","1e815b98-7caf-45ab-8b49-87153e211cc7"],"mac_address":"02:00:00:13:4c:fd","modification_date":"2025-01-27T13:54:31.818980+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2729"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:54:39 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 46b592c8-e4b3-49ab-a2ba-f753c9408606
-        status: 200 OK
-        code: 200
-        duration: 181.89975ms
+        duration: 522.498167ms
     - id: 104
       request:
         proto: HTTP/1.1
@@ -5186,8 +5186,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a1de608c-4136-462d-875c-cc274949abe3
         method: GET
       response:
         proto: HTTP/2.0
@@ -5195,22 +5195,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 478
+        content_length: 1054
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:53:59.732072+00:00","id":"d71bb31d-3a42-435d-81e7-f5a73ebbd51d","ipam_ip_ids":["a0ecce20-89f8-434e-a9fc-4db517b8bbef","1e815b98-7caf-45ab-8b49-87153e211cc7"],"mac_address":"02:00:00:13:4c:fd","modification_date":"2025-01-27T13:54:31.818980+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"created_at":"2025-02-11T14:24:35.842692Z","dhcp_enabled":true,"id":"a1de608c-4136-462d-875c-cc274949abe3","name":"private_network_instance_02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-11T14:24:35.842692Z","id":"72b9eafe-2e09-48d5-ae5d-9d63ebebc738","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.12.0/22","updated_at":"2025-02-11T14:24:35.842692Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-11T14:24:35.842692Z","id":"c37fba53-d26d-41b9-986a-cc71dcbca69e","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:cfb4::/64","updated_at":"2025-02-11T14:24:35.842692Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-11T14:24:35.842692Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "478"
+                - "1054"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:39 GMT
-            Link:
-                - </servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics?page=1&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:24:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5218,12 +5216,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4f64bcc8-0014-42d9-bb41-9b708c9b7a04
-            X-Total-Count:
-                - "1"
+                - efae06ab-6f1c-47a6-a223-44416fecc96c
         status: 200 OK
         code: 200
-        duration: 106.997709ms
+        duration: 60.120625ms
     - id: 105
       request:
         proto: HTTP/1.1
@@ -5239,8 +5235,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04
         method: GET
       response:
         proto: HTTP/2.0
@@ -5248,20 +5244,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2729
+        content_length: 2283
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"102","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:53:55.578717+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:53:59.732072+00:00","id":"d71bb31d-3a42-435d-81e7-f5a73ebbd51d","ipam_ip_ids":["a0ecce20-89f8-434e-a9fc-4db517b8bbef","1e815b98-7caf-45ab-8b49-87153e211cc7"],"mac_address":"02:00:00:13:4c:fd","modification_date":"2025-01-27T13:54:31.818980+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:48.517107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-zealous-tesla","id":"d6a4ef64-1630-4987-aabb-e733f3478c04","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"803","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f9","maintenances":[],"modification_date":"2025-02-11T14:23:53.803702+00:00","name":"tf-srv-zealous-tesla","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:23:55.533598+00:00","id":"865cfe47-19b9-403a-9b38-6f30061479fc","ipam_ip_ids":["bb477641-af00-42e0-af75-9b6b1bfac443","b39378f6-3d8d-4588-a4d6-11cfa06a3d57"],"mac_address":"02:00:00:19:0c:9a","modification_date":"2025-02-11T14:24:28.375342+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"810a8a91-0c84-4910-9038-f757b08e6d92","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2729"
+                - "2283"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:39 GMT
+                - Tue, 11 Feb 2025 14:24:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5269,10 +5265,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d3ee7d57-f96b-437c-a41e-038d3a17447e
+                - 57468b39-7b5d-4052-a11e-91301a773e2d
         status: 200 OK
         code: 200
-        duration: 163.535125ms
+        duration: 235.145417ms
     - id: 106
       request:
         proto: HTTP/1.1
@@ -5288,8 +5284,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics/d71bb31d-3a42-435d-81e7-f5a73ebbd51d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -5297,20 +5293,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 475
+        content_length: 478
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:53:59.732072+00:00","id":"d71bb31d-3a42-435d-81e7-f5a73ebbd51d","ipam_ip_ids":["a0ecce20-89f8-434e-a9fc-4db517b8bbef","1e815b98-7caf-45ab-8b49-87153e211cc7"],"mac_address":"02:00:00:13:4c:fd","modification_date":"2025-01-27T13:54:31.818980+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nics":[{"creation_date":"2025-02-11T14:23:55.533598+00:00","id":"865cfe47-19b9-403a-9b38-6f30061479fc","ipam_ip_ids":["bb477641-af00-42e0-af75-9b6b1bfac443","b39378f6-3d8d-4588-a4d6-11cfa06a3d57"],"mac_address":"02:00:00:19:0c:9a","modification_date":"2025-02-11T14:24:28.375342+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "475"
+                - "478"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:39 GMT
+                - Tue, 11 Feb 2025 14:24:36 GMT
+            Link:
+                - </servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics?page=1&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5318,10 +5316,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 122bf2f6-d1ea-4a61-8a35-91453f8ef746
+                - fdec07ac-a999-4913-b919-166bd306e370
+            X-Total-Count:
+                - "1"
         status: 200 OK
         code: 200
-        duration: 87.914375ms
+        duration: 89.259167ms
     - id: 107
       request:
         proto: HTTP/1.1
@@ -5337,27 +5337,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics/d71bb31d-3a42-435d-81e7-f5a73ebbd51d
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 2283
         uncompressed: false
-        body: ""
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:48.517107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-zealous-tesla","id":"d6a4ef64-1630-4987-aabb-e733f3478c04","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"803","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f9","maintenances":[],"modification_date":"2025-02-11T14:23:53.803702+00:00","name":"tf-srv-zealous-tesla","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:23:55.533598+00:00","id":"865cfe47-19b9-403a-9b38-6f30061479fc","ipam_ip_ids":["bb477641-af00-42e0-af75-9b6b1bfac443","b39378f6-3d8d-4588-a4d6-11cfa06a3d57"],"mac_address":"02:00:00:19:0c:9a","modification_date":"2025-02-11T14:24:28.375342+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"810a8a91-0c84-4910-9038-f757b08e6d92","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
+            Content-Length:
+                - "2283"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:40 GMT
+                - Tue, 11 Feb 2025 14:24:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5365,10 +5367,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c2f2b026-9441-4858-99f9-eb08b810ae35
-        status: 204 No Content
-        code: 204
-        duration: 394.568167ms
+                - fb0390d9-a598-4c1a-a3a8-153c30394767
+        status: 200 OK
+        code: 200
+        duration: 220.803459ms
     - id: 108
       request:
         proto: HTTP/1.1
@@ -5384,8 +5386,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics/d71bb31d-3a42-435d-81e7-f5a73ebbd51d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics/865cfe47-19b9-403a-9b38-6f30061479fc
         method: GET
       response:
         proto: HTTP/2.0
@@ -5393,20 +5395,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 148
+        content_length: 475
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"d71bb31d-3a42-435d-81e7-f5a73ebbd51d","type":"not_found"}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:23:55.533598+00:00","id":"865cfe47-19b9-403a-9b38-6f30061479fc","ipam_ip_ids":["bb477641-af00-42e0-af75-9b6b1bfac443","b39378f6-3d8d-4588-a4d6-11cfa06a3d57"],"mac_address":"02:00:00:19:0c:9a","modification_date":"2025-02-11T14:24:28.375342+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "148"
+                - "475"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:40 GMT
+                - Tue, 11 Feb 2025 14:24:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5414,50 +5416,46 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 02c11048-46a5-41d8-b170-177efc5bcaa5
-        status: 404 Not Found
-        code: 404
-        duration: 113.133333ms
+                - 1f368ff5-e977-4d57-a7d5-25f9c24967de
+        status: 200 OK
+        code: 200
+        duration: 79.599417ms
     - id: 109
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 61
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292"}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics/865cfe47-19b9-403a-9b38-6f30061479fc
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 473
+        content_length: 0
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:54:40.587961+00:00","id":"a38eca4f-163a-405b-b6ed-d8d511b9211f","ipam_ip_ids":["8425f76c-dbb9-4ed0-96df-ad0daea19ac1","0b65b9ac-a68c-4e9d-84d9-81339c8cf140"],"mac_address":"02:00:00:15:45:27","modification_date":"2025-01-27T13:54:40.813390+00:00","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: ""
         headers:
-            Content-Length:
-                - "473"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:41 GMT
+                - Tue, 11 Feb 2025 14:24:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5465,10 +5463,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c8a57131-d06a-494c-8249-62606b5eaf12
-        status: 201 Created
-        code: 201
-        duration: 1.188406s
+                - 8a3511c2-bbc0-4d25-876f-20be792cd339
+        status: 204 No Content
+        code: 204
+        duration: 405.625708ms
     - id: 110
       request:
         proto: HTTP/1.1
@@ -5484,9 +5482,60 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics/a38eca4f-163a-405b-b6ed-d8d511b9211f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics/865cfe47-19b9-403a-9b38-6f30061479fc
         method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 148
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"865cfe47-19b9-403a-9b38-6f30061479fc","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "148"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - cf9a4c0e-1fce-40cc-9f74-e895f98f365a
+        status: 404 Not Found
+        code: 404
+        duration: 96.100208ms
+    - id: 111
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 61
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"private_network_id":"a1de608c-4136-462d-875c-cc274949abe3"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -5495,7 +5544,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:54:40.587961+00:00","id":"a38eca4f-163a-405b-b6ed-d8d511b9211f","ipam_ip_ids":["8425f76c-dbb9-4ed0-96df-ad0daea19ac1","0b65b9ac-a68c-4e9d-84d9-81339c8cf140"],"mac_address":"02:00:00:15:45:27","modification_date":"2025-01-27T13:54:40.813390+00:00","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:24:37.560939+00:00","id":"29a0e16b-6212-4d47-8bdf-61163fc50fc1","ipam_ip_ids":["7fb71eeb-de4e-4cf3-aa92-9e9d052a3487","ea171bd6-12e5-4bec-83c1-ff7025332a36"],"mac_address":"02:00:00:1a:ef:a5","modification_date":"2025-02-11T14:24:37.790782+00:00","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -5504,9 +5553,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:41 GMT
+                - Tue, 11 Feb 2025 14:24:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5514,59 +5563,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8258f394-b7d1-4c71-a11a-634d18e59bad
-        status: 200 OK
-        code: 200
-        duration: 82.545042ms
-    - id: 111
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics/a38eca4f-163a-405b-b6ed-d8d511b9211f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 475
-        uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:54:40.587961+00:00","id":"a38eca4f-163a-405b-b6ed-d8d511b9211f","ipam_ip_ids":["8425f76c-dbb9-4ed0-96df-ad0daea19ac1","0b65b9ac-a68c-4e9d-84d9-81339c8cf140"],"mac_address":"02:00:00:15:45:27","modification_date":"2025-01-27T13:54:42.290771+00:00","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "475"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:54:46 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - e58fb4ce-0abb-4bf3-a3b1-8a3022a260f9
-        status: 200 OK
-        code: 200
-        duration: 80.773875ms
+                - 7bf9aa4a-528d-4b4e-a369-0981022dc285
+        status: 201 Created
+        code: 201
+        duration: 1.043525042s
     - id: 112
       request:
         proto: HTTP/1.1
@@ -5582,8 +5582,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics/a38eca4f-163a-405b-b6ed-d8d511b9211f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics/29a0e16b-6212-4d47-8bdf-61163fc50fc1
         method: GET
       response:
         proto: HTTP/2.0
@@ -5591,20 +5591,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 475
+        content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:54:40.587961+00:00","id":"a38eca4f-163a-405b-b6ed-d8d511b9211f","ipam_ip_ids":["8425f76c-dbb9-4ed0-96df-ad0daea19ac1","0b65b9ac-a68c-4e9d-84d9-81339c8cf140"],"mac_address":"02:00:00:15:45:27","modification_date":"2025-01-27T13:54:42.290771+00:00","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:24:37.560939+00:00","id":"29a0e16b-6212-4d47-8bdf-61163fc50fc1","ipam_ip_ids":["7fb71eeb-de4e-4cf3-aa92-9e9d052a3487","ea171bd6-12e5-4bec-83c1-ff7025332a36"],"mac_address":"02:00:00:1a:ef:a5","modification_date":"2025-02-11T14:24:37.790782+00:00","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "475"
+                - "473"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:46 GMT
+                - Tue, 11 Feb 2025 14:24:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5612,10 +5612,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 06850db8-a420-4509-aaf8-f890324ed85f
+                - fa7fc097-6429-4869-9fe1-3ff524105ffe
         status: 200 OK
         code: 200
-        duration: 103.359375ms
+        duration: 114.370208ms
     - id: 113
       request:
         proto: HTTP/1.1
@@ -5631,8 +5631,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics/29a0e16b-6212-4d47-8bdf-61163fc50fc1
         method: GET
       response:
         proto: HTTP/2.0
@@ -5640,20 +5640,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2729
+        content_length: 475
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"102","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:53:55.578717+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:54:40.587961+00:00","id":"a38eca4f-163a-405b-b6ed-d8d511b9211f","ipam_ip_ids":["8425f76c-dbb9-4ed0-96df-ad0daea19ac1","0b65b9ac-a68c-4e9d-84d9-81339c8cf140"],"mac_address":"02:00:00:15:45:27","modification_date":"2025-01-27T13:54:42.290771+00:00","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:24:37.560939+00:00","id":"29a0e16b-6212-4d47-8bdf-61163fc50fc1","ipam_ip_ids":["7fb71eeb-de4e-4cf3-aa92-9e9d052a3487","ea171bd6-12e5-4bec-83c1-ff7025332a36"],"mac_address":"02:00:00:1a:ef:a5","modification_date":"2025-02-11T14:24:38.989455+00:00","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2729"
+                - "475"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:47 GMT
+                - Tue, 11 Feb 2025 14:24:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5661,10 +5661,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8d24dbda-3817-428e-8376-662fe4d0556c
+                - 3daf9700-8702-43ad-8542-a5b40e6749a3
         status: 200 OK
         code: 200
-        duration: 187.303209ms
+        duration: 79.365041ms
     - id: 114
       request:
         proto: HTTP/1.1
@@ -5680,8 +5680,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics/29a0e16b-6212-4d47-8bdf-61163fc50fc1
         method: GET
       response:
         proto: HTTP/2.0
@@ -5689,20 +5689,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2729
+        content_length: 475
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"102","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:53:55.578717+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:54:40.587961+00:00","id":"a38eca4f-163a-405b-b6ed-d8d511b9211f","ipam_ip_ids":["8425f76c-dbb9-4ed0-96df-ad0daea19ac1","0b65b9ac-a68c-4e9d-84d9-81339c8cf140"],"mac_address":"02:00:00:15:45:27","modification_date":"2025-01-27T13:54:42.290771+00:00","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:24:37.560939+00:00","id":"29a0e16b-6212-4d47-8bdf-61163fc50fc1","ipam_ip_ids":["7fb71eeb-de4e-4cf3-aa92-9e9d052a3487","ea171bd6-12e5-4bec-83c1-ff7025332a36"],"mac_address":"02:00:00:1a:ef:a5","modification_date":"2025-02-11T14:24:38.989455+00:00","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2729"
+                - "475"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:46 GMT
+                - Tue, 11 Feb 2025 14:24:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5710,10 +5710,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 26b430f5-b83a-464b-aff1-1b55ec81f1a2
+                - 533e2f16-f605-4e03-857a-78e6aefd9e61
         status: 200 OK
         code: 200
-        duration: 193.22925ms
+        duration: 86.92025ms
     - id: 115
       request:
         proto: HTTP/1.1
@@ -5729,8 +5729,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/1197fc24-679a-40dc-9858-30c145bbfa4a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04
         method: GET
       response:
         proto: HTTP/2.0
@@ -5738,20 +5738,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 521
+        content_length: 2283
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:48.517107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-zealous-tesla","id":"d6a4ef64-1630-4987-aabb-e733f3478c04","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"803","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f9","maintenances":[],"modification_date":"2025-02-11T14:23:53.803702+00:00","name":"tf-srv-zealous-tesla","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:24:37.560939+00:00","id":"29a0e16b-6212-4d47-8bdf-61163fc50fc1","ipam_ip_ids":["7fb71eeb-de4e-4cf3-aa92-9e9d052a3487","ea171bd6-12e5-4bec-83c1-ff7025332a36"],"mac_address":"02:00:00:1a:ef:a5","modification_date":"2025-02-11T14:24:38.989455+00:00","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"810a8a91-0c84-4910-9038-f757b08e6d92","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "521"
+                - "2283"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:47 GMT
+                - Tue, 11 Feb 2025 14:24:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5759,10 +5759,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ab3b3549-d9e2-4c70-b5c7-0994bd21e2c0
+                - 0188312b-b615-44bd-ad2f-68acaca644f2
         status: 200 OK
         code: 200
-        duration: 80.421958ms
+        duration: 193.4735ms
     - id: 116
       request:
         proto: HTTP/1.1
@@ -5778,8 +5778,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04
         method: GET
       response:
         proto: HTTP/2.0
@@ -5787,20 +5787,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 2283
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:48.517107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-zealous-tesla","id":"d6a4ef64-1630-4987-aabb-e733f3478c04","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"803","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f9","maintenances":[],"modification_date":"2025-02-11T14:23:53.803702+00:00","name":"tf-srv-zealous-tesla","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:24:37.560939+00:00","id":"29a0e16b-6212-4d47-8bdf-61163fc50fc1","ipam_ip_ids":["7fb71eeb-de4e-4cf3-aa92-9e9d052a3487","ea171bd6-12e5-4bec-83c1-ff7025332a36"],"mac_address":"02:00:00:1a:ef:a5","modification_date":"2025-02-11T14:24:38.989455+00:00","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"810a8a91-0c84-4910-9038-f757b08e6d92","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "17"
+                - "2283"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:47 GMT
+                - Tue, 11 Feb 2025 14:24:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5808,10 +5808,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a13c2211-0354-4323-8117-64bc69fd35bf
+                - 4c24ecd2-c9ee-4e99-810b-bb4661f73772
         status: 200 OK
         code: 200
-        duration: 80.4405ms
+        duration: 192.834125ms
     - id: 117
       request:
         proto: HTTP/1.1
@@ -5827,8 +5827,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/810a8a91-0c84-4910-9038-f757b08e6d92
         method: GET
       response:
         proto: HTTP/2.0
@@ -5836,22 +5836,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 478
+        content_length: 143
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:54:40.587961+00:00","id":"a38eca4f-163a-405b-b6ed-d8d511b9211f","ipam_ip_ids":["8425f76c-dbb9-4ed0-96df-ad0daea19ac1","0b65b9ac-a68c-4e9d-84d9-81339c8cf140"],"mac_address":"02:00:00:15:45:27","modification_date":"2025-01-27T13:54:42.290771+00:00","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"810a8a91-0c84-4910-9038-f757b08e6d92","type":"not_found"}'
         headers:
             Content-Length:
-                - "478"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:47 GMT
-            Link:
-                - </servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics?page=1&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:24:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5859,12 +5857,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 69a9a1a3-1ce2-481a-9ee8-19827d7b6f7e
-            X-Total-Count:
-                - "1"
-        status: 200 OK
-        code: 200
-        duration: 84.926ms
+                - 70327c52-2604-4d9a-9f96-f6e314d3f058
+        status: 404 Not Found
+        code: 404
+        duration: 39.371583ms
     - id: 118
       request:
         proto: HTTP/1.1
@@ -5880,8 +5876,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/810a8a91-0c84-4910-9038-f757b08e6d92
         method: GET
       response:
         proto: HTTP/2.0
@@ -5889,22 +5885,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 478
+        content_length: 701
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:54:40.587961+00:00","id":"a38eca4f-163a-405b-b6ed-d8d511b9211f","ipam_ip_ids":["8425f76c-dbb9-4ed0-96df-ad0daea19ac1","0b65b9ac-a68c-4e9d-84d9-81339c8cf140"],"mac_address":"02:00:00:15:45:27","modification_date":"2025-01-27T13:54:42.290771+00:00","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"created_at":"2025-02-11T14:23:48.722794Z","id":"810a8a91-0c84-4910-9038-f757b08e6d92","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:48.722794Z","id":"5b696577-55c8-4230-9368-a29e9ea2b0e5","product_resource_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:48.722794Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "478"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:47 GMT
-            Link:
-                - </servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics?page=1&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:24:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5912,12 +5906,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bf1b6dd8-539d-4634-87aa-4810e48a49cf
-            X-Total-Count:
-                - "1"
+                - 22944733-a631-48ba-8ea4-4c5e6b51d497
         status: 200 OK
         code: 200
-        duration: 121.608792ms
+        duration: 62.137125ms
     - id: 119
       request:
         proto: HTTP/1.1
@@ -5933,8 +5925,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7e4f4db4-f983-4fad-ab8e-abb34f3b0292
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -5942,20 +5934,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1054
+        content_length: 17
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:54:39.033868Z","dhcp_enabled":true,"id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","name":"private_network_instance_02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:54:39.033868Z","id":"5a031fb6-7da9-444c-be5e-0fc437f0c3d1","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.24.0/22","updated_at":"2025-01-27T13:54:39.033868Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:54:39.033868Z","id":"e3b82fe9-ecc2-4b25-af4f-169257e510e8","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:e3cd::/64","updated_at":"2025-01-27T13:54:39.033868Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:54:39.033868Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "1054"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:48 GMT
+                - Tue, 11 Feb 2025 14:24:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5963,10 +5955,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e3f4cc91-7fc7-4798-a042-d67ae3809234
+                - 076b8287-2658-406c-8fd8-95f67c0add41
         status: 200 OK
         code: 200
-        duration: 27.43675ms
+        duration: 86.922125ms
     - id: 120
       request:
         proto: HTTP/1.1
@@ -5982,8 +5974,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6e43bd7f-e7d5-4d93-999e-26abbc550834
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -5991,20 +5983,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1051
+        content_length: 478
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:53:39.867750Z","dhcp_enabled":true,"id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:53:39.867750Z","id":"3b4ac01d-048a-4077-a2b6-b5e344768fc3","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.20.0/22","updated_at":"2025-01-27T13:53:39.867750Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:53:39.867750Z","id":"32ddd6f5-f125-4418-b7c2-18de23d13498","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:e437::/64","updated_at":"2025-01-27T13:53:39.867750Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:53:39.867750Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"private_nics":[{"creation_date":"2025-02-11T14:24:37.560939+00:00","id":"29a0e16b-6212-4d47-8bdf-61163fc50fc1","ipam_ip_ids":["7fb71eeb-de4e-4cf3-aa92-9e9d052a3487","ea171bd6-12e5-4bec-83c1-ff7025332a36"],"mac_address":"02:00:00:1a:ef:a5","modification_date":"2025-02-11T14:24:38.989455+00:00","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "1051"
+                - "478"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:48 GMT
+                - Tue, 11 Feb 2025 14:24:44 GMT
+            Link:
+                - </servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics?page=1&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6012,10 +6006,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c93d68e4-6b60-4f4d-87f9-0eae62759473
+                - 76eada43-08a6-4f0c-a155-aa9a4b6fe8b9
+            X-Total-Count:
+                - "1"
         status: 200 OK
         code: 200
-        duration: 55.983292ms
+        duration: 102.159417ms
     - id: 121
       request:
         proto: HTTP/1.1
@@ -6031,8 +6027,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -6040,20 +6036,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2729
+        content_length: 478
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"102","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:53:55.578717+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:54:40.587961+00:00","id":"a38eca4f-163a-405b-b6ed-d8d511b9211f","ipam_ip_ids":["8425f76c-dbb9-4ed0-96df-ad0daea19ac1","0b65b9ac-a68c-4e9d-84d9-81339c8cf140"],"mac_address":"02:00:00:15:45:27","modification_date":"2025-01-27T13:54:42.290771+00:00","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"private_nics":[{"creation_date":"2025-02-11T14:24:37.560939+00:00","id":"29a0e16b-6212-4d47-8bdf-61163fc50fc1","ipam_ip_ids":["7fb71eeb-de4e-4cf3-aa92-9e9d052a3487","ea171bd6-12e5-4bec-83c1-ff7025332a36"],"mac_address":"02:00:00:1a:ef:a5","modification_date":"2025-02-11T14:24:38.989455+00:00","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "2729"
+                - "478"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:48 GMT
+                - Tue, 11 Feb 2025 14:24:44 GMT
+            Link:
+                - </servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics?page=1&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6061,10 +6059,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 219660ba-c193-4c4e-be3d-489048e0ee73
+                - b989e91e-870e-46d9-b37c-bead9306babc
+            X-Total-Count:
+                - "1"
         status: 200 OK
         code: 200
-        duration: 154.741834ms
+        duration: 84.986875ms
     - id: 122
       request:
         proto: HTTP/1.1
@@ -6080,8 +6080,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/1197fc24-679a-40dc-9858-30c145bbfa4a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a1de608c-4136-462d-875c-cc274949abe3
         method: GET
       response:
         proto: HTTP/2.0
@@ -6089,20 +6089,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 521
+        content_length: 1054
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T14:24:35.842692Z","dhcp_enabled":true,"id":"a1de608c-4136-462d-875c-cc274949abe3","name":"private_network_instance_02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-11T14:24:35.842692Z","id":"72b9eafe-2e09-48d5-ae5d-9d63ebebc738","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.12.0/22","updated_at":"2025-02-11T14:24:35.842692Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-11T14:24:35.842692Z","id":"c37fba53-d26d-41b9-986a-cc71dcbca69e","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:cfb4::/64","updated_at":"2025-02-11T14:24:35.842692Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-11T14:24:35.842692Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "521"
+                - "1054"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:47 GMT
+                - Tue, 11 Feb 2025 14:24:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6110,10 +6110,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 744945c6-5604-458e-904d-a120b89a6a28
+                - 27a16189-6ac6-4544-ab1a-97294e4e3c5b
         status: 200 OK
         code: 200
-        duration: 86.564125ms
+        duration: 114.878625ms
     - id: 123
       request:
         proto: HTTP/1.1
@@ -6129,8 +6129,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8e85576b-7702-4413-866b-4f684d7dcfb6
         method: GET
       response:
         proto: HTTP/2.0
@@ -6138,20 +6138,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 1051
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"created_at":"2025-02-11T14:23:46.151993Z","dhcp_enabled":true,"id":"8e85576b-7702-4413-866b-4f684d7dcfb6","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-11T14:23:46.151993Z","id":"ae5ebb5e-3140-4c2a-aebb-7c2492695024","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.16.0/22","updated_at":"2025-02-11T14:23:46.151993Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-11T14:23:46.151993Z","id":"db3dfab7-aa89-48aa-90db-b0af2fbbe71b","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:819d::/64","updated_at":"2025-02-11T14:23:46.151993Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-11T14:23:46.151993Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "17"
+                - "1051"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:48 GMT
+                - Tue, 11 Feb 2025 14:24:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6159,10 +6159,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bf4ad903-440f-4018-97c4-b68ded22b203
+                - e7ff48f1-3024-47fe-9add-649ea10ae82c
         status: 200 OK
         code: 200
-        duration: 76.496625ms
+        duration: 126.226792ms
     - id: 124
       request:
         proto: HTTP/1.1
@@ -6178,8 +6178,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04
         method: GET
       response:
         proto: HTTP/2.0
@@ -6187,22 +6187,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 478
+        content_length: 2283
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:54:40.587961+00:00","id":"a38eca4f-163a-405b-b6ed-d8d511b9211f","ipam_ip_ids":["8425f76c-dbb9-4ed0-96df-ad0daea19ac1","0b65b9ac-a68c-4e9d-84d9-81339c8cf140"],"mac_address":"02:00:00:15:45:27","modification_date":"2025-01-27T13:54:42.290771+00:00","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:48.517107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-zealous-tesla","id":"d6a4ef64-1630-4987-aabb-e733f3478c04","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"803","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f9","maintenances":[],"modification_date":"2025-02-11T14:23:53.803702+00:00","name":"tf-srv-zealous-tesla","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:24:37.560939+00:00","id":"29a0e16b-6212-4d47-8bdf-61163fc50fc1","ipam_ip_ids":["7fb71eeb-de4e-4cf3-aa92-9e9d052a3487","ea171bd6-12e5-4bec-83c1-ff7025332a36"],"mac_address":"02:00:00:1a:ef:a5","modification_date":"2025-02-11T14:24:38.989455+00:00","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"810a8a91-0c84-4910-9038-f757b08e6d92","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "478"
+                - "2283"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:48 GMT
-            Link:
-                - </servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics?page=1&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:24:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6210,12 +6208,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bb5495bf-1dbc-462e-8aa8-460698df6442
-            X-Total-Count:
-                - "1"
+                - cc6b0429-5fe3-4847-8eee-94641a191e44
         status: 200 OK
         code: 200
-        duration: 82.443125ms
+        duration: 164.463666ms
     - id: 125
       request:
         proto: HTTP/1.1
@@ -6231,8 +6227,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6e43bd7f-e7d5-4d93-999e-26abbc550834
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/810a8a91-0c84-4910-9038-f757b08e6d92
         method: GET
       response:
         proto: HTTP/2.0
@@ -6240,20 +6236,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1051
+        content_length: 143
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:53:39.867750Z","dhcp_enabled":true,"id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:53:39.867750Z","id":"3b4ac01d-048a-4077-a2b6-b5e344768fc3","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.20.0/22","updated_at":"2025-01-27T13:53:39.867750Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:53:39.867750Z","id":"32ddd6f5-f125-4418-b7c2-18de23d13498","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:e437::/64","updated_at":"2025-01-27T13:53:39.867750Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:53:39.867750Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"810a8a91-0c84-4910-9038-f757b08e6d92","type":"not_found"}'
         headers:
             Content-Length:
-                - "1051"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:49 GMT
+                - Tue, 11 Feb 2025 14:24:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6261,10 +6257,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4bfc5a1a-a8bf-4baa-9507-c543268f5e98
-        status: 200 OK
-        code: 200
-        duration: 360.407542ms
+                - 44133d5f-c758-4555-aba4-118ab73af140
+        status: 404 Not Found
+        code: 404
+        duration: 31.444084ms
     - id: 126
       request:
         proto: HTTP/1.1
@@ -6280,8 +6276,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7e4f4db4-f983-4fad-ab8e-abb34f3b0292
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/810a8a91-0c84-4910-9038-f757b08e6d92
         method: GET
       response:
         proto: HTTP/2.0
@@ -6289,20 +6285,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1054
+        content_length: 701
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:54:39.033868Z","dhcp_enabled":true,"id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","name":"private_network_instance_02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:54:39.033868Z","id":"5a031fb6-7da9-444c-be5e-0fc437f0c3d1","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.24.0/22","updated_at":"2025-01-27T13:54:39.033868Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:54:39.033868Z","id":"e3b82fe9-ecc2-4b25-af4f-169257e510e8","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:e3cd::/64","updated_at":"2025-01-27T13:54:39.033868Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:54:39.033868Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"created_at":"2025-02-11T14:23:48.722794Z","id":"810a8a91-0c84-4910-9038-f757b08e6d92","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:48.722794Z","id":"5b696577-55c8-4230-9368-a29e9ea2b0e5","product_resource_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:48.722794Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1054"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:49 GMT
+                - Tue, 11 Feb 2025 14:24:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6310,10 +6306,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7d700916-9de1-4100-b5cb-08a0e22ca98c
+                - 5333a6b1-726d-4fd2-972e-3f2790a9d758
         status: 200 OK
         code: 200
-        duration: 362.043375ms
+        duration: 66.839375ms
     - id: 127
       request:
         proto: HTTP/1.1
@@ -6329,8 +6325,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -6338,20 +6334,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2729
+        content_length: 17
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"102","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:53:55.578717+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:54:40.587961+00:00","id":"a38eca4f-163a-405b-b6ed-d8d511b9211f","ipam_ip_ids":["8425f76c-dbb9-4ed0-96df-ad0daea19ac1","0b65b9ac-a68c-4e9d-84d9-81339c8cf140"],"mac_address":"02:00:00:15:45:27","modification_date":"2025-01-27T13:54:42.290771+00:00","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "2729"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:48 GMT
+                - Tue, 11 Feb 2025 14:24:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6359,10 +6355,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8b1b2eca-fbd1-48da-86f7-838ddd5097cf
+                - e56d051a-04c9-4d11-b9d0-08d1b85f8512
         status: 200 OK
         code: 200
-        duration: 155.1315ms
+        duration: 76.146166ms
     - id: 128
       request:
         proto: HTTP/1.1
@@ -6378,8 +6374,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/1197fc24-679a-40dc-9858-30c145bbfa4a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -6387,20 +6383,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 521
+        content_length: 478
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"private_nics":[{"creation_date":"2025-02-11T14:24:37.560939+00:00","id":"29a0e16b-6212-4d47-8bdf-61163fc50fc1","ipam_ip_ids":["7fb71eeb-de4e-4cf3-aa92-9e9d052a3487","ea171bd6-12e5-4bec-83c1-ff7025332a36"],"mac_address":"02:00:00:1a:ef:a5","modification_date":"2025-02-11T14:24:38.989455+00:00","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "521"
+                - "478"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:49 GMT
+                - Tue, 11 Feb 2025 14:24:45 GMT
+            Link:
+                - </servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics?page=1&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6408,10 +6406,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f03c867c-86b5-4630-9bde-3365ab71d0bd
+                - 06e92f26-1912-44c2-aebb-621cea862a79
+            X-Total-Count:
+                - "1"
         status: 200 OK
         code: 200
-        duration: 85.948791ms
+        duration: 100.708917ms
     - id: 129
       request:
         proto: HTTP/1.1
@@ -6427,8 +6427,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a1de608c-4136-462d-875c-cc274949abe3
         method: GET
       response:
         proto: HTTP/2.0
@@ -6436,20 +6436,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 1054
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"created_at":"2025-02-11T14:24:35.842692Z","dhcp_enabled":true,"id":"a1de608c-4136-462d-875c-cc274949abe3","name":"private_network_instance_02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-11T14:24:35.842692Z","id":"72b9eafe-2e09-48d5-ae5d-9d63ebebc738","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.12.0/22","updated_at":"2025-02-11T14:24:35.842692Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-11T14:24:35.842692Z","id":"c37fba53-d26d-41b9-986a-cc71dcbca69e","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:cfb4::/64","updated_at":"2025-02-11T14:24:35.842692Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-11T14:24:35.842692Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "17"
+                - "1054"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:49 GMT
+                - Tue, 11 Feb 2025 14:24:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6457,10 +6457,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6234a7b4-abcd-4729-afd6-0a0b50963cb8
+                - f2b4d7b0-ba07-41d2-a997-9e9a222f53c9
         status: 200 OK
         code: 200
-        duration: 83.888666ms
+        duration: 29.980375ms
     - id: 130
       request:
         proto: HTTP/1.1
@@ -6476,8 +6476,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8e85576b-7702-4413-866b-4f684d7dcfb6
         method: GET
       response:
         proto: HTTP/2.0
@@ -6485,22 +6485,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 478
+        content_length: 1051
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:54:40.587961+00:00","id":"a38eca4f-163a-405b-b6ed-d8d511b9211f","ipam_ip_ids":["8425f76c-dbb9-4ed0-96df-ad0daea19ac1","0b65b9ac-a68c-4e9d-84d9-81339c8cf140"],"mac_address":"02:00:00:15:45:27","modification_date":"2025-01-27T13:54:42.290771+00:00","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"created_at":"2025-02-11T14:23:46.151993Z","dhcp_enabled":true,"id":"8e85576b-7702-4413-866b-4f684d7dcfb6","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-11T14:23:46.151993Z","id":"ae5ebb5e-3140-4c2a-aebb-7c2492695024","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.16.0/22","updated_at":"2025-02-11T14:23:46.151993Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-11T14:23:46.151993Z","id":"db3dfab7-aa89-48aa-90db-b0af2fbbe71b","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:819d::/64","updated_at":"2025-02-11T14:23:46.151993Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-11T14:23:46.151993Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "478"
+                - "1051"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:49 GMT
-            Link:
-                - </servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics?page=1&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:24:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6508,12 +6506,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5121f331-3d30-4ee6-9e42-260333e8d06d
-            X-Total-Count:
-                - "1"
+                - 6fae4c7f-31f6-46a0-a03f-ac9c15df6473
         status: 200 OK
         code: 200
-        duration: 86.829291ms
+        duration: 33.580917ms
     - id: 131
       request:
         proto: HTTP/1.1
@@ -6529,8 +6525,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04
         method: GET
       response:
         proto: HTTP/2.0
@@ -6538,20 +6534,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2729
+        content_length: 2283
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"102","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:53:55.578717+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:54:40.587961+00:00","id":"a38eca4f-163a-405b-b6ed-d8d511b9211f","ipam_ip_ids":["8425f76c-dbb9-4ed0-96df-ad0daea19ac1","0b65b9ac-a68c-4e9d-84d9-81339c8cf140"],"mac_address":"02:00:00:15:45:27","modification_date":"2025-01-27T13:54:42.290771+00:00","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:48.517107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-zealous-tesla","id":"d6a4ef64-1630-4987-aabb-e733f3478c04","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"803","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f9","maintenances":[],"modification_date":"2025-02-11T14:23:53.803702+00:00","name":"tf-srv-zealous-tesla","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:24:37.560939+00:00","id":"29a0e16b-6212-4d47-8bdf-61163fc50fc1","ipam_ip_ids":["7fb71eeb-de4e-4cf3-aa92-9e9d052a3487","ea171bd6-12e5-4bec-83c1-ff7025332a36"],"mac_address":"02:00:00:1a:ef:a5","modification_date":"2025-02-11T14:24:38.989455+00:00","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"810a8a91-0c84-4910-9038-f757b08e6d92","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2729"
+                - "2283"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:50 GMT
+                - Tue, 11 Feb 2025 14:24:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6559,10 +6555,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 870ad184-8558-45af-9c2e-e50e3b33dc61
+                - d9f6cfe4-8ef2-445b-989e-93fbfc6fcd8d
         status: 200 OK
         code: 200
-        duration: 441.672625ms
+        duration: 162.88025ms
     - id: 132
       request:
         proto: HTTP/1.1
@@ -6578,8 +6574,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/810a8a91-0c84-4910-9038-f757b08e6d92
         method: GET
       response:
         proto: HTTP/2.0
@@ -6587,22 +6583,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 478
+        content_length: 143
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:54:40.587961+00:00","id":"a38eca4f-163a-405b-b6ed-d8d511b9211f","ipam_ip_ids":["8425f76c-dbb9-4ed0-96df-ad0daea19ac1","0b65b9ac-a68c-4e9d-84d9-81339c8cf140"],"mac_address":"02:00:00:15:45:27","modification_date":"2025-01-27T13:54:42.290771+00:00","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"810a8a91-0c84-4910-9038-f757b08e6d92","type":"not_found"}'
         headers:
             Content-Length:
-                - "478"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:50 GMT
-            Link:
-                - </servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics?page=1&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:24:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6610,12 +6604,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e11330ec-d0c4-4a58-95fe-f64c6d36efc9
-            X-Total-Count:
-                - "1"
-        status: 200 OK
-        code: 200
-        duration: 80.791416ms
+                - ecea5088-a270-49d5-88fb-519187999e50
+        status: 404 Not Found
+        code: 404
+        duration: 33.027375ms
     - id: 133
       request:
         proto: HTTP/1.1
@@ -6631,8 +6623,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/810a8a91-0c84-4910-9038-f757b08e6d92
         method: GET
       response:
         proto: HTTP/2.0
@@ -6640,20 +6632,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2729
+        content_length: 701
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"102","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:53:55.578717+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:54:40.587961+00:00","id":"a38eca4f-163a-405b-b6ed-d8d511b9211f","ipam_ip_ids":["8425f76c-dbb9-4ed0-96df-ad0daea19ac1","0b65b9ac-a68c-4e9d-84d9-81339c8cf140"],"mac_address":"02:00:00:15:45:27","modification_date":"2025-01-27T13:54:42.290771+00:00","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T14:23:48.722794Z","id":"810a8a91-0c84-4910-9038-f757b08e6d92","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:48.722794Z","id":"5b696577-55c8-4230-9368-a29e9ea2b0e5","product_resource_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:48.722794Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2729"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:50 GMT
+                - Tue, 11 Feb 2025 14:24:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6661,50 +6653,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 34929a3c-cd60-41e3-bef3-1faf4af1f5ad
+                - 8ad62500-c2e6-4ed6-b07f-c68443f6ec44
         status: 200 OK
         code: 200
-        duration: 151.198167ms
+        duration: 59.310917ms
     - id: 134
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 61
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834"}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/user_data
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 473
+        content_length: 17
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:54:50.452882+00:00","id":"ae150e34-4ac3-489a-8619-21d89e61a745","ipam_ip_ids":["5ead0b49-b09e-4102-82b3-0779121f65bf","d686b484-54e4-46fa-b786-6009beed0c51"],"mac_address":"02:00:00:11:5e:87","modification_date":"2025-01-27T13:54:50.635722+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "473"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:51 GMT
+                - Tue, 11 Feb 2025 14:24:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6712,10 +6702,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - da811255-cb24-46dc-945b-d739a8381875
-        status: 201 Created
-        code: 201
-        duration: 1.077983625s
+                - 50434eb1-37af-4ad3-8a2f-b79894f28c08
+        status: 200 OK
+        code: 200
+        duration: 77.912292ms
     - id: 135
       request:
         proto: HTTP/1.1
@@ -6731,8 +6721,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics/ae150e34-4ac3-489a-8619-21d89e61a745
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -6740,20 +6730,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 473
+        content_length: 478
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:54:50.452882+00:00","id":"ae150e34-4ac3-489a-8619-21d89e61a745","ipam_ip_ids":["5ead0b49-b09e-4102-82b3-0779121f65bf","d686b484-54e4-46fa-b786-6009beed0c51"],"mac_address":"02:00:00:11:5e:87","modification_date":"2025-01-27T13:54:50.635722+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nics":[{"creation_date":"2025-02-11T14:24:37.560939+00:00","id":"29a0e16b-6212-4d47-8bdf-61163fc50fc1","ipam_ip_ids":["7fb71eeb-de4e-4cf3-aa92-9e9d052a3487","ea171bd6-12e5-4bec-83c1-ff7025332a36"],"mac_address":"02:00:00:1a:ef:a5","modification_date":"2025-02-11T14:24:38.989455+00:00","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "473"
+                - "478"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:51 GMT
+                - Tue, 11 Feb 2025 14:24:45 GMT
+            Link:
+                - </servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics?page=1&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6761,10 +6753,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f5e404da-b502-4132-98f4-032dd338eae1
+                - d9170532-aaf4-48ff-b220-30d41f0e778f
+            X-Total-Count:
+                - "1"
         status: 200 OK
         code: 200
-        duration: 82.372833ms
+        duration: 87.696583ms
     - id: 136
       request:
         proto: HTTP/1.1
@@ -6780,8 +6774,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics/ae150e34-4ac3-489a-8619-21d89e61a745
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04
         method: GET
       response:
         proto: HTTP/2.0
@@ -6789,20 +6783,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 475
+        content_length: 2283
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:54:50.452882+00:00","id":"ae150e34-4ac3-489a-8619-21d89e61a745","ipam_ip_ids":["5ead0b49-b09e-4102-82b3-0779121f65bf","d686b484-54e4-46fa-b786-6009beed0c51"],"mac_address":"02:00:00:11:5e:87","modification_date":"2025-01-27T13:54:52.261879+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:48.517107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-zealous-tesla","id":"d6a4ef64-1630-4987-aabb-e733f3478c04","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"803","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f9","maintenances":[],"modification_date":"2025-02-11T14:23:53.803702+00:00","name":"tf-srv-zealous-tesla","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:24:37.560939+00:00","id":"29a0e16b-6212-4d47-8bdf-61163fc50fc1","ipam_ip_ids":["7fb71eeb-de4e-4cf3-aa92-9e9d052a3487","ea171bd6-12e5-4bec-83c1-ff7025332a36"],"mac_address":"02:00:00:1a:ef:a5","modification_date":"2025-02-11T14:24:38.989455+00:00","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"810a8a91-0c84-4910-9038-f757b08e6d92","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "475"
+                - "2283"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:56 GMT
+                - Tue, 11 Feb 2025 14:24:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6810,10 +6804,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 116c6993-e7da-4b49-9058-822f98445f0f
+                - 2d83a8be-011d-42ce-acf2-b446b61dc030
         status: 200 OK
         code: 200
-        duration: 91.094333ms
+        duration: 167.117125ms
     - id: 137
       request:
         proto: HTTP/1.1
@@ -6829,8 +6823,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics/ae150e34-4ac3-489a-8619-21d89e61a745
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -6838,20 +6832,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 475
+        content_length: 478
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:54:50.452882+00:00","id":"ae150e34-4ac3-489a-8619-21d89e61a745","ipam_ip_ids":["5ead0b49-b09e-4102-82b3-0779121f65bf","d686b484-54e4-46fa-b786-6009beed0c51"],"mac_address":"02:00:00:11:5e:87","modification_date":"2025-01-27T13:54:52.261879+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nics":[{"creation_date":"2025-02-11T14:24:37.560939+00:00","id":"29a0e16b-6212-4d47-8bdf-61163fc50fc1","ipam_ip_ids":["7fb71eeb-de4e-4cf3-aa92-9e9d052a3487","ea171bd6-12e5-4bec-83c1-ff7025332a36"],"mac_address":"02:00:00:1a:ef:a5","modification_date":"2025-02-11T14:24:38.989455+00:00","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "475"
+                - "478"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:56 GMT
+                - Tue, 11 Feb 2025 14:24:46 GMT
+            Link:
+                - </servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics?page=1&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6859,10 +6855,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 33d4aaa9-3646-4ff6-a7fb-534836e2af97
+                - 887f3236-20db-4443-a63b-51f260fd8ef5
+            X-Total-Count:
+                - "1"
         status: 200 OK
         code: 200
-        duration: 92.875584ms
+        duration: 99.452708ms
     - id: 138
       request:
         proto: HTTP/1.1
@@ -6878,8 +6876,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04
         method: GET
       response:
         proto: HTTP/2.0
@@ -6887,20 +6885,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3189
+        content_length: 2283
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"102","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:53:55.578717+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:54:40.587961+00:00","id":"a38eca4f-163a-405b-b6ed-d8d511b9211f","ipam_ip_ids":["8425f76c-dbb9-4ed0-96df-ad0daea19ac1","0b65b9ac-a68c-4e9d-84d9-81339c8cf140"],"mac_address":"02:00:00:15:45:27","modification_date":"2025-01-27T13:54:42.290771+00:00","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2025-01-27T13:54:50.452882+00:00","id":"ae150e34-4ac3-489a-8619-21d89e61a745","ipam_ip_ids":["5ead0b49-b09e-4102-82b3-0779121f65bf","d686b484-54e4-46fa-b786-6009beed0c51"],"mac_address":"02:00:00:11:5e:87","modification_date":"2025-01-27T13:54:52.261879+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:48.517107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-zealous-tesla","id":"d6a4ef64-1630-4987-aabb-e733f3478c04","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"803","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f9","maintenances":[],"modification_date":"2025-02-11T14:23:53.803702+00:00","name":"tf-srv-zealous-tesla","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:24:37.560939+00:00","id":"29a0e16b-6212-4d47-8bdf-61163fc50fc1","ipam_ip_ids":["7fb71eeb-de4e-4cf3-aa92-9e9d052a3487","ea171bd6-12e5-4bec-83c1-ff7025332a36"],"mac_address":"02:00:00:1a:ef:a5","modification_date":"2025-02-11T14:24:38.989455+00:00","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"810a8a91-0c84-4910-9038-f757b08e6d92","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "3189"
+                - "2283"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:56 GMT
+                - Tue, 11 Feb 2025 14:24:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6908,48 +6906,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b18c8a2c-2cfb-43a1-8e84-fc7f2f2c086e
+                - bc954246-213f-4f3e-a7a6-061a2de660cc
         status: 200 OK
         code: 200
-        duration: 187.216333ms
+        duration: 152.168333ms
     - id: 139
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 61
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6"}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3189
+        content_length: 473
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"102","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:53:55.578717+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:54:40.587961+00:00","id":"a38eca4f-163a-405b-b6ed-d8d511b9211f","ipam_ip_ids":["8425f76c-dbb9-4ed0-96df-ad0daea19ac1","0b65b9ac-a68c-4e9d-84d9-81339c8cf140"],"mac_address":"02:00:00:15:45:27","modification_date":"2025-01-27T13:54:42.290771+00:00","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2025-01-27T13:54:50.452882+00:00","id":"ae150e34-4ac3-489a-8619-21d89e61a745","ipam_ip_ids":["5ead0b49-b09e-4102-82b3-0779121f65bf","d686b484-54e4-46fa-b786-6009beed0c51"],"mac_address":"02:00:00:11:5e:87","modification_date":"2025-01-27T13:54:52.261879+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:24:46.947272+00:00","id":"db2f7418-6db6-4b24-a15a-5aa66b0ff512","ipam_ip_ids":["2fcbfc86-40b5-4625-88c6-bd89022d9cb1","0082a51f-dce1-4f79-8ccb-102c3a3f23ad"],"mac_address":"02:00:00:1d:10:95","modification_date":"2025-02-11T14:24:47.166198+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "3189"
+                - "473"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:57 GMT
+                - Tue, 11 Feb 2025 14:24:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6957,10 +6957,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7bb1b1d1-3ee3-451e-9fc0-deb9fdaa3ec4
-        status: 200 OK
-        code: 200
-        duration: 199.660417ms
+                - cc369acc-fa07-41c4-ad9c-131c76b82e74
+        status: 201 Created
+        code: 201
+        duration: 1.135078583s
     - id: 140
       request:
         proto: HTTP/1.1
@@ -6976,8 +6976,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/1197fc24-679a-40dc-9858-30c145bbfa4a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics/db2f7418-6db6-4b24-a15a-5aa66b0ff512
         method: GET
       response:
         proto: HTTP/2.0
@@ -6985,20 +6985,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 521
+        content_length: 473
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:24:46.947272+00:00","id":"db2f7418-6db6-4b24-a15a-5aa66b0ff512","ipam_ip_ids":["2fcbfc86-40b5-4625-88c6-bd89022d9cb1","0082a51f-dce1-4f79-8ccb-102c3a3f23ad"],"mac_address":"02:00:00:1d:10:95","modification_date":"2025-02-11T14:24:47.166198+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "521"
+                - "473"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:56 GMT
+                - Tue, 11 Feb 2025 14:24:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -7006,10 +7006,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e1fc01ff-6b5b-43e0-9e63-cacecaf689ca
+                - 7950de67-90d1-4752-8b54-e9314ecfe05b
         status: 200 OK
         code: 200
-        duration: 124.054125ms
+        duration: 88.614833ms
     - id: 141
       request:
         proto: HTTP/1.1
@@ -7025,8 +7025,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics/db2f7418-6db6-4b24-a15a-5aa66b0ff512
         method: GET
       response:
         proto: HTTP/2.0
@@ -7034,20 +7034,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 475
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:24:46.947272+00:00","id":"db2f7418-6db6-4b24-a15a-5aa66b0ff512","ipam_ip_ids":["2fcbfc86-40b5-4625-88c6-bd89022d9cb1","0082a51f-dce1-4f79-8ccb-102c3a3f23ad"],"mac_address":"02:00:00:1d:10:95","modification_date":"2025-02-11T14:24:48.595649+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "17"
+                - "475"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:57 GMT
+                - Tue, 11 Feb 2025 14:24:52 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -7055,10 +7055,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 56d9e8e1-c0c3-4d14-9d58-3818fb4c62d0
+                - 7733a3fc-659c-40ae-bb6d-0f0e62d90f7d
         status: 200 OK
         code: 200
-        duration: 98.268916ms
+        duration: 113.072583ms
     - id: 142
       request:
         proto: HTTP/1.1
@@ -7074,8 +7074,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics/db2f7418-6db6-4b24-a15a-5aa66b0ff512
         method: GET
       response:
         proto: HTTP/2.0
@@ -7083,22 +7083,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 938
+        content_length: 475
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:54:40.587961+00:00","id":"a38eca4f-163a-405b-b6ed-d8d511b9211f","ipam_ip_ids":["8425f76c-dbb9-4ed0-96df-ad0daea19ac1","0b65b9ac-a68c-4e9d-84d9-81339c8cf140"],"mac_address":"02:00:00:15:45:27","modification_date":"2025-01-27T13:54:42.290771+00:00","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2025-01-27T13:54:50.452882+00:00","id":"ae150e34-4ac3-489a-8619-21d89e61a745","ipam_ip_ids":["5ead0b49-b09e-4102-82b3-0779121f65bf","d686b484-54e4-46fa-b786-6009beed0c51"],"mac_address":"02:00:00:11:5e:87","modification_date":"2025-01-27T13:54:52.261879+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:24:46.947272+00:00","id":"db2f7418-6db6-4b24-a15a-5aa66b0ff512","ipam_ip_ids":["2fcbfc86-40b5-4625-88c6-bd89022d9cb1","0082a51f-dce1-4f79-8ccb-102c3a3f23ad"],"mac_address":"02:00:00:1d:10:95","modification_date":"2025-02-11T14:24:48.595649+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "938"
+                - "475"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:57 GMT
-            Link:
-                - </servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics?page=1&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:24:52 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -7106,12 +7104,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5bbb61fb-72a3-443e-9eca-43ec71c1a0a3
-            X-Total-Count:
-                - "2"
+                - c1309026-5a87-41ec-a48d-036cb226e468
         status: 200 OK
         code: 200
-        duration: 91.871083ms
+        duration: 98.896ms
     - id: 143
       request:
         proto: HTTP/1.1
@@ -7127,8 +7123,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04
         method: GET
       response:
         proto: HTTP/2.0
@@ -7136,22 +7132,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 938
+        content_length: 2743
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:54:40.587961+00:00","id":"a38eca4f-163a-405b-b6ed-d8d511b9211f","ipam_ip_ids":["8425f76c-dbb9-4ed0-96df-ad0daea19ac1","0b65b9ac-a68c-4e9d-84d9-81339c8cf140"],"mac_address":"02:00:00:15:45:27","modification_date":"2025-01-27T13:54:42.290771+00:00","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2025-01-27T13:54:50.452882+00:00","id":"ae150e34-4ac3-489a-8619-21d89e61a745","ipam_ip_ids":["5ead0b49-b09e-4102-82b3-0779121f65bf","d686b484-54e4-46fa-b786-6009beed0c51"],"mac_address":"02:00:00:11:5e:87","modification_date":"2025-01-27T13:54:52.261879+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:48.517107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-zealous-tesla","id":"d6a4ef64-1630-4987-aabb-e733f3478c04","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"803","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f9","maintenances":[],"modification_date":"2025-02-11T14:23:53.803702+00:00","name":"tf-srv-zealous-tesla","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:24:37.560939+00:00","id":"29a0e16b-6212-4d47-8bdf-61163fc50fc1","ipam_ip_ids":["7fb71eeb-de4e-4cf3-aa92-9e9d052a3487","ea171bd6-12e5-4bec-83c1-ff7025332a36"],"mac_address":"02:00:00:1a:ef:a5","modification_date":"2025-02-11T14:24:38.989455+00:00","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2025-02-11T14:24:46.947272+00:00","id":"db2f7418-6db6-4b24-a15a-5aa66b0ff512","ipam_ip_ids":["2fcbfc86-40b5-4625-88c6-bd89022d9cb1","0082a51f-dce1-4f79-8ccb-102c3a3f23ad"],"mac_address":"02:00:00:1d:10:95","modification_date":"2025-02-11T14:24:48.595649+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"810a8a91-0c84-4910-9038-f757b08e6d92","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "938"
+                - "2743"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:57 GMT
-            Link:
-                - </servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics?page=1&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:24:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -7159,12 +7153,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d3d59297-e69c-4284-bd08-f7698b883cd2
-            X-Total-Count:
-                - "2"
+                - 353fc88f-ba63-484b-a003-31d24ded2321
         status: 200 OK
         code: 200
-        duration: 95.603291ms
+        duration: 191.384291ms
     - id: 144
       request:
         proto: HTTP/1.1
@@ -7180,8 +7172,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7e4f4db4-f983-4fad-ab8e-abb34f3b0292
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04
         method: GET
       response:
         proto: HTTP/2.0
@@ -7189,20 +7181,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1054
+        content_length: 2743
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:54:39.033868Z","dhcp_enabled":true,"id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","name":"private_network_instance_02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:54:39.033868Z","id":"5a031fb6-7da9-444c-be5e-0fc437f0c3d1","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.24.0/22","updated_at":"2025-01-27T13:54:39.033868Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:54:39.033868Z","id":"e3b82fe9-ecc2-4b25-af4f-169257e510e8","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:e3cd::/64","updated_at":"2025-01-27T13:54:39.033868Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:54:39.033868Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:48.517107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-zealous-tesla","id":"d6a4ef64-1630-4987-aabb-e733f3478c04","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"803","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f9","maintenances":[],"modification_date":"2025-02-11T14:23:53.803702+00:00","name":"tf-srv-zealous-tesla","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:24:37.560939+00:00","id":"29a0e16b-6212-4d47-8bdf-61163fc50fc1","ipam_ip_ids":["7fb71eeb-de4e-4cf3-aa92-9e9d052a3487","ea171bd6-12e5-4bec-83c1-ff7025332a36"],"mac_address":"02:00:00:1a:ef:a5","modification_date":"2025-02-11T14:24:38.989455+00:00","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2025-02-11T14:24:46.947272+00:00","id":"db2f7418-6db6-4b24-a15a-5aa66b0ff512","ipam_ip_ids":["2fcbfc86-40b5-4625-88c6-bd89022d9cb1","0082a51f-dce1-4f79-8ccb-102c3a3f23ad"],"mac_address":"02:00:00:1d:10:95","modification_date":"2025-02-11T14:24:48.595649+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"810a8a91-0c84-4910-9038-f757b08e6d92","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1054"
+                - "2743"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:57 GMT
+                - Tue, 11 Feb 2025 14:24:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -7210,10 +7202,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - aacdea5e-866f-41dc-9a17-1178bdffe81a
+                - 2204e173-6f39-4a14-9f8f-51418497e1f3
         status: 200 OK
         code: 200
-        duration: 29.910292ms
+        duration: 180.509833ms
     - id: 145
       request:
         proto: HTTP/1.1
@@ -7229,8 +7221,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6e43bd7f-e7d5-4d93-999e-26abbc550834
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/810a8a91-0c84-4910-9038-f757b08e6d92
         method: GET
       response:
         proto: HTTP/2.0
@@ -7238,20 +7230,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1051
+        content_length: 143
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:53:39.867750Z","dhcp_enabled":true,"id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:53:39.867750Z","id":"3b4ac01d-048a-4077-a2b6-b5e344768fc3","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.20.0/22","updated_at":"2025-01-27T13:53:39.867750Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:53:39.867750Z","id":"32ddd6f5-f125-4418-b7c2-18de23d13498","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:e437::/64","updated_at":"2025-01-27T13:53:39.867750Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:53:39.867750Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"810a8a91-0c84-4910-9038-f757b08e6d92","type":"not_found"}'
         headers:
             Content-Length:
-                - "1051"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:57 GMT
+                - Tue, 11 Feb 2025 14:24:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -7259,10 +7251,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1a9e5489-94ac-41f4-b08f-154ab79afd36
-        status: 200 OK
-        code: 200
-        duration: 32.84225ms
+                - dd4c31b6-f555-447b-b519-01e0638e24d8
+        status: 404 Not Found
+        code: 404
+        duration: 42.670875ms
     - id: 146
       request:
         proto: HTTP/1.1
@@ -7278,8 +7270,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/810a8a91-0c84-4910-9038-f757b08e6d92
         method: GET
       response:
         proto: HTTP/2.0
@@ -7287,20 +7279,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3189
+        content_length: 701
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"102","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:53:55.578717+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:54:40.587961+00:00","id":"a38eca4f-163a-405b-b6ed-d8d511b9211f","ipam_ip_ids":["8425f76c-dbb9-4ed0-96df-ad0daea19ac1","0b65b9ac-a68c-4e9d-84d9-81339c8cf140"],"mac_address":"02:00:00:15:45:27","modification_date":"2025-01-27T13:54:42.290771+00:00","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2025-01-27T13:54:50.452882+00:00","id":"ae150e34-4ac3-489a-8619-21d89e61a745","ipam_ip_ids":["5ead0b49-b09e-4102-82b3-0779121f65bf","d686b484-54e4-46fa-b786-6009beed0c51"],"mac_address":"02:00:00:11:5e:87","modification_date":"2025-01-27T13:54:52.261879+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T14:23:48.722794Z","id":"810a8a91-0c84-4910-9038-f757b08e6d92","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:48.722794Z","id":"5b696577-55c8-4230-9368-a29e9ea2b0e5","product_resource_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:48.722794Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "3189"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:57 GMT
+                - Tue, 11 Feb 2025 14:24:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -7308,10 +7300,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6fcd5f95-98c0-48c6-a9cb-e50beee8d462
+                - 85f938ad-d1c3-436d-bfdb-816c60916bda
         status: 200 OK
         code: 200
-        duration: 153.597583ms
+        duration: 74.336083ms
     - id: 147
       request:
         proto: HTTP/1.1
@@ -7327,8 +7319,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/1197fc24-679a-40dc-9858-30c145bbfa4a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -7336,20 +7328,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 521
+        content_length: 17
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "521"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:57 GMT
+                - Tue, 11 Feb 2025 14:24:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -7357,10 +7349,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c40fa9d1-4b2a-4181-9da3-385bc67f931b
+                - 4fe4e929-82ab-4995-8029-9c600ef1516d
         status: 200 OK
         code: 200
-        duration: 107.413292ms
+        duration: 74.219958ms
     - id: 148
       request:
         proto: HTTP/1.1
@@ -7376,8 +7368,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -7385,20 +7377,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 938
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"private_nics":[{"creation_date":"2025-02-11T14:24:37.560939+00:00","id":"29a0e16b-6212-4d47-8bdf-61163fc50fc1","ipam_ip_ids":["7fb71eeb-de4e-4cf3-aa92-9e9d052a3487","ea171bd6-12e5-4bec-83c1-ff7025332a36"],"mac_address":"02:00:00:1a:ef:a5","modification_date":"2025-02-11T14:24:38.989455+00:00","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2025-02-11T14:24:46.947272+00:00","id":"db2f7418-6db6-4b24-a15a-5aa66b0ff512","ipam_ip_ids":["2fcbfc86-40b5-4625-88c6-bd89022d9cb1","0082a51f-dce1-4f79-8ccb-102c3a3f23ad"],"mac_address":"02:00:00:1d:10:95","modification_date":"2025-02-11T14:24:48.595649+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "17"
+                - "938"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:57 GMT
+                - Tue, 11 Feb 2025 14:24:53 GMT
+            Link:
+                - </servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics?page=1&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -7406,10 +7400,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9e1ea56f-5bd4-4777-8431-e11b2e0c37fa
+                - dc0cfa1b-810b-45b6-8149-6970363daed3
+            X-Total-Count:
+                - "2"
         status: 200 OK
         code: 200
-        duration: 100.854333ms
+        duration: 99.474167ms
     - id: 149
       request:
         proto: HTTP/1.1
@@ -7425,8 +7421,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -7436,7 +7432,7 @@ interactions:
         trailer: {}
         content_length: 938
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:54:40.587961+00:00","id":"a38eca4f-163a-405b-b6ed-d8d511b9211f","ipam_ip_ids":["8425f76c-dbb9-4ed0-96df-ad0daea19ac1","0b65b9ac-a68c-4e9d-84d9-81339c8cf140"],"mac_address":"02:00:00:15:45:27","modification_date":"2025-01-27T13:54:42.290771+00:00","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2025-01-27T13:54:50.452882+00:00","id":"ae150e34-4ac3-489a-8619-21d89e61a745","ipam_ip_ids":["5ead0b49-b09e-4102-82b3-0779121f65bf","d686b484-54e4-46fa-b786-6009beed0c51"],"mac_address":"02:00:00:11:5e:87","modification_date":"2025-01-27T13:54:52.261879+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"private_nics":[{"creation_date":"2025-02-11T14:24:37.560939+00:00","id":"29a0e16b-6212-4d47-8bdf-61163fc50fc1","ipam_ip_ids":["7fb71eeb-de4e-4cf3-aa92-9e9d052a3487","ea171bd6-12e5-4bec-83c1-ff7025332a36"],"mac_address":"02:00:00:1a:ef:a5","modification_date":"2025-02-11T14:24:38.989455+00:00","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2025-02-11T14:24:46.947272+00:00","id":"db2f7418-6db6-4b24-a15a-5aa66b0ff512","ipam_ip_ids":["2fcbfc86-40b5-4625-88c6-bd89022d9cb1","0082a51f-dce1-4f79-8ccb-102c3a3f23ad"],"mac_address":"02:00:00:1d:10:95","modification_date":"2025-02-11T14:24:48.595649+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
                 - "938"
@@ -7445,11 +7441,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:57 GMT
+                - Tue, 11 Feb 2025 14:24:53 GMT
             Link:
-                - </servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics?page=1&per_page=50&>; rel="last"
+                - </servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics?page=1&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -7457,12 +7453,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c3f22e58-47aa-4e8d-8e5a-b8802b83f427
+                - 4afbf2cd-4bf9-4879-92a2-1fd8c2c159d3
             X-Total-Count:
                 - "2"
         status: 200 OK
         code: 200
-        duration: 104.374916ms
+        duration: 72.63175ms
     - id: 150
       request:
         proto: HTTP/1.1
@@ -7478,8 +7474,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7e4f4db4-f983-4fad-ab8e-abb34f3b0292
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8e85576b-7702-4413-866b-4f684d7dcfb6
         method: GET
       response:
         proto: HTTP/2.0
@@ -7487,20 +7483,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1054
+        content_length: 1051
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:54:39.033868Z","dhcp_enabled":true,"id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","name":"private_network_instance_02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:54:39.033868Z","id":"5a031fb6-7da9-444c-be5e-0fc437f0c3d1","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.24.0/22","updated_at":"2025-01-27T13:54:39.033868Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:54:39.033868Z","id":"e3b82fe9-ecc2-4b25-af4f-169257e510e8","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:e3cd::/64","updated_at":"2025-01-27T13:54:39.033868Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:54:39.033868Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"created_at":"2025-02-11T14:23:46.151993Z","dhcp_enabled":true,"id":"8e85576b-7702-4413-866b-4f684d7dcfb6","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-11T14:23:46.151993Z","id":"ae5ebb5e-3140-4c2a-aebb-7c2492695024","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.16.0/22","updated_at":"2025-02-11T14:23:46.151993Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-11T14:23:46.151993Z","id":"db3dfab7-aa89-48aa-90db-b0af2fbbe71b","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:819d::/64","updated_at":"2025-02-11T14:23:46.151993Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-11T14:23:46.151993Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "1054"
+                - "1051"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:58 GMT
+                - Tue, 11 Feb 2025 14:24:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -7508,10 +7504,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 22e2b893-b553-4530-948e-dfa5ad412c8c
+                - 3bc00122-3242-439b-8ef8-5527b8ff0bd4
         status: 200 OK
         code: 200
-        duration: 29.722708ms
+        duration: 28.511792ms
     - id: 151
       request:
         proto: HTTP/1.1
@@ -7527,8 +7523,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6e43bd7f-e7d5-4d93-999e-26abbc550834
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a1de608c-4136-462d-875c-cc274949abe3
         method: GET
       response:
         proto: HTTP/2.0
@@ -7536,20 +7532,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1051
+        content_length: 1054
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:53:39.867750Z","dhcp_enabled":true,"id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:53:39.867750Z","id":"3b4ac01d-048a-4077-a2b6-b5e344768fc3","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.20.0/22","updated_at":"2025-01-27T13:53:39.867750Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:53:39.867750Z","id":"32ddd6f5-f125-4418-b7c2-18de23d13498","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:e437::/64","updated_at":"2025-01-27T13:53:39.867750Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:53:39.867750Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"created_at":"2025-02-11T14:24:35.842692Z","dhcp_enabled":true,"id":"a1de608c-4136-462d-875c-cc274949abe3","name":"private_network_instance_02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-11T14:24:35.842692Z","id":"72b9eafe-2e09-48d5-ae5d-9d63ebebc738","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.12.0/22","updated_at":"2025-02-11T14:24:35.842692Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-11T14:24:35.842692Z","id":"c37fba53-d26d-41b9-986a-cc71dcbca69e","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:cfb4::/64","updated_at":"2025-02-11T14:24:35.842692Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-11T14:24:35.842692Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "1051"
+                - "1054"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:58 GMT
+                - Tue, 11 Feb 2025 14:24:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -7557,10 +7553,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a68e6bf5-5523-4e21-80fa-385ca48bfe1a
+                - ff6058e7-7662-4f14-9055-7893737a3f3e
         status: 200 OK
         code: 200
-        duration: 29.532917ms
+        duration: 31.20125ms
     - id: 152
       request:
         proto: HTTP/1.1
@@ -7576,8 +7572,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04
         method: GET
       response:
         proto: HTTP/2.0
@@ -7585,20 +7581,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3189
+        content_length: 2743
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"102","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:53:55.578717+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:54:40.587961+00:00","id":"a38eca4f-163a-405b-b6ed-d8d511b9211f","ipam_ip_ids":["8425f76c-dbb9-4ed0-96df-ad0daea19ac1","0b65b9ac-a68c-4e9d-84d9-81339c8cf140"],"mac_address":"02:00:00:15:45:27","modification_date":"2025-01-27T13:54:42.290771+00:00","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2025-01-27T13:54:50.452882+00:00","id":"ae150e34-4ac3-489a-8619-21d89e61a745","ipam_ip_ids":["5ead0b49-b09e-4102-82b3-0779121f65bf","d686b484-54e4-46fa-b786-6009beed0c51"],"mac_address":"02:00:00:11:5e:87","modification_date":"2025-01-27T13:54:52.261879+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:48.517107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-zealous-tesla","id":"d6a4ef64-1630-4987-aabb-e733f3478c04","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"803","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f9","maintenances":[],"modification_date":"2025-02-11T14:23:53.803702+00:00","name":"tf-srv-zealous-tesla","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:24:37.560939+00:00","id":"29a0e16b-6212-4d47-8bdf-61163fc50fc1","ipam_ip_ids":["7fb71eeb-de4e-4cf3-aa92-9e9d052a3487","ea171bd6-12e5-4bec-83c1-ff7025332a36"],"mac_address":"02:00:00:1a:ef:a5","modification_date":"2025-02-11T14:24:38.989455+00:00","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2025-02-11T14:24:46.947272+00:00","id":"db2f7418-6db6-4b24-a15a-5aa66b0ff512","ipam_ip_ids":["2fcbfc86-40b5-4625-88c6-bd89022d9cb1","0082a51f-dce1-4f79-8ccb-102c3a3f23ad"],"mac_address":"02:00:00:1d:10:95","modification_date":"2025-02-11T14:24:48.595649+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"810a8a91-0c84-4910-9038-f757b08e6d92","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "3189"
+                - "2743"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:58 GMT
+                - Tue, 11 Feb 2025 14:24:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -7606,10 +7602,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5b122577-37f0-4cf0-bcd7-96bf5ce3b9c3
+                - 557ef92b-8150-49c7-9b85-595bb6734b97
         status: 200 OK
         code: 200
-        duration: 147.965917ms
+        duration: 171.685083ms
     - id: 153
       request:
         proto: HTTP/1.1
@@ -7625,8 +7621,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/1197fc24-679a-40dc-9858-30c145bbfa4a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/810a8a91-0c84-4910-9038-f757b08e6d92
         method: GET
       response:
         proto: HTTP/2.0
@@ -7634,20 +7630,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 521
+        content_length: 143
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"810a8a91-0c84-4910-9038-f757b08e6d92","type":"not_found"}'
         headers:
             Content-Length:
-                - "521"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:58 GMT
+                - Tue, 11 Feb 2025 14:24:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -7655,10 +7651,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3cafb4d3-3844-405d-8a54-cb0ce59e5ccf
-        status: 200 OK
-        code: 200
-        duration: 79.6205ms
+                - 4378238e-d245-49a9-8762-7e241bd5f5b5
+        status: 404 Not Found
+        code: 404
+        duration: 41.023167ms
     - id: 154
       request:
         proto: HTTP/1.1
@@ -7674,8 +7670,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/810a8a91-0c84-4910-9038-f757b08e6d92
         method: GET
       response:
         proto: HTTP/2.0
@@ -7683,20 +7679,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 701
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"created_at":"2025-02-11T14:23:48.722794Z","id":"810a8a91-0c84-4910-9038-f757b08e6d92","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:48.722794Z","id":"5b696577-55c8-4230-9368-a29e9ea2b0e5","product_resource_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:48.722794Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "17"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:58 GMT
+                - Tue, 11 Feb 2025 14:24:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -7704,10 +7700,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fe93659c-8dea-4107-9fa1-3fcb872aa79b
+                - 307b75e6-3aa1-4d78-ba46-092e9f063aec
         status: 200 OK
         code: 200
-        duration: 73.729291ms
+        duration: 83.284041ms
     - id: 155
       request:
         proto: HTTP/1.1
@@ -7723,8 +7719,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -7732,22 +7728,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 938
+        content_length: 17
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:54:40.587961+00:00","id":"a38eca4f-163a-405b-b6ed-d8d511b9211f","ipam_ip_ids":["8425f76c-dbb9-4ed0-96df-ad0daea19ac1","0b65b9ac-a68c-4e9d-84d9-81339c8cf140"],"mac_address":"02:00:00:15:45:27","modification_date":"2025-01-27T13:54:42.290771+00:00","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2025-01-27T13:54:50.452882+00:00","id":"ae150e34-4ac3-489a-8619-21d89e61a745","ipam_ip_ids":["5ead0b49-b09e-4102-82b3-0779121f65bf","d686b484-54e4-46fa-b786-6009beed0c51"],"mac_address":"02:00:00:11:5e:87","modification_date":"2025-01-27T13:54:52.261879+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "938"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:58 GMT
-            Link:
-                - </servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics?page=1&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:24:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -7755,12 +7749,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 34c8836e-8203-4c4b-96a0-acbbbf84ab40
-            X-Total-Count:
-                - "2"
+                - b2283dd2-4db8-4cd6-b0c6-62eb19cd3f51
         status: 200 OK
         code: 200
-        duration: 93.557917ms
+        duration: 101.829459ms
     - id: 156
       request:
         proto: HTTP/1.1
@@ -7776,8 +7768,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -7785,20 +7777,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3189
+        content_length: 938
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"102","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:53:55.578717+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:54:40.587961+00:00","id":"a38eca4f-163a-405b-b6ed-d8d511b9211f","ipam_ip_ids":["8425f76c-dbb9-4ed0-96df-ad0daea19ac1","0b65b9ac-a68c-4e9d-84d9-81339c8cf140"],"mac_address":"02:00:00:15:45:27","modification_date":"2025-01-27T13:54:42.290771+00:00","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2025-01-27T13:54:50.452882+00:00","id":"ae150e34-4ac3-489a-8619-21d89e61a745","ipam_ip_ids":["5ead0b49-b09e-4102-82b3-0779121f65bf","d686b484-54e4-46fa-b786-6009beed0c51"],"mac_address":"02:00:00:11:5e:87","modification_date":"2025-01-27T13:54:52.261879+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"private_nics":[{"creation_date":"2025-02-11T14:24:37.560939+00:00","id":"29a0e16b-6212-4d47-8bdf-61163fc50fc1","ipam_ip_ids":["7fb71eeb-de4e-4cf3-aa92-9e9d052a3487","ea171bd6-12e5-4bec-83c1-ff7025332a36"],"mac_address":"02:00:00:1a:ef:a5","modification_date":"2025-02-11T14:24:38.989455+00:00","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2025-02-11T14:24:46.947272+00:00","id":"db2f7418-6db6-4b24-a15a-5aa66b0ff512","ipam_ip_ids":["2fcbfc86-40b5-4625-88c6-bd89022d9cb1","0082a51f-dce1-4f79-8ccb-102c3a3f23ad"],"mac_address":"02:00:00:1d:10:95","modification_date":"2025-02-11T14:24:48.595649+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "3189"
+                - "938"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:59 GMT
+                - Tue, 11 Feb 2025 14:24:54 GMT
+            Link:
+                - </servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics?page=1&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -7806,10 +7800,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a1b8227c-386d-431e-b0f8-7364fea9fa50
+                - 299fa7b8-5b02-4f9e-a2cc-960696fdcb9d
+            X-Total-Count:
+                - "2"
         status: 200 OK
         code: 200
-        duration: 254.271916ms
+        duration: 94.75025ms
     - id: 157
       request:
         proto: HTTP/1.1
@@ -7825,8 +7821,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8e85576b-7702-4413-866b-4f684d7dcfb6
         method: GET
       response:
         proto: HTTP/2.0
@@ -7834,22 +7830,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 938
+        content_length: 1051
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T13:54:40.587961+00:00","id":"a38eca4f-163a-405b-b6ed-d8d511b9211f","ipam_ip_ids":["8425f76c-dbb9-4ed0-96df-ad0daea19ac1","0b65b9ac-a68c-4e9d-84d9-81339c8cf140"],"mac_address":"02:00:00:15:45:27","modification_date":"2025-01-27T13:54:42.290771+00:00","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2025-01-27T13:54:50.452882+00:00","id":"ae150e34-4ac3-489a-8619-21d89e61a745","ipam_ip_ids":["5ead0b49-b09e-4102-82b3-0779121f65bf","d686b484-54e4-46fa-b786-6009beed0c51"],"mac_address":"02:00:00:11:5e:87","modification_date":"2025-01-27T13:54:52.261879+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"created_at":"2025-02-11T14:23:46.151993Z","dhcp_enabled":true,"id":"8e85576b-7702-4413-866b-4f684d7dcfb6","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-11T14:23:46.151993Z","id":"ae5ebb5e-3140-4c2a-aebb-7c2492695024","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.16.0/22","updated_at":"2025-02-11T14:23:46.151993Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-11T14:23:46.151993Z","id":"db3dfab7-aa89-48aa-90db-b0af2fbbe71b","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:819d::/64","updated_at":"2025-02-11T14:23:46.151993Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-11T14:23:46.151993Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "938"
+                - "1051"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:59 GMT
-            Link:
-                - </servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics?page=1&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:24:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -7857,12 +7851,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cd1cdb2e-0368-4a55-ab8b-dc1d376fc970
-            X-Total-Count:
-                - "2"
+                - 619295c1-3c42-4554-ae6b-56179fbd2923
         status: 200 OK
         code: 200
-        duration: 85.22975ms
+        duration: 30.345916ms
     - id: 158
       request:
         proto: HTTP/1.1
@@ -7878,8 +7870,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a1de608c-4136-462d-875c-cc274949abe3
         method: GET
       response:
         proto: HTTP/2.0
@@ -7887,20 +7879,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3189
+        content_length: 1054
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"102","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:53:55.578717+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:54:40.587961+00:00","id":"a38eca4f-163a-405b-b6ed-d8d511b9211f","ipam_ip_ids":["8425f76c-dbb9-4ed0-96df-ad0daea19ac1","0b65b9ac-a68c-4e9d-84d9-81339c8cf140"],"mac_address":"02:00:00:15:45:27","modification_date":"2025-01-27T13:54:42.290771+00:00","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2025-01-27T13:54:50.452882+00:00","id":"ae150e34-4ac3-489a-8619-21d89e61a745","ipam_ip_ids":["5ead0b49-b09e-4102-82b3-0779121f65bf","d686b484-54e4-46fa-b786-6009beed0c51"],"mac_address":"02:00:00:11:5e:87","modification_date":"2025-01-27T13:54:52.261879+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T14:24:35.842692Z","dhcp_enabled":true,"id":"a1de608c-4136-462d-875c-cc274949abe3","name":"private_network_instance_02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-11T14:24:35.842692Z","id":"72b9eafe-2e09-48d5-ae5d-9d63ebebc738","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.12.0/22","updated_at":"2025-02-11T14:24:35.842692Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-11T14:24:35.842692Z","id":"c37fba53-d26d-41b9-986a-cc71dcbca69e","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:cfb4::/64","updated_at":"2025-02-11T14:24:35.842692Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-11T14:24:35.842692Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "3189"
+                - "1054"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:59 GMT
+                - Tue, 11 Feb 2025 14:24:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -7908,10 +7900,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b6047d15-7133-4525-80bf-25917e5e643d
+                - 5c4f2c1a-d9ee-40a7-8a0f-417a59d4f0fc
         status: 200 OK
         code: 200
-        duration: 143.461667ms
+        duration: 31.706125ms
     - id: 159
       request:
         proto: HTTP/1.1
@@ -7927,8 +7919,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics/a38eca4f-163a-405b-b6ed-d8d511b9211f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04
         method: GET
       response:
         proto: HTTP/2.0
@@ -7936,20 +7928,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 475
+        content_length: 2743
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:54:40.587961+00:00","id":"a38eca4f-163a-405b-b6ed-d8d511b9211f","ipam_ip_ids":["8425f76c-dbb9-4ed0-96df-ad0daea19ac1","0b65b9ac-a68c-4e9d-84d9-81339c8cf140"],"mac_address":"02:00:00:15:45:27","modification_date":"2025-01-27T13:54:42.290771+00:00","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:48.517107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-zealous-tesla","id":"d6a4ef64-1630-4987-aabb-e733f3478c04","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"803","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f9","maintenances":[],"modification_date":"2025-02-11T14:23:53.803702+00:00","name":"tf-srv-zealous-tesla","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:24:37.560939+00:00","id":"29a0e16b-6212-4d47-8bdf-61163fc50fc1","ipam_ip_ids":["7fb71eeb-de4e-4cf3-aa92-9e9d052a3487","ea171bd6-12e5-4bec-83c1-ff7025332a36"],"mac_address":"02:00:00:1a:ef:a5","modification_date":"2025-02-11T14:24:38.989455+00:00","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2025-02-11T14:24:46.947272+00:00","id":"db2f7418-6db6-4b24-a15a-5aa66b0ff512","ipam_ip_ids":["2fcbfc86-40b5-4625-88c6-bd89022d9cb1","0082a51f-dce1-4f79-8ccb-102c3a3f23ad"],"mac_address":"02:00:00:1d:10:95","modification_date":"2025-02-11T14:24:48.595649+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"810a8a91-0c84-4910-9038-f757b08e6d92","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "475"
+                - "2743"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:59 GMT
+                - Tue, 11 Feb 2025 14:24:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -7957,10 +7949,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2f1fd1ac-83b7-49fc-ab21-333f24442fbd
+                - d336600d-8580-4a90-8c1c-be09fb342af2
         status: 200 OK
         code: 200
-        duration: 86.924042ms
+        duration: 160.792167ms
     - id: 160
       request:
         proto: HTTP/1.1
@@ -7976,27 +7968,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics/a38eca4f-163a-405b-b6ed-d8d511b9211f
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/810a8a91-0c84-4910-9038-f757b08e6d92
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 143
         uncompressed: false
-        body: ""
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"810a8a91-0c84-4910-9038-f757b08e6d92","type":"not_found"}'
         headers:
+            Content-Length:
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:00 GMT
+                - Tue, 11 Feb 2025 14:24:54 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -8004,10 +7998,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b83b1219-2ec2-43d5-8ea0-b44596866e45
-        status: 204 No Content
-        code: 204
-        duration: 464.505625ms
+                - 0ece5f3f-5960-4d0b-af9b-92597fd1f807
+        status: 404 Not Found
+        code: 404
+        duration: 34.556375ms
     - id: 161
       request:
         proto: HTTP/1.1
@@ -8023,8 +8017,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics/a38eca4f-163a-405b-b6ed-d8d511b9211f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/810a8a91-0c84-4910-9038-f757b08e6d92
         method: GET
       response:
         proto: HTTP/2.0
@@ -8032,20 +8026,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 148
+        content_length: 701
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"a38eca4f-163a-405b-b6ed-d8d511b9211f","type":"not_found"}'
+        body: '{"created_at":"2025-02-11T14:23:48.722794Z","id":"810a8a91-0c84-4910-9038-f757b08e6d92","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:48.722794Z","id":"5b696577-55c8-4230-9368-a29e9ea2b0e5","product_resource_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:48.722794Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "148"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:00 GMT
+                - Tue, 11 Feb 2025 14:24:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -8053,10 +8047,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7fff9a49-2358-4dd7-b57b-f649495021b4
-        status: 404 Not Found
-        code: 404
-        duration: 223.75075ms
+                - 38009a00-ae6a-488e-8704-102d88213287
+        status: 200 OK
+        code: 200
+        duration: 424.624417ms
     - id: 162
       request:
         proto: HTTP/1.1
@@ -8072,8 +8066,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -8081,20 +8075,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2729
+        content_length: 17
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"102","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:53:55.578717+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T13:54:50.452882+00:00","id":"ae150e34-4ac3-489a-8619-21d89e61a745","ipam_ip_ids":["5ead0b49-b09e-4102-82b3-0779121f65bf","d686b484-54e4-46fa-b786-6009beed0c51"],"mac_address":"02:00:00:11:5e:87","modification_date":"2025-01-27T13:54:52.261879+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "2729"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:00 GMT
+                - Tue, 11 Feb 2025 14:24:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -8102,10 +8096,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e25de2f6-896d-4da4-9837-5db0eff27fef
+                - ceedaf7a-77d9-4751-8dbe-953f9baccc42
         status: 200 OK
         code: 200
-        duration: 165.969458ms
+        duration: 74.170041ms
     - id: 163
       request:
         proto: HTTP/1.1
@@ -8121,8 +8115,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics/ae150e34-4ac3-489a-8619-21d89e61a745
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -8130,20 +8124,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 475
+        content_length: 938
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T13:54:50.452882+00:00","id":"ae150e34-4ac3-489a-8619-21d89e61a745","ipam_ip_ids":["5ead0b49-b09e-4102-82b3-0779121f65bf","d686b484-54e4-46fa-b786-6009beed0c51"],"mac_address":"02:00:00:11:5e:87","modification_date":"2025-01-27T13:54:52.261879+00:00","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","server_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nics":[{"creation_date":"2025-02-11T14:24:37.560939+00:00","id":"29a0e16b-6212-4d47-8bdf-61163fc50fc1","ipam_ip_ids":["7fb71eeb-de4e-4cf3-aa92-9e9d052a3487","ea171bd6-12e5-4bec-83c1-ff7025332a36"],"mac_address":"02:00:00:1a:ef:a5","modification_date":"2025-02-11T14:24:38.989455+00:00","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2025-02-11T14:24:46.947272+00:00","id":"db2f7418-6db6-4b24-a15a-5aa66b0ff512","ipam_ip_ids":["2fcbfc86-40b5-4625-88c6-bd89022d9cb1","0082a51f-dce1-4f79-8ccb-102c3a3f23ad"],"mac_address":"02:00:00:1d:10:95","modification_date":"2025-02-11T14:24:48.595649+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "475"
+                - "938"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:00 GMT
+                - Tue, 11 Feb 2025 14:24:55 GMT
+            Link:
+                - </servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics?page=1&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -8151,10 +8147,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ececa8df-29eb-4ecd-a808-57527c42ca6a
+                - e3c23121-249d-4d1b-a77d-0884a5aa8df1
+            X-Total-Count:
+                - "2"
         status: 200 OK
         code: 200
-        duration: 101.544375ms
+        duration: 87.876542ms
     - id: 164
       request:
         proto: HTTP/1.1
@@ -8170,8 +8168,208 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics/ae150e34-4ac3-489a-8619-21d89e61a745
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2743
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:48.517107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-zealous-tesla","id":"d6a4ef64-1630-4987-aabb-e733f3478c04","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"803","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f9","maintenances":[],"modification_date":"2025-02-11T14:23:53.803702+00:00","name":"tf-srv-zealous-tesla","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:24:37.560939+00:00","id":"29a0e16b-6212-4d47-8bdf-61163fc50fc1","ipam_ip_ids":["7fb71eeb-de4e-4cf3-aa92-9e9d052a3487","ea171bd6-12e5-4bec-83c1-ff7025332a36"],"mac_address":"02:00:00:1a:ef:a5","modification_date":"2025-02-11T14:24:38.989455+00:00","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2025-02-11T14:24:46.947272+00:00","id":"db2f7418-6db6-4b24-a15a-5aa66b0ff512","ipam_ip_ids":["2fcbfc86-40b5-4625-88c6-bd89022d9cb1","0082a51f-dce1-4f79-8ccb-102c3a3f23ad"],"mac_address":"02:00:00:1d:10:95","modification_date":"2025-02-11T14:24:48.595649+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"810a8a91-0c84-4910-9038-f757b08e6d92","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2743"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4416211e-454c-4669-b7b2-b77418577e62
+        status: 200 OK
+        code: 200
+        duration: 184.417084ms
+    - id: 165
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 938
+        uncompressed: false
+        body: '{"private_nics":[{"creation_date":"2025-02-11T14:24:37.560939+00:00","id":"29a0e16b-6212-4d47-8bdf-61163fc50fc1","ipam_ip_ids":["7fb71eeb-de4e-4cf3-aa92-9e9d052a3487","ea171bd6-12e5-4bec-83c1-ff7025332a36"],"mac_address":"02:00:00:1a:ef:a5","modification_date":"2025-02-11T14:24:38.989455+00:00","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2025-02-11T14:24:46.947272+00:00","id":"db2f7418-6db6-4b24-a15a-5aa66b0ff512","ipam_ip_ids":["2fcbfc86-40b5-4625-88c6-bd89022d9cb1","0082a51f-dce1-4f79-8ccb-102c3a3f23ad"],"mac_address":"02:00:00:1d:10:95","modification_date":"2025-02-11T14:24:48.595649+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        headers:
+            Content-Length:
+                - "938"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:55 GMT
+            Link:
+                - </servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics?page=1&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f2d69d97-af10-4ab5-baf3-41f3fe2411c4
+            X-Total-Count:
+                - "2"
+        status: 200 OK
+        code: 200
+        duration: 90.224583ms
+    - id: 166
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2743
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:48.517107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-zealous-tesla","id":"d6a4ef64-1630-4987-aabb-e733f3478c04","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"803","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f9","maintenances":[],"modification_date":"2025-02-11T14:23:53.803702+00:00","name":"tf-srv-zealous-tesla","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:24:37.560939+00:00","id":"29a0e16b-6212-4d47-8bdf-61163fc50fc1","ipam_ip_ids":["7fb71eeb-de4e-4cf3-aa92-9e9d052a3487","ea171bd6-12e5-4bec-83c1-ff7025332a36"],"mac_address":"02:00:00:1a:ef:a5","modification_date":"2025-02-11T14:24:38.989455+00:00","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2025-02-11T14:24:46.947272+00:00","id":"db2f7418-6db6-4b24-a15a-5aa66b0ff512","ipam_ip_ids":["2fcbfc86-40b5-4625-88c6-bd89022d9cb1","0082a51f-dce1-4f79-8ccb-102c3a3f23ad"],"mac_address":"02:00:00:1d:10:95","modification_date":"2025-02-11T14:24:48.595649+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"810a8a91-0c84-4910-9038-f757b08e6d92","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2743"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b35c52f7-1e96-482f-a686-ba166c4b058f
+        status: 200 OK
+        code: 200
+        duration: 192.542209ms
+    - id: 167
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics/29a0e16b-6212-4d47-8bdf-61163fc50fc1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 475
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:24:37.560939+00:00","id":"29a0e16b-6212-4d47-8bdf-61163fc50fc1","ipam_ip_ids":["7fb71eeb-de4e-4cf3-aa92-9e9d052a3487","ea171bd6-12e5-4bec-83c1-ff7025332a36"],"mac_address":"02:00:00:1a:ef:a5","modification_date":"2025-02-11T14:24:38.989455+00:00","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "475"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 37d9eb10-b372-4535-8b73-d4cb387e0971
+        status: 200 OK
+        code: 200
+        duration: 82.806667ms
+    - id: 168
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics/29a0e16b-6212-4d47-8bdf-61163fc50fc1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -8188,9 +8386,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:00 GMT
+                - Tue, 11 Feb 2025 14:24:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -8198,206 +8396,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 633c3d54-0877-47d8-ae52-6913ab1aa10b
+                - d75d2c0a-5dff-4da0-af17-499feb691537
         status: 204 No Content
         code: 204
-        duration: 359.040208ms
-    - id: 165
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics/ae150e34-4ac3-489a-8619-21d89e61a745
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 148
-        uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"ae150e34-4ac3-489a-8619-21d89e61a745","type":"not_found"}'
-        headers:
-            Content-Length:
-                - "148"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:55:00 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 78654994-18b7-4a60-89ee-20b7d7ae93db
-        status: 404 Not Found
-        code: 404
-        duration: 118.128416ms
-    - id: 166
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2271
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"102","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:53:55.578717+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2271"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:55:01 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 19e1e394-7cb4-41a7-8048-13909d95af3a
-        status: 200 OK
-        code: 200
-        duration: 199.384958ms
-    - id: 167
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2271
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"102","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:53:55.578717+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2271"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:55:01 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 3bb6265d-ba8d-4a48-bb92-c7ba80934783
-        status: 200 OK
-        code: 200
-        duration: 177.258209ms
-    - id: 168
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/1197fc24-679a-40dc-9858-30c145bbfa4a
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 521
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "521"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:55:01 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 4475984d-f36c-4e57-9c50-fc98079015c0
-        status: 200 OK
-        code: 200
-        duration: 123.953ms
+        duration: 417.973833ms
     - id: 169
       request:
         proto: HTTP/1.1
@@ -8413,8 +8415,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics/29a0e16b-6212-4d47-8bdf-61163fc50fc1
         method: GET
       response:
         proto: HTTP/2.0
@@ -8422,20 +8424,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 148
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"29a0e16b-6212-4d47-8bdf-61163fc50fc1","type":"not_found"}'
         headers:
             Content-Length:
-                - "17"
+                - "148"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:01 GMT
+                - Tue, 11 Feb 2025 14:24:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -8443,10 +8445,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1fcea2b9-52ff-4e19-93d1-57918e440ac1
-        status: 200 OK
-        code: 200
-        duration: 208.1975ms
+                - d04600ed-e501-49a4-8b61-c543496248bd
+        status: 404 Not Found
+        code: 404
+        duration: 90.408375ms
     - id: 170
       request:
         proto: HTTP/1.1
@@ -8462,8 +8464,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04
         method: GET
       response:
         proto: HTTP/2.0
@@ -8471,22 +8473,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 2283
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:48.517107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-zealous-tesla","id":"d6a4ef64-1630-4987-aabb-e733f3478c04","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"803","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f9","maintenances":[],"modification_date":"2025-02-11T14:23:53.803702+00:00","name":"tf-srv-zealous-tesla","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-11T14:24:46.947272+00:00","id":"db2f7418-6db6-4b24-a15a-5aa66b0ff512","ipam_ip_ids":["2fcbfc86-40b5-4625-88c6-bd89022d9cb1","0082a51f-dce1-4f79-8ccb-102c3a3f23ad"],"mac_address":"02:00:00:1d:10:95","modification_date":"2025-02-11T14:24:48.595649+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"810a8a91-0c84-4910-9038-f757b08e6d92","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "20"
+                - "2283"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:01 GMT
-            Link:
-                - </servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:24:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -8494,12 +8494,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2c9da9fd-8a36-4623-95f1-3a8632aa9370
-            X-Total-Count:
-                - "0"
+                - 8c22ec9b-6d20-44e5-8b5b-095508f0d90d
         status: 200 OK
         code: 200
-        duration: 106.186125ms
+        duration: 155.341625ms
     - id: 171
       request:
         proto: HTTP/1.1
@@ -8515,8 +8513,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics/db2f7418-6db6-4b24-a15a-5aa66b0ff512
         method: GET
       response:
         proto: HTTP/2.0
@@ -8524,20 +8522,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2271
+        content_length: 475
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"102","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:53:55.578717+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-11T14:24:46.947272+00:00","id":"db2f7418-6db6-4b24-a15a-5aa66b0ff512","ipam_ip_ids":["2fcbfc86-40b5-4625-88c6-bd89022d9cb1","0082a51f-dce1-4f79-8ccb-102c3a3f23ad"],"mac_address":"02:00:00:1d:10:95","modification_date":"2025-02-11T14:24:48.595649+00:00","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","server_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2271"
+                - "475"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:02 GMT
+                - Tue, 11 Feb 2025 14:24:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -8545,10 +8543,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1a551f11-9b75-4513-ac89-8491a8199b5c
+                - b19596c7-ff65-451e-9618-bdc720fd2513
         status: 200 OK
         code: 200
-        duration: 181.52925ms
+        duration: 89.105375ms
     - id: 172
       request:
         proto: HTTP/1.1
@@ -8564,29 +8562,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7e4f4db4-f983-4fad-ab8e-abb34f3b0292
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics/db2f7418-6db6-4b24-a15a-5aa66b0ff512
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1054
+        content_length: 0
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:54:39.033868Z","dhcp_enabled":true,"id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","name":"private_network_instance_02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:54:39.033868Z","id":"5a031fb6-7da9-444c-be5e-0fc437f0c3d1","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.24.0/22","updated_at":"2025-01-27T13:54:39.033868Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:54:39.033868Z","id":"e3b82fe9-ecc2-4b25-af4f-169257e510e8","private_network_id":"7e4f4db4-f983-4fad-ab8e-abb34f3b0292","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:e3cd::/64","updated_at":"2025-01-27T13:54:39.033868Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:54:39.033868Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: ""
         headers:
-            Content-Length:
-                - "1054"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:02 GMT
+                - Tue, 11 Feb 2025 14:24:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -8594,10 +8590,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3a46c6c3-eae8-4c3b-9ff2-498fc45ef726
-        status: 200 OK
-        code: 200
-        duration: 23.530458ms
+                - ffbd8f03-123b-48cd-a4b7-49f0462491c4
+        status: 204 No Content
+        code: 204
+        duration: 408.679542ms
     - id: 173
       request:
         proto: HTTP/1.1
@@ -8613,8 +8609,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6e43bd7f-e7d5-4d93-999e-26abbc550834
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics/db2f7418-6db6-4b24-a15a-5aa66b0ff512
         method: GET
       response:
         proto: HTTP/2.0
@@ -8622,20 +8618,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1051
+        content_length: 148
         uncompressed: false
-        body: '{"created_at":"2025-01-27T13:53:39.867750Z","dhcp_enabled":true,"id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T13:53:39.867750Z","id":"3b4ac01d-048a-4077-a2b6-b5e344768fc3","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.20.0/22","updated_at":"2025-01-27T13:53:39.867750Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T13:53:39.867750Z","id":"32ddd6f5-f125-4418-b7c2-18de23d13498","private_network_id":"6e43bd7f-e7d5-4d93-999e-26abbc550834","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:e437::/64","updated_at":"2025-01-27T13:53:39.867750Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T13:53:39.867750Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"db2f7418-6db6-4b24-a15a-5aa66b0ff512","type":"not_found"}'
         headers:
             Content-Length:
-                - "1051"
+                - "148"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:02 GMT
+                - Tue, 11 Feb 2025 14:24:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -8643,10 +8639,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e3ad4cf5-e39b-4411-ae84-b97ee6c01bb0
-        status: 200 OK
-        code: 200
-        duration: 31.159541ms
+                - d04751e2-0d0d-4fa3-a65e-3e0afdad89fe
+        status: 404 Not Found
+        code: 404
+        duration: 80.18225ms
     - id: 174
       request:
         proto: HTTP/1.1
@@ -8662,8 +8658,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04
         method: GET
       response:
         proto: HTTP/2.0
@@ -8671,20 +8667,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2271
+        content_length: 1825
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"102","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:53:55.578717+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:48.517107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-zealous-tesla","id":"d6a4ef64-1630-4987-aabb-e733f3478c04","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"803","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f9","maintenances":[],"modification_date":"2025-02-11T14:23:53.803702+00:00","name":"tf-srv-zealous-tesla","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"810a8a91-0c84-4910-9038-f757b08e6d92","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2271"
+                - "1825"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:02 GMT
+                - Tue, 11 Feb 2025 14:24:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -8692,10 +8688,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 34ee73f6-c430-4819-93be-3921ef963ac6
+                - 95f21f04-3bc9-4c9c-89e3-d0df8cba8b6d
         status: 200 OK
         code: 200
-        duration: 281.0195ms
+        duration: 189.056208ms
     - id: 175
       request:
         proto: HTTP/1.1
@@ -8711,8 +8707,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/1197fc24-679a-40dc-9858-30c145bbfa4a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04
         method: GET
       response:
         proto: HTTP/2.0
@@ -8720,20 +8716,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 521
+        content_length: 1825
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:48.517107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-zealous-tesla","id":"d6a4ef64-1630-4987-aabb-e733f3478c04","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"803","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f9","maintenances":[],"modification_date":"2025-02-11T14:23:53.803702+00:00","name":"tf-srv-zealous-tesla","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"810a8a91-0c84-4910-9038-f757b08e6d92","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "521"
+                - "1825"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:02 GMT
+                - Tue, 11 Feb 2025 14:24:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -8741,10 +8737,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c6dcef89-1f01-48ce-8c01-a66049847c7d
+                - 7bcb0c17-63b7-4434-a3b5-73c0d6b680e8
         status: 200 OK
         code: 200
-        duration: 108.914ms
+        duration: 158.383625ms
     - id: 176
       request:
         proto: HTTP/1.1
@@ -8760,8 +8756,106 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/810a8a91-0c84-4910-9038-f757b08e6d92
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"810a8a91-0c84-4910-9038-f757b08e6d92","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2f061fa9-dd5c-4ddd-b1fb-cda2e164e3c0
+        status: 404 Not Found
+        code: 404
+        duration: 31.820333ms
+    - id: 177
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/810a8a91-0c84-4910-9038-f757b08e6d92
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:23:48.722794Z","id":"810a8a91-0c84-4910-9038-f757b08e6d92","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:48.722794Z","id":"5b696577-55c8-4230-9368-a29e9ea2b0e5","product_resource_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:48.722794Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ff5823a3-5bb3-4c77-b907-bebfd8145315
+        status: 200 OK
+        code: 200
+        duration: 69.80025ms
+    - id: 178
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -8780,9 +8874,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:02 GMT
+                - Tue, 11 Feb 2025 14:24:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -8790,11 +8884,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cde05d62-b38e-4bfa-92ba-27b2193746a6
+                - d16340a5-00b9-4f01-819c-5b7480de1caa
         status: 200 OK
         code: 200
-        duration: 86.715ms
-    - id: 177
+        duration: 99.182709ms
+    - id: 179
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -8809,8 +8903,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -8829,11 +8923,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:02 GMT
+                - Tue, 11 Feb 2025 14:24:58 GMT
             Link:
-                - </servers/44be618c-4ff5-4b62-ac34-867025adcc7e/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -8841,13 +8935,13 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d68eb9b3-968a-4e4a-b963-4d8dc08647e6
+                - 0182910e-9546-465c-acd9-f5b43bea026a
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 99.026333ms
-    - id: 178
+        duration: 93.8505ms
+    - id: 180
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -8862,8 +8956,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04
         method: GET
       response:
         proto: HTTP/2.0
@@ -8871,20 +8965,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2271
+        content_length: 1825
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"102","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:53:55.578717+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:48.517107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-zealous-tesla","id":"d6a4ef64-1630-4987-aabb-e733f3478c04","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"803","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f9","maintenances":[],"modification_date":"2025-02-11T14:23:53.803702+00:00","name":"tf-srv-zealous-tesla","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"810a8a91-0c84-4910-9038-f757b08e6d92","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2271"
+                - "1825"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:03 GMT
+                - Tue, 11 Feb 2025 14:24:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -8892,11 +8986,456 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cdd3f307-a29d-40e1-a552-f663c998e3dd
+                - 29ba423a-5ab8-4130-874b-a98eb4df5e55
         status: 200 OK
         code: 200
-        duration: 180.624708ms
-    - id: 179
+        duration: 148.425292ms
+    - id: 181
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a1de608c-4136-462d-875c-cc274949abe3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1054
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:24:35.842692Z","dhcp_enabled":true,"id":"a1de608c-4136-462d-875c-cc274949abe3","name":"private_network_instance_02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-11T14:24:35.842692Z","id":"72b9eafe-2e09-48d5-ae5d-9d63ebebc738","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.12.0/22","updated_at":"2025-02-11T14:24:35.842692Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-11T14:24:35.842692Z","id":"c37fba53-d26d-41b9-986a-cc71dcbca69e","private_network_id":"a1de608c-4136-462d-875c-cc274949abe3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:cfb4::/64","updated_at":"2025-02-11T14:24:35.842692Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-11T14:24:35.842692Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        headers:
+            Content-Length:
+                - "1054"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - dbb1470b-5c19-4e52-a5e8-cbbd6fa408e6
+        status: 200 OK
+        code: 200
+        duration: 41.598542ms
+    - id: 182
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8e85576b-7702-4413-866b-4f684d7dcfb6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1051
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:23:46.151993Z","dhcp_enabled":true,"id":"8e85576b-7702-4413-866b-4f684d7dcfb6","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-11T14:23:46.151993Z","id":"ae5ebb5e-3140-4c2a-aebb-7c2492695024","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.16.0/22","updated_at":"2025-02-11T14:23:46.151993Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-11T14:23:46.151993Z","id":"db3dfab7-aa89-48aa-90db-b0af2fbbe71b","private_network_id":"8e85576b-7702-4413-866b-4f684d7dcfb6","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:819d::/64","updated_at":"2025-02-11T14:23:46.151993Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-11T14:23:46.151993Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        headers:
+            Content-Length:
+                - "1051"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7e208b9c-c618-44c2-86ff-00e702f25ce9
+        status: 200 OK
+        code: 200
+        duration: 42.208458ms
+    - id: 183
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1825
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:48.517107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-zealous-tesla","id":"d6a4ef64-1630-4987-aabb-e733f3478c04","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"803","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f9","maintenances":[],"modification_date":"2025-02-11T14:23:53.803702+00:00","name":"tf-srv-zealous-tesla","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"810a8a91-0c84-4910-9038-f757b08e6d92","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1825"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3bedcf0d-42ba-4f7c-9093-bd813ce69616
+        status: 200 OK
+        code: 200
+        duration: 166.444125ms
+    - id: 184
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/810a8a91-0c84-4910-9038-f757b08e6d92
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"810a8a91-0c84-4910-9038-f757b08e6d92","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d79ce128-d4dd-4528-95d3-93593d0104c8
+        status: 404 Not Found
+        code: 404
+        duration: 33.590458ms
+    - id: 185
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/810a8a91-0c84-4910-9038-f757b08e6d92
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:23:48.722794Z","id":"810a8a91-0c84-4910-9038-f757b08e6d92","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:48.722794Z","id":"5b696577-55c8-4230-9368-a29e9ea2b0e5","product_resource_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:48.722794Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9b366048-222e-4a3a-8ac6-5f15c42b96ce
+        status: 200 OK
+        code: 200
+        duration: 65.384834ms
+    - id: 186
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/user_data
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 17
+        uncompressed: false
+        body: '{"user_data":[]}'
+        headers:
+            Content-Length:
+                - "17"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2b9094d5-48d1-4377-a093-d2e4ebe0d625
+        status: 200 OK
+        code: 200
+        duration: 81.919167ms
+    - id: 187
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 20
+        uncompressed: false
+        body: '{"private_nics":[]}'
+        headers:
+            Content-Length:
+                - "20"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:58 GMT
+            Link:
+                - </servers/d6a4ef64-1630-4987-aabb-e733f3478c04/private_nics?page=0&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 701174bc-d694-4db0-8c6c-20a2fd3664c2
+            X-Total-Count:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 84.557833ms
+    - id: 188
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1825
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:48.517107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-zealous-tesla","id":"d6a4ef64-1630-4987-aabb-e733f3478c04","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"803","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f9","maintenances":[],"modification_date":"2025-02-11T14:23:53.803702+00:00","name":"tf-srv-zealous-tesla","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"810a8a91-0c84-4910-9038-f757b08e6d92","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1825"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 393d81fb-b32a-4a20-bf4b-b9a822fbfdea
+        status: 200 OK
+        code: 200
+        duration: 141.746334ms
+    - id: 189
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/810a8a91-0c84-4910-9038-f757b08e6d92
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:23:48.722794Z","id":"810a8a91-0c84-4910-9038-f757b08e6d92","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:48.722794Z","id":"5b696577-55c8-4230-9368-a29e9ea2b0e5","product_resource_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:48.722794Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b74559cf-e953-4b46-a5d1-93227a5568af
+        status: 200 OK
+        code: 200
+        duration: 71.5185ms
+    - id: 190
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -8913,8 +9452,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -8924,7 +9463,7 @@ interactions:
         trailer: {}
         content_length: 352
         uncompressed: false
-        body: '{"task":{"description":"server_poweroff","href_from":"/servers/44be618c-4ff5-4b62-ac34-867025adcc7e/action","href_result":"/servers/44be618c-4ff5-4b62-ac34-867025adcc7e","id":"ef77cce8-6af5-4533-be21-b86c7984b263","progress":0,"started_at":"2025-01-27T13:55:03.781962+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_poweroff","href_from":"/servers/d6a4ef64-1630-4987-aabb-e733f3478c04/action","href_result":"/servers/d6a4ef64-1630-4987-aabb-e733f3478c04","id":"ccc76e9e-a76c-4f42-9b0a-a468f734a414","progress":0,"started_at":"2025-02-11T14:25:00.386102+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "352"
@@ -8933,11 +9472,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:03 GMT
+                - Tue, 11 Feb 2025 14:25:00 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/ef77cce8-6af5-4533-be21-b86c7984b263
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/ccc76e9e-a76c-4f42-9b0a-a468f734a414
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -8945,543 +9484,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a75a55f9-ee58-4534-9a9d-30d37361d3e0
+                - 1af2271e-6134-4d60-9a9c-f7dfee74cd49
         status: 202 Accepted
         code: 202
-        duration: 307.886958ms
-    - id: 180
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2231
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"102","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:55:03.547510+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2231"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:55:03 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - fc7c4d2d-57b0-4d25-bab9-02bbee2a3c8c
-        status: 200 OK
-        code: 200
-        duration: 205.86275ms
-    - id: 181
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7e4f4db4-f983-4fad-ab8e-abb34f3b0292
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:55:04 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - bd281988-95df-4b30-8ea6-e6eb87aa90aa
-        status: 204 No Content
-        code: 204
-        duration: 1.265047584s
-    - id: 182
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6e43bd7f-e7d5-4d93-999e-26abbc550834
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:55:04 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - f0d7ed2b-cb79-438a-bb40-300952c8fb31
-        status: 204 No Content
-        code: 204
-        duration: 1.355426042s
-    - id: 183
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2231
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"102","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:55:03.547510+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2231"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:55:09 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - a48fdeed-a476-4333-b04d-7adc0479a376
-        status: 200 OK
-        code: 200
-        duration: 202.092625ms
-    - id: 184
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2231
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"102","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:55:03.547510+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2231"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:55:14 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 49ba0182-443c-4f0f-8009-5b28b739f12f
-        status: 200 OK
-        code: 200
-        duration: 181.386084ms
-    - id: 185
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2231
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"102","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:55:03.547510+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2231"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:55:19 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - e2aff932-279c-4c17-9c4e-35e417efa0e1
-        status: 200 OK
-        code: 200
-        duration: 207.552625ms
-    - id: 186
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2231
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"102","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:55:03.547510+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2231"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:55:24 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 6c2eac07-fcd3-4ae8-bdcd-b2bf2243b05a
-        status: 200 OK
-        code: 200
-        duration: 174.058792ms
-    - id: 187
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2115
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:55:27.851133+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2115"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:55:29 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 395e4ecb-68a1-4cae-8a87-d82123effd60
-        status: 200 OK
-        code: 200
-        duration: 152.052625ms
-    - id: 188
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2115
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:53:41.719194+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-musing-johnson","id":"44be618c-4ff5-4b62-ac34-867025adcc7e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:5b","maintenances":[],"modification_date":"2025-01-27T13:55:27.851133+00:00","name":"tf-srv-musing-johnson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:53:41.719194+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"44be618c-4ff5-4b62-ac34-867025adcc7e","name":"tf-srv-musing-johnson"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2115"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:55:30 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - e783ffba-3e6b-48a6-9763-ec68fa74dc4a
-        status: 200 OK
-        code: 200
-        duration: 225.07225ms
-    - id: 189
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:55:29 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 0ff34eec-ac85-410e-bcaf-6e95a1da22e3
-        status: 204 No Content
-        code: 204
-        duration: 223.971209ms
-    - id: 190
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 143
-        uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","type":"not_found"}'
-        headers:
-            Content-Length:
-                - "143"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:55:30 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - c77231c3-9c8a-41bf-9f64-36ff703a5e42
-        status: 404 Not Found
-        code: 404
-        duration: 111.244959ms
+        duration: 461.438417ms
     - id: 191
       request:
         proto: HTTP/1.1
@@ -9497,8 +9503,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/1197fc24-679a-40dc-9858-30c145bbfa4a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04
         method: GET
       response:
         proto: HTTP/2.0
@@ -9506,20 +9512,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 446
+        content_length: 1785
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:53:41.719194+00:00","export_uri":null,"id":"1197fc24-679a-40dc-9858-30c145bbfa4a","modification_date":"2025-01-27T13:55:30.199918+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:48.517107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-zealous-tesla","id":"d6a4ef64-1630-4987-aabb-e733f3478c04","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"803","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f9","maintenances":[],"modification_date":"2025-02-11T14:25:00.000413+00:00","name":"tf-srv-zealous-tesla","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"810a8a91-0c84-4910-9038-f757b08e6d92","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "446"
+                - "1785"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:30 GMT
+                - Tue, 11 Feb 2025 14:25:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -9527,10 +9533,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e0020b38-edc8-458a-9628-bef8f1ddfb8f
+                - aee6bf0b-ae85-4755-85f5-1281fdf974d2
         status: 200 OK
         code: 200
-        duration: 78.109541ms
+        duration: 151.676208ms
     - id: 192
       request:
         proto: HTTP/1.1
@@ -9546,8 +9552,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/1197fc24-679a-40dc-9858-30c145bbfa4a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8e85576b-7702-4413-866b-4f684d7dcfb6
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -9564,9 +9570,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:30 GMT
+                - Tue, 11 Feb 2025 14:25:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -9574,10 +9580,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f74babe4-be9a-4913-bf70-7fbc0a3b016d
+                - 85c43e4c-f6ba-48db-9527-f91ed3fd2b2c
         status: 204 No Content
         code: 204
-        duration: 196.430791ms
+        duration: 1.178605958s
     - id: 193
       request:
         proto: HTTP/1.1
@@ -9593,8 +9599,298 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/44be618c-4ff5-4b62-ac34-867025adcc7e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a1de608c-4136-462d-875c-cc274949abe3
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1587ef02-e576-4f63-805e-1e711d42019a
+        status: 204 No Content
+        code: 204
+        duration: 1.179536375s
+    - id: 194
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1785
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:48.517107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-zealous-tesla","id":"d6a4ef64-1630-4987-aabb-e733f3478c04","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"803","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f9","maintenances":[],"modification_date":"2025-02-11T14:25:00.000413+00:00","name":"tf-srv-zealous-tesla","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"810a8a91-0c84-4910-9038-f757b08e6d92","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1785"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e87ce7fe-debf-4192-b5ac-54d14303a840
+        status: 200 OK
+        code: 200
+        duration: 278.535291ms
+    - id: 195
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1785
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:48.517107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-zealous-tesla","id":"d6a4ef64-1630-4987-aabb-e733f3478c04","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"803","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:f9","maintenances":[],"modification_date":"2025-02-11T14:25:00.000413+00:00","name":"tf-srv-zealous-tesla","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"810a8a91-0c84-4910-9038-f757b08e6d92","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1785"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:10 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d935994b-cf7d-455d-9fa0-937e51216816
+        status: 200 OK
+        code: 200
+        duration: 166.025292ms
+    - id: 196
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1670
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:48.517107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-zealous-tesla","id":"d6a4ef64-1630-4987-aabb-e733f3478c04","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:f9","maintenances":[],"modification_date":"2025-02-11T14:25:15.195557+00:00","name":"tf-srv-zealous-tesla","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"810a8a91-0c84-4910-9038-f757b08e6d92","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1670"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:15 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 73dcf1ad-74a3-4991-91a1-3012d331291b
+        status: 200 OK
+        code: 200
+        duration: 157.73425ms
+    - id: 197
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1670
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:48.517107+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-zealous-tesla","id":"d6a4ef64-1630-4987-aabb-e733f3478c04","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:f9","maintenances":[],"modification_date":"2025-02-11T14:25:15.195557+00:00","name":"tf-srv-zealous-tesla","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"810a8a91-0c84-4910-9038-f757b08e6d92","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1670"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:16 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 537af7cc-e77d-4719-abc7-90b89667db87
+        status: 200 OK
+        code: 200
+        duration: 143.32275ms
+    - id: 198
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:16 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 176add72-c5c5-4546-acd5-1aff64f8a9ca
+        status: 204 No Content
+        code: 204
+        duration: 286.589417ms
+    - id: 199
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04
         method: GET
       response:
         proto: HTTP/2.0
@@ -9604,7 +9900,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"44be618c-4ff5-4b62-ac34-867025adcc7e","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -9613,9 +9909,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:55:30 GMT
+                - Tue, 11 Feb 2025 14:25:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -9623,7 +9919,201 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f08673c0-273e-4b48-9105-092bddcb168a
+                - 423c8ac7-8f83-4ca2-b053-ec84d918a5c1
         status: 404 Not Found
         code: 404
-        duration: 98.989583ms
+        duration: 87.313458ms
+    - id: 200
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/810a8a91-0c84-4910-9038-f757b08e6d92
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"810a8a91-0c84-4910-9038-f757b08e6d92","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:16 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7e92cddc-45c6-490e-9487-4ffcfc09d4ef
+        status: 404 Not Found
+        code: 404
+        duration: 35.477625ms
+    - id: 201
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/810a8a91-0c84-4910-9038-f757b08e6d92
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 494
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:23:48.722794Z","id":"810a8a91-0c84-4910-9038-f757b08e6d92","last_detached_at":"2025-02-11T14:25:16.709553Z","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:25:16.709553Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "494"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:16 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8a30bd9b-f4dc-4197-9503-ce9204c36480
+        status: 200 OK
+        code: 200
+        duration: 92.120584ms
+    - id: 202
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/810a8a91-0c84-4910-9038-f757b08e6d92
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:16 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 25143bbd-5c19-4701-b56b-cbfbff634ad1
+        status: 204 No Content
+        code: 204
+        duration: 126.499458ms
+    - id: 203
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d6a4ef64-1630-4987-aabb-e733f3478c04
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"d6a4ef64-1630-4987-aabb-e733f3478c04","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:16 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 55b4016b-66b4-4ba9-92cd-afd9f4e706d0
+        status: 404 Not Found
+        code: 404
+        duration: 95.613041ms

--- a/internal/services/instance/testdata/server-root-volume-boot.cassette.yaml
+++ b/internal/services/instance/testdata/server-root-volume-boot.cassette.yaml
@@ -16,7 +16,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
         method: GET
       response:
@@ -25,22 +25,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 38539
+        content_length: 35639
         uncompressed: false
-        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
+        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
         headers:
             Content-Length:
-                - "38539"
+                - "35639"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:00 GMT
+                - Tue, 11 Feb 2025 14:23:25 GMT
             Link:
                 - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,12 +48,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ddb2535a-9d98-4a23-93c9-fe92dd26fbc4
+                - 235ca9d4-4716-493b-8eee-354cb34424a2
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 55.967625ms
+        duration: 58.713125ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -69,7 +69,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
         method: GET
       response:
@@ -78,22 +78,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 14208
+        content_length: 13164
         uncompressed: false
-        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
         headers:
             Content-Length:
-                - "14208"
+                - "13164"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:00 GMT
+                - Tue, 11 Feb 2025 14:23:25 GMT
             Link:
                 - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -101,12 +101,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4c51067f-6d26-40c4-8fb2-80514c6da70e
+                - 6010d5c4-8820-43e4-b01c-fa4558b97faa
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 58.787666ms
+        duration: 70.584ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -122,8 +122,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_local&zone=fr-par-1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_sbs&zone=fr-par-1
         method: GET
       response:
         proto: HTTP/2.0
@@ -131,20 +131,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1300
+        content_length: 1296
         uncompressed: false
-        body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"56d4019c-8305-467a-a3f2-70498ad799df","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
+        body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"57509e82-ac3b-49b7-9970-97b60f40ff72","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"9b647e1e-253a-41e7-8c15-911c622ee2dc","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"}],"total_count":2}'
         headers:
             Content-Length:
-                - "1300"
+                - "1296"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:00 GMT
+                - Tue, 11 Feb 2025 14:23:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -152,28 +152,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9e6cd96d-60f4-46e9-ad29-b28ccccbc932
+                - a6b00964-45a5-4b31-98c7-d7928c737851
         status: 200 OK
         code: 200
-        duration: 91.008291ms
+        duration: 75.065125ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 347
+        content_length: 300
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-srv-pensive-varahamihira","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","volumes":{"0":{"boot":true,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":["terraform-test","scaleway_instance_server","root_volume"]}'
+        body: '{"name":"tf-srv-pensive-jepsen","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"57509e82-ac3b-49b7-9970-97b60f40ff72","volumes":{"0":{"boot":true}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":["terraform-test","scaleway_instance_server","root_volume"]}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
         method: POST
       response:
@@ -182,22 +182,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2191
+        content_length: 1730
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:54:01.525175+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-varahamihira","id":"9d66af43-e6f7-4ff9-a90a-e14908cb3692","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:73","maintenances":[],"modification_date":"2025-01-27T13:54:01.525175+00:00","name":"tf-srv-pensive-varahamihira","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","root_volume"],"volumes":{"0":{"boot":true,"creation_date":"2025-01-27T13:54:01.525175+00:00","export_uri":null,"id":"5092a797-c588-4b10-a180-4a5366ea76ae","modification_date":"2025-01-27T13:54:01.525175+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9d66af43-e6f7-4ff9-a90a-e14908cb3692","name":"tf-srv-pensive-varahamihira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:26.639103+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-jepsen","id":"8ed35d58-b2c7-42f8-9d69-70227b03cf4c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ef","maintenances":[],"modification_date":"2025-02-11T14:23:26.639103+00:00","name":"tf-srv-pensive-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","root_volume"],"volumes":{"0":{"boot":true,"id":"d84621f4-f149-40fa-b32b-27c04635940b","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2191"
+                - "1730"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:01 GMT
+                - Tue, 11 Feb 2025 14:23:26 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9d66af43-e6f7-4ff9-a90a-e14908cb3692
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8ed35d58-b2c7-42f8-9d69-70227b03cf4c
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -205,10 +205,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1f395641-2d01-49d4-afb7-7d1d75de6e51
+                - 5e5d9517-989a-4b02-bb73-240d4769e06c
         status: 201 Created
         code: 201
-        duration: 912.817917ms
+        duration: 953.050292ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -224,8 +224,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9d66af43-e6f7-4ff9-a90a-e14908cb3692
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8ed35d58-b2c7-42f8-9d69-70227b03cf4c
         method: GET
       response:
         proto: HTTP/2.0
@@ -233,20 +233,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2191
+        content_length: 1730
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:54:01.525175+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-varahamihira","id":"9d66af43-e6f7-4ff9-a90a-e14908cb3692","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:73","maintenances":[],"modification_date":"2025-01-27T13:54:01.525175+00:00","name":"tf-srv-pensive-varahamihira","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","root_volume"],"volumes":{"0":{"boot":true,"creation_date":"2025-01-27T13:54:01.525175+00:00","export_uri":null,"id":"5092a797-c588-4b10-a180-4a5366ea76ae","modification_date":"2025-01-27T13:54:01.525175+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9d66af43-e6f7-4ff9-a90a-e14908cb3692","name":"tf-srv-pensive-varahamihira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:26.639103+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-jepsen","id":"8ed35d58-b2c7-42f8-9d69-70227b03cf4c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ef","maintenances":[],"modification_date":"2025-02-11T14:23:26.639103+00:00","name":"tf-srv-pensive-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","root_volume"],"volumes":{"0":{"boot":true,"id":"d84621f4-f149-40fa-b32b-27c04635940b","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2191"
+                - "1730"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:01 GMT
+                - Tue, 11 Feb 2025 14:23:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -254,10 +254,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3fd5a36b-b38a-48b6-be32-dfcd8f28e41f
+                - 8400300b-4588-4e81-8ebf-79849e1273dd
         status: 200 OK
         code: 200
-        duration: 133.684667ms
+        duration: 198.147917ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -273,8 +273,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9d66af43-e6f7-4ff9-a90a-e14908cb3692
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8ed35d58-b2c7-42f8-9d69-70227b03cf4c
         method: GET
       response:
         proto: HTTP/2.0
@@ -282,20 +282,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2191
+        content_length: 1730
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:54:01.525175+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-varahamihira","id":"9d66af43-e6f7-4ff9-a90a-e14908cb3692","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:73","maintenances":[],"modification_date":"2025-01-27T13:54:01.525175+00:00","name":"tf-srv-pensive-varahamihira","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","root_volume"],"volumes":{"0":{"boot":true,"creation_date":"2025-01-27T13:54:01.525175+00:00","export_uri":null,"id":"5092a797-c588-4b10-a180-4a5366ea76ae","modification_date":"2025-01-27T13:54:01.525175+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9d66af43-e6f7-4ff9-a90a-e14908cb3692","name":"tf-srv-pensive-varahamihira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:26.639103+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-jepsen","id":"8ed35d58-b2c7-42f8-9d69-70227b03cf4c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ef","maintenances":[],"modification_date":"2025-02-11T14:23:26.639103+00:00","name":"tf-srv-pensive-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","root_volume"],"volumes":{"0":{"boot":true,"id":"d84621f4-f149-40fa-b32b-27c04635940b","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2191"
+                - "1730"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:01 GMT
+                - Tue, 11 Feb 2025 14:23:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -303,10 +303,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f26f7dea-eaa2-4f11-ac53-7f45e4e6e6ac
+                - f204f545-949b-4b90-8436-85b8972ae18a
         status: 200 OK
         code: 200
-        duration: 145.06125ms
+        duration: 169.252666ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -322,8 +322,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9d66af43-e6f7-4ff9-a90a-e14908cb3692
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8ed35d58-b2c7-42f8-9d69-70227b03cf4c
         method: GET
       response:
         proto: HTTP/2.0
@@ -331,20 +331,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2191
+        content_length: 1730
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:54:01.525175+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-varahamihira","id":"9d66af43-e6f7-4ff9-a90a-e14908cb3692","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:73","maintenances":[],"modification_date":"2025-01-27T13:54:01.525175+00:00","name":"tf-srv-pensive-varahamihira","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","root_volume"],"volumes":{"0":{"boot":true,"creation_date":"2025-01-27T13:54:01.525175+00:00","export_uri":null,"id":"5092a797-c588-4b10-a180-4a5366ea76ae","modification_date":"2025-01-27T13:54:01.525175+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9d66af43-e6f7-4ff9-a90a-e14908cb3692","name":"tf-srv-pensive-varahamihira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:26.639103+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-jepsen","id":"8ed35d58-b2c7-42f8-9d69-70227b03cf4c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ef","maintenances":[],"modification_date":"2025-02-11T14:23:26.639103+00:00","name":"tf-srv-pensive-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","root_volume"],"volumes":{"0":{"boot":true,"id":"d84621f4-f149-40fa-b32b-27c04635940b","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2191"
+                - "1730"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:02 GMT
+                - Tue, 11 Feb 2025 14:23:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -352,10 +352,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 04d89ce6-96c3-4c73-a72f-b4c299e0059d
+                - 54271890-dc1b-4387-9149-c0cf9edabd8c
         status: 200 OK
         code: 200
-        duration: 143.077542ms
+        duration: 161.547875ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -371,8 +371,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/5092a797-c588-4b10-a180-4a5366ea76ae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/d84621f4-f149-40fa-b32b-27c04635940b
         method: GET
       response:
         proto: HTTP/2.0
@@ -380,20 +380,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 527
+        content_length: 143
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:54:01.525175+00:00","export_uri":null,"id":"5092a797-c588-4b10-a180-4a5366ea76ae","modification_date":"2025-01-27T13:54:01.525175+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9d66af43-e6f7-4ff9-a90a-e14908cb3692","name":"tf-srv-pensive-varahamihira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"d84621f4-f149-40fa-b32b-27c04635940b","type":"not_found"}'
         headers:
             Content-Length:
-                - "527"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:02 GMT
+                - Tue, 11 Feb 2025 14:23:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -401,10 +401,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 333ce240-e168-414f-9890-f9ee04c25cf4
-        status: 200 OK
-        code: 200
-        duration: 86.391875ms
+                - 15c3416f-d215-40b1-9bd6-32ea4d36c273
+        status: 404 Not Found
+        code: 404
+        duration: 27.023792ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -420,8 +420,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9d66af43-e6f7-4ff9-a90a-e14908cb3692/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/d84621f4-f149-40fa-b32b-27c04635940b
         method: GET
       response:
         proto: HTTP/2.0
@@ -429,20 +429,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 701
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"created_at":"2025-02-11T14:23:26.855600Z","id":"d84621f4-f149-40fa-b32b-27c04635940b","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:26.855600Z","id":"89ff0a24-f923-44d2-abe2-53d052696904","product_resource_id":"8ed35d58-b2c7-42f8-9d69-70227b03cf4c","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:26.855600Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "17"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:02 GMT
+                - Tue, 11 Feb 2025 14:23:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -450,10 +450,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d3b4a7cd-75fa-4cfd-956a-48b866136665
+                - 67cc1435-99b0-41b0-a95e-c4df25a29d8b
         status: 200 OK
         code: 200
-        duration: 81.448083ms
+        duration: 80.419709ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -469,8 +469,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9d66af43-e6f7-4ff9-a90a-e14908cb3692/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8ed35d58-b2c7-42f8-9d69-70227b03cf4c/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -478,22 +478,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 17
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "20"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:02 GMT
-            Link:
-                - </servers/9d66af43-e6f7-4ff9-a90a-e14908cb3692/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:23:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -501,12 +499,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d1d7edf4-53bc-43f0-bcb9-4bcc8a8f4cd6
-            X-Total-Count:
-                - "0"
+                - e986175c-34b8-4441-8fef-fbc62370a9c1
         status: 200 OK
         code: 200
-        duration: 86.043833ms
+        duration: 97.786958ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -522,8 +518,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9d66af43-e6f7-4ff9-a90a-e14908cb3692
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8ed35d58-b2c7-42f8-9d69-70227b03cf4c/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -531,20 +527,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2191
+        content_length: 20
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:54:01.525175+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-varahamihira","id":"9d66af43-e6f7-4ff9-a90a-e14908cb3692","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:73","maintenances":[],"modification_date":"2025-01-27T13:54:01.525175+00:00","name":"tf-srv-pensive-varahamihira","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","root_volume"],"volumes":{"0":{"boot":true,"creation_date":"2025-01-27T13:54:01.525175+00:00","export_uri":null,"id":"5092a797-c588-4b10-a180-4a5366ea76ae","modification_date":"2025-01-27T13:54:01.525175+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9d66af43-e6f7-4ff9-a90a-e14908cb3692","name":"tf-srv-pensive-varahamihira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "2191"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:02 GMT
+                - Tue, 11 Feb 2025 14:23:27 GMT
+            Link:
+                - </servers/8ed35d58-b2c7-42f8-9d69-70227b03cf4c/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -552,10 +550,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d7397850-9149-4105-a847-2b916cf14937
+                - a2411108-9cc5-423c-8d38-e9843dff18fa
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 141.437917ms
+        duration: 90.095792ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -571,8 +571,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9d66af43-e6f7-4ff9-a90a-e14908cb3692
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8ed35d58-b2c7-42f8-9d69-70227b03cf4c
         method: GET
       response:
         proto: HTTP/2.0
@@ -580,20 +580,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2191
+        content_length: 1730
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:54:01.525175+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-varahamihira","id":"9d66af43-e6f7-4ff9-a90a-e14908cb3692","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:73","maintenances":[],"modification_date":"2025-01-27T13:54:01.525175+00:00","name":"tf-srv-pensive-varahamihira","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","root_volume"],"volumes":{"0":{"boot":true,"creation_date":"2025-01-27T13:54:01.525175+00:00","export_uri":null,"id":"5092a797-c588-4b10-a180-4a5366ea76ae","modification_date":"2025-01-27T13:54:01.525175+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9d66af43-e6f7-4ff9-a90a-e14908cb3692","name":"tf-srv-pensive-varahamihira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:26.639103+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-jepsen","id":"8ed35d58-b2c7-42f8-9d69-70227b03cf4c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ef","maintenances":[],"modification_date":"2025-02-11T14:23:26.639103+00:00","name":"tf-srv-pensive-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","root_volume"],"volumes":{"0":{"boot":true,"id":"d84621f4-f149-40fa-b32b-27c04635940b","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2191"
+                - "1730"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:03 GMT
+                - Tue, 11 Feb 2025 14:23:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -601,10 +601,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1e5b67d2-a1c9-41c2-aeee-7f3ea11a0521
+                - 4593c2b2-a7f5-4575-adee-df2f24906f96
         status: 200 OK
         code: 200
-        duration: 179.290167ms
+        duration: 155.957583ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -620,8 +620,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/5092a797-c588-4b10-a180-4a5366ea76ae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8ed35d58-b2c7-42f8-9d69-70227b03cf4c
         method: GET
       response:
         proto: HTTP/2.0
@@ -629,20 +629,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 527
+        content_length: 1730
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:54:01.525175+00:00","export_uri":null,"id":"5092a797-c588-4b10-a180-4a5366ea76ae","modification_date":"2025-01-27T13:54:01.525175+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9d66af43-e6f7-4ff9-a90a-e14908cb3692","name":"tf-srv-pensive-varahamihira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:26.639103+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-jepsen","id":"8ed35d58-b2c7-42f8-9d69-70227b03cf4c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ef","maintenances":[],"modification_date":"2025-02-11T14:23:26.639103+00:00","name":"tf-srv-pensive-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","root_volume"],"volumes":{"0":{"boot":true,"id":"d84621f4-f149-40fa-b32b-27c04635940b","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "527"
+                - "1730"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:03 GMT
+                - Tue, 11 Feb 2025 14:23:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -650,10 +650,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a07015c9-8964-4516-a696-8d9b9ff3822b
+                - d1aad0c4-4d1b-4528-9670-9e88b237e451
         status: 200 OK
         code: 200
-        duration: 82.632583ms
+        duration: 169.9945ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -669,8 +669,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9d66af43-e6f7-4ff9-a90a-e14908cb3692/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/d84621f4-f149-40fa-b32b-27c04635940b
         method: GET
       response:
         proto: HTTP/2.0
@@ -678,20 +678,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 143
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"d84621f4-f149-40fa-b32b-27c04635940b","type":"not_found"}'
         headers:
             Content-Length:
-                - "17"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:03 GMT
+                - Tue, 11 Feb 2025 14:23:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -699,10 +699,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - df7aa00c-e670-40a6-98ae-14c84412f96e
-        status: 200 OK
-        code: 200
-        duration: 91.1845ms
+                - 79ef454f-2010-474e-a6c8-695da6761b05
+        status: 404 Not Found
+        code: 404
+        duration: 29.986375ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -718,8 +718,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9d66af43-e6f7-4ff9-a90a-e14908cb3692/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/d84621f4-f149-40fa-b32b-27c04635940b
         method: GET
       response:
         proto: HTTP/2.0
@@ -727,22 +727,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 701
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"created_at":"2025-02-11T14:23:26.855600Z","id":"d84621f4-f149-40fa-b32b-27c04635940b","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:26.855600Z","id":"89ff0a24-f923-44d2-abe2-53d052696904","product_resource_id":"8ed35d58-b2c7-42f8-9d69-70227b03cf4c","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:26.855600Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "20"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:02 GMT
-            Link:
-                - </servers/9d66af43-e6f7-4ff9-a90a-e14908cb3692/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:23:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -750,12 +748,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2263ca1f-66ef-489b-9324-fe82c31053d1
-            X-Total-Count:
-                - "0"
+                - 35359bf8-1f06-495f-8a84-6bd578f36606
         status: 200 OK
         code: 200
-        duration: 104.844292ms
+        duration: 80.439666ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -771,8 +767,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9d66af43-e6f7-4ff9-a90a-e14908cb3692
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8ed35d58-b2c7-42f8-9d69-70227b03cf4c/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -780,20 +776,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2191
+        content_length: 17
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:54:01.525175+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-varahamihira","id":"9d66af43-e6f7-4ff9-a90a-e14908cb3692","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:73","maintenances":[],"modification_date":"2025-01-27T13:54:01.525175+00:00","name":"tf-srv-pensive-varahamihira","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","root_volume"],"volumes":{"0":{"boot":true,"creation_date":"2025-01-27T13:54:01.525175+00:00","export_uri":null,"id":"5092a797-c588-4b10-a180-4a5366ea76ae","modification_date":"2025-01-27T13:54:01.525175+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9d66af43-e6f7-4ff9-a90a-e14908cb3692","name":"tf-srv-pensive-varahamihira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "2191"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:03 GMT
+                - Tue, 11 Feb 2025 14:23:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -801,10 +797,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7a35be62-235c-43bc-b0a6-3930398e3e45
+                - dc3f536c-aa51-437a-88f6-8cf45327d68d
         status: 200 OK
         code: 200
-        duration: 152.18575ms
+        duration: 70.811125ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -820,8 +816,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/5092a797-c588-4b10-a180-4a5366ea76ae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8ed35d58-b2c7-42f8-9d69-70227b03cf4c/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -829,20 +825,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 527
+        content_length: 20
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:54:01.525175+00:00","export_uri":null,"id":"5092a797-c588-4b10-a180-4a5366ea76ae","modification_date":"2025-01-27T13:54:01.525175+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9d66af43-e6f7-4ff9-a90a-e14908cb3692","name":"tf-srv-pensive-varahamihira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "527"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:03 GMT
+                - Tue, 11 Feb 2025 14:23:28 GMT
+            Link:
+                - </servers/8ed35d58-b2c7-42f8-9d69-70227b03cf4c/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -850,10 +848,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 57692c9d-d9e9-42e0-aa0a-d7c567312fa7
+                - 765aaa35-85bc-4100-90be-75f7838bcaa0
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 73.689167ms
+        duration: 88.514125ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -869,8 +869,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9d66af43-e6f7-4ff9-a90a-e14908cb3692/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8ed35d58-b2c7-42f8-9d69-70227b03cf4c
         method: GET
       response:
         proto: HTTP/2.0
@@ -878,20 +878,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 1730
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:26.639103+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-jepsen","id":"8ed35d58-b2c7-42f8-9d69-70227b03cf4c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ef","maintenances":[],"modification_date":"2025-02-11T14:23:26.639103+00:00","name":"tf-srv-pensive-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","root_volume"],"volumes":{"0":{"boot":true,"id":"d84621f4-f149-40fa-b32b-27c04635940b","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "17"
+                - "1730"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:03 GMT
+                - Tue, 11 Feb 2025 14:23:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -899,10 +899,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7d653069-300f-48b7-a925-946c139c1e5b
+                - c8cfdf18-181e-4a18-825f-a7007b9c822a
         status: 200 OK
         code: 200
-        duration: 84.762375ms
+        duration: 150.874292ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -918,8 +918,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9d66af43-e6f7-4ff9-a90a-e14908cb3692/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/d84621f4-f149-40fa-b32b-27c04635940b
         method: GET
       response:
         proto: HTTP/2.0
@@ -927,22 +927,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 143
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"d84621f4-f149-40fa-b32b-27c04635940b","type":"not_found"}'
         headers:
             Content-Length:
-                - "20"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:03 GMT
-            Link:
-                - </servers/9d66af43-e6f7-4ff9-a90a-e14908cb3692/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:23:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -950,12 +948,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cdce23a6-a8bb-4f1c-a196-10bd366af51b
-            X-Total-Count:
-                - "0"
-        status: 200 OK
-        code: 200
-        duration: 93.480084ms
+                - 42422677-0d92-4939-b8d1-fb38ae036efc
+        status: 404 Not Found
+        code: 404
+        duration: 33.211792ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -971,8 +967,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9d66af43-e6f7-4ff9-a90a-e14908cb3692
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/d84621f4-f149-40fa-b32b-27c04635940b
         method: GET
       response:
         proto: HTTP/2.0
@@ -980,20 +976,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2191
+        content_length: 701
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:54:01.525175+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-varahamihira","id":"9d66af43-e6f7-4ff9-a90a-e14908cb3692","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:73","maintenances":[],"modification_date":"2025-01-27T13:54:01.525175+00:00","name":"tf-srv-pensive-varahamihira","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","root_volume"],"volumes":{"0":{"boot":true,"creation_date":"2025-01-27T13:54:01.525175+00:00","export_uri":null,"id":"5092a797-c588-4b10-a180-4a5366ea76ae","modification_date":"2025-01-27T13:54:01.525175+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9d66af43-e6f7-4ff9-a90a-e14908cb3692","name":"tf-srv-pensive-varahamihira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T14:23:26.855600Z","id":"d84621f4-f149-40fa-b32b-27c04635940b","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:26.855600Z","id":"89ff0a24-f923-44d2-abe2-53d052696904","product_resource_id":"8ed35d58-b2c7-42f8-9d69-70227b03cf4c","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:26.855600Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2191"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:04 GMT
+                - Tue, 11 Feb 2025 14:23:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1001,50 +997,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 16332472-d87e-4369-80da-5be33ac97269
+                - 5a206880-9e79-4499-aa85-4c89c21c87b9
         status: 200 OK
         code: 200
-        duration: 131.849375ms
+        duration: 65.39475ms
     - id: 20
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 116
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"volumes":{"0":{"id":"5092a797-c588-4b10-a180-4a5366ea76ae","boot":false,"name":"tf-vol-optimistic-varahamihira"}}}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9d66af43-e6f7-4ff9-a90a-e14908cb3692
-        method: PATCH
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8ed35d58-b2c7-42f8-9d69-70227b03cf4c/user_data
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2192
+        content_length: 17
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:54:01.525175+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-varahamihira","id":"9d66af43-e6f7-4ff9-a90a-e14908cb3692","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:73","maintenances":[],"modification_date":"2025-01-27T13:54:04.476224+00:00","name":"tf-srv-pensive-varahamihira","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","root_volume"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:54:01.525175+00:00","export_uri":null,"id":"5092a797-c588-4b10-a180-4a5366ea76ae","modification_date":"2025-01-27T13:54:01.525175+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9d66af43-e6f7-4ff9-a90a-e14908cb3692","name":"tf-srv-pensive-varahamihira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "2192"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:04 GMT
+                - Tue, 11 Feb 2025 14:23:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1052,10 +1046,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cec5822f-5f72-4dea-b77f-2d585df4351c
+                - cb6264a2-0e48-434a-aa12-83ab2e0730cd
         status: 200 OK
         code: 200
-        duration: 231.583291ms
+        duration: 78.562459ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1071,8 +1065,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9d66af43-e6f7-4ff9-a90a-e14908cb3692
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8ed35d58-b2c7-42f8-9d69-70227b03cf4c/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1080,20 +1074,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2192
+        content_length: 20
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:54:01.525175+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-varahamihira","id":"9d66af43-e6f7-4ff9-a90a-e14908cb3692","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:73","maintenances":[],"modification_date":"2025-01-27T13:54:04.476224+00:00","name":"tf-srv-pensive-varahamihira","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","root_volume"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:54:01.525175+00:00","export_uri":null,"id":"5092a797-c588-4b10-a180-4a5366ea76ae","modification_date":"2025-01-27T13:54:01.525175+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9d66af43-e6f7-4ff9-a90a-e14908cb3692","name":"tf-srv-pensive-varahamihira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "2192"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:04 GMT
+                - Tue, 11 Feb 2025 14:23:29 GMT
+            Link:
+                - </servers/8ed35d58-b2c7-42f8-9d69-70227b03cf4c/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1101,10 +1097,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2f6e9b9e-d80a-4c84-8a52-cdb40e010415
+                - 0c4749ed-3595-4669-aaf5-44602f6fd919
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 129.748709ms
+        duration: 93.398583ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1120,8 +1118,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9d66af43-e6f7-4ff9-a90a-e14908cb3692
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8ed35d58-b2c7-42f8-9d69-70227b03cf4c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1129,20 +1127,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2192
+        content_length: 1730
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:54:01.525175+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-varahamihira","id":"9d66af43-e6f7-4ff9-a90a-e14908cb3692","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:73","maintenances":[],"modification_date":"2025-01-27T13:54:04.476224+00:00","name":"tf-srv-pensive-varahamihira","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","root_volume"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:54:01.525175+00:00","export_uri":null,"id":"5092a797-c588-4b10-a180-4a5366ea76ae","modification_date":"2025-01-27T13:54:01.525175+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9d66af43-e6f7-4ff9-a90a-e14908cb3692","name":"tf-srv-pensive-varahamihira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:26.639103+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-jepsen","id":"8ed35d58-b2c7-42f8-9d69-70227b03cf4c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ef","maintenances":[],"modification_date":"2025-02-11T14:23:26.639103+00:00","name":"tf-srv-pensive-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","root_volume"],"volumes":{"0":{"boot":true,"id":"d84621f4-f149-40fa-b32b-27c04635940b","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2192"
+                - "1730"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:05 GMT
+                - Tue, 11 Feb 2025 14:23:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1150,48 +1148,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f67994af-184d-4556-b5f2-1b93bd124ba4
+                - 34d04db0-3bf7-48c2-9390-46bd6bee85cf
         status: 200 OK
         code: 200
-        duration: 118.320583ms
+        duration: 196.781333ms
     - id: 23
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 105
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"volumes":{"0":{"id":"d84621f4-f149-40fa-b32b-27c04635940b","boot":false,"name":"tf-vol-adoring-nash"}}}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/5092a797-c588-4b10-a180-4a5366ea76ae
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8ed35d58-b2c7-42f8-9d69-70227b03cf4c
+        method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 527
+        content_length: 1731
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:54:01.525175+00:00","export_uri":null,"id":"5092a797-c588-4b10-a180-4a5366ea76ae","modification_date":"2025-01-27T13:54:01.525175+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9d66af43-e6f7-4ff9-a90a-e14908cb3692","name":"tf-srv-pensive-varahamihira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:26.639103+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-jepsen","id":"8ed35d58-b2c7-42f8-9d69-70227b03cf4c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ef","maintenances":[],"modification_date":"2025-02-11T14:23:30.121103+00:00","name":"tf-srv-pensive-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","root_volume"],"volumes":{"0":{"boot":false,"id":"d84621f4-f149-40fa-b32b-27c04635940b","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "527"
+                - "1731"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:06 GMT
+                - Tue, 11 Feb 2025 14:23:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1199,10 +1199,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c212be4e-7233-49a1-881f-850d73daf837
+                - c713d85a-9f62-4da9-8ade-4d0134c61206
         status: 200 OK
         code: 200
-        duration: 88.1165ms
+        duration: 276.86ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1218,8 +1218,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9d66af43-e6f7-4ff9-a90a-e14908cb3692/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8ed35d58-b2c7-42f8-9d69-70227b03cf4c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1227,20 +1227,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 1731
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:26.639103+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-jepsen","id":"8ed35d58-b2c7-42f8-9d69-70227b03cf4c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ef","maintenances":[],"modification_date":"2025-02-11T14:23:30.121103+00:00","name":"tf-srv-pensive-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","root_volume"],"volumes":{"0":{"boot":false,"id":"d84621f4-f149-40fa-b32b-27c04635940b","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "17"
+                - "1731"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:06 GMT
+                - Tue, 11 Feb 2025 14:23:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1248,10 +1248,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8b86683c-d3f3-4072-a887-7297b1dee5f3
+                - ac354c84-d0fb-407b-bf43-daeec1da64cd
         status: 200 OK
         code: 200
-        duration: 101.157333ms
+        duration: 532.409666ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1267,8 +1267,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9d66af43-e6f7-4ff9-a90a-e14908cb3692/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8ed35d58-b2c7-42f8-9d69-70227b03cf4c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1276,22 +1276,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 1731
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:26.639103+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-jepsen","id":"8ed35d58-b2c7-42f8-9d69-70227b03cf4c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ef","maintenances":[],"modification_date":"2025-02-11T14:23:30.121103+00:00","name":"tf-srv-pensive-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","root_volume"],"volumes":{"0":{"boot":false,"id":"d84621f4-f149-40fa-b32b-27c04635940b","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "20"
+                - "1731"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:06 GMT
-            Link:
-                - </servers/9d66af43-e6f7-4ff9-a90a-e14908cb3692/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:23:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1299,12 +1297,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7f31c7b9-0906-450e-9aa1-b4c2e3502805
-            X-Total-Count:
-                - "0"
+                - 9f80bd04-c11c-4802-9af3-3453f2d926b0
         status: 200 OK
         code: 200
-        duration: 110.305ms
+        duration: 272.128291ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1320,8 +1316,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9d66af43-e6f7-4ff9-a90a-e14908cb3692
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/d84621f4-f149-40fa-b32b-27c04635940b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1329,20 +1325,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2192
+        content_length: 143
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:54:01.525175+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-varahamihira","id":"9d66af43-e6f7-4ff9-a90a-e14908cb3692","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:73","maintenances":[],"modification_date":"2025-01-27T13:54:04.476224+00:00","name":"tf-srv-pensive-varahamihira","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","root_volume"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:54:01.525175+00:00","export_uri":null,"id":"5092a797-c588-4b10-a180-4a5366ea76ae","modification_date":"2025-01-27T13:54:01.525175+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9d66af43-e6f7-4ff9-a90a-e14908cb3692","name":"tf-srv-pensive-varahamihira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"d84621f4-f149-40fa-b32b-27c04635940b","type":"not_found"}'
         headers:
             Content-Length:
-                - "2192"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:06 GMT
+                - Tue, 11 Feb 2025 14:23:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1350,10 +1346,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 167f72c5-d2d0-43bd-952d-e5cc6257556b
-        status: 200 OK
-        code: 200
-        duration: 135.58925ms
+                - c74da57c-93de-4635-80bd-5a53c3e60ffd
+        status: 404 Not Found
+        code: 404
+        duration: 28.587667ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1369,8 +1365,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9d66af43-e6f7-4ff9-a90a-e14908cb3692
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/d84621f4-f149-40fa-b32b-27c04635940b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1378,20 +1374,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2192
+        content_length: 701
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:54:01.525175+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-varahamihira","id":"9d66af43-e6f7-4ff9-a90a-e14908cb3692","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:73","maintenances":[],"modification_date":"2025-01-27T13:54:04.476224+00:00","name":"tf-srv-pensive-varahamihira","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","root_volume"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:54:01.525175+00:00","export_uri":null,"id":"5092a797-c588-4b10-a180-4a5366ea76ae","modification_date":"2025-01-27T13:54:01.525175+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9d66af43-e6f7-4ff9-a90a-e14908cb3692","name":"tf-srv-pensive-varahamihira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T14:23:26.855600Z","id":"d84621f4-f149-40fa-b32b-27c04635940b","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:26.855600Z","id":"89ff0a24-f923-44d2-abe2-53d052696904","product_resource_id":"8ed35d58-b2c7-42f8-9d69-70227b03cf4c","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:26.855600Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2192"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:06 GMT
+                - Tue, 11 Feb 2025 14:23:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1399,10 +1395,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 81819801-b847-4bd6-9c96-7e4f89165ed0
+                - 3ae1c6e6-d1a8-4e67-a584-1d827704b404
         status: 200 OK
         code: 200
-        duration: 135.277292ms
+        duration: 81.761708ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1418,57 +1414,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/5092a797-c588-4b10-a180-4a5366ea76ae
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 527
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:54:01.525175+00:00","export_uri":null,"id":"5092a797-c588-4b10-a180-4a5366ea76ae","modification_date":"2025-01-27T13:54:01.525175+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9d66af43-e6f7-4ff9-a90a-e14908cb3692","name":"tf-srv-pensive-varahamihira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "527"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:54:06 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 3a259779-cd72-4718-894a-f6eb8d187c95
-        status: 200 OK
-        code: 200
-        duration: 78.224292ms
-    - id: 29
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9d66af43-e6f7-4ff9-a90a-e14908cb3692/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8ed35d58-b2c7-42f8-9d69-70227b03cf4c/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1487,9 +1434,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:07 GMT
+                - Tue, 11 Feb 2025 14:23:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1497,11 +1444,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 035719ce-d7e0-4553-9bf8-f5ca24101c8f
+                - 15be38af-8760-4c0d-b73c-c3eff0175907
         status: 200 OK
         code: 200
-        duration: 92.716375ms
-    - id: 30
+        duration: 100.24425ms
+    - id: 29
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1516,8 +1463,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9d66af43-e6f7-4ff9-a90a-e14908cb3692/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8ed35d58-b2c7-42f8-9d69-70227b03cf4c/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1536,11 +1483,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:06 GMT
+                - Tue, 11 Feb 2025 14:23:31 GMT
             Link:
-                - </servers/9d66af43-e6f7-4ff9-a90a-e14908cb3692/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/8ed35d58-b2c7-42f8-9d69-70227b03cf4c/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1548,12 +1495,61 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3f006768-911d-41b5-b891-fbe12b1b6f64
+                - eaa52893-ac63-4892-97ae-ce3b3883cc1d
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 78.819042ms
+        duration: 87.770833ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8ed35d58-b2c7-42f8-9d69-70227b03cf4c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1731
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:26.639103+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-jepsen","id":"8ed35d58-b2c7-42f8-9d69-70227b03cf4c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ef","maintenances":[],"modification_date":"2025-02-11T14:23:30.121103+00:00","name":"tf-srv-pensive-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","root_volume"],"volumes":{"0":{"boot":false,"id":"d84621f4-f149-40fa-b32b-27c04635940b","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1731"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:31 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - cf9dff9b-581e-404b-847c-70123cd0a575
+        status: 200 OK
+        code: 200
+        duration: 170.229583ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1569,8 +1565,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9d66af43-e6f7-4ff9-a90a-e14908cb3692
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8ed35d58-b2c7-42f8-9d69-70227b03cf4c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1578,20 +1574,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2192
+        content_length: 1731
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:54:01.525175+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-varahamihira","id":"9d66af43-e6f7-4ff9-a90a-e14908cb3692","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:73","maintenances":[],"modification_date":"2025-01-27T13:54:04.476224+00:00","name":"tf-srv-pensive-varahamihira","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","root_volume"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:54:01.525175+00:00","export_uri":null,"id":"5092a797-c588-4b10-a180-4a5366ea76ae","modification_date":"2025-01-27T13:54:01.525175+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9d66af43-e6f7-4ff9-a90a-e14908cb3692","name":"tf-srv-pensive-varahamihira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:26.639103+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-jepsen","id":"8ed35d58-b2c7-42f8-9d69-70227b03cf4c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ef","maintenances":[],"modification_date":"2025-02-11T14:23:30.121103+00:00","name":"tf-srv-pensive-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","root_volume"],"volumes":{"0":{"boot":false,"id":"d84621f4-f149-40fa-b32b-27c04635940b","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2192"
+                - "1731"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:07 GMT
+                - Tue, 11 Feb 2025 14:23:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1599,10 +1595,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 66bf6b72-984f-4d68-b6d7-5e21821acd10
+                - 9e9e7c61-f9d5-42c6-9f4b-3247ed1cc391
         status: 200 OK
         code: 200
-        duration: 156.48725ms
+        duration: 328.838333ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1618,8 +1614,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9d66af43-e6f7-4ff9-a90a-e14908cb3692
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/d84621f4-f149-40fa-b32b-27c04635940b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1627,20 +1623,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2192
+        content_length: 143
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:54:01.525175+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-varahamihira","id":"9d66af43-e6f7-4ff9-a90a-e14908cb3692","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:73","maintenances":[],"modification_date":"2025-01-27T13:54:04.476224+00:00","name":"tf-srv-pensive-varahamihira","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","root_volume"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:54:01.525175+00:00","export_uri":null,"id":"5092a797-c588-4b10-a180-4a5366ea76ae","modification_date":"2025-01-27T13:54:01.525175+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"9d66af43-e6f7-4ff9-a90a-e14908cb3692","name":"tf-srv-pensive-varahamihira"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"d84621f4-f149-40fa-b32b-27c04635940b","type":"not_found"}'
         headers:
             Content-Length:
-                - "2192"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:07 GMT
+                - Tue, 11 Feb 2025 14:23:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1648,10 +1644,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a9293d97-55c9-478e-8662-b10159bbae76
-        status: 200 OK
-        code: 200
-        duration: 145.100917ms
+                - a37131c3-72e8-4902-8183-41fe2c7bb3ac
+        status: 404 Not Found
+        code: 404
+        duration: 37.675208ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1667,27 +1663,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9d66af43-e6f7-4ff9-a90a-e14908cb3692
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/d84621f4-f149-40fa-b32b-27c04635940b
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 701
         uncompressed: false
-        body: ""
+        body: '{"created_at":"2025-02-11T14:23:26.855600Z","id":"d84621f4-f149-40fa-b32b-27c04635940b","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:26.855600Z","id":"89ff0a24-f923-44d2-abe2-53d052696904","product_resource_id":"8ed35d58-b2c7-42f8-9d69-70227b03cf4c","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:26.855600Z","zone":"fr-par-1"}'
         headers:
+            Content-Length:
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:07 GMT
+                - Tue, 11 Feb 2025 14:23:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1695,10 +1693,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 42991341-dae2-4802-a31e-1bb4e6cd4992
-        status: 204 No Content
-        code: 204
-        duration: 205.615625ms
+                - 5065e6f6-183f-4426-8c41-92dcbb58bb99
+        status: 200 OK
+        code: 200
+        duration: 68.2705ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1714,8 +1712,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9d66af43-e6f7-4ff9-a90a-e14908cb3692
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8ed35d58-b2c7-42f8-9d69-70227b03cf4c/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1723,20 +1721,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 143
+        content_length: 17
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"9d66af43-e6f7-4ff9-a90a-e14908cb3692","type":"not_found"}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "143"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:07 GMT
+                - Tue, 11 Feb 2025 14:23:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1744,10 +1742,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b1e01fbb-4cab-42f2-b827-cc2fc285b851
-        status: 404 Not Found
-        code: 404
-        duration: 88.694541ms
+                - 737455c2-0961-4024-a84e-d45e8318c9e5
+        status: 200 OK
+        code: 200
+        duration: 77.266125ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1763,8 +1761,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/5092a797-c588-4b10-a180-4a5366ea76ae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8ed35d58-b2c7-42f8-9d69-70227b03cf4c/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1772,20 +1770,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 446
+        content_length: 20
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:54:01.525175+00:00","export_uri":null,"id":"5092a797-c588-4b10-a180-4a5366ea76ae","modification_date":"2025-01-27T13:54:07.848382+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "446"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:08 GMT
+                - Tue, 11 Feb 2025 14:23:32 GMT
+            Link:
+                - </servers/8ed35d58-b2c7-42f8-9d69-70227b03cf4c/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1793,10 +1793,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 923f35bf-7bdf-4d42-9cb9-8444e68d2cd0
+                - f156760c-5f5c-41af-9eca-927e8927d7d9
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 84.888875ms
+        duration: 85.120584ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1812,8 +1814,106 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/5092a797-c588-4b10-a180-4a5366ea76ae
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8ed35d58-b2c7-42f8-9d69-70227b03cf4c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1731
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:26.639103+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-jepsen","id":"8ed35d58-b2c7-42f8-9d69-70227b03cf4c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ef","maintenances":[],"modification_date":"2025-02-11T14:23:30.121103+00:00","name":"tf-srv-pensive-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","root_volume"],"volumes":{"0":{"boot":false,"id":"d84621f4-f149-40fa-b32b-27c04635940b","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1731"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - cec47159-6e84-4f80-b5ee-2b499318d001
+        status: 200 OK
+        code: 200
+        duration: 176.264375ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8ed35d58-b2c7-42f8-9d69-70227b03cf4c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1731
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:26.639103+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-jepsen","id":"8ed35d58-b2c7-42f8-9d69-70227b03cf4c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ef","maintenances":[],"modification_date":"2025-02-11T14:23:30.121103+00:00","name":"tf-srv-pensive-jepsen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","root_volume"],"volumes":{"0":{"boot":false,"id":"d84621f4-f149-40fa-b32b-27c04635940b","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1731"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1c24ffec-6a2a-4aa6-b81e-790b55c2141f
+        status: 200 OK
+        code: 200
+        duration: 185.168625ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8ed35d58-b2c7-42f8-9d69-70227b03cf4c
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1830,9 +1930,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:08 GMT
+                - Tue, 11 Feb 2025 14:23:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1840,11 +1940,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d2a65a3f-aff3-429a-ac73-82acfc632e3d
+                - 8465b65a-99cd-4be3-93e9-2a32f5b3f7ad
         status: 204 No Content
         code: 204
-        duration: 185.563541ms
-    - id: 37
+        duration: 281.439125ms
+    - id: 39
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1859,8 +1959,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9d66af43-e6f7-4ff9-a90a-e14908cb3692
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8ed35d58-b2c7-42f8-9d69-70227b03cf4c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1870,7 +1970,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"9d66af43-e6f7-4ff9-a90a-e14908cb3692","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"8ed35d58-b2c7-42f8-9d69-70227b03cf4c","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -1879,9 +1979,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:08 GMT
+                - Tue, 11 Feb 2025 14:23:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1889,7 +1989,201 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c1549675-c559-4642-ad6a-4edb139f8d56
+                - b52069dd-1e1f-4eef-8957-a53e16da7adf
         status: 404 Not Found
         code: 404
-        duration: 162.043791ms
+        duration: 96.325541ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/d84621f4-f149-40fa-b32b-27c04635940b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"d84621f4-f149-40fa-b32b-27c04635940b","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c21b3706-b7aa-4d08-8e0b-3e77694844fc
+        status: 404 Not Found
+        code: 404
+        duration: 29.995083ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/d84621f4-f149-40fa-b32b-27c04635940b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 494
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:23:26.855600Z","id":"d84621f4-f149-40fa-b32b-27c04635940b","last_detached_at":"2025-02-11T14:23:33.437061Z","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:33.437061Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "494"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b9b02976-7efa-49a6-9cef-cc59cb792188
+        status: 200 OK
+        code: 200
+        duration: 59.20075ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/d84621f4-f149-40fa-b32b-27c04635940b
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a0ebd2e6-d737-403a-b675-0d48468830b6
+        status: 204 No Content
+        code: 204
+        duration: 135.387917ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8ed35d58-b2c7-42f8-9d69-70227b03cf4c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"8ed35d58-b2c7-42f8-9d69-70227b03cf4c","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0db274e0-d0cb-47ba-99b4-0f200d12c4ea
+        status: 404 Not Found
+        code: 404
+        duration: 115.194125ms

--- a/internal/services/instance/testdata/server-server-with-block-non-default-zone.cassette.yaml
+++ b/internal/services/instance/testdata/server-server-with-block-non-default-zone.cassette.yaml
@@ -18,7 +18,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes
         method: POST
       response:
@@ -29,7 +29,7 @@ interactions:
         trailer: {}
         content_length: 425
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:52:56.320660+00:00","export_uri":null,"id":"e277f123-698d-4d8c-be5e-1c098f6644f2","modification_date":"2025-01-27T13:52:56.320660+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:36.236981+00:00","export_uri":null,"id":"43d46d3d-d5e5-48c8-879f-d0af9a680db7","modification_date":"2025-02-11T14:22:36.236981+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}}'
         headers:
             Content-Length:
                 - "425"
@@ -38,11 +38,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:55 GMT
+                - Tue, 11 Feb 2025 14:22:35 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/e277f123-698d-4d8c-be5e-1c098f6644f2
+                - https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/43d46d3d-d5e5-48c8-879f-d0af9a680db7
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -50,10 +50,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fa95185b-1a5e-4de0-aa06-00441c3d516f
+                - e964110f-ea11-4eb2-943c-eca22ad6dead
         status: 201 Created
         code: 201
-        duration: 335.519792ms
+        duration: 623.383041ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -69,8 +69,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/e277f123-698d-4d8c-be5e-1c098f6644f2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/43d46d3d-d5e5-48c8-879f-d0af9a680db7
         method: GET
       response:
         proto: HTTP/2.0
@@ -80,7 +80,7 @@ interactions:
         trailer: {}
         content_length: 425
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:52:56.320660+00:00","export_uri":null,"id":"e277f123-698d-4d8c-be5e-1c098f6644f2","modification_date":"2025-01-27T13:52:56.320660+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:36.236981+00:00","export_uri":null,"id":"43d46d3d-d5e5-48c8-879f-d0af9a680db7","modification_date":"2025-02-11T14:22:36.236981+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}}'
         headers:
             Content-Length:
                 - "425"
@@ -89,9 +89,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:56 GMT
+                - Tue, 11 Feb 2025 14:22:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -99,10 +99,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5d2d07bb-fd6c-40a6-9984-f6e63208b955
+                - 4b1b72e9-7a44-41bc-b88e-3109bdccf3b1
         status: 200 OK
         code: 200
-        duration: 124.451959ms
+        duration: 109.188083ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -118,8 +118,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/e277f123-698d-4d8c-be5e-1c098f6644f2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/43d46d3d-d5e5-48c8-879f-d0af9a680db7
         method: GET
       response:
         proto: HTTP/2.0
@@ -129,7 +129,7 @@ interactions:
         trailer: {}
         content_length: 425
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:52:56.320660+00:00","export_uri":null,"id":"e277f123-698d-4d8c-be5e-1c098f6644f2","modification_date":"2025-01-27T13:52:56.320660+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:36.236981+00:00","export_uri":null,"id":"43d46d3d-d5e5-48c8-879f-d0af9a680db7","modification_date":"2025-02-11T14:22:36.236981+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}}'
         headers:
             Content-Length:
                 - "425"
@@ -138,9 +138,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:56 GMT
+                - Tue, 11 Feb 2025 14:22:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -148,10 +148,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1e929176-0009-4b67-96e6-34e244098a12
+                - a588181e-0e43-42ac-9d91-b370a5bfd208
         status: 200 OK
         code: 200
-        duration: 111.320958ms
+        duration: 121.08175ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -167,7 +167,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/products/servers?page=1
         method: GET
       response:
@@ -176,22 +176,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 38478
+        content_length: 35578
         uncompressed: false
-        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
+        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
         headers:
             Content-Length:
-                - "38478"
+                - "35578"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:56 GMT
+                - Tue, 11 Feb 2025 14:22:36 GMT
             Link:
                 - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -199,12 +199,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 14edceac-3c03-455e-a096-e45469aca32a
+                - cf19ca48-7c0f-4a37-89fe-53443697deb9
             X-Total-Count:
                 - "62"
         status: 200 OK
         code: 200
-        duration: 77.68525ms
+        duration: 59.93225ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -220,7 +220,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/products/servers?page=2
         method: GET
       response:
@@ -229,22 +229,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 9617
+        content_length: 8921
         uncompressed: false
-        body: '{"servers":{"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+        body: '{"servers":{"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
         headers:
             Content-Length:
-                - "9617"
+                - "8921"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:56 GMT
+                - Tue, 11 Feb 2025 14:22:36 GMT
             Link:
                 - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -252,12 +252,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - da30cb64-3999-4893-8ea4-49171a0d0a89
+                - b0b5c300-8922-4c00-a68f-7af737e64ca7
             X-Total-Count:
                 - "62"
         status: 200 OK
         code: 200
-        duration: 64.788167ms
+        duration: 55.765416ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -273,8 +273,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/e277f123-698d-4d8c-be5e-1c098f6644f2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/43d46d3d-d5e5-48c8-879f-d0af9a680db7
         method: GET
       response:
         proto: HTTP/2.0
@@ -284,7 +284,7 @@ interactions:
         trailer: {}
         content_length: 425
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:52:56.320660+00:00","export_uri":null,"id":"e277f123-698d-4d8c-be5e-1c098f6644f2","modification_date":"2025-01-27T13:52:56.320660+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:36.236981+00:00","export_uri":null,"id":"43d46d3d-d5e5-48c8-879f-d0af9a680db7","modification_date":"2025-02-11T14:22:36.236981+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}}'
         headers:
             Content-Length:
                 - "425"
@@ -293,9 +293,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:56 GMT
+                - Tue, 11 Feb 2025 14:22:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -303,10 +303,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a293d60b-8380-4914-ace3-6c9cabb539e1
+                - b78ee945-75eb-43e5-b205-4394f14c11ff
         status: 200 OK
         code: 200
-        duration: 106.304542ms
+        duration: 107.554917ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -322,8 +322,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_local&zone=nl-ams-1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_sbs&zone=nl-ams-1
         method: GET
       response:
         proto: HTTP/2.0
@@ -331,20 +331,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1300
+        content_length: 1296
         uncompressed: false
-        body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"cfdfa4c8-0463-4553-8387-07723eed7c85","label":"ubuntu_focal","type":"instance_local","zone":"nl-ams-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"eb44fed4-fc9f-46bb-9085-6a7343847a8b","label":"ubuntu_focal","type":"instance_local","zone":"nl-ams-1"}],"total_count":2}'
+        body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"26cfb16a-ceae-420b-95e4-03dbfe6d5291","label":"ubuntu_focal","type":"instance_sbs","zone":"nl-ams-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"71fbae84-e539-43e3-b005-10d1fb69ea99","label":"ubuntu_focal","type":"instance_sbs","zone":"nl-ams-1"}],"total_count":2}'
         headers:
             Content-Length:
-                - "1300"
+                - "1296"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:56 GMT
+                - Tue, 11 Feb 2025 14:22:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -352,28 +352,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8a1f1643-87dc-41ff-9a58-673f3ec48865
+                - c5d19d2e-fbaf-42ca-a3a1-164a3142b050
         status: 200 OK
         code: 200
-        duration: 74.243375ms
+        duration: 93.843709ms
     - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 338
+        content_length: 313
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-srv-tender-kepler","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"eb44fed4-fc9f-46bb-9085-6a7343847a8b","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"},"1":{"id":"e277f123-698d-4d8c-be5e-1c098f6644f2","name":"main"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+        body: '{"name":"tf-srv-bold-hertz","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"71fbae84-e539-43e3-b005-10d1fb69ea99","volumes":{"0":{"boot":false,"size":20000000000},"1":{"id":"43d46d3d-d5e5-48c8-879f-d0af9a680db7","name":"main"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers
         method: POST
       response:
@@ -382,22 +382,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2621
+        content_length: 2170
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:57.460930+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-kepler","id":"b592b445-a82a-4d80-82c9-7851d57d6ced","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:27.368621+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"eb44fed4-fc9f-46bb-9085-6a7343847a8b","modification_date":"2024-10-14T09:05:27.368621+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"cf215cac-3791-430e-8208-99725a5858bd","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:41:9a:ed","maintenances":[],"modification_date":"2025-01-27T13:52:57.460930+00:00","name":"tf-srv-tender-kepler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:57.460930+00:00","export_uri":null,"id":"47a3cd02-ccbe-4d55-b783-7fae6b32b6a2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:56.320660+00:00","export_uri":null,"id":"e277f123-698d-4d8c-be5e-1c098f6644f2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.347282+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-hertz","id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:22.717411+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"71fbae84-e539-43e3-b005-10d1fb69ea99","modification_date":"2024-10-14T09:05:22.717411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f7bbdae8-5ab4-4536-bcdc-cd613f449c86","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:42:a0:05","maintenances":[],"modification_date":"2025-02-11T14:22:37.347282+00:00","name":"tf-srv-bold-hertz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"89136d0f-11b8-4f5f-8db2-c0778ee5fed8","volume_type":"sbs_volume","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.236981+00:00","export_uri":null,"id":"43d46d3d-d5e5-48c8-879f-d0af9a680db7","modification_date":"2025-02-11T14:22:37.347282+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","name":"tf-srv-bold-hertz"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
         headers:
             Content-Length:
-                - "2621"
+                - "2170"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:57 GMT
+                - Tue, 11 Feb 2025 14:22:37 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/b592b445-a82a-4d80-82c9-7851d57d6ced
+                - https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3ded52fe-89a1-44b2-a06e-3152cc12605c
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -405,10 +405,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1c62ad20-88c4-47c4-871b-cfa3133df361
+                - 39b0e814-0d20-4934-bd44-4c78ef357167
         status: 201 Created
         code: 201
-        duration: 997.333917ms
+        duration: 1.207823834s
     - id: 8
       request:
         proto: HTTP/1.1
@@ -424,8 +424,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/b592b445-a82a-4d80-82c9-7851d57d6ced
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3ded52fe-89a1-44b2-a06e-3152cc12605c
         method: GET
       response:
         proto: HTTP/2.0
@@ -433,20 +433,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2621
+        content_length: 2170
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:57.460930+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-kepler","id":"b592b445-a82a-4d80-82c9-7851d57d6ced","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:27.368621+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"eb44fed4-fc9f-46bb-9085-6a7343847a8b","modification_date":"2024-10-14T09:05:27.368621+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"cf215cac-3791-430e-8208-99725a5858bd","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:41:9a:ed","maintenances":[],"modification_date":"2025-01-27T13:52:57.460930+00:00","name":"tf-srv-tender-kepler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:57.460930+00:00","export_uri":null,"id":"47a3cd02-ccbe-4d55-b783-7fae6b32b6a2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:56.320660+00:00","export_uri":null,"id":"e277f123-698d-4d8c-be5e-1c098f6644f2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.347282+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-hertz","id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:22.717411+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"71fbae84-e539-43e3-b005-10d1fb69ea99","modification_date":"2024-10-14T09:05:22.717411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f7bbdae8-5ab4-4536-bcdc-cd613f449c86","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:42:a0:05","maintenances":[],"modification_date":"2025-02-11T14:22:37.347282+00:00","name":"tf-srv-bold-hertz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"89136d0f-11b8-4f5f-8db2-c0778ee5fed8","volume_type":"sbs_volume","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.236981+00:00","export_uri":null,"id":"43d46d3d-d5e5-48c8-879f-d0af9a680db7","modification_date":"2025-02-11T14:22:37.347282+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","name":"tf-srv-bold-hertz"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
         headers:
             Content-Length:
-                - "2621"
+                - "2170"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:57 GMT
+                - Tue, 11 Feb 2025 14:22:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -454,10 +454,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f7889b8d-6b9a-47cc-a152-f593c8851d45
+                - 9b6785b6-1c3f-4cf2-823a-9e72828dfda7
         status: 200 OK
         code: 200
-        duration: 161.480958ms
+        duration: 209.752417ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -473,8 +473,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/b592b445-a82a-4d80-82c9-7851d57d6ced
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3ded52fe-89a1-44b2-a06e-3152cc12605c
         method: GET
       response:
         proto: HTTP/2.0
@@ -482,20 +482,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2621
+        content_length: 2170
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:57.460930+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-kepler","id":"b592b445-a82a-4d80-82c9-7851d57d6ced","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:27.368621+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"eb44fed4-fc9f-46bb-9085-6a7343847a8b","modification_date":"2024-10-14T09:05:27.368621+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"cf215cac-3791-430e-8208-99725a5858bd","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:41:9a:ed","maintenances":[],"modification_date":"2025-01-27T13:52:57.460930+00:00","name":"tf-srv-tender-kepler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:57.460930+00:00","export_uri":null,"id":"47a3cd02-ccbe-4d55-b783-7fae6b32b6a2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:56.320660+00:00","export_uri":null,"id":"e277f123-698d-4d8c-be5e-1c098f6644f2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.347282+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-hertz","id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:22.717411+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"71fbae84-e539-43e3-b005-10d1fb69ea99","modification_date":"2024-10-14T09:05:22.717411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f7bbdae8-5ab4-4536-bcdc-cd613f449c86","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:42:a0:05","maintenances":[],"modification_date":"2025-02-11T14:22:37.347282+00:00","name":"tf-srv-bold-hertz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"89136d0f-11b8-4f5f-8db2-c0778ee5fed8","volume_type":"sbs_volume","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.236981+00:00","export_uri":null,"id":"43d46d3d-d5e5-48c8-879f-d0af9a680db7","modification_date":"2025-02-11T14:22:37.347282+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","name":"tf-srv-bold-hertz"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
         headers:
             Content-Length:
-                - "2621"
+                - "2170"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:57 GMT
+                - Tue, 11 Feb 2025 14:22:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -503,11 +503,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 13c55cd4-e880-4848-889f-10874a430bcb
+                - 06320b0f-e298-4fdb-836b-a94d9d3cd61f
         status: 200 OK
         code: 200
-        duration: 167.231584ms
+        duration: 207.77625ms
     - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/nl-ams-1/volumes/89136d0f-11b8-4f5f-8db2-c0778ee5fed8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:22:37.576522Z","id":"89136d0f-11b8-4f5f-8db2-c0778ee5fed8","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"f7bbdae8-5ab4-4536-bcdc-cd613f449c86","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:37.576522Z","id":"0f4a0987-2f4f-4ff0-a6ad-a9b9b03820d7","product_resource_id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":20000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:37.576522Z","zone":"nl-ams-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:22:38 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 32d3940a-2163-4613-b2b9-471ba53a4482
+        status: 200 OK
+        code: 200
+        duration: 87.23875ms
+    - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -524,8 +573,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/b592b445-a82a-4d80-82c9-7851d57d6ced/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3ded52fe-89a1-44b2-a06e-3152cc12605c/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -535,7 +584,7 @@ interactions:
         trailer: {}
         content_length: 357
         uncompressed: false
-        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/b592b445-a82a-4d80-82c9-7851d57d6ced/action","href_result":"/servers/b592b445-a82a-4d80-82c9-7851d57d6ced","id":"0e819270-5ec1-41c0-a17d-a4b25aacfd28","progress":0,"started_at":"2025-01-27T13:52:58.618205+00:00","status":"pending","terminated_at":null,"zone":"nl-ams-1"}}'
+        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/3ded52fe-89a1-44b2-a06e-3152cc12605c/action","href_result":"/servers/3ded52fe-89a1-44b2-a06e-3152cc12605c","id":"f2d574b7-8da2-4005-bf67-11d7ff5d7f9f","progress":0,"started_at":"2025-02-11T14:22:38.868812+00:00","status":"pending","terminated_at":null,"zone":"nl-ams-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -544,11 +593,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:58 GMT
+                - Tue, 11 Feb 2025 14:22:38 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/nl-ams-1/tasks/0e819270-5ec1-41c0-a17d-a4b25aacfd28
+                - https://api.scaleway.com/instance/v1/zones/nl-ams-1/tasks/f2d574b7-8da2-4005-bf67-11d7ff5d7f9f
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -556,59 +605,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 384e1c79-e1dd-4f40-935c-f7e6c481add6
+                - 6bd985f5-9a59-418d-be10-9ce3cb6e42b1
         status: 202 Accepted
         code: 202
-        duration: 356.9815ms
-    - id: 11
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/b592b445-a82a-4d80-82c9-7851d57d6ced
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2643
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:57.460930+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-kepler","id":"b592b445-a82a-4d80-82c9-7851d57d6ced","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:27.368621+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"eb44fed4-fc9f-46bb-9085-6a7343847a8b","modification_date":"2024-10-14T09:05:27.368621+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"cf215cac-3791-430e-8208-99725a5858bd","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:41:9a:ed","maintenances":[],"modification_date":"2025-01-27T13:52:58.337885+00:00","name":"tf-srv-tender-kepler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:57.460930+00:00","export_uri":null,"id":"47a3cd02-ccbe-4d55-b783-7fae6b32b6a2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:56.320660+00:00","export_uri":null,"id":"e277f123-698d-4d8c-be5e-1c098f6644f2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
-        headers:
-            Content-Length:
-                - "2643"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:52:58 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - a7ae027d-7f3d-42e9-bb68-3949a58cc6f6
-        status: 200 OK
-        code: 200
-        duration: 200.132625ms
+        duration: 306.12475ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -624,8 +624,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/b592b445-a82a-4d80-82c9-7851d57d6ced
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3ded52fe-89a1-44b2-a06e-3152cc12605c
         method: GET
       response:
         proto: HTTP/2.0
@@ -633,20 +633,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2747
+        content_length: 2192
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:57.460930+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-kepler","id":"b592b445-a82a-4d80-82c9-7851d57d6ced","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:27.368621+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"eb44fed4-fc9f-46bb-9085-6a7343847a8b","modification_date":"2024-10-14T09:05:27.368621+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"cf215cac-3791-430e-8208-99725a5858bd","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"2002","node_id":"42","platform_id":"23","zone_id":"nl-ams-1"},"mac_address":"de:00:00:41:9a:ed","maintenances":[],"modification_date":"2025-01-27T13:52:58.337885+00:00","name":"tf-srv-tender-kepler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:57.460930+00:00","export_uri":null,"id":"47a3cd02-ccbe-4d55-b783-7fae6b32b6a2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:56.320660+00:00","export_uri":null,"id":"e277f123-698d-4d8c-be5e-1c098f6644f2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.347282+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-hertz","id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:22.717411+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"71fbae84-e539-43e3-b005-10d1fb69ea99","modification_date":"2024-10-14T09:05:22.717411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f7bbdae8-5ab4-4536-bcdc-cd613f449c86","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:42:a0:05","maintenances":[],"modification_date":"2025-02-11T14:22:38.638786+00:00","name":"tf-srv-bold-hertz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"id":"89136d0f-11b8-4f5f-8db2-c0778ee5fed8","volume_type":"sbs_volume","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.236981+00:00","export_uri":null,"id":"43d46d3d-d5e5-48c8-879f-d0af9a680db7","modification_date":"2025-02-11T14:22:37.347282+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","name":"tf-srv-bold-hertz"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
         headers:
             Content-Length:
-                - "2747"
+                - "2192"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:04 GMT
+                - Tue, 11 Feb 2025 14:22:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -654,10 +654,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - aecbf5ad-bbe6-4c73-9bd8-27b2514960db
+                - daa4f838-8b91-4422-b5ac-3969d5c10dde
         status: 200 OK
         code: 200
-        duration: 387.365583ms
+        duration: 202.927ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -673,8 +673,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/b592b445-a82a-4d80-82c9-7851d57d6ced
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3ded52fe-89a1-44b2-a06e-3152cc12605c
         method: GET
       response:
         proto: HTTP/2.0
@@ -682,20 +682,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2747
+        content_length: 2327
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:57.460930+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-kepler","id":"b592b445-a82a-4d80-82c9-7851d57d6ced","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:27.368621+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"eb44fed4-fc9f-46bb-9085-6a7343847a8b","modification_date":"2024-10-14T09:05:27.368621+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"cf215cac-3791-430e-8208-99725a5858bd","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"2002","node_id":"42","platform_id":"23","zone_id":"nl-ams-1"},"mac_address":"de:00:00:41:9a:ed","maintenances":[],"modification_date":"2025-01-27T13:52:58.337885+00:00","name":"tf-srv-tender-kepler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:57.460930+00:00","export_uri":null,"id":"47a3cd02-ccbe-4d55-b783-7fae6b32b6a2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:56.320660+00:00","export_uri":null,"id":"e277f123-698d-4d8c-be5e-1c098f6644f2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.347282+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-hertz","id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:22.717411+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"71fbae84-e539-43e3-b005-10d1fb69ea99","modification_date":"2024-10-14T09:05:22.717411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f7bbdae8-5ab4-4536-bcdc-cd613f449c86","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"1401","node_id":"15","platform_id":"23","zone_id":"nl-ams-1"},"mac_address":"de:00:00:42:a0:05","maintenances":[],"modification_date":"2025-02-11T14:22:43.913581+00:00","name":"tf-srv-bold-hertz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"89136d0f-11b8-4f5f-8db2-c0778ee5fed8","volume_type":"sbs_volume","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.236981+00:00","export_uri":null,"id":"43d46d3d-d5e5-48c8-879f-d0af9a680db7","modification_date":"2025-02-11T14:22:37.347282+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","name":"tf-srv-bold-hertz"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
         headers:
             Content-Length:
-                - "2747"
+                - "2327"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:09 GMT
+                - Tue, 11 Feb 2025 14:22:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -703,10 +703,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 33c16fca-9365-4088-ac95-f8db28167663
+                - b9af2b08-4edc-4f28-b21f-0e4ce9749927
         status: 200 OK
         code: 200
-        duration: 176.911625ms
+        duration: 219.496ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -722,8 +722,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/b592b445-a82a-4d80-82c9-7851d57d6ced
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3ded52fe-89a1-44b2-a06e-3152cc12605c
         method: GET
       response:
         proto: HTTP/2.0
@@ -731,20 +731,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2747
+        content_length: 2327
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:57.460930+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-kepler","id":"b592b445-a82a-4d80-82c9-7851d57d6ced","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:27.368621+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"eb44fed4-fc9f-46bb-9085-6a7343847a8b","modification_date":"2024-10-14T09:05:27.368621+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"cf215cac-3791-430e-8208-99725a5858bd","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"2002","node_id":"42","platform_id":"23","zone_id":"nl-ams-1"},"mac_address":"de:00:00:41:9a:ed","maintenances":[],"modification_date":"2025-01-27T13:52:58.337885+00:00","name":"tf-srv-tender-kepler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:57.460930+00:00","export_uri":null,"id":"47a3cd02-ccbe-4d55-b783-7fae6b32b6a2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:56.320660+00:00","export_uri":null,"id":"e277f123-698d-4d8c-be5e-1c098f6644f2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.347282+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-hertz","id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:22.717411+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"71fbae84-e539-43e3-b005-10d1fb69ea99","modification_date":"2024-10-14T09:05:22.717411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f7bbdae8-5ab4-4536-bcdc-cd613f449c86","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"1401","node_id":"15","platform_id":"23","zone_id":"nl-ams-1"},"mac_address":"de:00:00:42:a0:05","maintenances":[],"modification_date":"2025-02-11T14:22:43.913581+00:00","name":"tf-srv-bold-hertz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"89136d0f-11b8-4f5f-8db2-c0778ee5fed8","volume_type":"sbs_volume","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.236981+00:00","export_uri":null,"id":"43d46d3d-d5e5-48c8-879f-d0af9a680db7","modification_date":"2025-02-11T14:22:37.347282+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","name":"tf-srv-bold-hertz"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
         headers:
             Content-Length:
-                - "2747"
+                - "2327"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:14 GMT
+                - Tue, 11 Feb 2025 14:22:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -752,10 +752,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3cb7bf36-16a6-4914-a869-117826be309b
+                - 2e675630-cd8b-4e5f-ad73-e2b4ccf181d3
         status: 200 OK
         code: 200
-        duration: 187.941125ms
+        duration: 205.802583ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -771,8 +771,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/b592b445-a82a-4d80-82c9-7851d57d6ced
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/89136d0f-11b8-4f5f-8db2-c0778ee5fed8
         method: GET
       response:
         proto: HTTP/2.0
@@ -780,20 +780,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2747
+        content_length: 143
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:57.460930+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-kepler","id":"b592b445-a82a-4d80-82c9-7851d57d6ced","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:27.368621+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"eb44fed4-fc9f-46bb-9085-6a7343847a8b","modification_date":"2024-10-14T09:05:27.368621+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"cf215cac-3791-430e-8208-99725a5858bd","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"2002","node_id":"42","platform_id":"23","zone_id":"nl-ams-1"},"mac_address":"de:00:00:41:9a:ed","maintenances":[],"modification_date":"2025-01-27T13:52:58.337885+00:00","name":"tf-srv-tender-kepler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:57.460930+00:00","export_uri":null,"id":"47a3cd02-ccbe-4d55-b783-7fae6b32b6a2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:56.320660+00:00","export_uri":null,"id":"e277f123-698d-4d8c-be5e-1c098f6644f2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"89136d0f-11b8-4f5f-8db2-c0778ee5fed8","type":"not_found"}'
         headers:
             Content-Length:
-                - "2747"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:19 GMT
+                - Tue, 11 Feb 2025 14:22:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -801,10 +801,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 05f15415-cec5-407b-87b0-d4d9f471b2a2
-        status: 200 OK
-        code: 200
-        duration: 169.478334ms
+                - 196ed188-cd7a-4421-8281-da7261ad15de
+        status: 404 Not Found
+        code: 404
+        duration: 61.532208ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -820,8 +820,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/b592b445-a82a-4d80-82c9-7851d57d6ced
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/nl-ams-1/volumes/89136d0f-11b8-4f5f-8db2-c0778ee5fed8
         method: GET
       response:
         proto: HTTP/2.0
@@ -829,20 +829,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2778
+        content_length: 701
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:57.460930+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-kepler","id":"b592b445-a82a-4d80-82c9-7851d57d6ced","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:27.368621+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"eb44fed4-fc9f-46bb-9085-6a7343847a8b","modification_date":"2024-10-14T09:05:27.368621+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"cf215cac-3791-430e-8208-99725a5858bd","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"2002","node_id":"42","platform_id":"23","zone_id":"nl-ams-1"},"mac_address":"de:00:00:41:9a:ed","maintenances":[],"modification_date":"2025-01-27T13:53:23.595653+00:00","name":"tf-srv-tender-kepler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:57.460930+00:00","export_uri":null,"id":"47a3cd02-ccbe-4d55-b783-7fae6b32b6a2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:56.320660+00:00","export_uri":null,"id":"e277f123-698d-4d8c-be5e-1c098f6644f2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
+        body: '{"created_at":"2025-02-11T14:22:37.576522Z","id":"89136d0f-11b8-4f5f-8db2-c0778ee5fed8","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"f7bbdae8-5ab4-4536-bcdc-cd613f449c86","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:37.576522Z","id":"0f4a0987-2f4f-4ff0-a6ad-a9b9b03820d7","product_resource_id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":20000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:37.576522Z","zone":"nl-ams-1"}'
         headers:
             Content-Length:
-                - "2778"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:24 GMT
+                - Tue, 11 Feb 2025 14:22:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -850,10 +850,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7d55a488-bbc1-4992-8746-7ce9d549bbee
+                - c34f8e68-5612-44b0-bc5a-6390f508b88d
         status: 200 OK
         code: 200
-        duration: 174.560791ms
+        duration: 91.449625ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -869,8 +869,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/b592b445-a82a-4d80-82c9-7851d57d6ced
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3ded52fe-89a1-44b2-a06e-3152cc12605c/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -878,20 +878,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2778
+        content_length: 17
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:57.460930+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-kepler","id":"b592b445-a82a-4d80-82c9-7851d57d6ced","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:27.368621+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"eb44fed4-fc9f-46bb-9085-6a7343847a8b","modification_date":"2024-10-14T09:05:27.368621+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"cf215cac-3791-430e-8208-99725a5858bd","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"2002","node_id":"42","platform_id":"23","zone_id":"nl-ams-1"},"mac_address":"de:00:00:41:9a:ed","maintenances":[],"modification_date":"2025-01-27T13:53:23.595653+00:00","name":"tf-srv-tender-kepler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:57.460930+00:00","export_uri":null,"id":"47a3cd02-ccbe-4d55-b783-7fae6b32b6a2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:56.320660+00:00","export_uri":null,"id":"e277f123-698d-4d8c-be5e-1c098f6644f2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "2778"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:25 GMT
+                - Tue, 11 Feb 2025 14:22:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -899,10 +899,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 02ca1cdc-6192-41a1-a533-e55a4891f006
+                - 0576ef58-1eb2-4c1d-92d7-6c4e0e2e383a
         status: 200 OK
         code: 200
-        duration: 171.823625ms
+        duration: 123.145833ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -918,8 +918,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/47a3cd02-ccbe-4d55-b783-7fae6b32b6a2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3ded52fe-89a1-44b2-a06e-3152cc12605c/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -927,20 +927,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 520
+        content_length: 20
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:52:57.460930+00:00","export_uri":null,"id":"47a3cd02-ccbe-4d55-b783-7fae6b32b6a2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"nl-ams-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "520"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:24 GMT
+                - Tue, 11 Feb 2025 14:22:44 GMT
+            Link:
+                - </servers/3ded52fe-89a1-44b2-a06e-3152cc12605c/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -948,10 +950,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 26bbd426-de8c-4734-be99-72551d1ff791
+                - 5de42c90-f1c6-4da2-9ac9-4f2a7c0bbf2a
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 127.49075ms
+        duration: 123.15625ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -967,8 +971,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/b592b445-a82a-4d80-82c9-7851d57d6ced/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3ded52fe-89a1-44b2-a06e-3152cc12605c
         method: GET
       response:
         proto: HTTP/2.0
@@ -976,20 +980,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 2327
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.347282+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-hertz","id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:22.717411+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"71fbae84-e539-43e3-b005-10d1fb69ea99","modification_date":"2024-10-14T09:05:22.717411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f7bbdae8-5ab4-4536-bcdc-cd613f449c86","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"1401","node_id":"15","platform_id":"23","zone_id":"nl-ams-1"},"mac_address":"de:00:00:42:a0:05","maintenances":[],"modification_date":"2025-02-11T14:22:43.913581+00:00","name":"tf-srv-bold-hertz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"89136d0f-11b8-4f5f-8db2-c0778ee5fed8","volume_type":"sbs_volume","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.236981+00:00","export_uri":null,"id":"43d46d3d-d5e5-48c8-879f-d0af9a680db7","modification_date":"2025-02-11T14:22:37.347282+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","name":"tf-srv-bold-hertz"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
         headers:
             Content-Length:
-                - "17"
+                - "2327"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:24 GMT
+                - Tue, 11 Feb 2025 14:22:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -997,10 +1001,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b6e0b705-4631-4da3-b7b4-4c72705e9199
+                - 001db143-d47f-4899-aaea-edc415208e93
         status: 200 OK
         code: 200
-        duration: 176.311167ms
+        duration: 176.142625ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1016,8 +1020,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/b592b445-a82a-4d80-82c9-7851d57d6ced/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/43d46d3d-d5e5-48c8-879f-d0af9a680db7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1025,22 +1029,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 496
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:36.236981+00:00","export_uri":null,"id":"43d46d3d-d5e5-48c8-879f-d0af9a680db7","modification_date":"2025-02-11T14:22:37.347282+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","name":"tf-srv-bold-hertz"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}}'
         headers:
             Content-Length:
-                - "20"
+                - "496"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:25 GMT
-            Link:
-                - </servers/b592b445-a82a-4d80-82c9-7851d57d6ced/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:22:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1048,12 +1050,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 47cd06e1-d3af-45bc-a686-c6336d3ee95e
-            X-Total-Count:
-                - "0"
+                - 8e262b95-4f6f-474d-b73b-93929fceec10
         status: 200 OK
         code: 200
-        duration: 102.566833ms
+        duration: 107.39375ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1069,8 +1069,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/b592b445-a82a-4d80-82c9-7851d57d6ced
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3ded52fe-89a1-44b2-a06e-3152cc12605c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1078,20 +1078,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2778
+        content_length: 2327
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:57.460930+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-kepler","id":"b592b445-a82a-4d80-82c9-7851d57d6ced","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:27.368621+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"eb44fed4-fc9f-46bb-9085-6a7343847a8b","modification_date":"2024-10-14T09:05:27.368621+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"cf215cac-3791-430e-8208-99725a5858bd","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"2002","node_id":"42","platform_id":"23","zone_id":"nl-ams-1"},"mac_address":"de:00:00:41:9a:ed","maintenances":[],"modification_date":"2025-01-27T13:53:23.595653+00:00","name":"tf-srv-tender-kepler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:57.460930+00:00","export_uri":null,"id":"47a3cd02-ccbe-4d55-b783-7fae6b32b6a2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:56.320660+00:00","export_uri":null,"id":"e277f123-698d-4d8c-be5e-1c098f6644f2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.347282+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-hertz","id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:22.717411+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"71fbae84-e539-43e3-b005-10d1fb69ea99","modification_date":"2024-10-14T09:05:22.717411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f7bbdae8-5ab4-4536-bcdc-cd613f449c86","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"1401","node_id":"15","platform_id":"23","zone_id":"nl-ams-1"},"mac_address":"de:00:00:42:a0:05","maintenances":[],"modification_date":"2025-02-11T14:22:43.913581+00:00","name":"tf-srv-bold-hertz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"89136d0f-11b8-4f5f-8db2-c0778ee5fed8","volume_type":"sbs_volume","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.236981+00:00","export_uri":null,"id":"43d46d3d-d5e5-48c8-879f-d0af9a680db7","modification_date":"2025-02-11T14:22:37.347282+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","name":"tf-srv-bold-hertz"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
         headers:
             Content-Length:
-                - "2778"
+                - "2327"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:25 GMT
+                - Tue, 11 Feb 2025 14:22:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1099,10 +1099,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - eb44f36e-de33-4f67-9243-27d0965d01dd
+                - c7b604f2-11ae-4b4c-8311-d5ee97b883c6
         status: 200 OK
         code: 200
-        duration: 187.349959ms
+        duration: 171.43775ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1118,8 +1118,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/e277f123-698d-4d8c-be5e-1c098f6644f2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/89136d0f-11b8-4f5f-8db2-c0778ee5fed8
         method: GET
       response:
         proto: HTTP/2.0
@@ -1127,20 +1127,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 499
+        content_length: 143
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:52:56.320660+00:00","export_uri":null,"id":"e277f123-698d-4d8c-be5e-1c098f6644f2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"89136d0f-11b8-4f5f-8db2-c0778ee5fed8","type":"not_found"}'
         headers:
             Content-Length:
-                - "499"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:25 GMT
+                - Tue, 11 Feb 2025 14:22:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1148,10 +1148,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f9a39c69-92f2-47a6-b2a8-982042905239
-        status: 200 OK
-        code: 200
-        duration: 116.823042ms
+                - 50cc9de4-0f44-4540-b0d8-3c2ca4a169a6
+        status: 404 Not Found
+        code: 404
+        duration: 58.847208ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1167,8 +1167,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/b592b445-a82a-4d80-82c9-7851d57d6ced
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/nl-ams-1/volumes/89136d0f-11b8-4f5f-8db2-c0778ee5fed8
         method: GET
       response:
         proto: HTTP/2.0
@@ -1176,20 +1176,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2778
+        content_length: 701
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:57.460930+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-kepler","id":"b592b445-a82a-4d80-82c9-7851d57d6ced","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:27.368621+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"eb44fed4-fc9f-46bb-9085-6a7343847a8b","modification_date":"2024-10-14T09:05:27.368621+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"cf215cac-3791-430e-8208-99725a5858bd","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"2002","node_id":"42","platform_id":"23","zone_id":"nl-ams-1"},"mac_address":"de:00:00:41:9a:ed","maintenances":[],"modification_date":"2025-01-27T13:53:23.595653+00:00","name":"tf-srv-tender-kepler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:57.460930+00:00","export_uri":null,"id":"47a3cd02-ccbe-4d55-b783-7fae6b32b6a2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:56.320660+00:00","export_uri":null,"id":"e277f123-698d-4d8c-be5e-1c098f6644f2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
+        body: '{"created_at":"2025-02-11T14:22:37.576522Z","id":"89136d0f-11b8-4f5f-8db2-c0778ee5fed8","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"f7bbdae8-5ab4-4536-bcdc-cd613f449c86","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:37.576522Z","id":"0f4a0987-2f4f-4ff0-a6ad-a9b9b03820d7","product_resource_id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":20000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:37.576522Z","zone":"nl-ams-1"}'
         headers:
             Content-Length:
-                - "2778"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:25 GMT
+                - Tue, 11 Feb 2025 14:22:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1197,10 +1197,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c37b7220-e5ea-4209-8ef7-c06913a8f79c
+                - 8dd9ffe9-9eed-4cf8-9cd7-eb9e25147ad6
         status: 200 OK
         code: 200
-        duration: 187.486708ms
+        duration: 90.776708ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1216,57 +1216,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/47a3cd02-ccbe-4d55-b783-7fae6b32b6a2
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 520
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:52:57.460930+00:00","export_uri":null,"id":"47a3cd02-ccbe-4d55-b783-7fae6b32b6a2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"nl-ams-1"}}'
-        headers:
-            Content-Length:
-                - "520"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:53:26 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 28a8e412-5ed6-4767-9e03-e318d83226c9
-        status: 200 OK
-        code: 200
-        duration: 106.863208ms
-    - id: 25
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/b592b445-a82a-4d80-82c9-7851d57d6ced/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3ded52fe-89a1-44b2-a06e-3152cc12605c/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1285,9 +1236,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:26 GMT
+                - Tue, 11 Feb 2025 14:22:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1295,11 +1246,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 06c962cb-b416-495b-bc84-bddf56e2529b
+                - 50c1cbaa-f125-4f1a-b382-c329cc6dd702
         status: 200 OK
         code: 200
-        duration: 119.10425ms
-    - id: 26
+        duration: 114.274208ms
+    - id: 25
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1314,8 +1265,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/b592b445-a82a-4d80-82c9-7851d57d6ced/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3ded52fe-89a1-44b2-a06e-3152cc12605c/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1334,11 +1285,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:26 GMT
+                - Tue, 11 Feb 2025 14:22:45 GMT
             Link:
-                - </servers/b592b445-a82a-4d80-82c9-7851d57d6ced/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/3ded52fe-89a1-44b2-a06e-3152cc12605c/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1346,12 +1297,61 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bbc9232f-899d-42c9-8035-08a624fa52be
+                - b48413cb-8e8e-41bd-9bf3-4a58e35e0bbe
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 114.755ms
+        duration: 122.309792ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3ded52fe-89a1-44b2-a06e-3152cc12605c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2327
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.347282+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-hertz","id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:22.717411+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"71fbae84-e539-43e3-b005-10d1fb69ea99","modification_date":"2024-10-14T09:05:22.717411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f7bbdae8-5ab4-4536-bcdc-cd613f449c86","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"1401","node_id":"15","platform_id":"23","zone_id":"nl-ams-1"},"mac_address":"de:00:00:42:a0:05","maintenances":[],"modification_date":"2025-02-11T14:22:43.913581+00:00","name":"tf-srv-bold-hertz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"89136d0f-11b8-4f5f-8db2-c0778ee5fed8","volume_type":"sbs_volume","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.236981+00:00","export_uri":null,"id":"43d46d3d-d5e5-48c8-879f-d0af9a680db7","modification_date":"2025-02-11T14:22:37.347282+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","name":"tf-srv-bold-hertz"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
+        headers:
+            Content-Length:
+                - "2327"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:22:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e6dfc497-f766-4024-86bd-02cc243ff5af
+        status: 200 OK
+        code: 200
+        duration: 258.262625ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1367,8 +1367,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/b592b445-a82a-4d80-82c9-7851d57d6ced
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/nl-ams-1/volumes/89136d0f-11b8-4f5f-8db2-c0778ee5fed8
         method: GET
       response:
         proto: HTTP/2.0
@@ -1376,20 +1376,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2778
+        content_length: 701
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:57.460930+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-kepler","id":"b592b445-a82a-4d80-82c9-7851d57d6ced","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:27.368621+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"eb44fed4-fc9f-46bb-9085-6a7343847a8b","modification_date":"2024-10-14T09:05:27.368621+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"cf215cac-3791-430e-8208-99725a5858bd","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"2002","node_id":"42","platform_id":"23","zone_id":"nl-ams-1"},"mac_address":"de:00:00:41:9a:ed","maintenances":[],"modification_date":"2025-01-27T13:53:23.595653+00:00","name":"tf-srv-tender-kepler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:57.460930+00:00","export_uri":null,"id":"47a3cd02-ccbe-4d55-b783-7fae6b32b6a2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:56.320660+00:00","export_uri":null,"id":"e277f123-698d-4d8c-be5e-1c098f6644f2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
+        body: '{"created_at":"2025-02-11T14:22:37.576522Z","id":"89136d0f-11b8-4f5f-8db2-c0778ee5fed8","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"f7bbdae8-5ab4-4536-bcdc-cd613f449c86","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:37.576522Z","id":"0f4a0987-2f4f-4ff0-a6ad-a9b9b03820d7","product_resource_id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":20000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:37.576522Z","zone":"nl-ams-1"}'
         headers:
             Content-Length:
-                - "2778"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:26 GMT
+                - Tue, 11 Feb 2025 14:22:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1397,10 +1397,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 68161d36-fb45-47a8-98a9-ddf99d2a9fa2
+                - 8e88905f-65fd-4ffc-8897-721bdc1f0678
         status: 200 OK
         code: 200
-        duration: 191.662709ms
+        duration: 89.796917ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1418,8 +1418,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/b592b445-a82a-4d80-82c9-7851d57d6ced/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3ded52fe-89a1-44b2-a06e-3152cc12605c/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -1429,7 +1429,7 @@ interactions:
         trailer: {}
         content_length: 352
         uncompressed: false
-        body: '{"task":{"description":"server_poweroff","href_from":"/servers/b592b445-a82a-4d80-82c9-7851d57d6ced/action","href_result":"/servers/b592b445-a82a-4d80-82c9-7851d57d6ced","id":"e1acb18c-8966-42eb-aca8-11ed4e565de9","progress":0,"started_at":"2025-01-27T13:53:27.369210+00:00","status":"pending","terminated_at":null,"zone":"nl-ams-1"}}'
+        body: '{"task":{"description":"server_poweroff","href_from":"/servers/3ded52fe-89a1-44b2-a06e-3152cc12605c/action","href_result":"/servers/3ded52fe-89a1-44b2-a06e-3152cc12605c","id":"1c6f2d33-f844-4577-8bc9-94a9221f2292","progress":0,"started_at":"2025-02-11T14:22:47.161886+00:00","status":"pending","terminated_at":null,"zone":"nl-ams-1"}}'
         headers:
             Content-Length:
                 - "352"
@@ -1438,11 +1438,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:27 GMT
+                - Tue, 11 Feb 2025 14:22:47 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/nl-ams-1/tasks/e1acb18c-8966-42eb-aca8-11ed4e565de9
+                - https://api.scaleway.com/instance/v1/zones/nl-ams-1/tasks/1c6f2d33-f844-4577-8bc9-94a9221f2292
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1450,10 +1450,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 41e590e5-7a00-4db5-8dec-b94a28794416
+                - 490de444-8d6f-4ad5-b9b7-3713e0414b4a
         status: 202 Accepted
         code: 202
-        duration: 311.999917ms
+        duration: 513.368208ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1469,8 +1469,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/b592b445-a82a-4d80-82c9-7851d57d6ced
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3ded52fe-89a1-44b2-a06e-3152cc12605c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1478,20 +1478,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2738
+        content_length: 2287
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:57.460930+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-kepler","id":"b592b445-a82a-4d80-82c9-7851d57d6ced","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:27.368621+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"eb44fed4-fc9f-46bb-9085-6a7343847a8b","modification_date":"2024-10-14T09:05:27.368621+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"cf215cac-3791-430e-8208-99725a5858bd","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"2002","node_id":"42","platform_id":"23","zone_id":"nl-ams-1"},"mac_address":"de:00:00:41:9a:ed","maintenances":[],"modification_date":"2025-01-27T13:53:27.121878+00:00","name":"tf-srv-tender-kepler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:57.460930+00:00","export_uri":null,"id":"47a3cd02-ccbe-4d55-b783-7fae6b32b6a2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:56.320660+00:00","export_uri":null,"id":"e277f123-698d-4d8c-be5e-1c098f6644f2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.347282+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-hertz","id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:22.717411+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"71fbae84-e539-43e3-b005-10d1fb69ea99","modification_date":"2024-10-14T09:05:22.717411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f7bbdae8-5ab4-4536-bcdc-cd613f449c86","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"1401","node_id":"15","platform_id":"23","zone_id":"nl-ams-1"},"mac_address":"de:00:00:42:a0:05","maintenances":[],"modification_date":"2025-02-11T14:22:46.732791+00:00","name":"tf-srv-bold-hertz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"89136d0f-11b8-4f5f-8db2-c0778ee5fed8","volume_type":"sbs_volume","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.236981+00:00","export_uri":null,"id":"43d46d3d-d5e5-48c8-879f-d0af9a680db7","modification_date":"2025-02-11T14:22:37.347282+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","name":"tf-srv-bold-hertz"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
         headers:
             Content-Length:
-                - "2738"
+                - "2287"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:27 GMT
+                - Tue, 11 Feb 2025 14:22:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1499,10 +1499,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f6bf7445-c7eb-4956-95db-d72cafae1300
+                - 2773d0b0-b595-4857-9596-bd52e400487e
         status: 200 OK
         code: 200
-        duration: 173.525584ms
+        duration: 191.481083ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1518,8 +1518,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/b592b445-a82a-4d80-82c9-7851d57d6ced
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3ded52fe-89a1-44b2-a06e-3152cc12605c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1527,20 +1527,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2738
+        content_length: 2287
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:57.460930+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-kepler","id":"b592b445-a82a-4d80-82c9-7851d57d6ced","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:27.368621+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"eb44fed4-fc9f-46bb-9085-6a7343847a8b","modification_date":"2024-10-14T09:05:27.368621+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"cf215cac-3791-430e-8208-99725a5858bd","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"2002","node_id":"42","platform_id":"23","zone_id":"nl-ams-1"},"mac_address":"de:00:00:41:9a:ed","maintenances":[],"modification_date":"2025-01-27T13:53:27.121878+00:00","name":"tf-srv-tender-kepler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:57.460930+00:00","export_uri":null,"id":"47a3cd02-ccbe-4d55-b783-7fae6b32b6a2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:56.320660+00:00","export_uri":null,"id":"e277f123-698d-4d8c-be5e-1c098f6644f2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.347282+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-hertz","id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:22.717411+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"71fbae84-e539-43e3-b005-10d1fb69ea99","modification_date":"2024-10-14T09:05:22.717411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f7bbdae8-5ab4-4536-bcdc-cd613f449c86","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"1401","node_id":"15","platform_id":"23","zone_id":"nl-ams-1"},"mac_address":"de:00:00:42:a0:05","maintenances":[],"modification_date":"2025-02-11T14:22:46.732791+00:00","name":"tf-srv-bold-hertz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"89136d0f-11b8-4f5f-8db2-c0778ee5fed8","volume_type":"sbs_volume","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.236981+00:00","export_uri":null,"id":"43d46d3d-d5e5-48c8-879f-d0af9a680db7","modification_date":"2025-02-11T14:22:37.347282+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","name":"tf-srv-bold-hertz"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
         headers:
             Content-Length:
-                - "2738"
+                - "2287"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:32 GMT
+                - Tue, 11 Feb 2025 14:22:52 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1548,10 +1548,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a82587c5-3ffc-4545-9f99-79047cc98a71
+                - 0b6ded48-99e6-4cd7-9a03-ca4433536477
         status: 200 OK
         code: 200
-        duration: 185.812667ms
+        duration: 219.662833ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1567,8 +1567,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/b592b445-a82a-4d80-82c9-7851d57d6ced
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3ded52fe-89a1-44b2-a06e-3152cc12605c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1576,20 +1576,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2738
+        content_length: 2287
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:57.460930+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-kepler","id":"b592b445-a82a-4d80-82c9-7851d57d6ced","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:27.368621+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"eb44fed4-fc9f-46bb-9085-6a7343847a8b","modification_date":"2024-10-14T09:05:27.368621+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"cf215cac-3791-430e-8208-99725a5858bd","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"2002","node_id":"42","platform_id":"23","zone_id":"nl-ams-1"},"mac_address":"de:00:00:41:9a:ed","maintenances":[],"modification_date":"2025-01-27T13:53:27.121878+00:00","name":"tf-srv-tender-kepler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:57.460930+00:00","export_uri":null,"id":"47a3cd02-ccbe-4d55-b783-7fae6b32b6a2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:56.320660+00:00","export_uri":null,"id":"e277f123-698d-4d8c-be5e-1c098f6644f2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.347282+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-hertz","id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:22.717411+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"71fbae84-e539-43e3-b005-10d1fb69ea99","modification_date":"2024-10-14T09:05:22.717411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f7bbdae8-5ab4-4536-bcdc-cd613f449c86","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"1401","node_id":"15","platform_id":"23","zone_id":"nl-ams-1"},"mac_address":"de:00:00:42:a0:05","maintenances":[],"modification_date":"2025-02-11T14:22:46.732791+00:00","name":"tf-srv-bold-hertz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"89136d0f-11b8-4f5f-8db2-c0778ee5fed8","volume_type":"sbs_volume","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.236981+00:00","export_uri":null,"id":"43d46d3d-d5e5-48c8-879f-d0af9a680db7","modification_date":"2025-02-11T14:22:37.347282+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","name":"tf-srv-bold-hertz"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
         headers:
             Content-Length:
-                - "2738"
+                - "2287"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:37 GMT
+                - Tue, 11 Feb 2025 14:22:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1597,10 +1597,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fdd9ec5d-1640-4ae1-84bb-622d2f269124
+                - 372014cd-ceae-4a90-95cb-7885930414b4
         status: 200 OK
         code: 200
-        duration: 169.55125ms
+        duration: 214.656834ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1616,8 +1616,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/b592b445-a82a-4d80-82c9-7851d57d6ced
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3ded52fe-89a1-44b2-a06e-3152cc12605c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1625,20 +1625,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2738
+        content_length: 2287
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:57.460930+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-kepler","id":"b592b445-a82a-4d80-82c9-7851d57d6ced","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:27.368621+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"eb44fed4-fc9f-46bb-9085-6a7343847a8b","modification_date":"2024-10-14T09:05:27.368621+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"cf215cac-3791-430e-8208-99725a5858bd","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"2002","node_id":"42","platform_id":"23","zone_id":"nl-ams-1"},"mac_address":"de:00:00:41:9a:ed","maintenances":[],"modification_date":"2025-01-27T13:53:27.121878+00:00","name":"tf-srv-tender-kepler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:57.460930+00:00","export_uri":null,"id":"47a3cd02-ccbe-4d55-b783-7fae6b32b6a2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:56.320660+00:00","export_uri":null,"id":"e277f123-698d-4d8c-be5e-1c098f6644f2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.347282+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-hertz","id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:22.717411+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"71fbae84-e539-43e3-b005-10d1fb69ea99","modification_date":"2024-10-14T09:05:22.717411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f7bbdae8-5ab4-4536-bcdc-cd613f449c86","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"1401","node_id":"15","platform_id":"23","zone_id":"nl-ams-1"},"mac_address":"de:00:00:42:a0:05","maintenances":[],"modification_date":"2025-02-11T14:22:46.732791+00:00","name":"tf-srv-bold-hertz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"89136d0f-11b8-4f5f-8db2-c0778ee5fed8","volume_type":"sbs_volume","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.236981+00:00","export_uri":null,"id":"43d46d3d-d5e5-48c8-879f-d0af9a680db7","modification_date":"2025-02-11T14:22:37.347282+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","name":"tf-srv-bold-hertz"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
         headers:
             Content-Length:
-                - "2738"
+                - "2287"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:42 GMT
+                - Tue, 11 Feb 2025 14:23:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1646,10 +1646,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 53aa762f-28b4-4fca-920e-555efb136826
+                - 3d83e794-c270-4fe6-8535-0187b393c514
         status: 200 OK
         code: 200
-        duration: 182.161209ms
+        duration: 196.069333ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1665,8 +1665,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/b592b445-a82a-4d80-82c9-7851d57d6ced
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3ded52fe-89a1-44b2-a06e-3152cc12605c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1674,20 +1674,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2738
+        content_length: 2287
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:57.460930+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-kepler","id":"b592b445-a82a-4d80-82c9-7851d57d6ced","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:27.368621+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"eb44fed4-fc9f-46bb-9085-6a7343847a8b","modification_date":"2024-10-14T09:05:27.368621+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"cf215cac-3791-430e-8208-99725a5858bd","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"2002","node_id":"42","platform_id":"23","zone_id":"nl-ams-1"},"mac_address":"de:00:00:41:9a:ed","maintenances":[],"modification_date":"2025-01-27T13:53:27.121878+00:00","name":"tf-srv-tender-kepler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:57.460930+00:00","export_uri":null,"id":"47a3cd02-ccbe-4d55-b783-7fae6b32b6a2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:56.320660+00:00","export_uri":null,"id":"e277f123-698d-4d8c-be5e-1c098f6644f2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.347282+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-hertz","id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:22.717411+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"71fbae84-e539-43e3-b005-10d1fb69ea99","modification_date":"2024-10-14T09:05:22.717411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f7bbdae8-5ab4-4536-bcdc-cd613f449c86","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"1401","node_id":"15","platform_id":"23","zone_id":"nl-ams-1"},"mac_address":"de:00:00:42:a0:05","maintenances":[],"modification_date":"2025-02-11T14:22:46.732791+00:00","name":"tf-srv-bold-hertz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"89136d0f-11b8-4f5f-8db2-c0778ee5fed8","volume_type":"sbs_volume","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.236981+00:00","export_uri":null,"id":"43d46d3d-d5e5-48c8-879f-d0af9a680db7","modification_date":"2025-02-11T14:22:37.347282+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","name":"tf-srv-bold-hertz"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
         headers:
             Content-Length:
-                - "2738"
+                - "2287"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:47 GMT
+                - Tue, 11 Feb 2025 14:23:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1695,10 +1695,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b8233850-67b4-4469-bdcf-d0c33dce5d1c
+                - 6419b480-8aa2-4d45-8f4e-dd444887a27c
         status: 200 OK
         code: 200
-        duration: 196.387833ms
+        duration: 204.390542ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1714,8 +1714,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/b592b445-a82a-4d80-82c9-7851d57d6ced
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3ded52fe-89a1-44b2-a06e-3152cc12605c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1723,20 +1723,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2738
+        content_length: 2287
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:57.460930+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-kepler","id":"b592b445-a82a-4d80-82c9-7851d57d6ced","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:27.368621+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"eb44fed4-fc9f-46bb-9085-6a7343847a8b","modification_date":"2024-10-14T09:05:27.368621+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"cf215cac-3791-430e-8208-99725a5858bd","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"2002","node_id":"42","platform_id":"23","zone_id":"nl-ams-1"},"mac_address":"de:00:00:41:9a:ed","maintenances":[],"modification_date":"2025-01-27T13:53:27.121878+00:00","name":"tf-srv-tender-kepler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:57.460930+00:00","export_uri":null,"id":"47a3cd02-ccbe-4d55-b783-7fae6b32b6a2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:56.320660+00:00","export_uri":null,"id":"e277f123-698d-4d8c-be5e-1c098f6644f2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.347282+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-hertz","id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:22.717411+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"71fbae84-e539-43e3-b005-10d1fb69ea99","modification_date":"2024-10-14T09:05:22.717411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f7bbdae8-5ab4-4536-bcdc-cd613f449c86","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"1401","node_id":"15","platform_id":"23","zone_id":"nl-ams-1"},"mac_address":"de:00:00:42:a0:05","maintenances":[],"modification_date":"2025-02-11T14:22:46.732791+00:00","name":"tf-srv-bold-hertz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"89136d0f-11b8-4f5f-8db2-c0778ee5fed8","volume_type":"sbs_volume","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.236981+00:00","export_uri":null,"id":"43d46d3d-d5e5-48c8-879f-d0af9a680db7","modification_date":"2025-02-11T14:22:37.347282+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","name":"tf-srv-bold-hertz"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
         headers:
             Content-Length:
-                - "2738"
+                - "2287"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:53 GMT
+                - Tue, 11 Feb 2025 14:23:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1744,10 +1744,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6dac52a5-35db-4ad2-9c49-f971b6ef68a3
+                - 2b903d21-88b5-46a3-9177-f28a6f71af69
         status: 200 OK
         code: 200
-        duration: 170.115125ms
+        duration: 205.883625ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1763,8 +1763,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/b592b445-a82a-4d80-82c9-7851d57d6ced
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3ded52fe-89a1-44b2-a06e-3152cc12605c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1772,20 +1772,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2738
+        content_length: 2287
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:57.460930+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-kepler","id":"b592b445-a82a-4d80-82c9-7851d57d6ced","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:27.368621+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"eb44fed4-fc9f-46bb-9085-6a7343847a8b","modification_date":"2024-10-14T09:05:27.368621+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"cf215cac-3791-430e-8208-99725a5858bd","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"2002","node_id":"42","platform_id":"23","zone_id":"nl-ams-1"},"mac_address":"de:00:00:41:9a:ed","maintenances":[],"modification_date":"2025-01-27T13:53:27.121878+00:00","name":"tf-srv-tender-kepler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:57.460930+00:00","export_uri":null,"id":"47a3cd02-ccbe-4d55-b783-7fae6b32b6a2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:56.320660+00:00","export_uri":null,"id":"e277f123-698d-4d8c-be5e-1c098f6644f2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.347282+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-hertz","id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:22.717411+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"71fbae84-e539-43e3-b005-10d1fb69ea99","modification_date":"2024-10-14T09:05:22.717411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f7bbdae8-5ab4-4536-bcdc-cd613f449c86","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"1401","node_id":"15","platform_id":"23","zone_id":"nl-ams-1"},"mac_address":"de:00:00:42:a0:05","maintenances":[],"modification_date":"2025-02-11T14:22:46.732791+00:00","name":"tf-srv-bold-hertz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"89136d0f-11b8-4f5f-8db2-c0778ee5fed8","volume_type":"sbs_volume","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.236981+00:00","export_uri":null,"id":"43d46d3d-d5e5-48c8-879f-d0af9a680db7","modification_date":"2025-02-11T14:22:37.347282+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","name":"tf-srv-bold-hertz"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
         headers:
             Content-Length:
-                - "2738"
+                - "2287"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:59 GMT
+                - Tue, 11 Feb 2025 14:23:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1793,10 +1793,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f23e55f6-f6fd-44f2-89bd-8a3e954eed26
+                - 051a065f-a029-4aeb-8d75-2a8ccab19266
         status: 200 OK
         code: 200
-        duration: 193.857709ms
+        duration: 404.9955ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1812,8 +1812,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/b592b445-a82a-4d80-82c9-7851d57d6ced
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3ded52fe-89a1-44b2-a06e-3152cc12605c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1821,20 +1821,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2738
+        content_length: 2170
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:57.460930+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-kepler","id":"b592b445-a82a-4d80-82c9-7851d57d6ced","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:27.368621+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"eb44fed4-fc9f-46bb-9085-6a7343847a8b","modification_date":"2024-10-14T09:05:27.368621+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"cf215cac-3791-430e-8208-99725a5858bd","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"2002","node_id":"42","platform_id":"23","zone_id":"nl-ams-1"},"mac_address":"de:00:00:41:9a:ed","maintenances":[],"modification_date":"2025-01-27T13:53:27.121878+00:00","name":"tf-srv-tender-kepler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:57.460930+00:00","export_uri":null,"id":"47a3cd02-ccbe-4d55-b783-7fae6b32b6a2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:56.320660+00:00","export_uri":null,"id":"e277f123-698d-4d8c-be5e-1c098f6644f2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.347282+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-hertz","id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:22.717411+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"71fbae84-e539-43e3-b005-10d1fb69ea99","modification_date":"2024-10-14T09:05:22.717411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f7bbdae8-5ab4-4536-bcdc-cd613f449c86","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:42:a0:05","maintenances":[],"modification_date":"2025-02-11T14:23:20.377551+00:00","name":"tf-srv-bold-hertz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"89136d0f-11b8-4f5f-8db2-c0778ee5fed8","volume_type":"sbs_volume","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.236981+00:00","export_uri":null,"id":"43d46d3d-d5e5-48c8-879f-d0af9a680db7","modification_date":"2025-02-11T14:22:37.347282+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","name":"tf-srv-bold-hertz"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
         headers:
             Content-Length:
-                - "2738"
+                - "2170"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:04 GMT
+                - Tue, 11 Feb 2025 14:23:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1842,10 +1842,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 18411d65-3d94-4455-8c4a-593f6906678e
+                - c2c8ac67-1a59-4bfd-8a79-47d4c3166238
         status: 200 OK
         code: 200
-        duration: 150.570583ms
+        duration: 174.576375ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1861,8 +1861,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/b592b445-a82a-4d80-82c9-7851d57d6ced
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3ded52fe-89a1-44b2-a06e-3152cc12605c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1870,20 +1870,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2738
+        content_length: 2170
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:57.460930+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-kepler","id":"b592b445-a82a-4d80-82c9-7851d57d6ced","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:27.368621+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"eb44fed4-fc9f-46bb-9085-6a7343847a8b","modification_date":"2024-10-14T09:05:27.368621+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"cf215cac-3791-430e-8208-99725a5858bd","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"2002","node_id":"42","platform_id":"23","zone_id":"nl-ams-1"},"mac_address":"de:00:00:41:9a:ed","maintenances":[],"modification_date":"2025-01-27T13:53:27.121878+00:00","name":"tf-srv-tender-kepler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:57.460930+00:00","export_uri":null,"id":"47a3cd02-ccbe-4d55-b783-7fae6b32b6a2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:56.320660+00:00","export_uri":null,"id":"e277f123-698d-4d8c-be5e-1c098f6644f2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.347282+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-hertz","id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:22.717411+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"71fbae84-e539-43e3-b005-10d1fb69ea99","modification_date":"2024-10-14T09:05:22.717411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"f7bbdae8-5ab4-4536-bcdc-cd613f449c86","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:42:a0:05","maintenances":[],"modification_date":"2025-02-11T14:23:20.377551+00:00","name":"tf-srv-bold-hertz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"89136d0f-11b8-4f5f-8db2-c0778ee5fed8","volume_type":"sbs_volume","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.236981+00:00","export_uri":null,"id":"43d46d3d-d5e5-48c8-879f-d0af9a680db7","modification_date":"2025-02-11T14:22:37.347282+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","name":"tf-srv-bold-hertz"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
         headers:
             Content-Length:
-                - "2738"
+                - "2170"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:09 GMT
+                - Tue, 11 Feb 2025 14:23:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1891,10 +1891,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ff03511c-4d2a-41af-a0ea-2550a9c13b90
+                - ae66b7bd-6e57-437d-8dd3-f2ee2802ef7c
         status: 200 OK
         code: 200
-        duration: 185.607208ms
+        duration: 194.891958ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1910,29 +1910,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/b592b445-a82a-4d80-82c9-7851d57d6ced
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3ded52fe-89a1-44b2-a06e-3152cc12605c
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2621
+        content_length: 0
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:57.460930+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-kepler","id":"b592b445-a82a-4d80-82c9-7851d57d6ced","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:27.368621+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"eb44fed4-fc9f-46bb-9085-6a7343847a8b","modification_date":"2024-10-14T09:05:27.368621+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"cf215cac-3791-430e-8208-99725a5858bd","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:41:9a:ed","maintenances":[],"modification_date":"2025-01-27T13:54:11.861376+00:00","name":"tf-srv-tender-kepler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:57.460930+00:00","export_uri":null,"id":"47a3cd02-ccbe-4d55-b783-7fae6b32b6a2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:56.320660+00:00","export_uri":null,"id":"e277f123-698d-4d8c-be5e-1c098f6644f2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
+        body: ""
         headers:
-            Content-Length:
-                - "2621"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:14 GMT
+                - Tue, 11 Feb 2025 14:23:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1940,10 +1938,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 71506bea-6645-4ba0-a1fe-e3755ea086af
-        status: 200 OK
-        code: 200
-        duration: 183.039708ms
+                - 476961b1-3da7-47db-bcf8-464b367c885a
+        status: 204 No Content
+        code: 204
+        duration: 501.363791ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1959,8 +1957,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/b592b445-a82a-4d80-82c9-7851d57d6ced
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3ded52fe-89a1-44b2-a06e-3152cc12605c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1968,20 +1966,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2621
+        content_length: 143
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:57.460930+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-kepler","id":"b592b445-a82a-4d80-82c9-7851d57d6ced","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:27.368621+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"eb44fed4-fc9f-46bb-9085-6a7343847a8b","modification_date":"2024-10-14T09:05:27.368621+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"cf215cac-3791-430e-8208-99725a5858bd","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"nl-ams-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:41:9a:ed","maintenances":[],"modification_date":"2025-01-27T13:54:11.861376+00:00","name":"tf-srv-tender-kepler","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"d19f1a5a-7605-4ed3-8cf0-0e93a7889d7b","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:57.460930+00:00","export_uri":null,"id":"47a3cd02-ccbe-4d55-b783-7fae6b32b6a2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"nl-ams-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:56.320660+00:00","export_uri":null,"id":"e277f123-698d-4d8c-be5e-1c098f6644f2","modification_date":"2025-01-27T13:52:57.460930+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b592b445-a82a-4d80-82c9-7851d57d6ced","name":"tf-srv-tender-kepler"},"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}},"zone":"nl-ams-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","type":"not_found"}'
         headers:
             Content-Length:
-                - "2621"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:15 GMT
+                - Tue, 11 Feb 2025 14:23:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1989,10 +1987,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - aed03258-c8dc-4246-ada8-b6eb6de56e00
-        status: 200 OK
-        code: 200
-        duration: 159.987708ms
+                - c2603872-f8d7-4e78-9424-4dc82994562c
+        status: 404 Not Found
+        code: 404
+        duration: 209.402167ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2008,27 +2006,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/b592b445-a82a-4d80-82c9-7851d57d6ced
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/89136d0f-11b8-4f5f-8db2-c0778ee5fed8
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 143
         uncompressed: false
-        body: ""
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"89136d0f-11b8-4f5f-8db2-c0778ee5fed8","type":"not_found"}'
         headers:
+            Content-Length:
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:15 GMT
+                - Tue, 11 Feb 2025 14:23:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2036,10 +2036,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4026b509-bef4-4bc8-a0ab-1dd5fe63d3f5
-        status: 204 No Content
-        code: 204
-        duration: 229.248375ms
+                - c94a9166-891c-4a4c-b474-acd6575e214f
+        status: 404 Not Found
+        code: 404
+        duration: 50.068167ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2055,8 +2055,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/b592b445-a82a-4d80-82c9-7851d57d6ced
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/nl-ams-1/volumes/89136d0f-11b8-4f5f-8db2-c0778ee5fed8
         method: GET
       response:
         proto: HTTP/2.0
@@ -2064,20 +2064,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 143
+        content_length: 494
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"b592b445-a82a-4d80-82c9-7851d57d6ced","type":"not_found"}'
+        body: '{"created_at":"2025-02-11T14:22:37.576522Z","id":"89136d0f-11b8-4f5f-8db2-c0778ee5fed8","last_detached_at":"2025-02-11T14:23:24.775018Z","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"f7bbdae8-5ab4-4536-bcdc-cd613f449c86","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":20000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:24.775018Z","zone":"nl-ams-1"}'
         headers:
             Content-Length:
-                - "143"
+                - "494"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:15 GMT
+                - Tue, 11 Feb 2025 14:23:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2085,10 +2085,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6e526b0f-f09b-4a4a-b7b6-86fe9f44109b
-        status: 404 Not Found
-        code: 404
-        duration: 100.405458ms
+                - 18729f98-779f-4d7e-8371-2232cb999455
+        status: 200 OK
+        code: 200
+        duration: 81.18325ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2104,29 +2104,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/47a3cd02-ccbe-4d55-b783-7fae6b32b6a2
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/nl-ams-1/volumes/89136d0f-11b8-4f5f-8db2-c0778ee5fed8
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 446
+        content_length: 0
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:52:57.460930+00:00","export_uri":null,"id":"47a3cd02-ccbe-4d55-b783-7fae6b32b6a2","modification_date":"2025-01-27T13:54:15.324501+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"nl-ams-1"}}'
+        body: ""
         headers:
-            Content-Length:
-                - "446"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:15 GMT
+                - Tue, 11 Feb 2025 14:23:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2134,10 +2132,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 59554f0d-2ea5-461f-b6b1-090294057f7c
-        status: 200 OK
-        code: 200
-        duration: 98.115583ms
+                - e17b217f-79b0-4fb5-b42b-622a1fbd6c7b
+        status: 204 No Content
+        code: 204
+        duration: 162.453833ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2153,27 +2151,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/47a3cd02-ccbe-4d55-b783-7fae6b32b6a2
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/43d46d3d-d5e5-48c8-879f-d0af9a680db7
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 425
         uncompressed: false
-        body: ""
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:36.236981+00:00","export_uri":null,"id":"43d46d3d-d5e5-48c8-879f-d0af9a680db7","modification_date":"2025-02-11T14:23:24.269801+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}}'
         headers:
+            Content-Length:
+                - "425"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:15 GMT
+                - Tue, 11 Feb 2025 14:23:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2181,10 +2181,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d51418f3-bb44-4a92-a613-8d0239ef5c6a
-        status: 204 No Content
-        code: 204
-        duration: 174.03475ms
+                - 79498266-3f14-4834-8ec2-050f72cb191f
+        status: 200 OK
+        code: 200
+        duration: 102.717542ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2200,57 +2200,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/e277f123-698d-4d8c-be5e-1c098f6644f2
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 425
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:52:56.320660+00:00","export_uri":null,"id":"e277f123-698d-4d8c-be5e-1c098f6644f2","modification_date":"2025-01-27T13:54:15.324501+00:00","name":"main","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":1000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"nl-ams-1"}}'
-        headers:
-            Content-Length:
-                - "425"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:54:15 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 7c2decfa-0c91-4a0e-9d08-0687aa0329a0
-        status: 200 OK
-        code: 200
-        duration: 101.140792ms
-    - id: 45
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/e277f123-698d-4d8c-be5e-1c098f6644f2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/43d46d3d-d5e5-48c8-879f-d0af9a680db7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2267,9 +2218,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:15 GMT
+                - Tue, 11 Feb 2025 14:23:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2277,11 +2228,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d3a214f2-8379-40fb-99c8-1b0f049014da
+                - 2e247b56-641f-476d-bd32-927431a59aea
         status: 204 No Content
         code: 204
-        duration: 192.176542ms
-    - id: 46
+        duration: 168.746541ms
+    - id: 45
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2296,8 +2247,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/b592b445-a82a-4d80-82c9-7851d57d6ced
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3ded52fe-89a1-44b2-a06e-3152cc12605c
         method: GET
       response:
         proto: HTTP/2.0
@@ -2307,7 +2258,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"b592b445-a82a-4d80-82c9-7851d57d6ced","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"3ded52fe-89a1-44b2-a06e-3152cc12605c","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -2316,9 +2267,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:16 GMT
+                - Tue, 11 Feb 2025 14:23:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2326,7 +2277,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a38ff916-3a14-4fa4-a422-40ec42cfb9a9
+                - e197bd84-3988-424d-995a-bb9e85ae8354
         status: 404 Not Found
         code: 404
-        duration: 108.343333ms
+        duration: 158.417291ms

--- a/internal/services/instance/testdata/server-user-data-basic.cassette.yaml
+++ b/internal/services/instance/testdata/server-user-data-basic.cassette.yaml
@@ -16,7 +16,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
         method: GET
       response:
@@ -25,22 +25,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 38539
+        content_length: 35639
         uncompressed: false
-        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
+        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
         headers:
             Content-Length:
-                - "38539"
+                - "35639"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:41 GMT
+                - Tue, 11 Feb 2025 14:22:35 GMT
             Link:
                 - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,12 +48,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 59d2fb6a-4cfe-4298-968f-2297b9779e8f
+                - 40c07554-74e4-43aa-be28-49abf49e0e6b
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 75.617875ms
+        duration: 371.013916ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -69,7 +69,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
         method: GET
       response:
@@ -78,22 +78,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 14208
+        content_length: 13164
         uncompressed: false
-        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
         headers:
             Content-Length:
-                - "14208"
+                - "13164"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:42 GMT
+                - Tue, 11 Feb 2025 14:22:36 GMT
             Link:
                 - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -101,12 +101,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 653397ca-08fe-478c-a03d-4b0b4a17dfe1
+                - 3824e702-5eec-48a7-b725-d2b380b937f4
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 54.012833ms
+        duration: 49.624625ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -122,8 +122,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_local&zone=fr-par-1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_sbs&zone=fr-par-1
         method: GET
       response:
         proto: HTTP/2.0
@@ -131,20 +131,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1300
+        content_length: 1296
         uncompressed: false
-        body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"56d4019c-8305-467a-a3f2-70498ad799df","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
+        body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"57509e82-ac3b-49b7-9970-97b60f40ff72","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"9b647e1e-253a-41e7-8c15-911c622ee2dc","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"}],"total_count":2}'
         headers:
             Content-Length:
-                - "1300"
+                - "1296"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:42 GMT
+                - Tue, 11 Feb 2025 14:22:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -152,28 +152,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e650d75f-be72-482e-8391-8c0c1ce25fab
+                - 38742930-e9d4-4c7a-b55f-fed4240ccef3
         status: 200 OK
         code: 200
-        duration: 82.068042ms
+        duration: 134.420917ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 276
+        content_length: 234
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-srv-youthful-keller","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+        body: '{"name":"tf-srv-pensive-swartz","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"57509e82-ac3b-49b7-9970-97b60f40ff72","volumes":{"0":{"boot":false}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
         method: POST
       response:
@@ -182,22 +182,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2118
+        content_length: 1672
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:42.688752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-keller","id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:9d","maintenances":[],"modification_date":"2025-01-27T13:47:42.688752+00:00","name":"tf-srv-youthful-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:42.688752+00:00","export_uri":null,"id":"32c7e95f-6250-4759-baff-a5834f4736da","modification_date":"2025-01-27T13:47:42.688752+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","name":"tf-srv-youthful-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.442075+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-swartz","id":"35fef105-bbe6-4bae-aa38-a83dc863c9ea","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:d1","maintenances":[],"modification_date":"2025-02-11T14:22:36.442075+00:00","name":"tf-srv-pensive-swartz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"dc31edbb-ec76-4d64-a580-032b08ab0d0c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2118"
+                - "1672"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:42 GMT
+                - Tue, 11 Feb 2025 14:22:37 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -205,10 +205,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7c4f334b-9362-431a-a705-bb6022de1124
+                - b692c3c6-2ac2-4c5f-af92-4c1f7e341595
         status: 201 Created
         code: 201
-        duration: 489.021417ms
+        duration: 1.150370084s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -224,8 +224,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea
         method: GET
       response:
         proto: HTTP/2.0
@@ -233,20 +233,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2118
+        content_length: 1672
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:42.688752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-keller","id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:9d","maintenances":[],"modification_date":"2025-01-27T13:47:42.688752+00:00","name":"tf-srv-youthful-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:42.688752+00:00","export_uri":null,"id":"32c7e95f-6250-4759-baff-a5834f4736da","modification_date":"2025-01-27T13:47:42.688752+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","name":"tf-srv-youthful-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.442075+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-swartz","id":"35fef105-bbe6-4bae-aa38-a83dc863c9ea","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:d1","maintenances":[],"modification_date":"2025-02-11T14:22:36.442075+00:00","name":"tf-srv-pensive-swartz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"dc31edbb-ec76-4d64-a580-032b08ab0d0c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2118"
+                - "1672"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:42 GMT
+                - Tue, 11 Feb 2025 14:22:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -254,10 +254,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f56135b4-072c-4a9b-86fc-c3e475727742
+                - 357dbb8e-c1c8-4c2b-889c-9d0a8769e274
         status: 200 OK
         code: 200
-        duration: 161.288375ms
+        duration: 163.830667ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -273,8 +273,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea
         method: GET
       response:
         proto: HTTP/2.0
@@ -282,20 +282,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2118
+        content_length: 1672
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:42.688752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-keller","id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:9d","maintenances":[],"modification_date":"2025-01-27T13:47:42.688752+00:00","name":"tf-srv-youthful-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:42.688752+00:00","export_uri":null,"id":"32c7e95f-6250-4759-baff-a5834f4736da","modification_date":"2025-01-27T13:47:42.688752+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","name":"tf-srv-youthful-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.442075+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-swartz","id":"35fef105-bbe6-4bae-aa38-a83dc863c9ea","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:d1","maintenances":[],"modification_date":"2025-02-11T14:22:36.442075+00:00","name":"tf-srv-pensive-swartz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"dc31edbb-ec76-4d64-a580-032b08ab0d0c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2118"
+                - "1672"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:43 GMT
+                - Tue, 11 Feb 2025 14:22:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -303,11 +303,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 18fae58f-6f46-4d90-9acf-8669a4c086be
+                - a2e6eacd-aed0-4e27-b252-710f8176d462
         status: 200 OK
         code: 200
-        duration: 406.305709ms
+        duration: 204.338916ms
     - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/dc31edbb-ec76-4d64-a580-032b08ab0d0c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:22:36.668230Z","id":"dc31edbb-ec76-4d64-a580-032b08ab0d0c","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:36.668230Z","id":"19a373d4-c004-4a2e-8c29-8ddfec3dfa4e","product_resource_id":"35fef105-bbe6-4bae-aa38-a83dc863c9ea","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:36.668230Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:22:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - afe2ab2e-2894-4cb9-9be0-c88f09ef19e8
+        status: 200 OK
+        code: 200
+        duration: 91.967834ms
+    - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -324,8 +373,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -335,7 +384,7 @@ interactions:
         trailer: {}
         content_length: 357
         uncompressed: false
-        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97/action","href_result":"/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97","id":"b5972bad-1f70-4ddf-af15-93000b5c640e","progress":0,"started_at":"2025-01-27T13:47:43.903658+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea/action","href_result":"/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea","id":"47b40999-d9a5-4764-953d-5a140e9ecfa9","progress":0,"started_at":"2025-02-11T14:22:38.283103+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -344,11 +393,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:43 GMT
+                - Tue, 11 Feb 2025 14:22:37 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/b5972bad-1f70-4ddf-af15-93000b5c640e
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/47b40999-d9a5-4764-953d-5a140e9ecfa9
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -356,59 +405,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1c41457c-2158-4048-97c4-b913ae59d78a
+                - 30b620bb-b135-4da2-860e-53281a7d4107
         status: 202 Accepted
         code: 202
-        duration: 476.941875ms
-    - id: 7
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2140
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:42.688752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-keller","id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:9d","maintenances":[],"modification_date":"2025-01-27T13:47:43.534210+00:00","name":"tf-srv-youthful-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:42.688752+00:00","export_uri":null,"id":"32c7e95f-6250-4759-baff-a5834f4736da","modification_date":"2025-01-27T13:47:42.688752+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","name":"tf-srv-youthful-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2140"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:47:43 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 62ec11fb-d35f-45ea-87a8-0858a754bd17
-        status: 200 OK
-        code: 200
-        duration: 162.628208ms
+        duration: 452.264417ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -424,8 +424,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea
         method: GET
       response:
         proto: HTTP/2.0
@@ -433,20 +433,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2243
+        content_length: 1694
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:42.688752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-keller","id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"802","node_id":"33","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:9d","maintenances":[],"modification_date":"2025-01-27T13:47:43.534210+00:00","name":"tf-srv-youthful-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:42.688752+00:00","export_uri":null,"id":"32c7e95f-6250-4759-baff-a5834f4736da","modification_date":"2025-01-27T13:47:42.688752+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","name":"tf-srv-youthful-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.442075+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-swartz","id":"35fef105-bbe6-4bae-aa38-a83dc863c9ea","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:d1","maintenances":[],"modification_date":"2025-02-11T14:22:37.889548+00:00","name":"tf-srv-pensive-swartz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"id":"dc31edbb-ec76-4d64-a580-032b08ab0d0c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2243"
+                - "1694"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:49 GMT
+                - Tue, 11 Feb 2025 14:22:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -454,10 +454,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e85f62bd-9722-44f7-803e-a75eb0ef6cf4
+                - a7a39e56-626b-4ad4-a745-5223ca1a7079
         status: 200 OK
         code: 200
-        duration: 144.169625ms
+        duration: 168.473834ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -473,8 +473,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea
         method: GET
       response:
         proto: HTTP/2.0
@@ -482,20 +482,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2274
+        content_length: 1828
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:42.688752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-keller","id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"802","node_id":"33","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:9d","maintenances":[],"modification_date":"2025-01-27T13:47:53.748126+00:00","name":"tf-srv-youthful-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:42.688752+00:00","export_uri":null,"id":"32c7e95f-6250-4759-baff-a5834f4736da","modification_date":"2025-01-27T13:47:42.688752+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","name":"tf-srv-youthful-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.442075+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-swartz","id":"35fef105-bbe6-4bae-aa38-a83dc863c9ea","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"48","hypervisor_id":"201","node_id":"12","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:d1","maintenances":[],"modification_date":"2025-02-11T14:22:42.174812+00:00","name":"tf-srv-pensive-swartz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"dc31edbb-ec76-4d64-a580-032b08ab0d0c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2274"
+                - "1828"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:54 GMT
+                - Tue, 11 Feb 2025 14:22:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -503,10 +503,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - eb4c9289-b0e8-4525-8039-2f88964cce62
+                - 306d0e6f-7506-400d-a5c2-d991e299c6a7
         status: 200 OK
         code: 200
-        duration: 155.193042ms
+        duration: 187.608125ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -522,8 +522,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea
         method: GET
       response:
         proto: HTTP/2.0
@@ -531,20 +531,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2274
+        content_length: 1828
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:42.688752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-keller","id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"802","node_id":"33","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:9d","maintenances":[],"modification_date":"2025-01-27T13:47:53.748126+00:00","name":"tf-srv-youthful-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:42.688752+00:00","export_uri":null,"id":"32c7e95f-6250-4759-baff-a5834f4736da","modification_date":"2025-01-27T13:47:42.688752+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","name":"tf-srv-youthful-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.442075+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-swartz","id":"35fef105-bbe6-4bae-aa38-a83dc863c9ea","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"48","hypervisor_id":"201","node_id":"12","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:d1","maintenances":[],"modification_date":"2025-02-11T14:22:42.174812+00:00","name":"tf-srv-pensive-swartz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"dc31edbb-ec76-4d64-a580-032b08ab0d0c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2274"
+                - "1828"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:54 GMT
+                - Tue, 11 Feb 2025 14:22:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -552,10 +552,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9431a633-b883-46af-a8ad-59db890c30e0
+                - c03515e2-77d7-40b7-af55-5674b798ada1
         status: 200 OK
         code: 200
-        duration: 190.094167ms
+        duration: 144.68275ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -571,8 +571,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/32c7e95f-6250-4759-baff-a5834f4736da
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/dc31edbb-ec76-4d64-a580-032b08ab0d0c
         method: GET
       response:
         proto: HTTP/2.0
@@ -580,20 +580,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 522
+        content_length: 143
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:47:42.688752+00:00","export_uri":null,"id":"32c7e95f-6250-4759-baff-a5834f4736da","modification_date":"2025-01-27T13:47:42.688752+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","name":"tf-srv-youthful-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"dc31edbb-ec76-4d64-a580-032b08ab0d0c","type":"not_found"}'
         headers:
             Content-Length:
-                - "522"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:54 GMT
+                - Tue, 11 Feb 2025 14:22:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -601,10 +601,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 18b4d693-df68-4d1f-ad32-4f5d0d5dacf8
-        status: 200 OK
-        code: 200
-        duration: 97.492208ms
+                - db12a005-2d91-4ca7-aeaf-4c61fdbbf540
+        status: 404 Not Found
+        code: 404
+        duration: 64.470583ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -620,8 +620,57 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/dc31edbb-ec76-4d64-a580-032b08ab0d0c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:22:36.668230Z","id":"dc31edbb-ec76-4d64-a580-032b08ab0d0c","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:36.668230Z","id":"19a373d4-c004-4a2e-8c29-8ddfec3dfa4e","product_resource_id":"35fef105-bbe6-4bae-aa38-a83dc863c9ea","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:36.668230Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:22:43 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f77c836b-fee4-47f3-85e0-9c7c1912fb4a
+        status: 200 OK
+        code: 200
+        duration: 69.706709ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -640,9 +689,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:54 GMT
+                - Tue, 11 Feb 2025 14:22:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -650,11 +699,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4133c556-cc13-4a17-8c5c-374c3e456f9a
+                - 388ac2d6-fb27-49b1-bb36-64a5893067b3
         status: 200 OK
         code: 200
-        duration: 89.141ms
-    - id: 13
+        duration: 79.249084ms
+    - id: 14
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -669,8 +718,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -689,11 +738,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:54 GMT
+                - Tue, 11 Feb 2025 14:22:43 GMT
             Link:
-                - </servers/584f617b-c9cf-4cc8-952a-e3613cd70b97/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -701,13 +750,13 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f8b3bcde-568e-4736-989f-0a2830923ec5
+                - f7670703-0cc9-4a79-a890-b550f5b5d231
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 96.377084ms
-    - id: 14
+        duration: 76.220375ms
+    - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -722,8 +771,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea
         method: GET
       response:
         proto: HTTP/2.0
@@ -731,20 +780,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2274
+        content_length: 1828
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:42.688752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-keller","id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"802","node_id":"33","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:9d","maintenances":[],"modification_date":"2025-01-27T13:47:53.748126+00:00","name":"tf-srv-youthful-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:42.688752+00:00","export_uri":null,"id":"32c7e95f-6250-4759-baff-a5834f4736da","modification_date":"2025-01-27T13:47:42.688752+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","name":"tf-srv-youthful-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.442075+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-swartz","id":"35fef105-bbe6-4bae-aa38-a83dc863c9ea","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"48","hypervisor_id":"201","node_id":"12","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:d1","maintenances":[],"modification_date":"2025-02-11T14:22:42.174812+00:00","name":"tf-srv-pensive-swartz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"dc31edbb-ec76-4d64-a580-032b08ab0d0c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2274"
+                - "1828"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:54 GMT
+                - Tue, 11 Feb 2025 14:22:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -752,11 +801,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1d4884d6-3288-4375-857b-94f80cfe63de
+                - 5e1008f7-42fa-48bf-9e3d-d383a4000425
         status: 200 OK
         code: 200
-        duration: 188.2875ms
-    - id: 15
+        duration: 156.713208ms
+    - id: 16
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -776,8 +825,8 @@ interactions:
             Content-Type:
                 - text/plain
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97/user_data/cloud-init
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea/user_data/cloud-init
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -794,9 +843,9 @@ interactions:
             Content-Type:
                 - text/plain
             Date:
-                - Mon, 27 Jan 2025 13:47:54 GMT
+                - Tue, 11 Feb 2025 14:22:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -804,59 +853,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 76fee2be-d881-4d21-baee-2481bf07ca9c
+                - 0daf4920-f3c8-41c3-be0f-02afda9a4305
         status: 204 No Content
         code: 204
-        duration: 123.286417ms
-    - id: 16
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2274
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:42.688752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-keller","id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"802","node_id":"33","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:9d","maintenances":[],"modification_date":"2025-01-27T13:47:53.748126+00:00","name":"tf-srv-youthful-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:42.688752+00:00","export_uri":null,"id":"32c7e95f-6250-4759-baff-a5834f4736da","modification_date":"2025-01-27T13:47:42.688752+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","name":"tf-srv-youthful-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2274"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:47:54 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 7424b09a-682a-4272-96be-965ab4ff3025
-        status: 200 OK
-        code: 200
-        duration: 199.486917ms
+        duration: 88.47125ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -872,8 +872,57 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97/user_data/cloud-init
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1828
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.442075+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-swartz","id":"35fef105-bbe6-4bae-aa38-a83dc863c9ea","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"48","hypervisor_id":"201","node_id":"12","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:d1","maintenances":[],"modification_date":"2025-02-11T14:22:42.174812+00:00","name":"tf-srv-pensive-swartz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"dc31edbb-ec76-4d64-a580-032b08ab0d0c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1828"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:22:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 414e85d2-75c6-48ad-9839-956f2680682e
+        status: 200 OK
+        code: 200
+        duration: 173.161834ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea/user_data/cloud-init
         method: GET
       response:
         proto: HTTP/2.0
@@ -895,9 +944,9 @@ interactions:
             Content-Type:
                 - text/plain
             Date:
-                - Mon, 27 Jan 2025 13:47:55 GMT
+                - Tue, 11 Feb 2025 14:22:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -905,59 +954,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2ab15c00-4b22-4a6e-9e5f-ec2af9cd9c7e
+                - 76e2eee7-d35a-479b-b579-4f2da8d3a25b
         status: 200 OK
         code: 200
-        duration: 100.232292ms
-    - id: 18
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2274
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:42.688752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-keller","id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"802","node_id":"33","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:9d","maintenances":[],"modification_date":"2025-01-27T13:47:53.748126+00:00","name":"tf-srv-youthful-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:42.688752+00:00","export_uri":null,"id":"32c7e95f-6250-4759-baff-a5834f4736da","modification_date":"2025-01-27T13:47:42.688752+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","name":"tf-srv-youthful-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2274"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:47:55 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 45af9661-37c6-4bc0-96be-8651dd559860
-        status: 200 OK
-        code: 200
-        duration: 179.826041ms
+        duration: 86.677458ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -973,8 +973,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/32c7e95f-6250-4759-baff-a5834f4736da
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea
         method: GET
       response:
         proto: HTTP/2.0
@@ -982,20 +982,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 522
+        content_length: 1828
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:47:42.688752+00:00","export_uri":null,"id":"32c7e95f-6250-4759-baff-a5834f4736da","modification_date":"2025-01-27T13:47:42.688752+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","name":"tf-srv-youthful-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.442075+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-swartz","id":"35fef105-bbe6-4bae-aa38-a83dc863c9ea","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"48","hypervisor_id":"201","node_id":"12","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:d1","maintenances":[],"modification_date":"2025-02-11T14:22:42.174812+00:00","name":"tf-srv-pensive-swartz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"dc31edbb-ec76-4d64-a580-032b08ab0d0c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "522"
+                - "1828"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:55 GMT
+                - Tue, 11 Feb 2025 14:22:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1003,10 +1003,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3e4a67ed-1b7c-4b34-a2e9-19cac4d5ab76
+                - b4186a52-ca04-4485-8878-233a597c73f3
         status: 200 OK
         code: 200
-        duration: 82.261209ms
+        duration: 173.049584ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1022,8 +1022,106 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/dc31edbb-ec76-4d64-a580-032b08ab0d0c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"dc31edbb-ec76-4d64-a580-032b08ab0d0c","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:22:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 98f554ba-a8c4-412c-a242-1136d0a69bb4
+        status: 404 Not Found
+        code: 404
+        duration: 32.783625ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/dc31edbb-ec76-4d64-a580-032b08ab0d0c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:22:36.668230Z","id":"dc31edbb-ec76-4d64-a580-032b08ab0d0c","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:36.668230Z","id":"19a373d4-c004-4a2e-8c29-8ddfec3dfa4e","product_resource_id":"35fef105-bbe6-4bae-aa38-a83dc863c9ea","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:36.668230Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:22:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c8ab4b68-1ec8-41ca-a25c-91ffd6b84d3e
+        status: 200 OK
+        code: 200
+        duration: 63.16275ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1042,9 +1140,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:55 GMT
+                - Tue, 11 Feb 2025 14:22:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1052,11 +1150,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 003dd4a6-3ad2-404d-b2d2-32b157a59900
+                - 0cdcac58-a29d-4274-a80f-d0c9b43de28d
         status: 200 OK
         code: 200
-        duration: 103.396459ms
-    - id: 21
+        duration: 84.939125ms
+    - id: 23
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1071,8 +1169,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97/user_data/cloud-init
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea/user_data/cloud-init
         method: GET
       response:
         proto: HTTP/2.0
@@ -1094,9 +1192,9 @@ interactions:
             Content-Type:
                 - text/plain
             Date:
-                - Mon, 27 Jan 2025 13:47:55 GMT
+                - Tue, 11 Feb 2025 14:22:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1104,11 +1202,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bf2edc90-5224-4c46-a237-a999940470e9
+                - 729a7a12-ec68-4608-9470-9bfa7cd51ea5
         status: 200 OK
         code: 200
-        duration: 104.535166ms
-    - id: 22
+        duration: 88.126083ms
+    - id: 24
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1123,8 +1221,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1143,11 +1241,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:55 GMT
+                - Tue, 11 Feb 2025 14:22:44 GMT
             Link:
-                - </servers/584f617b-c9cf-4cc8-952a-e3613cd70b97/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1155,13 +1253,13 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6c60ce64-2d07-4119-8998-1cde2a06ecb6
+                - ba6c3ba0-2ef7-46c5-8b89-fbcdf42d3579
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 85.008875ms
-    - id: 23
+        duration: 87.171666ms
+    - id: 25
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1176,8 +1274,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea
         method: GET
       response:
         proto: HTTP/2.0
@@ -1185,20 +1283,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2274
+        content_length: 1828
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:42.688752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-keller","id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"802","node_id":"33","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:9d","maintenances":[],"modification_date":"2025-01-27T13:47:53.748126+00:00","name":"tf-srv-youthful-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:42.688752+00:00","export_uri":null,"id":"32c7e95f-6250-4759-baff-a5834f4736da","modification_date":"2025-01-27T13:47:42.688752+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","name":"tf-srv-youthful-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.442075+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-swartz","id":"35fef105-bbe6-4bae-aa38-a83dc863c9ea","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"48","hypervisor_id":"201","node_id":"12","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:d1","maintenances":[],"modification_date":"2025-02-11T14:22:42.174812+00:00","name":"tf-srv-pensive-swartz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"dc31edbb-ec76-4d64-a580-032b08ab0d0c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2274"
+                - "1828"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:56 GMT
+                - Tue, 11 Feb 2025 14:22:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1206,11 +1304,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4956fa66-53ae-450a-9e15-f1b81b98d7eb
+                - ecee194e-415d-419c-8dfa-3d6f49c06273
         status: 200 OK
         code: 200
-        duration: 156.801708ms
-    - id: 24
+        duration: 212.573166ms
+    - id: 26
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1225,8 +1323,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97/user_data/cloud-init
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea/user_data/cloud-init
         method: GET
       response:
         proto: HTTP/2.0
@@ -1248,9 +1346,9 @@ interactions:
             Content-Type:
                 - text/plain
             Date:
-                - Mon, 27 Jan 2025 13:47:56 GMT
+                - Tue, 11 Feb 2025 14:22:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1258,11 +1356,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3ffdf1d8-bab4-4aee-988b-539d7426efe2
+                - 82255e2e-ea81-4cfb-b593-ac4689300c21
         status: 200 OK
         code: 200
-        duration: 115.36425ms
-    - id: 25
+        duration: 103.79875ms
+    - id: 27
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1277,8 +1375,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97/user_data/cloud-init
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea/user_data/cloud-init
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1295,9 +1393,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:56 GMT
+                - Tue, 11 Feb 2025 14:22:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1305,11 +1403,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dbb20dfd-59c5-44d4-a51b-6cdd03c8621f
+                - e26649f9-db1a-4b49-8d5d-14b2e72198ec
         status: 204 No Content
         code: 204
-        duration: 109.87725ms
-    - id: 26
+        duration: 82.450542ms
+    - id: 28
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1324,8 +1422,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea
         method: GET
       response:
         proto: HTTP/2.0
@@ -1333,20 +1431,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2274
+        content_length: 1828
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:42.688752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-keller","id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"802","node_id":"33","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:9d","maintenances":[],"modification_date":"2025-01-27T13:47:53.748126+00:00","name":"tf-srv-youthful-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:42.688752+00:00","export_uri":null,"id":"32c7e95f-6250-4759-baff-a5834f4736da","modification_date":"2025-01-27T13:47:42.688752+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","name":"tf-srv-youthful-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.442075+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-swartz","id":"35fef105-bbe6-4bae-aa38-a83dc863c9ea","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"48","hypervisor_id":"201","node_id":"12","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:d1","maintenances":[],"modification_date":"2025-02-11T14:22:42.174812+00:00","name":"tf-srv-pensive-swartz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"dc31edbb-ec76-4d64-a580-032b08ab0d0c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2274"
+                - "1828"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:57 GMT
+                - Tue, 11 Feb 2025 14:22:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1354,11 +1452,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c518f9fc-67ff-482b-8e8c-85b9835b01b5
+                - 1f7db5cc-7654-4955-a66c-8c9507ed8e13
         status: 200 OK
         code: 200
-        duration: 164.576667ms
-    - id: 27
+        duration: 146.696042ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/dc31edbb-ec76-4d64-a580-032b08ab0d0c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:22:36.668230Z","id":"dc31edbb-ec76-4d64-a580-032b08ab0d0c","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:22:36.668230Z","id":"19a373d4-c004-4a2e-8c29-8ddfec3dfa4e","product_resource_id":"35fef105-bbe6-4bae-aa38-a83dc863c9ea","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:22:36.668230Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:22:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a5c307ab-762b-4c09-bff4-5e41edebaff4
+        status: 200 OK
+        code: 200
+        duration: 75.88325ms
+    - id: 30
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1375,8 +1522,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -1386,7 +1533,7 @@ interactions:
         trailer: {}
         content_length: 352
         uncompressed: false
-        body: '{"task":{"description":"server_poweroff","href_from":"/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97/action","href_result":"/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97","id":"80414041-4cfd-4d63-8212-36b530a66559","progress":0,"started_at":"2025-01-27T13:47:57.611229+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_poweroff","href_from":"/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea/action","href_result":"/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea","id":"6a7ec596-e7bf-4f7a-999f-b4d76dd47c96","progress":0,"started_at":"2025-02-11T14:22:46.508614+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "352"
@@ -1395,11 +1542,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:47:57 GMT
+                - Tue, 11 Feb 2025 14:22:46 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/80414041-4cfd-4d63-8212-36b530a66559
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/6a7ec596-e7bf-4f7a-999f-b4d76dd47c96
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1407,157 +1554,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ca00401c-1f25-4650-ac91-b69eeb7c4014
+                - 45024854-6d1d-4316-a56d-3203f4dd586a
         status: 202 Accepted
         code: 202
-        duration: 516.587209ms
-    - id: 28
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2234
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:42.688752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-keller","id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"802","node_id":"33","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:9d","maintenances":[],"modification_date":"2025-01-27T13:47:57.213250+00:00","name":"tf-srv-youthful-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:42.688752+00:00","export_uri":null,"id":"32c7e95f-6250-4759-baff-a5834f4736da","modification_date":"2025-01-27T13:47:42.688752+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","name":"tf-srv-youthful-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2234"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:47:57 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 62d8125b-0506-4d07-9051-92eeaebd3823
-        status: 200 OK
-        code: 200
-        duration: 196.945875ms
-    - id: 29
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2234
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:42.688752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-keller","id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"802","node_id":"33","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:9d","maintenances":[],"modification_date":"2025-01-27T13:47:57.213250+00:00","name":"tf-srv-youthful-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:42.688752+00:00","export_uri":null,"id":"32c7e95f-6250-4759-baff-a5834f4736da","modification_date":"2025-01-27T13:47:42.688752+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","name":"tf-srv-youthful-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2234"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:48:02 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 33668de0-646d-438e-93cb-590e7f84e393
-        status: 200 OK
-        code: 200
-        duration: 162.785333ms
-    - id: 30
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2234
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:42.688752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-keller","id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"802","node_id":"33","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:9d","maintenances":[],"modification_date":"2025-01-27T13:47:57.213250+00:00","name":"tf-srv-youthful-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:42.688752+00:00","export_uri":null,"id":"32c7e95f-6250-4759-baff-a5834f4736da","modification_date":"2025-01-27T13:47:42.688752+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","name":"tf-srv-youthful-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2234"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:48:07 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 6c050bf0-85e2-4aaa-9df4-ff83993d38f4
-        status: 200 OK
-        code: 200
-        duration: 186.217208ms
+        duration: 226.212792ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1573,8 +1573,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea
         method: GET
       response:
         proto: HTTP/2.0
@@ -1582,20 +1582,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2234
+        content_length: 1788
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:42.688752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-keller","id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"802","node_id":"33","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:9d","maintenances":[],"modification_date":"2025-01-27T13:47:57.213250+00:00","name":"tf-srv-youthful-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:42.688752+00:00","export_uri":null,"id":"32c7e95f-6250-4759-baff-a5834f4736da","modification_date":"2025-01-27T13:47:42.688752+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","name":"tf-srv-youthful-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.442075+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-swartz","id":"35fef105-bbe6-4bae-aa38-a83dc863c9ea","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"48","hypervisor_id":"201","node_id":"12","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:d1","maintenances":[],"modification_date":"2025-02-11T14:22:46.338821+00:00","name":"tf-srv-pensive-swartz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"dc31edbb-ec76-4d64-a580-032b08ab0d0c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2234"
+                - "1788"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:13 GMT
+                - Tue, 11 Feb 2025 14:22:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1603,10 +1603,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3c5aaddf-2591-4a65-88fb-13b442607013
+                - bfcd9353-303d-4c07-9267-c471bb875e47
         status: 200 OK
         code: 200
-        duration: 164.882458ms
+        duration: 170.167708ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1622,8 +1622,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea
         method: GET
       response:
         proto: HTTP/2.0
@@ -1631,20 +1631,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2234
+        content_length: 1788
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:42.688752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-keller","id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"802","node_id":"33","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:9d","maintenances":[],"modification_date":"2025-01-27T13:47:57.213250+00:00","name":"tf-srv-youthful-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:42.688752+00:00","export_uri":null,"id":"32c7e95f-6250-4759-baff-a5834f4736da","modification_date":"2025-01-27T13:47:42.688752+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","name":"tf-srv-youthful-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.442075+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-swartz","id":"35fef105-bbe6-4bae-aa38-a83dc863c9ea","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"48","hypervisor_id":"201","node_id":"12","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:d1","maintenances":[],"modification_date":"2025-02-11T14:22:46.338821+00:00","name":"tf-srv-pensive-swartz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"dc31edbb-ec76-4d64-a580-032b08ab0d0c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2234"
+                - "1788"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:18 GMT
+                - Tue, 11 Feb 2025 14:22:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1652,10 +1652,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3e35aecf-3f64-40f7-9e2d-3102d542cc76
+                - a7bd6529-c853-4c2c-87e1-25467c303e3d
         status: 200 OK
         code: 200
-        duration: 158.487042ms
+        duration: 167.367833ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1671,8 +1671,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea
         method: GET
       response:
         proto: HTTP/2.0
@@ -1680,20 +1680,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2234
+        content_length: 1788
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:42.688752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-keller","id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"802","node_id":"33","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:9d","maintenances":[],"modification_date":"2025-01-27T13:47:57.213250+00:00","name":"tf-srv-youthful-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:42.688752+00:00","export_uri":null,"id":"32c7e95f-6250-4759-baff-a5834f4736da","modification_date":"2025-01-27T13:47:42.688752+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","name":"tf-srv-youthful-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.442075+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-swartz","id":"35fef105-bbe6-4bae-aa38-a83dc863c9ea","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"48","hypervisor_id":"201","node_id":"12","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:d1","maintenances":[],"modification_date":"2025-02-11T14:22:46.338821+00:00","name":"tf-srv-pensive-swartz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"dc31edbb-ec76-4d64-a580-032b08ab0d0c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2234"
+                - "1788"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:38 GMT
+                - Tue, 11 Feb 2025 14:22:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1701,10 +1701,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 035b00ff-ece0-4fe2-8e91-a9803b88086e
+                - ed22b727-871d-4bb5-bd8f-86403255454b
         status: 200 OK
         code: 200
-        duration: 16.23682275s
+        duration: 152.31925ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1720,8 +1720,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea
         method: GET
       response:
         proto: HTTP/2.0
@@ -1729,20 +1729,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2118
+        content_length: 1788
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:42.688752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-keller","id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:9d","maintenances":[],"modification_date":"2025-01-27T13:48:38.988626+00:00","name":"tf-srv-youthful-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:42.688752+00:00","export_uri":null,"id":"32c7e95f-6250-4759-baff-a5834f4736da","modification_date":"2025-01-27T13:47:42.688752+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","name":"tf-srv-youthful-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.442075+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-swartz","id":"35fef105-bbe6-4bae-aa38-a83dc863c9ea","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"48","hypervisor_id":"201","node_id":"12","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:d1","maintenances":[],"modification_date":"2025-02-11T14:22:46.338821+00:00","name":"tf-srv-pensive-swartz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"dc31edbb-ec76-4d64-a580-032b08ab0d0c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2118"
+                - "1788"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:44 GMT
+                - Tue, 11 Feb 2025 14:23:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1750,10 +1750,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2fde7879-579e-42f4-827e-6c70e2f5f4ae
+                - 6a4e18a5-2446-434f-8d09-c620fa63a662
         status: 200 OK
         code: 200
-        duration: 175.692333ms
+        duration: 193.605167ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1769,8 +1769,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea
         method: GET
       response:
         proto: HTTP/2.0
@@ -1778,20 +1778,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2118
+        content_length: 1788
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:47:42.688752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-youthful-keller","id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:9d","maintenances":[],"modification_date":"2025-01-27T13:48:38.988626+00:00","name":"tf-srv-youthful-keller","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:47:42.688752+00:00","export_uri":null,"id":"32c7e95f-6250-4759-baff-a5834f4736da","modification_date":"2025-01-27T13:47:42.688752+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","name":"tf-srv-youthful-keller"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.442075+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-swartz","id":"35fef105-bbe6-4bae-aa38-a83dc863c9ea","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"48","hypervisor_id":"201","node_id":"12","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:d1","maintenances":[],"modification_date":"2025-02-11T14:22:46.338821+00:00","name":"tf-srv-pensive-swartz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"dc31edbb-ec76-4d64-a580-032b08ab0d0c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2118"
+                - "1788"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:44 GMT
+                - Tue, 11 Feb 2025 14:23:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1799,10 +1799,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 569d3caa-bec5-49fb-852e-02bb9a89e273
+                - 79c1c741-b4fc-4f5d-9d45-fc4bc143356e
         status: 200 OK
         code: 200
-        duration: 134.667583ms
+        duration: 167.049583ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1818,27 +1818,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 1788
         uncompressed: false
-        body: ""
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.442075+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-swartz","id":"35fef105-bbe6-4bae-aa38-a83dc863c9ea","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"48","hypervisor_id":"201","node_id":"12","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:d1","maintenances":[],"modification_date":"2025-02-11T14:22:46.338821+00:00","name":"tf-srv-pensive-swartz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"dc31edbb-ec76-4d64-a580-032b08ab0d0c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
+            Content-Length:
+                - "1788"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:45 GMT
+                - Tue, 11 Feb 2025 14:23:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1846,10 +1848,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 63c30312-909b-4024-aae3-0da9a68b6efa
-        status: 204 No Content
-        code: 204
-        duration: 172.643375ms
+                - 7f8e076e-b2d0-4899-8fe6-12ee424b751b
+        status: 200 OK
+        code: 200
+        duration: 236.84875ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1865,8 +1867,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea
         method: GET
       response:
         proto: HTTP/2.0
@@ -1874,20 +1876,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 143
+        content_length: 1788
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","type":"not_found"}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.442075+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-swartz","id":"35fef105-bbe6-4bae-aa38-a83dc863c9ea","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"48","hypervisor_id":"201","node_id":"12","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:d1","maintenances":[],"modification_date":"2025-02-11T14:22:46.338821+00:00","name":"tf-srv-pensive-swartz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"dc31edbb-ec76-4d64-a580-032b08ab0d0c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "143"
+                - "1788"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:44 GMT
+                - Tue, 11 Feb 2025 14:23:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1895,10 +1897,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 17affb0f-8eac-4361-955a-6db754b6741f
-        status: 404 Not Found
-        code: 404
-        duration: 109.816709ms
+                - 34ac0c6a-fe46-4d5e-aa97-809621efe759
+        status: 200 OK
+        code: 200
+        duration: 186.028125ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1914,8 +1916,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/32c7e95f-6250-4759-baff-a5834f4736da
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea
         method: GET
       response:
         proto: HTTP/2.0
@@ -1923,20 +1925,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 446
+        content_length: 1672
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:47:42.688752+00:00","export_uri":null,"id":"32c7e95f-6250-4759-baff-a5834f4736da","modification_date":"2025-01-27T13:48:45.169045+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.442075+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-swartz","id":"35fef105-bbe6-4bae-aa38-a83dc863c9ea","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:d1","maintenances":[],"modification_date":"2025-02-11T14:23:19.509970+00:00","name":"tf-srv-pensive-swartz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"dc31edbb-ec76-4d64-a580-032b08ab0d0c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "446"
+                - "1672"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:45 GMT
+                - Tue, 11 Feb 2025 14:23:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1944,10 +1946,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ab6017f2-7116-47e1-a0f9-9e8d9d1d4eab
+                - aeb0cdda-efb4-4490-a709-c29a1532f3ec
         status: 200 OK
         code: 200
-        duration: 76.783083ms
+        duration: 141.6765ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1963,8 +1965,57 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/32c7e95f-6250-4759-baff-a5834f4736da
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1672
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:36.442075+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-pensive-swartz","id":"35fef105-bbe6-4bae-aa38-a83dc863c9ea","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:d1","maintenances":[],"modification_date":"2025-02-11T14:23:19.509970+00:00","name":"tf-srv-pensive-swartz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"dc31edbb-ec76-4d64-a580-032b08ab0d0c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1672"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e512e1ce-71e6-4488-80e8-bd2247ff35b5
+        status: 200 OK
+        code: 200
+        duration: 133.920584ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1981,9 +2032,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:45 GMT
+                - Tue, 11 Feb 2025 14:23:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1991,11 +2042,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5a1b8f1e-237a-4ca8-8192-e13c43ec909b
+                - cd0b5dd8-d5d9-45d7-ae0c-1cb6fb1cca96
         status: 204 No Content
         code: 204
-        duration: 137.88975ms
-    - id: 40
+        duration: 471.117292ms
+    - id: 41
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2010,8 +2061,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/584f617b-c9cf-4cc8-952a-e3613cd70b97
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea
         method: GET
       response:
         proto: HTTP/2.0
@@ -2021,7 +2072,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"584f617b-c9cf-4cc8-952a-e3613cd70b97","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"35fef105-bbe6-4bae-aa38-a83dc863c9ea","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -2030,9 +2081,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:45 GMT
+                - Tue, 11 Feb 2025 14:23:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2040,7 +2091,201 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - da234371-3f16-42e0-8db9-2f25d8477070
+                - 4147d71a-10ea-42b5-b40a-d42aba153509
         status: 404 Not Found
         code: 404
-        duration: 103.0675ms
+        duration: 70.240292ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/dc31edbb-ec76-4d64-a580-032b08ab0d0c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"dc31edbb-ec76-4d64-a580-032b08ab0d0c","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1bb3995a-6f7d-44fa-91d8-022edda17f5d
+        status: 404 Not Found
+        code: 404
+        duration: 38.94775ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/dc31edbb-ec76-4d64-a580-032b08ab0d0c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 494
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:22:36.668230Z","id":"dc31edbb-ec76-4d64-a580-032b08ab0d0c","last_detached_at":"2025-02-11T14:23:23.622977Z","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:23.622977Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "494"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d6eb54f1-cfe3-4a0c-a226-0a4025c1b6e7
+        status: 200 OK
+        code: 200
+        duration: 100.705ms
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/dc31edbb-ec76-4d64-a580-032b08ab0d0c
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0be13baf-2070-4d5d-9378-c4d43ac1686f
+        status: 204 No Content
+        code: 204
+        duration: 117.253292ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/35fef105-bbe6-4bae-aa38-a83dc863c9ea
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"35fef105-bbe6-4bae-aa38-a83dc863c9ea","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 795f6721-45c2-4032-a569-6fca3f60e546
+        status: 404 Not Found
+        code: 404
+        duration: 90.264459ms

--- a/internal/services/instance/testdata/server-user-data-with-cloud-init-at-start.cassette.yaml
+++ b/internal/services/instance/testdata/server-user-data-with-cloud-init-at-start.cassette.yaml
@@ -16,7 +16,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
         method: GET
       response:
@@ -25,22 +25,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 38539
+        content_length: 35639
         uncompressed: false
-        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
+        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
         headers:
             Content-Length:
-                - "38539"
+                - "35639"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:11 GMT
+                - Tue, 11 Feb 2025 14:23:24 GMT
             Link:
                 - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,12 +48,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 584cd425-f14c-4f02-b966-b4575ea8eecc
+                - 1a913099-3614-4097-91b0-d90c7845f7ab
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 55.855459ms
+        duration: 58.514041ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -69,7 +69,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
         method: GET
       response:
@@ -78,22 +78,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 14208
+        content_length: 13164
         uncompressed: false
-        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
         headers:
             Content-Length:
-                - "14208"
+                - "13164"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:11 GMT
+                - Tue, 11 Feb 2025 14:23:24 GMT
             Link:
                 - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -101,12 +101,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5ab3b089-21bf-4e61-9d76-4fc32f9b651a
+                - 615727d8-1363-4965-ad57-44b90e0aaeb9
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 39.269583ms
+        duration: 44.121917ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -122,8 +122,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_local&zone=fr-par-1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_sbs&zone=fr-par-1
         method: GET
       response:
         proto: HTTP/2.0
@@ -131,20 +131,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1300
+        content_length: 1296
         uncompressed: false
-        body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"56d4019c-8305-467a-a3f2-70498ad799df","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
+        body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"57509e82-ac3b-49b7-9970-97b60f40ff72","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"9b647e1e-253a-41e7-8c15-911c622ee2dc","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"}],"total_count":2}'
         headers:
             Content-Length:
-                - "1300"
+                - "1296"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:12 GMT
+                - Tue, 11 Feb 2025 14:23:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -152,28 +152,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3293fb28-f84f-47cf-b6f5-9d0b4a871f5c
+                - 31b66b03-2e43-4d38-8bc6-2dac672d83fe
         status: 200 OK
         code: 200
-        duration: 85.143833ms
+        duration: 74.010875ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 272
+        content_length: 237
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-srv-funny-tharp","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+        body: '{"name":"tf-srv-quizzical-greider","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"57509e82-ac3b-49b7-9970-97b60f40ff72","volumes":{"0":{"boot":false}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
         method: POST
       response:
@@ -182,22 +182,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2106
+        content_length: 1678
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:12.431883+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-tharp","id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:ff","maintenances":[],"modification_date":"2025-01-27T13:52:12.431883+00:00","name":"tf-srv-funny-tharp","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:12.431883+00:00","export_uri":null,"id":"75be1145-1b2a-492d-9d96-bb8d053e6ced","modification_date":"2025-01-27T13:52:12.431883+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","name":"tf-srv-funny-tharp"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:25.163086+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quizzical-greider","id":"5a9cb023-8726-4757-82a7-529ba08c7181","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ed","maintenances":[],"modification_date":"2025-02-11T14:23:25.163086+00:00","name":"tf-srv-quizzical-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2106"
+                - "1678"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:13 GMT
+                - Tue, 11 Feb 2025 14:23:25 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -205,10 +205,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0c63d3f3-e9cd-4754-a66f-bb8778c521a2
+                - 7d55a793-a1de-44e3-8e14-d0c10fb7009b
         status: 201 Created
         code: 201
-        duration: 1.329813083s
+        duration: 1.129553s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -224,8 +224,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181
         method: GET
       response:
         proto: HTTP/2.0
@@ -233,20 +233,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2106
+        content_length: 1678
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:12.431883+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-tharp","id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:ff","maintenances":[],"modification_date":"2025-01-27T13:52:12.431883+00:00","name":"tf-srv-funny-tharp","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:12.431883+00:00","export_uri":null,"id":"75be1145-1b2a-492d-9d96-bb8d053e6ced","modification_date":"2025-01-27T13:52:12.431883+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","name":"tf-srv-funny-tharp"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:25.163086+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quizzical-greider","id":"5a9cb023-8726-4757-82a7-529ba08c7181","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ed","maintenances":[],"modification_date":"2025-02-11T14:23:25.163086+00:00","name":"tf-srv-quizzical-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2106"
+                - "1678"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:13 GMT
+                - Tue, 11 Feb 2025 14:23:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -254,10 +254,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 59405d0e-2bb3-4c9d-919d-d22bf3390810
+                - 9809f702-ede7-4527-aac9-6b9092615e20
         status: 200 OK
         code: 200
-        duration: 185.677375ms
+        duration: 166.361875ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -273,8 +273,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181
         method: GET
       response:
         proto: HTTP/2.0
@@ -282,20 +282,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2106
+        content_length: 1678
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:12.431883+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-tharp","id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:ff","maintenances":[],"modification_date":"2025-01-27T13:52:12.431883+00:00","name":"tf-srv-funny-tharp","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:12.431883+00:00","export_uri":null,"id":"75be1145-1b2a-492d-9d96-bb8d053e6ced","modification_date":"2025-01-27T13:52:12.431883+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","name":"tf-srv-funny-tharp"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:25.163086+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quizzical-greider","id":"5a9cb023-8726-4757-82a7-529ba08c7181","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ed","maintenances":[],"modification_date":"2025-02-11T14:23:25.163086+00:00","name":"tf-srv-quizzical-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2106"
+                - "1678"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:13 GMT
+                - Tue, 11 Feb 2025 14:23:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -303,10 +303,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b6bb5a9f-7d1a-4833-8d7b-2039c38098cc
+                - c88b4a04-1235-4314-b55c-05e1f32c03e5
         status: 200 OK
         code: 200
-        duration: 175.909625ms
+        duration: 165.386542ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -322,8 +322,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -342,9 +342,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:13 GMT
+                - Tue, 11 Feb 2025 14:23:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -352,60 +352,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8c0a6a7c-93d4-403c-b5f7-05bbfbcd5caa
+                - 85332cf0-9181-4f6a-afd7-3b82d8053097
         status: 200 OK
         code: 200
-        duration: 123.950625ms
+        duration: 88.413084ms
     - id: 7
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 3
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: bar
-        form: {}
-        headers:
-            Content-Type:
-                - text/plain
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50/user_data/foo
-        method: PATCH
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - text/plain
-            Date:
-                - Mon, 27 Jan 2025 13:52:13 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - c504f9e0-200f-4a3f-9fc8-abd47aa88978
-        status: 204 No Content
-        code: 204
-        duration: 106.553916ms
-    - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -425,8 +376,8 @@ interactions:
             Content-Type:
                 - text/plain
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50/user_data/cloud-init
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181/user_data/cloud-init
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -443,9 +394,9 @@ interactions:
             Content-Type:
                 - text/plain
             Date:
-                - Mon, 27 Jan 2025 13:52:13 GMT
+                - Tue, 11 Feb 2025 14:23:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -453,10 +404,59 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1ff19898-bca4-4cd4-a12d-bf15300a2047
+                - b82abc12-35ef-49b5-b8f0-cd485fb840a3
         status: 204 No Content
         code: 204
-        duration: 99.73625ms
+        duration: 102.177ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 3
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: bar
+        form: {}
+        headers:
+            Content-Type:
+                - text/plain
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181/user_data/foo
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - text/plain
+            Date:
+                - Tue, 11 Feb 2025 14:23:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 57cf20f9-af39-4634-a7ee-2eae3c85b9d5
+        status: 204 No Content
+        code: 204
+        duration: 122.202542ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -472,8 +472,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181
         method: GET
       response:
         proto: HTTP/2.0
@@ -481,20 +481,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2106
+        content_length: 1678
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:12.431883+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-tharp","id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:ff","maintenances":[],"modification_date":"2025-01-27T13:52:12.431883+00:00","name":"tf-srv-funny-tharp","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:12.431883+00:00","export_uri":null,"id":"75be1145-1b2a-492d-9d96-bb8d053e6ced","modification_date":"2025-01-27T13:52:12.431883+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","name":"tf-srv-funny-tharp"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:25.163086+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quizzical-greider","id":"5a9cb023-8726-4757-82a7-529ba08c7181","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ed","maintenances":[],"modification_date":"2025-02-11T14:23:25.163086+00:00","name":"tf-srv-quizzical-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2106"
+                - "1678"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:13 GMT
+                - Tue, 11 Feb 2025 14:23:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -502,11 +502,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f21873df-36c3-4929-87bc-4ad29c08284a
+                - 11431315-f8bc-4cbd-98e4-8e9361411919
         status: 200 OK
         code: 200
-        duration: 147.263958ms
+        duration: 145.056834ms
     - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/4e04cfc2-6982-41d3-99ec-c9618d959e15
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:23:25.372077Z","id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:25.372077Z","id":"786497c6-8fc4-4517-a072-cc4bd815d611","product_resource_id":"5a9cb023-8726-4757-82a7-529ba08c7181","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:25.372077Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5523c6ad-ad05-4984-81f6-9b1304131d82
+        status: 200 OK
+        code: 200
+        duration: 74.914917ms
+    - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -523,8 +572,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -534,7 +583,7 @@ interactions:
         trailer: {}
         content_length: 357
         uncompressed: false
-        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50/action","href_result":"/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50","id":"9406b34d-b808-4398-9bdd-332cb34cd274","progress":0,"started_at":"2025-01-27T13:52:14.580523+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/5a9cb023-8726-4757-82a7-529ba08c7181/action","href_result":"/servers/5a9cb023-8726-4757-82a7-529ba08c7181","id":"94313824-bbe3-43f7-b926-194297e0afd3","progress":0,"started_at":"2025-02-11T14:23:26.817221+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -543,11 +592,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:14 GMT
+                - Tue, 11 Feb 2025 14:23:26 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/9406b34d-b808-4398-9bdd-332cb34cd274
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/94313824-bbe3-43f7-b926-194297e0afd3
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -555,59 +604,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 773dec14-3ffd-4620-8dfe-d14802c70f0e
+                - aa67cf71-2fba-4643-a5ff-49ab97b0987c
         status: 202 Accepted
         code: 202
-        duration: 367.63075ms
-    - id: 11
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2128
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:12.431883+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-tharp","id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:ff","maintenances":[],"modification_date":"2025-01-27T13:52:14.323362+00:00","name":"tf-srv-funny-tharp","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:12.431883+00:00","export_uri":null,"id":"75be1145-1b2a-492d-9d96-bb8d053e6ced","modification_date":"2025-01-27T13:52:12.431883+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","name":"tf-srv-funny-tharp"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2128"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:52:14 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - f03ffd25-a196-4b1a-a31c-8ed40876df3c
-        status: 200 OK
-        code: 200
-        duration: 186.241458ms
+        duration: 272.201875ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -623,8 +623,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181
         method: GET
       response:
         proto: HTTP/2.0
@@ -632,20 +632,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2232
+        content_length: 1700
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:12.431883+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-tharp","id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1001","node_id":"15","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ff","maintenances":[],"modification_date":"2025-01-27T13:52:14.323362+00:00","name":"tf-srv-funny-tharp","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:12.431883+00:00","export_uri":null,"id":"75be1145-1b2a-492d-9d96-bb8d053e6ced","modification_date":"2025-01-27T13:52:12.431883+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","name":"tf-srv-funny-tharp"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:25.163086+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quizzical-greider","id":"5a9cb023-8726-4757-82a7-529ba08c7181","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ed","maintenances":[],"modification_date":"2025-02-11T14:23:26.604468+00:00","name":"tf-srv-quizzical-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2232"
+                - "1700"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:19 GMT
+                - Tue, 11 Feb 2025 14:23:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -653,10 +653,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0986fb17-3e92-4ef2-b4e9-f1c02c957387
+                - 24e2675b-fa5e-4142-ab7e-a44d692d4e4d
         status: 200 OK
         code: 200
-        duration: 202.600375ms
+        duration: 181.564916ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -672,8 +672,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181
         method: GET
       response:
         proto: HTTP/2.0
@@ -681,20 +681,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2232
+        content_length: 1803
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:12.431883+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-tharp","id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1001","node_id":"15","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ff","maintenances":[],"modification_date":"2025-01-27T13:52:14.323362+00:00","name":"tf-srv-funny-tharp","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:12.431883+00:00","export_uri":null,"id":"75be1145-1b2a-492d-9d96-bb8d053e6ced","modification_date":"2025-01-27T13:52:12.431883+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","name":"tf-srv-funny-tharp"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:25.163086+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quizzical-greider","id":"5a9cb023-8726-4757-82a7-529ba08c7181","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"201","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:ed","maintenances":[],"modification_date":"2025-02-11T14:23:26.604468+00:00","name":"tf-srv-quizzical-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2232"
+                - "1803"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:24 GMT
+                - Tue, 11 Feb 2025 14:23:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -702,10 +702,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c46c438b-7521-48d2-b99c-b71711ba2d3d
+                - c1db4500-d8f5-468b-929f-5dfa4a5dadeb
         status: 200 OK
         code: 200
-        duration: 201.229542ms
+        duration: 167.959334ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -721,8 +721,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181
         method: GET
       response:
         proto: HTTP/2.0
@@ -730,20 +730,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2263
+        content_length: 1803
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:12.431883+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-tharp","id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1001","node_id":"15","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ff","maintenances":[],"modification_date":"2025-01-27T13:52:28.285305+00:00","name":"tf-srv-funny-tharp","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:12.431883+00:00","export_uri":null,"id":"75be1145-1b2a-492d-9d96-bb8d053e6ced","modification_date":"2025-01-27T13:52:12.431883+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","name":"tf-srv-funny-tharp"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:25.163086+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quizzical-greider","id":"5a9cb023-8726-4757-82a7-529ba08c7181","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"201","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:ed","maintenances":[],"modification_date":"2025-02-11T14:23:26.604468+00:00","name":"tf-srv-quizzical-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2263"
+                - "1803"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:30 GMT
+                - Tue, 11 Feb 2025 14:23:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -751,10 +751,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 67d5e150-3da4-45cb-a780-152a862ee0b1
+                - a6a8cefc-f03e-4e9f-a636-f956bfb61256
         status: 200 OK
         code: 200
-        duration: 206.894667ms
+        duration: 221.627917ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -770,8 +770,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181
         method: GET
       response:
         proto: HTTP/2.0
@@ -779,20 +779,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2263
+        content_length: 1803
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:12.431883+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-tharp","id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1001","node_id":"15","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ff","maintenances":[],"modification_date":"2025-01-27T13:52:28.285305+00:00","name":"tf-srv-funny-tharp","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:12.431883+00:00","export_uri":null,"id":"75be1145-1b2a-492d-9d96-bb8d053e6ced","modification_date":"2025-01-27T13:52:12.431883+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","name":"tf-srv-funny-tharp"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:25.163086+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quizzical-greider","id":"5a9cb023-8726-4757-82a7-529ba08c7181","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"201","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:ed","maintenances":[],"modification_date":"2025-02-11T14:23:26.604468+00:00","name":"tf-srv-quizzical-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2263"
+                - "1803"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:30 GMT
+                - Tue, 11 Feb 2025 14:23:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -800,10 +800,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e9a9e81e-bf9e-483f-b95d-ef81a34200d7
+                - 0063531b-9176-48a2-9217-da8c2678d7c9
         status: 200 OK
         code: 200
-        duration: 163.096834ms
+        duration: 187.35175ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -819,8 +819,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/75be1145-1b2a-492d-9d96-bb8d053e6ced
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181
         method: GET
       response:
         proto: HTTP/2.0
@@ -828,20 +828,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 518
+        content_length: 1803
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:52:12.431883+00:00","export_uri":null,"id":"75be1145-1b2a-492d-9d96-bb8d053e6ced","modification_date":"2025-01-27T13:52:12.431883+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","name":"tf-srv-funny-tharp"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:25.163086+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quizzical-greider","id":"5a9cb023-8726-4757-82a7-529ba08c7181","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"201","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:ed","maintenances":[],"modification_date":"2025-02-11T14:23:26.604468+00:00","name":"tf-srv-quizzical-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "518"
+                - "1803"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:30 GMT
+                - Tue, 11 Feb 2025 14:23:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -849,10 +849,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d41df4c1-1c8d-43a1-9289-69aeb6e06672
+                - c6a319c3-abce-4575-b694-f2bfd88597d2
         status: 200 OK
         code: 200
-        duration: 106.700333ms
+        duration: 544.944125ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -868,8 +868,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181
         method: GET
       response:
         proto: HTTP/2.0
@@ -877,20 +877,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 36
+        content_length: 1803
         uncompressed: false
-        body: '{"user_data":["cloud-init","foo"]}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:25.163086+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quizzical-greider","id":"5a9cb023-8726-4757-82a7-529ba08c7181","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"201","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:ed","maintenances":[],"modification_date":"2025-02-11T14:23:26.604468+00:00","name":"tf-srv-quizzical-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "36"
+                - "1803"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:30 GMT
+                - Tue, 11 Feb 2025 14:23:52 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -898,10 +898,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 550cfe48-30fa-499f-8ff1-5ec9ac511d22
+                - fed610ba-af70-4e0d-b874-bfb74001a7df
         status: 200 OK
         code: 200
-        duration: 93.425875ms
+        duration: 178.576917ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -917,8 +917,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50/user_data/cloud-init
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181
         method: GET
       response:
         proto: HTTP/2.0
@@ -926,23 +926,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 49
+        content_length: 1803
         uncompressed: false
-        body: |
-            #cloud-config
-            apt_update: true
-            apt_upgrade: true
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:25.163086+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quizzical-greider","id":"5a9cb023-8726-4757-82a7-529ba08c7181","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"201","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:ed","maintenances":[],"modification_date":"2025-02-11T14:23:26.604468+00:00","name":"tf-srv-quizzical-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "49"
+                - "1803"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
-                - text/plain
+                - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:30 GMT
+                - Tue, 11 Feb 2025 14:23:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -950,10 +947,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ad46d3aa-1525-4326-8a4e-6052e1f9b035
+                - e5d38fac-fad3-4301-956a-0a5ee4af8c46
         status: 200 OK
         code: 200
-        duration: 103.842666ms
+        duration: 179.827584ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -969,8 +966,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50/user_data/foo
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181
         method: GET
       response:
         proto: HTTP/2.0
@@ -978,20 +975,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3
+        content_length: 1803
         uncompressed: false
-        body: bar
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:25.163086+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quizzical-greider","id":"5a9cb023-8726-4757-82a7-529ba08c7181","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"201","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:ed","maintenances":[],"modification_date":"2025-02-11T14:23:26.604468+00:00","name":"tf-srv-quizzical-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "3"
+                - "1803"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
-                - text/plain
+                - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:30 GMT
+                - Tue, 11 Feb 2025 14:24:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -999,10 +996,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 81182835-d748-49e4-a553-e7fab46eb3e8
+                - a4c90976-f150-4c15-94c1-b93046b031ca
         status: 200 OK
         code: 200
-        duration: 93.354541ms
+        duration: 207.116541ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1018,8 +1015,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181
         method: GET
       response:
         proto: HTTP/2.0
@@ -1027,22 +1024,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 1803
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:25.163086+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quizzical-greider","id":"5a9cb023-8726-4757-82a7-529ba08c7181","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"201","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:ed","maintenances":[],"modification_date":"2025-02-11T14:23:26.604468+00:00","name":"tf-srv-quizzical-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "20"
+                - "1803"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:31 GMT
-            Link:
-                - </servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:24:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1050,12 +1045,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ae4a27b1-8dc5-4bfa-a26d-132cf0d157c5
-            X-Total-Count:
-                - "0"
+                - a0d489b0-5804-4bf9-ae96-cc6ce0c4133c
         status: 200 OK
         code: 200
-        duration: 117.989416ms
+        duration: 186.048875ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1071,8 +1064,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181
         method: GET
       response:
         proto: HTTP/2.0
@@ -1080,20 +1073,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2263
+        content_length: 1803
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:12.431883+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-tharp","id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1001","node_id":"15","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ff","maintenances":[],"modification_date":"2025-01-27T13:52:28.285305+00:00","name":"tf-srv-funny-tharp","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:12.431883+00:00","export_uri":null,"id":"75be1145-1b2a-492d-9d96-bb8d053e6ced","modification_date":"2025-01-27T13:52:12.431883+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","name":"tf-srv-funny-tharp"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:25.163086+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quizzical-greider","id":"5a9cb023-8726-4757-82a7-529ba08c7181","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"201","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:ed","maintenances":[],"modification_date":"2025-02-11T14:23:26.604468+00:00","name":"tf-srv-quizzical-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2263"
+                - "1803"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:30 GMT
+                - Tue, 11 Feb 2025 14:24:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1101,10 +1094,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 53d5f82f-d1db-4bd1-bbcd-2b896728702f
+                - f688c9b6-30f7-474d-a011-0043e74aa5d5
         status: 200 OK
         code: 200
-        duration: 268.727ms
+        duration: 148.979708ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1120,8 +1113,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181
         method: GET
       response:
         proto: HTTP/2.0
@@ -1129,20 +1122,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2263
+        content_length: 1803
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:12.431883+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-tharp","id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1001","node_id":"15","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ff","maintenances":[],"modification_date":"2025-01-27T13:52:28.285305+00:00","name":"tf-srv-funny-tharp","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:12.431883+00:00","export_uri":null,"id":"75be1145-1b2a-492d-9d96-bb8d053e6ced","modification_date":"2025-01-27T13:52:12.431883+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","name":"tf-srv-funny-tharp"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:25.163086+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quizzical-greider","id":"5a9cb023-8726-4757-82a7-529ba08c7181","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"201","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:ed","maintenances":[],"modification_date":"2025-02-11T14:23:26.604468+00:00","name":"tf-srv-quizzical-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2263"
+                - "1803"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:31 GMT
+                - Tue, 11 Feb 2025 14:24:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1150,10 +1143,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 60904645-0c05-4c8d-a1fd-788dfed15de1
+                - 7b06a946-7d98-4d5b-8b1e-466f39451fc3
         status: 200 OK
         code: 200
-        duration: 197.245417ms
+        duration: 219.396083ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1169,8 +1162,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/75be1145-1b2a-492d-9d96-bb8d053e6ced
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181
         method: GET
       response:
         proto: HTTP/2.0
@@ -1178,20 +1171,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 518
+        content_length: 1803
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:52:12.431883+00:00","export_uri":null,"id":"75be1145-1b2a-492d-9d96-bb8d053e6ced","modification_date":"2025-01-27T13:52:12.431883+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","name":"tf-srv-funny-tharp"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:25.163086+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quizzical-greider","id":"5a9cb023-8726-4757-82a7-529ba08c7181","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"201","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:ed","maintenances":[],"modification_date":"2025-02-11T14:23:26.604468+00:00","name":"tf-srv-quizzical-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "518"
+                - "1803"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:31 GMT
+                - Tue, 11 Feb 2025 14:24:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1199,10 +1192,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ce2541fd-c41e-440a-bc7b-f56780e58ab0
+                - ec764f93-df6e-479b-8c6f-6df43c9c5e73
         status: 200 OK
         code: 200
-        duration: 91.540584ms
+        duration: 244.301708ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1218,8 +1211,400 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1803
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:25.163086+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quizzical-greider","id":"5a9cb023-8726-4757-82a7-529ba08c7181","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"201","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:ed","maintenances":[],"modification_date":"2025-02-11T14:23:26.604468+00:00","name":"tf-srv-quizzical-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1803"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:29 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6232c1b5-a4f8-4543-a85f-2b323758e88c
+        status: 200 OK
+        code: 200
+        duration: 194.933584ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1803
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:25.163086+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quizzical-greider","id":"5a9cb023-8726-4757-82a7-529ba08c7181","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"201","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:ed","maintenances":[],"modification_date":"2025-02-11T14:23:26.604468+00:00","name":"tf-srv-quizzical-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1803"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d2956f86-4083-45a9-84fe-13b4cb96eff2
+        status: 200 OK
+        code: 200
+        duration: 151.680208ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1803
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:25.163086+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quizzical-greider","id":"5a9cb023-8726-4757-82a7-529ba08c7181","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"201","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:ed","maintenances":[],"modification_date":"2025-02-11T14:23:26.604468+00:00","name":"tf-srv-quizzical-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1803"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:39 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ea0afc9d-1de2-46ca-b0e4-3abc36756917
+        status: 200 OK
+        code: 200
+        duration: 185.596584ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1803
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:25.163086+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quizzical-greider","id":"5a9cb023-8726-4757-82a7-529ba08c7181","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"201","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:ed","maintenances":[],"modification_date":"2025-02-11T14:23:26.604468+00:00","name":"tf-srv-quizzical-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1803"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a34d9d3b-53a6-40e1-bb07-87376692ba56
+        status: 200 OK
+        code: 200
+        duration: 172.532584ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1834
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:25.163086+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quizzical-greider","id":"5a9cb023-8726-4757-82a7-529ba08c7181","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"201","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:ed","maintenances":[],"modification_date":"2025-02-11T14:24:45.553189+00:00","name":"tf-srv-quizzical-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1834"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d3f5e2c0-f1b2-4590-92eb-cf2213b0544c
+        status: 200 OK
+        code: 200
+        duration: 178.917708ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1834
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:25.163086+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quizzical-greider","id":"5a9cb023-8726-4757-82a7-529ba08c7181","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"201","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:ed","maintenances":[],"modification_date":"2025-02-11T14:24:45.553189+00:00","name":"tf-srv-quizzical-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1834"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7efa9782-4283-4131-8540-980a47d77137
+        status: 200 OK
+        code: 200
+        duration: 161.434625ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/4e04cfc2-6982-41d3-99ec-c9618d959e15
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c0627b88-c07c-4ef6-958f-b877ee11005f
+        status: 404 Not Found
+        code: 404
+        duration: 36.330792ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/4e04cfc2-6982-41d3-99ec-c9618d959e15
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:23:25.372077Z","id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:25.372077Z","id":"786497c6-8fc4-4517-a072-cc4bd815d611","product_resource_id":"5a9cb023-8726-4757-82a7-529ba08c7181","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:25.372077Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 76e2d76d-55cd-4a40-bc7f-866530c6b1f5
+        status: 200 OK
+        code: 200
+        duration: 81.682875ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1238,9 +1623,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:31 GMT
+                - Tue, 11 Feb 2025 14:24:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1248,11 +1633,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 40ac3068-3675-48d5-a4ab-242bae30bf7c
+                - 4aaef2cf-856e-4443-8478-2f81d259193a
         status: 200 OK
         code: 200
-        duration: 93.90225ms
-    - id: 25
+        duration: 80.977125ms
+    - id: 33
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1267,8 +1652,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50/user_data/cloud-init
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181/user_data/cloud-init
         method: GET
       response:
         proto: HTTP/2.0
@@ -1290,9 +1675,9 @@ interactions:
             Content-Type:
                 - text/plain
             Date:
-                - Mon, 27 Jan 2025 13:52:31 GMT
+                - Tue, 11 Feb 2025 14:24:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1300,11 +1685,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a684fb1f-e890-4975-b4c9-257e4e0505f9
+                - e87ad6a3-4435-4ba7-bb67-b074ef725363
         status: 200 OK
         code: 200
-        duration: 127.671292ms
-    - id: 26
+        duration: 89.282208ms
+    - id: 34
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1319,8 +1704,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50/user_data/foo
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181/user_data/foo
         method: GET
       response:
         proto: HTTP/2.0
@@ -1339,9 +1724,9 @@ interactions:
             Content-Type:
                 - text/plain
             Date:
-                - Mon, 27 Jan 2025 13:52:31 GMT
+                - Tue, 11 Feb 2025 14:24:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1349,11 +1734,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 82e31927-27aa-438e-863e-3df06c05ba1e
+                - 9f17ece6-d0aa-4652-8940-7bfae1041d4f
         status: 200 OK
         code: 200
-        duration: 98.006708ms
-    - id: 27
+        duration: 105.417042ms
+    - id: 35
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1368,8 +1753,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1388,11 +1773,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:32 GMT
+                - Tue, 11 Feb 2025 14:24:50 GMT
             Link:
-                - </servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/5a9cb023-8726-4757-82a7-529ba08c7181/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1400,13 +1785,13 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1cb9ef5e-fa2a-4bde-8497-c923aac5e9f5
+                - 8d13f82c-6e2c-4483-92ad-eb133fb9be0f
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 89.188541ms
-    - id: 28
+        duration: 201.4565ms
+    - id: 36
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1421,8 +1806,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181
         method: GET
       response:
         proto: HTTP/2.0
@@ -1430,20 +1815,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2263
+        content_length: 1834
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:12.431883+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-tharp","id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1001","node_id":"15","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ff","maintenances":[],"modification_date":"2025-01-27T13:52:28.285305+00:00","name":"tf-srv-funny-tharp","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:12.431883+00:00","export_uri":null,"id":"75be1145-1b2a-492d-9d96-bb8d053e6ced","modification_date":"2025-01-27T13:52:12.431883+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","name":"tf-srv-funny-tharp"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:25.163086+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quizzical-greider","id":"5a9cb023-8726-4757-82a7-529ba08c7181","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"201","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:ed","maintenances":[],"modification_date":"2025-02-11T14:24:45.553189+00:00","name":"tf-srv-quizzical-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2263"
+                - "1834"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:32 GMT
+                - Tue, 11 Feb 2025 14:24:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1451,11 +1836,459 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 763e5d96-27f7-4553-b1b8-7a788de16a53
+                - c848abe9-5bb3-4fe8-b943-460ae1a6c9e4
         status: 200 OK
         code: 200
-        duration: 169.975666ms
-    - id: 29
+        duration: 181.437416ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1834
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:25.163086+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quizzical-greider","id":"5a9cb023-8726-4757-82a7-529ba08c7181","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"201","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:ed","maintenances":[],"modification_date":"2025-02-11T14:24:45.553189+00:00","name":"tf-srv-quizzical-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1834"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 40c5fb86-6662-4f6c-ab54-e0c2e36aaf81
+        status: 200 OK
+        code: 200
+        duration: 229.200125ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/4e04cfc2-6982-41d3-99ec-c9618d959e15
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 720be0e0-3a54-4782-bfd2-3a90f9cea80b
+        status: 404 Not Found
+        code: 404
+        duration: 54.588791ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/4e04cfc2-6982-41d3-99ec-c9618d959e15
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:23:25.372077Z","id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:25.372077Z","id":"786497c6-8fc4-4517-a072-cc4bd815d611","product_resource_id":"5a9cb023-8726-4757-82a7-529ba08c7181","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:25.372077Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9861c2d9-a7d1-467b-8f77-61c42400d503
+        status: 200 OK
+        code: 200
+        duration: 83.631125ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181/user_data
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 36
+        uncompressed: false
+        body: '{"user_data":["cloud-init","foo"]}'
+        headers:
+            Content-Length:
+                - "36"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 676e2d0d-ed79-4442-a014-cc37a72cc0c3
+        status: 200 OK
+        code: 200
+        duration: 93.14925ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181/user_data/cloud-init
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 49
+        uncompressed: false
+        body: |
+            #cloud-config
+            apt_update: true
+            apt_upgrade: true
+        headers:
+            Content-Length:
+                - "49"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - text/plain
+            Date:
+                - Tue, 11 Feb 2025 14:24:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 85a54ce8-3019-44f8-91ce-083e1b81156c
+        status: 200 OK
+        code: 200
+        duration: 80.742292ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181/user_data/foo
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3
+        uncompressed: false
+        body: bar
+        headers:
+            Content-Length:
+                - "3"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - text/plain
+            Date:
+                - Tue, 11 Feb 2025 14:24:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 054aaffd-60c3-460f-a7b0-8c6397927088
+        status: 200 OK
+        code: 200
+        duration: 96.151625ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 20
+        uncompressed: false
+        body: '{"private_nics":[]}'
+        headers:
+            Content-Length:
+                - "20"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:52 GMT
+            Link:
+                - </servers/5a9cb023-8726-4757-82a7-529ba08c7181/private_nics?page=0&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2c73c0f6-bb2b-46c6-9047-4dd780540260
+            X-Total-Count:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 90.813459ms
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1834
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:25.163086+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quizzical-greider","id":"5a9cb023-8726-4757-82a7-529ba08c7181","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"201","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:ed","maintenances":[],"modification_date":"2025-02-11T14:24:45.553189+00:00","name":"tf-srv-quizzical-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1834"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 85c3daee-397e-4be5-9134-1b0e17ecdbc0
+        status: 200 OK
+        code: 200
+        duration: 157.880625ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/4e04cfc2-6982-41d3-99ec-c9618d959e15
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:23:25.372077Z","id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:25.372077Z","id":"786497c6-8fc4-4517-a072-cc4bd815d611","product_resource_id":"5a9cb023-8726-4757-82a7-529ba08c7181","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:25.372077Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4cc0c650-ccec-4c17-841c-e3292469a0ea
+        status: 200 OK
+        code: 200
+        duration: 71.330125ms
+    - id: 46
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1472,8 +2305,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -1483,7 +2316,7 @@ interactions:
         trailer: {}
         content_length: 352
         uncompressed: false
-        body: '{"task":{"description":"server_poweroff","href_from":"/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50/action","href_result":"/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50","id":"f46956b7-3ef0-4cda-8e17-9d1a7f63d6ba","progress":0,"started_at":"2025-01-27T13:52:32.982400+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_poweroff","href_from":"/servers/5a9cb023-8726-4757-82a7-529ba08c7181/action","href_result":"/servers/5a9cb023-8726-4757-82a7-529ba08c7181","id":"718943a8-60b1-4c6b-baec-a96de9ad5bc0","progress":0,"started_at":"2025-02-11T14:24:53.162486+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "352"
@@ -1492,11 +2325,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:32 GMT
+                - Tue, 11 Feb 2025 14:24:52 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/f46956b7-3ef0-4cda-8e17-9d1a7f63d6ba
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/718943a8-60b1-4c6b-baec-a96de9ad5bc0
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1504,11 +2337,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b34fd9a8-a37d-4674-a1ca-8194b8631a6c
+                - 80f995f7-9b50-417d-a608-65710de50dd1
         status: 202 Accepted
         code: 202
-        duration: 252.524542ms
-    - id: 30
+        duration: 244.3075ms
+    - id: 47
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1523,8 +2356,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181
         method: GET
       response:
         proto: HTTP/2.0
@@ -1532,20 +2365,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2223
+        content_length: 1794
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:12.431883+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-tharp","id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1001","node_id":"15","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ff","maintenances":[],"modification_date":"2025-01-27T13:52:32.787244+00:00","name":"tf-srv-funny-tharp","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:12.431883+00:00","export_uri":null,"id":"75be1145-1b2a-492d-9d96-bb8d053e6ced","modification_date":"2025-01-27T13:52:12.431883+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","name":"tf-srv-funny-tharp"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:25.163086+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quizzical-greider","id":"5a9cb023-8726-4757-82a7-529ba08c7181","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"201","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:ed","maintenances":[],"modification_date":"2025-02-11T14:24:52.960374+00:00","name":"tf-srv-quizzical-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2223"
+                - "1794"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:32 GMT
+                - Tue, 11 Feb 2025 14:24:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1553,11 +2386,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 34e8f215-c19b-4618-a657-8922927fed71
+                - 1dbec79d-c0ea-454f-8beb-1cadb7782ee3
         status: 200 OK
         code: 200
-        duration: 154.675875ms
-    - id: 31
+        duration: 216.033625ms
+    - id: 48
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1572,8 +2405,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181
         method: GET
       response:
         proto: HTTP/2.0
@@ -1581,20 +2414,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2223
+        content_length: 1794
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:12.431883+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-tharp","id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1001","node_id":"15","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ff","maintenances":[],"modification_date":"2025-01-27T13:52:32.787244+00:00","name":"tf-srv-funny-tharp","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:12.431883+00:00","export_uri":null,"id":"75be1145-1b2a-492d-9d96-bb8d053e6ced","modification_date":"2025-01-27T13:52:12.431883+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","name":"tf-srv-funny-tharp"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:25.163086+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quizzical-greider","id":"5a9cb023-8726-4757-82a7-529ba08c7181","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"201","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:ed","maintenances":[],"modification_date":"2025-02-11T14:24:52.960374+00:00","name":"tf-srv-quizzical-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2223"
+                - "1794"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:38 GMT
+                - Tue, 11 Feb 2025 14:24:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1602,11 +2435,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b8ccc8f6-5ca2-4af2-a846-9107db92b1be
+                - 65705ff0-7194-4f1b-9e98-9694dc454fc2
         status: 200 OK
         code: 200
-        duration: 312.660625ms
-    - id: 32
+        duration: 172.941875ms
+    - id: 49
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1621,8 +2454,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181
         method: GET
       response:
         proto: HTTP/2.0
@@ -1630,20 +2463,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2223
+        content_length: 1794
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:12.431883+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-tharp","id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1001","node_id":"15","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ff","maintenances":[],"modification_date":"2025-01-27T13:52:32.787244+00:00","name":"tf-srv-funny-tharp","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:12.431883+00:00","export_uri":null,"id":"75be1145-1b2a-492d-9d96-bb8d053e6ced","modification_date":"2025-01-27T13:52:12.431883+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","name":"tf-srv-funny-tharp"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:25.163086+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quizzical-greider","id":"5a9cb023-8726-4757-82a7-529ba08c7181","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"201","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:ed","maintenances":[],"modification_date":"2025-02-11T14:24:52.960374+00:00","name":"tf-srv-quizzical-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2223"
+                - "1794"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:43 GMT
+                - Tue, 11 Feb 2025 14:25:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1651,11 +2484,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6d713245-4ec2-49d9-b20a-7e04bfaf9d58
+                - 0a2185a9-db42-4861-883e-14c8267467d2
         status: 200 OK
         code: 200
-        duration: 175.065334ms
-    - id: 33
+        duration: 159.49ms
+    - id: 50
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1670,8 +2503,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181
         method: GET
       response:
         proto: HTTP/2.0
@@ -1679,20 +2512,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2223
+        content_length: 1794
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:12.431883+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-tharp","id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1001","node_id":"15","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ff","maintenances":[],"modification_date":"2025-01-27T13:52:32.787244+00:00","name":"tf-srv-funny-tharp","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:12.431883+00:00","export_uri":null,"id":"75be1145-1b2a-492d-9d96-bb8d053e6ced","modification_date":"2025-01-27T13:52:12.431883+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","name":"tf-srv-funny-tharp"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:25.163086+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quizzical-greider","id":"5a9cb023-8726-4757-82a7-529ba08c7181","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"201","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:ed","maintenances":[],"modification_date":"2025-02-11T14:24:52.960374+00:00","name":"tf-srv-quizzical-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2223"
+                - "1794"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:48 GMT
+                - Tue, 11 Feb 2025 14:25:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1700,11 +2533,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 629e4425-503e-4c0f-a012-5f3d1aa01092
+                - 6da3fff1-f9b9-459a-98c9-700471b83153
         status: 200 OK
         code: 200
-        duration: 159.183ms
-    - id: 34
+        duration: 176.8245ms
+    - id: 51
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1719,8 +2552,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181
         method: GET
       response:
         proto: HTTP/2.0
@@ -1728,20 +2561,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2223
+        content_length: 1794
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:12.431883+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-tharp","id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1001","node_id":"15","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ff","maintenances":[],"modification_date":"2025-01-27T13:52:32.787244+00:00","name":"tf-srv-funny-tharp","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:12.431883+00:00","export_uri":null,"id":"75be1145-1b2a-492d-9d96-bb8d053e6ced","modification_date":"2025-01-27T13:52:12.431883+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","name":"tf-srv-funny-tharp"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:25.163086+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quizzical-greider","id":"5a9cb023-8726-4757-82a7-529ba08c7181","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"201","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:ed","maintenances":[],"modification_date":"2025-02-11T14:24:52.960374+00:00","name":"tf-srv-quizzical-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2223"
+                - "1794"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:53 GMT
+                - Tue, 11 Feb 2025 14:25:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1749,11 +2582,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5ebd0256-d5a6-40d2-ae46-92b2adeeb3b8
+                - 27b33d12-de3e-459c-9901-4d1a865c42cb
         status: 200 OK
         code: 200
-        duration: 194.263833ms
-    - id: 35
+        duration: 179.500458ms
+    - id: 52
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1768,8 +2601,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181
         method: GET
       response:
         proto: HTTP/2.0
@@ -1777,20 +2610,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2223
+        content_length: 1794
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:12.431883+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-tharp","id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1001","node_id":"15","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ff","maintenances":[],"modification_date":"2025-01-27T13:52:32.787244+00:00","name":"tf-srv-funny-tharp","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:12.431883+00:00","export_uri":null,"id":"75be1145-1b2a-492d-9d96-bb8d053e6ced","modification_date":"2025-01-27T13:52:12.431883+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","name":"tf-srv-funny-tharp"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:25.163086+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quizzical-greider","id":"5a9cb023-8726-4757-82a7-529ba08c7181","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"201","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:ed","maintenances":[],"modification_date":"2025-02-11T14:24:52.960374+00:00","name":"tf-srv-quizzical-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2223"
+                - "1794"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:59 GMT
+                - Tue, 11 Feb 2025 14:25:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1798,11 +2631,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f720e3b5-7644-4d5e-9291-40c719b18105
+                - 772489dd-c321-4b41-bb13-41da48ea7645
         status: 200 OK
         code: 200
-        duration: 169.423792ms
-    - id: 36
+        duration: 159.517ms
+    - id: 53
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1817,8 +2650,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181
         method: GET
       response:
         proto: HTTP/2.0
@@ -1826,20 +2659,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2223
+        content_length: 1794
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:12.431883+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-tharp","id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1001","node_id":"15","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ff","maintenances":[],"modification_date":"2025-01-27T13:52:32.787244+00:00","name":"tf-srv-funny-tharp","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:12.431883+00:00","export_uri":null,"id":"75be1145-1b2a-492d-9d96-bb8d053e6ced","modification_date":"2025-01-27T13:52:12.431883+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","name":"tf-srv-funny-tharp"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:25.163086+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quizzical-greider","id":"5a9cb023-8726-4757-82a7-529ba08c7181","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"201","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:ed","maintenances":[],"modification_date":"2025-02-11T14:24:52.960374+00:00","name":"tf-srv-quizzical-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2223"
+                - "1794"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:03 GMT
+                - Tue, 11 Feb 2025 14:25:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1847,11 +2680,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8397d1b0-5848-481f-bb18-c573e9f0a2ed
+                - 89807218-0a9b-417c-8710-12669d1d1d3a
         status: 200 OK
         code: 200
-        duration: 210.988542ms
-    - id: 37
+        duration: 157.582333ms
+    - id: 54
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1866,8 +2699,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181
         method: GET
       response:
         proto: HTTP/2.0
@@ -1875,20 +2708,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2223
+        content_length: 1678
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:12.431883+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-tharp","id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1001","node_id":"15","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ff","maintenances":[],"modification_date":"2025-01-27T13:52:32.787244+00:00","name":"tf-srv-funny-tharp","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:12.431883+00:00","export_uri":null,"id":"75be1145-1b2a-492d-9d96-bb8d053e6ced","modification_date":"2025-01-27T13:52:12.431883+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","name":"tf-srv-funny-tharp"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:25.163086+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quizzical-greider","id":"5a9cb023-8726-4757-82a7-529ba08c7181","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ed","maintenances":[],"modification_date":"2025-02-11T14:25:26.363609+00:00","name":"tf-srv-quizzical-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2223"
+                - "1678"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:09 GMT
+                - Tue, 11 Feb 2025 14:25:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1896,11 +2729,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4145dbb8-c465-42c6-903c-49d3b324fb62
+                - 5a0ea711-3588-4ee8-8987-0ac2adce262a
         status: 200 OK
         code: 200
-        duration: 197.25075ms
-    - id: 38
+        duration: 181.65375ms
+    - id: 55
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1915,8 +2748,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181
         method: GET
       response:
         proto: HTTP/2.0
@@ -1924,20 +2757,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2223
+        content_length: 1678
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:12.431883+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-tharp","id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1001","node_id":"15","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:ff","maintenances":[],"modification_date":"2025-01-27T13:52:32.787244+00:00","name":"tf-srv-funny-tharp","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:12.431883+00:00","export_uri":null,"id":"75be1145-1b2a-492d-9d96-bb8d053e6ced","modification_date":"2025-01-27T13:52:12.431883+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","name":"tf-srv-funny-tharp"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:25.163086+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quizzical-greider","id":"5a9cb023-8726-4757-82a7-529ba08c7181","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:ed","maintenances":[],"modification_date":"2025-02-11T14:25:26.363609+00:00","name":"tf-srv-quizzical-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2223"
+                - "1678"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:14 GMT
+                - Tue, 11 Feb 2025 14:25:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1945,11 +2778,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5fddd055-7060-49c7-8968-638d2575888e
+                - 6bf125c6-b1df-432c-849f-9ca1ef8d7597
         status: 200 OK
         code: 200
-        duration: 207.663041ms
-    - id: 39
+        duration: 166.303125ms
+    - id: 56
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1964,106 +2797,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2106
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:12.431883+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-tharp","id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:ff","maintenances":[],"modification_date":"2025-01-27T13:53:15.499933+00:00","name":"tf-srv-funny-tharp","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:12.431883+00:00","export_uri":null,"id":"75be1145-1b2a-492d-9d96-bb8d053e6ced","modification_date":"2025-01-27T13:52:12.431883+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","name":"tf-srv-funny-tharp"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2106"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:53:19 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 9f0908c7-dd10-430b-934c-232a2ea92a67
-        status: 200 OK
-        code: 200
-        duration: 143.588708ms
-    - id: 40
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2106
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:12.431883+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-tharp","id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:ff","maintenances":[],"modification_date":"2025-01-27T13:53:15.499933+00:00","name":"tf-srv-funny-tharp","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:12.431883+00:00","export_uri":null,"id":"75be1145-1b2a-492d-9d96-bb8d053e6ced","modification_date":"2025-01-27T13:52:12.431883+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","name":"tf-srv-funny-tharp"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2106"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:53:20 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - e047a38e-86dd-4407-ae9f-f8b54e9c0fc6
-        status: 200 OK
-        code: 200
-        duration: 253.022958ms
-    - id: 41
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2080,9 +2815,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:19 GMT
+                - Tue, 11 Feb 2025 14:25:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2090,11 +2825,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2dae4785-f8ac-4af0-bf16-906194c076ce
+                - 2465ea90-2b59-453e-b475-b0924a61bd48
         status: 204 No Content
         code: 204
-        duration: 167.245042ms
-    - id: 42
+        duration: 249.870792ms
+    - id: 57
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2109,8 +2844,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181
         method: GET
       response:
         proto: HTTP/2.0
@@ -2120,7 +2855,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"5a9cb023-8726-4757-82a7-529ba08c7181","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -2129,9 +2864,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:20 GMT
+                - Tue, 11 Feb 2025 14:25:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2139,11 +2874,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a33d4225-fb5e-4865-8e7c-070d3d5e30e6
+                - b49365ef-877c-4e1a-b91a-dc7a05fa0704
         status: 404 Not Found
         code: 404
-        duration: 92.414917ms
-    - id: 43
+        duration: 102.336625ms
+    - id: 58
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2158,8 +2893,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/75be1145-1b2a-492d-9d96-bb8d053e6ced
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/4e04cfc2-6982-41d3-99ec-c9618d959e15
         method: GET
       response:
         proto: HTTP/2.0
@@ -2167,20 +2902,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 446
+        content_length: 143
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:52:12.431883+00:00","export_uri":null,"id":"75be1145-1b2a-492d-9d96-bb8d053e6ced","modification_date":"2025-01-27T13:53:20.235773+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","type":"not_found"}'
         headers:
             Content-Length:
-                - "446"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:20 GMT
+                - Tue, 11 Feb 2025 14:25:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2188,11 +2923,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 39bcdbad-e73e-4c65-b262-e1b3da671430
-        status: 200 OK
-        code: 200
-        duration: 71.612292ms
-    - id: 44
+                - 09ff9f59-44b2-4715-a4e4-13c4d8651ba5
+        status: 404 Not Found
+        code: 404
+        duration: 29.55725ms
+    - id: 59
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2207,8 +2942,57 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/75be1145-1b2a-492d-9d96-bb8d053e6ced
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/4e04cfc2-6982-41d3-99ec-c9618d959e15
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 494
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:23:25.372077Z","id":"4e04cfc2-6982-41d3-99ec-c9618d959e15","last_detached_at":"2025-02-11T14:25:30.108666Z","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:25:30.108666Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "494"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ec0fbf6b-a253-4232-bcda-ecb6ff191693
+        status: 200 OK
+        code: 200
+        duration: 57.029625ms
+    - id: 60
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/4e04cfc2-6982-41d3-99ec-c9618d959e15
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2225,9 +3009,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:20 GMT
+                - Tue, 11 Feb 2025 14:25:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2235,11 +3019,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4635f725-2165-46bc-b5b0-5b0742d166a1
+                - bf0b27c5-6020-4dea-af25-c5c5665274f2
         status: 204 No Content
         code: 204
-        duration: 161.701625ms
-    - id: 45
+        duration: 143.871416ms
+    - id: 61
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2254,8 +3038,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b34fa905-cbcd-45a6-be1c-eeef841f3d50
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5a9cb023-8726-4757-82a7-529ba08c7181
         method: GET
       response:
         proto: HTTP/2.0
@@ -2265,7 +3049,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"b34fa905-cbcd-45a6-be1c-eeef841f3d50","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"5a9cb023-8726-4757-82a7-529ba08c7181","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -2274,9 +3058,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:20 GMT
+                - Tue, 11 Feb 2025 14:25:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2284,7 +3068,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2c66f736-69e2-4f94-8d58-0527fa8eb964
+                - e427c39a-29f2-41dc-a02e-6442a9eb84aa
         status: 404 Not Found
         code: 404
-        duration: 85.973541ms
+        duration: 70.607584ms

--- a/internal/services/instance/testdata/server-user-data-without-cloud-init-at-start.cassette.yaml
+++ b/internal/services/instance/testdata/server-user-data-without-cloud-init-at-start.cassette.yaml
@@ -16,7 +16,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
         method: GET
       response:
@@ -25,22 +25,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 38539
+        content_length: 35639
         uncompressed: false
-        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
+        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
         headers:
             Content-Length:
-                - "38539"
+                - "35639"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:38 GMT
+                - Tue, 11 Feb 2025 14:23:22 GMT
             Link:
                 - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,12 +48,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 74ff50bd-8f1a-4ea9-87ce-5cf9ed9ca838
+                - 917d8102-60cc-43b5-8ee4-b3c726c652a6
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 41.564541ms
+        duration: 60.005958ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -69,7 +69,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
         method: GET
       response:
@@ -78,22 +78,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 14208
+        content_length: 13164
         uncompressed: false
-        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
         headers:
             Content-Length:
-                - "14208"
+                - "13164"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:38 GMT
+                - Tue, 11 Feb 2025 14:23:22 GMT
             Link:
                 - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -101,12 +101,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bbef4eba-7aeb-4ca2-8098-60a5993b0c1f
+                - 617f5152-0d49-4dea-b159-fe296104ee42
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 49.663458ms
+        duration: 46.31825ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -122,8 +122,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_local&zone=fr-par-1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_sbs&zone=fr-par-1
         method: GET
       response:
         proto: HTTP/2.0
@@ -131,20 +131,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1300
+        content_length: 1296
         uncompressed: false
-        body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"56d4019c-8305-467a-a3f2-70498ad799df","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
+        body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"57509e82-ac3b-49b7-9970-97b60f40ff72","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"9b647e1e-253a-41e7-8c15-911c622ee2dc","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"}],"total_count":2}'
         headers:
             Content-Length:
-                - "1300"
+                - "1296"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:38 GMT
+                - Tue, 11 Feb 2025 14:23:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -152,28 +152,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9b7bf8df-8910-42bb-b6cb-402450fd3fa9
+                - d2f5d2e7-583b-4604-8990-9da0b1c4a4a5
         status: 200 OK
         code: 200
-        duration: 77.149667ms
+        duration: 71.332542ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 336
+        content_length: 318
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-srv-bold-raman","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":["terraform-test","scaleway_instance_server","user_data"]}'
+        body: '{"name":"tf-srv-clever-lamport","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"57509e82-ac3b-49b7-9970-97b60f40ff72","volumes":{"0":{"boot":false,"size":20000000000}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":["terraform-test","scaleway_instance_server","user_data"]}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
         method: POST
       response:
@@ -182,22 +182,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2160
+        content_length: 1729
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:39.041885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-raman","id":"67989537-8f92-404e-9f2e-2710d405987f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:e5","maintenances":[],"modification_date":"2025-01-27T13:51:39.041885+00:00","name":"tf-srv-bold-raman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:39.041885+00:00","export_uri":null,"id":"f1b682db-eff5-416c-80c8-168a3c883385","modification_date":"2025-01-27T13:51:39.041885+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"67989537-8f92-404e-9f2e-2710d405987f","name":"tf-srv-bold-raman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:23.351804+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-lamport","id":"f62102df-b5f4-41a0-9f69-5f92a08bef6e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:eb","maintenances":[],"modification_date":"2025-02-11T14:23:23.351804+00:00","name":"tf-srv-clever-lamport","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"id":"f2e598d4-e262-464c-8936-029ec09368c8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2160"
+                - "1729"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:39 GMT
+                - Tue, 11 Feb 2025 14:23:23 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -205,10 +205,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e854a60d-0f16-4559-bea4-7460d12aa20f
+                - 6471a9d6-ef49-4ad7-a5ce-bcc593ae4275
         status: 201 Created
         code: 201
-        duration: 663.727083ms
+        duration: 906.439292ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -224,8 +224,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e
         method: GET
       response:
         proto: HTTP/2.0
@@ -233,20 +233,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2160
+        content_length: 1729
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:39.041885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-raman","id":"67989537-8f92-404e-9f2e-2710d405987f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:e5","maintenances":[],"modification_date":"2025-01-27T13:51:39.041885+00:00","name":"tf-srv-bold-raman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:39.041885+00:00","export_uri":null,"id":"f1b682db-eff5-416c-80c8-168a3c883385","modification_date":"2025-01-27T13:51:39.041885+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"67989537-8f92-404e-9f2e-2710d405987f","name":"tf-srv-bold-raman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:23.351804+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-lamport","id":"f62102df-b5f4-41a0-9f69-5f92a08bef6e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:eb","maintenances":[],"modification_date":"2025-02-11T14:23:23.351804+00:00","name":"tf-srv-clever-lamport","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"id":"f2e598d4-e262-464c-8936-029ec09368c8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2160"
+                - "1729"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:39 GMT
+                - Tue, 11 Feb 2025 14:23:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -254,10 +254,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cd7ceb11-3a6d-40a4-b176-a851ef59dd08
+                - 28b60ba8-e759-48fd-8f43-c26f783bd426
         status: 200 OK
         code: 200
-        duration: 136.28475ms
+        duration: 142.285333ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -273,8 +273,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e
         method: GET
       response:
         proto: HTTP/2.0
@@ -282,20 +282,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2160
+        content_length: 1729
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:39.041885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-raman","id":"67989537-8f92-404e-9f2e-2710d405987f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:e5","maintenances":[],"modification_date":"2025-01-27T13:51:39.041885+00:00","name":"tf-srv-bold-raman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:39.041885+00:00","export_uri":null,"id":"f1b682db-eff5-416c-80c8-168a3c883385","modification_date":"2025-01-27T13:51:39.041885+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"67989537-8f92-404e-9f2e-2710d405987f","name":"tf-srv-bold-raman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:23.351804+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-lamport","id":"f62102df-b5f4-41a0-9f69-5f92a08bef6e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:eb","maintenances":[],"modification_date":"2025-02-11T14:23:23.351804+00:00","name":"tf-srv-clever-lamport","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"id":"f2e598d4-e262-464c-8936-029ec09368c8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2160"
+                - "1729"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:39 GMT
+                - Tue, 11 Feb 2025 14:23:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -303,11 +303,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 133bb233-7fe7-4b22-b310-fbfd3b77105d
+                - f85ab4f3-8435-4768-bc86-d7f134ed6720
         status: 200 OK
         code: 200
-        duration: 152.885958ms
+        duration: 175.550167ms
     - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/f2e598d4-e262-464c-8936-029ec09368c8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:23:23.559738Z","id":"f2e598d4-e262-464c-8936-029ec09368c8","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:23.559738Z","id":"7161822b-524f-4a32-963b-b715b4da45c6","product_resource_id":"f62102df-b5f4-41a0-9f69-5f92a08bef6e","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":20000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:23.559738Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:24 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7e9b1c78-f89a-4199-a5c9-5c8ef8c0597c
+        status: 200 OK
+        code: 200
+        duration: 60.591708ms
+    - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -324,8 +373,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -335,7 +384,7 @@ interactions:
         trailer: {}
         content_length: 357
         uncompressed: false
-        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/67989537-8f92-404e-9f2e-2710d405987f/action","href_result":"/servers/67989537-8f92-404e-9f2e-2710d405987f","id":"0d3cb7cc-aafe-4cd4-be98-77287d949bc0","progress":0,"started_at":"2025-01-27T13:51:39.998971+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e/action","href_result":"/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e","id":"b1d25929-696c-42a4-b0b3-e8f06146681e","progress":0,"started_at":"2025-02-11T14:23:24.464345+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -344,11 +393,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:39 GMT
+                - Tue, 11 Feb 2025 14:23:24 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/0d3cb7cc-aafe-4cd4-be98-77287d949bc0
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/b1d25929-696c-42a4-b0b3-e8f06146681e
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -356,59 +405,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0c69da5f-3a23-494f-adee-2c02b9c3dc90
+                - c10d1676-f321-4272-8928-468385b7b025
         status: 202 Accepted
         code: 202
-        duration: 338.141416ms
-    - id: 7
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2182
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:39.041885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-raman","id":"67989537-8f92-404e-9f2e-2710d405987f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:e5","maintenances":[],"modification_date":"2025-01-27T13:51:39.767558+00:00","name":"tf-srv-bold-raman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:39.041885+00:00","export_uri":null,"id":"f1b682db-eff5-416c-80c8-168a3c883385","modification_date":"2025-01-27T13:51:39.041885+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"67989537-8f92-404e-9f2e-2710d405987f","name":"tf-srv-bold-raman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2182"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:40 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 7ecfef77-cc2c-436c-a66a-6694c1ac493c
-        status: 200 OK
-        code: 200
-        duration: 172.391334ms
+        duration: 278.518042ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -424,8 +424,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e
         method: GET
       response:
         proto: HTTP/2.0
@@ -433,20 +433,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2286
+        content_length: 1751
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:39.041885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-raman","id":"67989537-8f92-404e-9f2e-2710d405987f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1102","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:e5","maintenances":[],"modification_date":"2025-01-27T13:51:39.767558+00:00","name":"tf-srv-bold-raman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:39.041885+00:00","export_uri":null,"id":"f1b682db-eff5-416c-80c8-168a3c883385","modification_date":"2025-01-27T13:51:39.041885+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"67989537-8f92-404e-9f2e-2710d405987f","name":"tf-srv-bold-raman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:23.351804+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-lamport","id":"f62102df-b5f4-41a0-9f69-5f92a08bef6e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:eb","maintenances":[],"modification_date":"2025-02-11T14:23:24.238032+00:00","name":"tf-srv-clever-lamport","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"id":"f2e598d4-e262-464c-8936-029ec09368c8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2286"
+                - "1751"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:45 GMT
+                - Tue, 11 Feb 2025 14:23:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -454,10 +454,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d5c7f15e-239d-4c2a-8218-435c9f089f94
+                - 55da650f-1399-4785-8e90-773f85927f2c
         status: 200 OK
         code: 200
-        duration: 165.552083ms
+        duration: 146.770125ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -473,8 +473,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e
         method: GET
       response:
         proto: HTTP/2.0
@@ -482,20 +482,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2286
+        content_length: 1885
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:39.041885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-raman","id":"67989537-8f92-404e-9f2e-2710d405987f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1102","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:e5","maintenances":[],"modification_date":"2025-01-27T13:51:39.767558+00:00","name":"tf-srv-bold-raman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:39.041885+00:00","export_uri":null,"id":"f1b682db-eff5-416c-80c8-168a3c883385","modification_date":"2025-01-27T13:51:39.041885+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"67989537-8f92-404e-9f2e-2710d405987f","name":"tf-srv-bold-raman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:23.351804+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-lamport","id":"f62102df-b5f4-41a0-9f69-5f92a08bef6e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"302","node_id":"34","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:eb","maintenances":[],"modification_date":"2025-02-11T14:23:28.155525+00:00","name":"tf-srv-clever-lamport","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"id":"f2e598d4-e262-464c-8936-029ec09368c8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2286"
+                - "1885"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:50 GMT
+                - Tue, 11 Feb 2025 14:23:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -503,10 +503,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0eecfe05-3569-4813-9d10-8acb1b435747
+                - 954d0f45-3e5d-4909-bc23-8b37247eae2c
         status: 200 OK
         code: 200
-        duration: 174.701583ms
+        duration: 213.932292ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -522,8 +522,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e
         method: GET
       response:
         proto: HTTP/2.0
@@ -531,20 +531,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2317
+        content_length: 1885
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:39.041885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-raman","id":"67989537-8f92-404e-9f2e-2710d405987f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1102","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:e5","maintenances":[],"modification_date":"2025-01-27T13:51:51.867096+00:00","name":"tf-srv-bold-raman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:39.041885+00:00","export_uri":null,"id":"f1b682db-eff5-416c-80c8-168a3c883385","modification_date":"2025-01-27T13:51:39.041885+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"67989537-8f92-404e-9f2e-2710d405987f","name":"tf-srv-bold-raman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:23.351804+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-lamport","id":"f62102df-b5f4-41a0-9f69-5f92a08bef6e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"302","node_id":"34","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:eb","maintenances":[],"modification_date":"2025-02-11T14:23:28.155525+00:00","name":"tf-srv-clever-lamport","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"id":"f2e598d4-e262-464c-8936-029ec09368c8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2317"
+                - "1885"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:55 GMT
+                - Tue, 11 Feb 2025 14:23:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -552,10 +552,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 45df24cb-5b71-4b28-b162-dcaaa34908e3
+                - 2f6b5811-9c32-431f-94b8-8ed2b06821ae
         status: 200 OK
         code: 200
-        duration: 215.892458ms
+        duration: 174.767625ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -571,8 +571,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f2e598d4-e262-464c-8936-029ec09368c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -580,20 +580,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2317
+        content_length: 143
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:39.041885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-raman","id":"67989537-8f92-404e-9f2e-2710d405987f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1102","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:e5","maintenances":[],"modification_date":"2025-01-27T13:51:51.867096+00:00","name":"tf-srv-bold-raman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:39.041885+00:00","export_uri":null,"id":"f1b682db-eff5-416c-80c8-168a3c883385","modification_date":"2025-01-27T13:51:39.041885+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"67989537-8f92-404e-9f2e-2710d405987f","name":"tf-srv-bold-raman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"f2e598d4-e262-464c-8936-029ec09368c8","type":"not_found"}'
         headers:
             Content-Length:
-                - "2317"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:55 GMT
+                - Tue, 11 Feb 2025 14:23:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -601,10 +601,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d2f1469a-f2b7-41c3-9a6f-62b541e1dd04
-        status: 200 OK
-        code: 200
-        duration: 178.3085ms
+                - 84b31dc5-a955-4e12-84f3-e59b00b97631
+        status: 404 Not Found
+        code: 404
+        duration: 42.032583ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -620,8 +620,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f1b682db-eff5-416c-80c8-168a3c883385
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/f2e598d4-e262-464c-8936-029ec09368c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -629,20 +629,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 517
+        content_length: 701
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:39.041885+00:00","export_uri":null,"id":"f1b682db-eff5-416c-80c8-168a3c883385","modification_date":"2025-01-27T13:51:39.041885+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"67989537-8f92-404e-9f2e-2710d405987f","name":"tf-srv-bold-raman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T14:23:23.559738Z","id":"f2e598d4-e262-464c-8936-029ec09368c8","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:23.559738Z","id":"7161822b-524f-4a32-963b-b715b4da45c6","product_resource_id":"f62102df-b5f4-41a0-9f69-5f92a08bef6e","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":20000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:23.559738Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "517"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:55 GMT
+                - Tue, 11 Feb 2025 14:23:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -650,10 +650,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c16dbc1b-495e-4c3a-9711-611b08331591
+                - 5906c520-710b-4da8-b7ca-ad4895376826
         status: 200 OK
         code: 200
-        duration: 85.33325ms
+        duration: 68.253625ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -669,8 +669,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -689,9 +689,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:56 GMT
+                - Tue, 11 Feb 2025 14:23:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -699,10 +699,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - efe6f1e7-00b4-4461-8352-e069a68cbe73
+                - 14019a7a-760d-45fe-a5fe-5b05f25cc70e
         status: 200 OK
         code: 200
-        duration: 103.706ms
+        duration: 89.989083ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -718,8 +718,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -738,11 +738,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:56 GMT
+                - Tue, 11 Feb 2025 14:23:30 GMT
             Link:
-                - </servers/67989537-8f92-404e-9f2e-2710d405987f/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -750,12 +750,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ead00118-ecb3-4528-bf33-bd3838a267c7
+                - c3e68822-3d83-4993-8559-5d136a4da9ac
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 105.196417ms
+        duration: 84.13325ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -771,8 +771,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e
         method: GET
       response:
         proto: HTTP/2.0
@@ -780,20 +780,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2317
+        content_length: 1885
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:39.041885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-raman","id":"67989537-8f92-404e-9f2e-2710d405987f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1102","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:e5","maintenances":[],"modification_date":"2025-01-27T13:51:51.867096+00:00","name":"tf-srv-bold-raman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:39.041885+00:00","export_uri":null,"id":"f1b682db-eff5-416c-80c8-168a3c883385","modification_date":"2025-01-27T13:51:39.041885+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"67989537-8f92-404e-9f2e-2710d405987f","name":"tf-srv-bold-raman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:23.351804+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-lamport","id":"f62102df-b5f4-41a0-9f69-5f92a08bef6e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"302","node_id":"34","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:eb","maintenances":[],"modification_date":"2025-02-11T14:23:28.155525+00:00","name":"tf-srv-clever-lamport","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"id":"f2e598d4-e262-464c-8936-029ec09368c8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2317"
+                - "1885"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:56 GMT
+                - Tue, 11 Feb 2025 14:23:30 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -801,10 +801,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0d38e33d-5a48-4dc4-9006-7b04bf76ea7b
+                - aefc1242-93e6-41d8-9d6e-cd01879c70a7
         status: 200 OK
         code: 200
-        duration: 180.58525ms
+        duration: 738.735959ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -820,8 +820,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e
         method: GET
       response:
         proto: HTTP/2.0
@@ -829,20 +829,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2317
+        content_length: 1885
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:39.041885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-raman","id":"67989537-8f92-404e-9f2e-2710d405987f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1102","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:e5","maintenances":[],"modification_date":"2025-01-27T13:51:51.867096+00:00","name":"tf-srv-bold-raman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:39.041885+00:00","export_uri":null,"id":"f1b682db-eff5-416c-80c8-168a3c883385","modification_date":"2025-01-27T13:51:39.041885+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"67989537-8f92-404e-9f2e-2710d405987f","name":"tf-srv-bold-raman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:23.351804+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-lamport","id":"f62102df-b5f4-41a0-9f69-5f92a08bef6e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"302","node_id":"34","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:eb","maintenances":[],"modification_date":"2025-02-11T14:23:28.155525+00:00","name":"tf-srv-clever-lamport","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"id":"f2e598d4-e262-464c-8936-029ec09368c8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2317"
+                - "1885"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:56 GMT
+                - Tue, 11 Feb 2025 14:23:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -850,10 +850,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d04df385-d20e-474c-8856-8ac62408b65b
+                - 893db75e-e6f4-4468-bccd-a1aca87ece9b
         status: 200 OK
         code: 200
-        duration: 177.527375ms
+        duration: 152.724166ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -869,8 +869,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f1b682db-eff5-416c-80c8-168a3c883385
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f2e598d4-e262-464c-8936-029ec09368c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -878,20 +878,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 517
+        content_length: 143
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:39.041885+00:00","export_uri":null,"id":"f1b682db-eff5-416c-80c8-168a3c883385","modification_date":"2025-01-27T13:51:39.041885+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"67989537-8f92-404e-9f2e-2710d405987f","name":"tf-srv-bold-raman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"f2e598d4-e262-464c-8936-029ec09368c8","type":"not_found"}'
         headers:
             Content-Length:
-                - "517"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:56 GMT
+                - Tue, 11 Feb 2025 14:23:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -899,10 +899,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 810e23f4-17d9-4dfb-b016-14960755cef5
-        status: 200 OK
-        code: 200
-        duration: 83.659542ms
+                - 476361b9-4e16-4497-894c-36fe882d1a15
+        status: 404 Not Found
+        code: 404
+        duration: 30.829709ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -918,8 +918,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/f2e598d4-e262-464c-8936-029ec09368c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -927,20 +927,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 701
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"created_at":"2025-02-11T14:23:23.559738Z","id":"f2e598d4-e262-464c-8936-029ec09368c8","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:23.559738Z","id":"7161822b-524f-4a32-963b-b715b4da45c6","product_resource_id":"f62102df-b5f4-41a0-9f69-5f92a08bef6e","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":20000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:23.559738Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "17"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:56 GMT
+                - Tue, 11 Feb 2025 14:23:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -948,10 +948,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f1ae65b9-d057-4dff-8d4f-4d9a45521ae6
+                - deb3652c-1ab0-455a-b8b3-a6c724797eb9
         status: 200 OK
         code: 200
-        duration: 93.373875ms
+        duration: 65.377125ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -967,8 +967,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -976,22 +976,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 17
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "20"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:57 GMT
-            Link:
-                - </servers/67989537-8f92-404e-9f2e-2710d405987f/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:23:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -999,12 +997,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 18c75ec4-33ff-4130-bbc7-033f65781bfe
-            X-Total-Count:
-                - "0"
+                - 07767f70-d9ca-4b62-805c-11416a062e5b
         status: 200 OK
         code: 200
-        duration: 96.222125ms
+        duration: 72.512166ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1020,155 +1016,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2317
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:39.041885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-raman","id":"67989537-8f92-404e-9f2e-2710d405987f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1102","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:e5","maintenances":[],"modification_date":"2025-01-27T13:51:51.867096+00:00","name":"tf-srv-bold-raman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:39.041885+00:00","export_uri":null,"id":"f1b682db-eff5-416c-80c8-168a3c883385","modification_date":"2025-01-27T13:51:39.041885+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"67989537-8f92-404e-9f2e-2710d405987f","name":"tf-srv-bold-raman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2317"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:57 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 0113f5a4-8eb2-4fef-bdb8-2aed877c799a
-        status: 200 OK
-        code: 200
-        duration: 158.985375ms
-    - id: 21
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f1b682db-eff5-416c-80c8-168a3c883385
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 517
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:39.041885+00:00","export_uri":null,"id":"f1b682db-eff5-416c-80c8-168a3c883385","modification_date":"2025-01-27T13:51:39.041885+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"67989537-8f92-404e-9f2e-2710d405987f","name":"tf-srv-bold-raman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "517"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:57 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - d372a0ff-7894-426e-ad5d-981e2e09511f
-        status: 200 OK
-        code: 200
-        duration: 65.944083ms
-    - id: 22
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f/user_data
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 17
-        uncompressed: false
-        body: '{"user_data":[]}'
-        headers:
-            Content-Length:
-                - "17"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:57 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 1d241ee5-65aa-48fe-89a3-83be0f48c3d7
-        status: 200 OK
-        code: 200
-        duration: 90.688291ms
-    - id: 23
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1187,11 +1036,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:57 GMT
+                - Tue, 11 Feb 2025 14:23:31 GMT
             Link:
-                - </servers/67989537-8f92-404e-9f2e-2710d405987f/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1199,12 +1048,159 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d5e06680-b669-48f7-bdfc-30e3e403abea
+                - 96ad01fa-4a46-4f1a-94b6-59b0d1c75ece
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 93.189541ms
+        duration: 93.088334ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1885
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:23.351804+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-lamport","id":"f62102df-b5f4-41a0-9f69-5f92a08bef6e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"302","node_id":"34","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:eb","maintenances":[],"modification_date":"2025-02-11T14:23:28.155525+00:00","name":"tf-srv-clever-lamport","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"id":"f2e598d4-e262-464c-8936-029ec09368c8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1885"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 28d2a841-5ad9-4fcf-a2a4-4d15064a9c56
+        status: 200 OK
+        code: 200
+        duration: 228.165708ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f2e598d4-e262-464c-8936-029ec09368c8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"f2e598d4-e262-464c-8936-029ec09368c8","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 93ba7530-244c-44af-bd1d-8323e3d4cc06
+        status: 404 Not Found
+        code: 404
+        duration: 35.459916ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/f2e598d4-e262-464c-8936-029ec09368c8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:23:23.559738Z","id":"f2e598d4-e262-464c-8936-029ec09368c8","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:23.559738Z","id":"7161822b-524f-4a32-963b-b715b4da45c6","product_resource_id":"f62102df-b5f4-41a0-9f69-5f92a08bef6e","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":20000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:23.559738Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c3d74c11-6dae-4ffb-8ab8-47d032725607
+        status: 200 OK
+        code: 200
+        duration: 68.071791ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1220,106 +1216,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2317
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:39.041885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-raman","id":"67989537-8f92-404e-9f2e-2710d405987f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1102","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:e5","maintenances":[],"modification_date":"2025-01-27T13:51:51.867096+00:00","name":"tf-srv-bold-raman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:39.041885+00:00","export_uri":null,"id":"f1b682db-eff5-416c-80c8-168a3c883385","modification_date":"2025-01-27T13:51:39.041885+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"67989537-8f92-404e-9f2e-2710d405987f","name":"tf-srv-bold-raman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2317"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:58 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 0bd639e6-3569-4ffe-801c-dcc4bcd84009
-        status: 200 OK
-        code: 200
-        duration: 185.179875ms
-    - id: 25
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2317
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:39.041885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-raman","id":"67989537-8f92-404e-9f2e-2710d405987f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1102","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:e5","maintenances":[],"modification_date":"2025-01-27T13:51:51.867096+00:00","name":"tf-srv-bold-raman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:39.041885+00:00","export_uri":null,"id":"f1b682db-eff5-416c-80c8-168a3c883385","modification_date":"2025-01-27T13:51:39.041885+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"67989537-8f92-404e-9f2e-2710d405987f","name":"tf-srv-bold-raman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2317"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:58 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 9a8f4fa9-057e-46b8-bb63-d8ed542a48c5
-        status: 200 OK
-        code: 200
-        duration: 191.959875ms
-    - id: 26
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1338,9 +1236,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:58 GMT
+                - Tue, 11 Feb 2025 14:23:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1348,11 +1246,211 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 54127b59-fd36-4481-a173-eb9413b68967
+                - a157c529-0e2e-4d90-8944-c946cb9d2796
         status: 200 OK
         code: 200
-        duration: 107.332166ms
+        duration: 82.392167ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 20
+        uncompressed: false
+        body: '{"private_nics":[]}'
+        headers:
+            Content-Length:
+                - "20"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:32 GMT
+            Link:
+                - </servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e/private_nics?page=0&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4be8dcd9-946d-46cc-9676-0c96ec78136e
+            X-Total-Count:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 88.507542ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1885
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:23.351804+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-lamport","id":"f62102df-b5f4-41a0-9f69-5f92a08bef6e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"302","node_id":"34","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:eb","maintenances":[],"modification_date":"2025-02-11T14:23:28.155525+00:00","name":"tf-srv-clever-lamport","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"id":"f2e598d4-e262-464c-8936-029ec09368c8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1885"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - bf393940-e241-4b2d-817b-57b0623075eb
+        status: 200 OK
+        code: 200
+        duration: 164.044625ms
     - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1885
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:23.351804+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-lamport","id":"f62102df-b5f4-41a0-9f69-5f92a08bef6e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"302","node_id":"34","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:eb","maintenances":[],"modification_date":"2025-02-11T14:23:28.155525+00:00","name":"tf-srv-clever-lamport","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"id":"f2e598d4-e262-464c-8936-029ec09368c8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1885"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - befed11e-6335-47ea-8aba-ded14523bc19
+        status: 200 OK
+        code: 200
+        duration: 158.257791ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e/user_data
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 17
+        uncompressed: false
+        body: '{"user_data":[]}'
+        headers:
+            Content-Length:
+                - "17"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f5c72890-6c0b-4cd7-a794-f28f4d151a75
+        status: 200 OK
+        code: 200
+        duration: 101.512459ms
+    - id: 29
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1372,8 +1470,8 @@ interactions:
             Content-Type:
                 - text/plain
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f/user_data/cloud-init
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e/user_data/cloud-init
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -1390,9 +1488,9 @@ interactions:
             Content-Type:
                 - text/plain
             Date:
-                - Mon, 27 Jan 2025 13:51:58 GMT
+                - Tue, 11 Feb 2025 14:23:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1400,108 +1498,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2221c2ee-8a81-4719-b55f-187778fbf13e
+                - 3187eb49-6799-465a-a64c-e40c51f30b81
         status: 204 No Content
         code: 204
-        duration: 97.493458ms
-    - id: 28
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2317
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:39.041885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-raman","id":"67989537-8f92-404e-9f2e-2710d405987f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1102","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:e5","maintenances":[],"modification_date":"2025-01-27T13:51:51.867096+00:00","name":"tf-srv-bold-raman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:39.041885+00:00","export_uri":null,"id":"f1b682db-eff5-416c-80c8-168a3c883385","modification_date":"2025-01-27T13:51:39.041885+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"67989537-8f92-404e-9f2e-2710d405987f","name":"tf-srv-bold-raman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2317"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:58 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 0d514958-0ad6-4868-8160-01311c105191
-        status: 200 OK
-        code: 200
-        duration: 149.450042ms
-    - id: 29
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2317
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:39.041885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-raman","id":"67989537-8f92-404e-9f2e-2710d405987f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1102","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:e5","maintenances":[],"modification_date":"2025-01-27T13:51:51.867096+00:00","name":"tf-srv-bold-raman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:39.041885+00:00","export_uri":null,"id":"f1b682db-eff5-416c-80c8-168a3c883385","modification_date":"2025-01-27T13:51:39.041885+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"67989537-8f92-404e-9f2e-2710d405987f","name":"tf-srv-bold-raman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2317"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:58 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 3da5f353-7882-4de0-afe0-baa7be3d73d3
-        status: 200 OK
-        code: 200
-        duration: 199.752041ms
+        duration: 110.874084ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1517,8 +1517,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f1b682db-eff5-416c-80c8-168a3c883385
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1526,20 +1526,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 517
+        content_length: 1885
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:39.041885+00:00","export_uri":null,"id":"f1b682db-eff5-416c-80c8-168a3c883385","modification_date":"2025-01-27T13:51:39.041885+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"67989537-8f92-404e-9f2e-2710d405987f","name":"tf-srv-bold-raman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:23.351804+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-lamport","id":"f62102df-b5f4-41a0-9f69-5f92a08bef6e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"302","node_id":"34","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:eb","maintenances":[],"modification_date":"2025-02-11T14:23:28.155525+00:00","name":"tf-srv-clever-lamport","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"id":"f2e598d4-e262-464c-8936-029ec09368c8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "517"
+                - "1885"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:58 GMT
+                - Tue, 11 Feb 2025 14:23:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1547,10 +1547,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5bf20299-18b2-47c0-b5e5-9f4042335fac
+                - 86dcf88d-0acb-4700-8388-6a1aa574cb92
         status: 200 OK
         code: 200
-        duration: 69.660375ms
+        duration: 178.175ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1566,8 +1566,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1575,20 +1575,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 29
+        content_length: 1885
         uncompressed: false
-        body: '{"user_data":["cloud-init"]}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:23.351804+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-lamport","id":"f62102df-b5f4-41a0-9f69-5f92a08bef6e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"302","node_id":"34","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:eb","maintenances":[],"modification_date":"2025-02-11T14:23:28.155525+00:00","name":"tf-srv-clever-lamport","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"id":"f2e598d4-e262-464c-8936-029ec09368c8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "29"
+                - "1885"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:58 GMT
+                - Tue, 11 Feb 2025 14:23:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1596,10 +1596,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3d01bcbd-5874-4b28-ac47-b26c74644ed4
+                - 37f1a636-feae-435d-a4e5-7bdc4e967716
         status: 200 OK
         code: 200
-        duration: 83.108541ms
+        duration: 191.730375ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1615,8 +1615,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f/user_data/cloud-init
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f2e598d4-e262-464c-8936-029ec09368c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -1624,23 +1624,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 49
+        content_length: 143
         uncompressed: false
-        body: |
-            #cloud-config
-            apt_update: true
-            apt_upgrade: true
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"f2e598d4-e262-464c-8936-029ec09368c8","type":"not_found"}'
         headers:
             Content-Length:
-                - "49"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
-                - text/plain
+                - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:58 GMT
+                - Tue, 11 Feb 2025 14:23:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1648,10 +1645,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3da24e63-f0c5-44b2-93ee-2e4c0fc6e95a
-        status: 200 OK
-        code: 200
-        duration: 83.471583ms
+                - ce1e215c-e03f-4651-a06e-d034025e2331
+        status: 404 Not Found
+        code: 404
+        duration: 34.579667ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1667,8 +1664,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/f2e598d4-e262-464c-8936-029ec09368c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -1676,22 +1673,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 701
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"created_at":"2025-02-11T14:23:23.559738Z","id":"f2e598d4-e262-464c-8936-029ec09368c8","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:23.559738Z","id":"7161822b-524f-4a32-963b-b715b4da45c6","product_resource_id":"f62102df-b5f4-41a0-9f69-5f92a08bef6e","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":20000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:23.559738Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "20"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:59 GMT
-            Link:
-                - </servers/67989537-8f92-404e-9f2e-2710d405987f/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:23:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1699,12 +1694,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 55357668-28ac-446a-8afa-5bc6e998b9ed
-            X-Total-Count:
-                - "0"
+                - 3d60ae5a-7d99-4bf3-a3b0-92f4c6a64d10
         status: 200 OK
         code: 200
-        duration: 89.311875ms
+        duration: 56.998125ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1720,155 +1713,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2317
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:39.041885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-raman","id":"67989537-8f92-404e-9f2e-2710d405987f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1102","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:e5","maintenances":[],"modification_date":"2025-01-27T13:51:51.867096+00:00","name":"tf-srv-bold-raman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:39.041885+00:00","export_uri":null,"id":"f1b682db-eff5-416c-80c8-168a3c883385","modification_date":"2025-01-27T13:51:39.041885+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"67989537-8f92-404e-9f2e-2710d405987f","name":"tf-srv-bold-raman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2317"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:59 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 43350f95-3953-4631-8416-12f628e3f7ee
-        status: 200 OK
-        code: 200
-        duration: 182.94025ms
-    - id: 35
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2317
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:39.041885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-raman","id":"67989537-8f92-404e-9f2e-2710d405987f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1102","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:e5","maintenances":[],"modification_date":"2025-01-27T13:51:51.867096+00:00","name":"tf-srv-bold-raman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:39.041885+00:00","export_uri":null,"id":"f1b682db-eff5-416c-80c8-168a3c883385","modification_date":"2025-01-27T13:51:39.041885+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"67989537-8f92-404e-9f2e-2710d405987f","name":"tf-srv-bold-raman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2317"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:59 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - d2478ec0-63f7-43f1-88c9-d41152341cbe
-        status: 200 OK
-        code: 200
-        duration: 207.838292ms
-    - id: 36
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f1b682db-eff5-416c-80c8-168a3c883385
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 517
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:39.041885+00:00","export_uri":null,"id":"f1b682db-eff5-416c-80c8-168a3c883385","modification_date":"2025-01-27T13:51:39.041885+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"67989537-8f92-404e-9f2e-2710d405987f","name":"tf-srv-bold-raman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "517"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:52:00 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - d101af7a-e2cb-4c9c-8deb-bba8b00e729d
-        status: 200 OK
-        code: 200
-        duration: 86.487084ms
-    - id: 37
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1887,9 +1733,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:00 GMT
+                - Tue, 11 Feb 2025 14:23:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1897,11 +1743,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3a7ff8d5-9667-40a4-a6ad-b072f6baf765
+                - 1673faa4-d304-4837-962d-d806645ccd3c
         status: 200 OK
         code: 200
-        duration: 89.286416ms
-    - id: 38
+        duration: 112.537083ms
+    - id: 35
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1916,8 +1762,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f/user_data/cloud-init
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e/user_data/cloud-init
         method: GET
       response:
         proto: HTTP/2.0
@@ -1939,9 +1785,9 @@ interactions:
             Content-Type:
                 - text/plain
             Date:
-                - Mon, 27 Jan 2025 13:51:59 GMT
+                - Tue, 11 Feb 2025 14:23:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1949,11 +1795,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6a496a56-01ae-456f-a9ce-c9e2816bf5d3
+                - 169764b5-aa5e-4966-b257-f9899af87c9e
         status: 200 OK
         code: 200
-        duration: 106.005791ms
-    - id: 39
+        duration: 88.999833ms
+    - id: 36
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1968,8 +1814,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1988,11 +1834,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:00 GMT
+                - Tue, 11 Feb 2025 14:23:33 GMT
             Link:
-                - </servers/67989537-8f92-404e-9f2e-2710d405987f/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2000,12 +1846,159 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 50ca1c9d-307e-498b-acb6-4705d8917b7c
+                - fcfe1f10-fedc-4856-a3d8-218d20d6c675
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 89.989042ms
+        duration: 71.028875ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1885
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:23.351804+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-lamport","id":"f62102df-b5f4-41a0-9f69-5f92a08bef6e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"302","node_id":"34","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:eb","maintenances":[],"modification_date":"2025-02-11T14:23:28.155525+00:00","name":"tf-srv-clever-lamport","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"id":"f2e598d4-e262-464c-8936-029ec09368c8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1885"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 40a954df-6092-4104-aebe-7d5f32c13ed0
+        status: 200 OK
+        code: 200
+        duration: 130.004125ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1885
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:23.351804+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-lamport","id":"f62102df-b5f4-41a0-9f69-5f92a08bef6e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"302","node_id":"34","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:eb","maintenances":[],"modification_date":"2025-02-11T14:23:28.155525+00:00","name":"tf-srv-clever-lamport","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"id":"f2e598d4-e262-464c-8936-029ec09368c8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1885"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ada2c659-6d0e-4939-9675-0a97fc201ee6
+        status: 200 OK
+        code: 200
+        duration: 167.512292ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f2e598d4-e262-464c-8936-029ec09368c8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"f2e598d4-e262-464c-8936-029ec09368c8","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ff54cdb4-c02e-42b5-bd50-55d6ed29a3e5
+        status: 404 Not Found
+        code: 404
+        duration: 34.305125ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2021,8 +2014,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/f2e598d4-e262-464c-8936-029ec09368c8
         method: GET
       response:
         proto: HTTP/2.0
@@ -2030,20 +2023,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2317
+        content_length: 701
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:39.041885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-raman","id":"67989537-8f92-404e-9f2e-2710d405987f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1102","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:e5","maintenances":[],"modification_date":"2025-01-27T13:51:51.867096+00:00","name":"tf-srv-bold-raman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:39.041885+00:00","export_uri":null,"id":"f1b682db-eff5-416c-80c8-168a3c883385","modification_date":"2025-01-27T13:51:39.041885+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"67989537-8f92-404e-9f2e-2710d405987f","name":"tf-srv-bold-raman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T14:23:23.559738Z","id":"f2e598d4-e262-464c-8936-029ec09368c8","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:23.559738Z","id":"7161822b-524f-4a32-963b-b715b4da45c6","product_resource_id":"f62102df-b5f4-41a0-9f69-5f92a08bef6e","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":20000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:23.559738Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2317"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:00 GMT
+                - Tue, 11 Feb 2025 14:23:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2051,11 +2044,263 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bc1724ae-d0ef-4af6-bd16-c81ca21a8f8f
+                - d4b84187-775a-4933-b9d8-51077ea9b9df
         status: 200 OK
         code: 200
-        duration: 193.895041ms
+        duration: 65.726834ms
     - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e/user_data
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 29
+        uncompressed: false
+        body: '{"user_data":["cloud-init"]}'
+        headers:
+            Content-Length:
+                - "29"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 91c51e0d-4b7e-4e8a-9cb3-04e21ac9e9df
+        status: 200 OK
+        code: 200
+        duration: 76.868417ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e/user_data/cloud-init
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 49
+        uncompressed: false
+        body: |
+            #cloud-config
+            apt_update: true
+            apt_upgrade: true
+        headers:
+            Content-Length:
+                - "49"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - text/plain
+            Date:
+                - Tue, 11 Feb 2025 14:23:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 38ca0600-55a1-4b94-9a3a-c95b377d27bd
+        status: 200 OK
+        code: 200
+        duration: 88.957625ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 20
+        uncompressed: false
+        body: '{"private_nics":[]}'
+        headers:
+            Content-Length:
+                - "20"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:34 GMT
+            Link:
+                - </servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e/private_nics?page=0&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d889fe17-4066-470b-94c1-ef93a15cc293
+            X-Total-Count:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 102.139708ms
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1885
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:23.351804+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-lamport","id":"f62102df-b5f4-41a0-9f69-5f92a08bef6e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"302","node_id":"34","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:eb","maintenances":[],"modification_date":"2025-02-11T14:23:28.155525+00:00","name":"tf-srv-clever-lamport","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"id":"f2e598d4-e262-464c-8936-029ec09368c8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1885"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 013291ff-0d68-43fe-a886-7f5975d321bf
+        status: 200 OK
+        code: 200
+        duration: 186.992542ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/f2e598d4-e262-464c-8936-029ec09368c8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:23:23.559738Z","id":"f2e598d4-e262-464c-8936-029ec09368c8","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:23:23.559738Z","id":"7161822b-524f-4a32-963b-b715b4da45c6","product_resource_id":"f62102df-b5f4-41a0-9f69-5f92a08bef6e","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":20000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:23:23.559738Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - efd6a84c-f7e6-43ad-8544-d5d8b4a6094e
+        status: 200 OK
+        code: 200
+        duration: 60.674834ms
+    - id: 46
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2072,8 +2317,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -2083,7 +2328,7 @@ interactions:
         trailer: {}
         content_length: 352
         uncompressed: false
-        body: '{"task":{"description":"server_poweroff","href_from":"/servers/67989537-8f92-404e-9f2e-2710d405987f/action","href_result":"/servers/67989537-8f92-404e-9f2e-2710d405987f","id":"3b19f913-127f-4554-84d8-859de357ea37","progress":0,"started_at":"2025-01-27T13:52:01.021409+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_poweroff","href_from":"/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e/action","href_result":"/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e","id":"a6913b0c-417a-4a4b-8682-447381b3c931","progress":0,"started_at":"2025-02-11T14:23:35.586002+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "352"
@@ -2092,11 +2337,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:00 GMT
+                - Tue, 11 Feb 2025 14:23:35 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/3b19f913-127f-4554-84d8-859de357ea37
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/a6913b0c-417a-4a4b-8682-447381b3c931
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2104,255 +2349,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c76cf27b-4519-4282-ba94-a86ff6feba84
+                - e457bb91-2eaa-4399-9e9f-da2a49a31790
         status: 202 Accepted
         code: 202
-        duration: 300.965791ms
-    - id: 42
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2277
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:39.041885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-raman","id":"67989537-8f92-404e-9f2e-2710d405987f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1102","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:e5","maintenances":[],"modification_date":"2025-01-27T13:52:00.801102+00:00","name":"tf-srv-bold-raman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:39.041885+00:00","export_uri":null,"id":"f1b682db-eff5-416c-80c8-168a3c883385","modification_date":"2025-01-27T13:51:39.041885+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"67989537-8f92-404e-9f2e-2710d405987f","name":"tf-srv-bold-raman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2277"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:52:00 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 20dff56f-82c3-4f58-90cf-1a633ee476ec
-        status: 200 OK
-        code: 200
-        duration: 207.383666ms
-    - id: 43
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2277
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:39.041885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-raman","id":"67989537-8f92-404e-9f2e-2710d405987f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1102","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:e5","maintenances":[],"modification_date":"2025-01-27T13:52:00.801102+00:00","name":"tf-srv-bold-raman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:39.041885+00:00","export_uri":null,"id":"f1b682db-eff5-416c-80c8-168a3c883385","modification_date":"2025-01-27T13:51:39.041885+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"67989537-8f92-404e-9f2e-2710d405987f","name":"tf-srv-bold-raman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2277"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:52:06 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - b933571f-d24f-47c3-98af-c1105d4ebfc0
-        status: 200 OK
-        code: 200
-        duration: 140.923292ms
-    - id: 44
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2277
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:39.041885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-raman","id":"67989537-8f92-404e-9f2e-2710d405987f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1102","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:e5","maintenances":[],"modification_date":"2025-01-27T13:52:00.801102+00:00","name":"tf-srv-bold-raman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:39.041885+00:00","export_uri":null,"id":"f1b682db-eff5-416c-80c8-168a3c883385","modification_date":"2025-01-27T13:51:39.041885+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"67989537-8f92-404e-9f2e-2710d405987f","name":"tf-srv-bold-raman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2277"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:52:11 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - c4deab8f-0e0b-4a49-a16d-e0a681efb4e8
-        status: 200 OK
-        code: 200
-        duration: 167.161541ms
-    - id: 45
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2277
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:39.041885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-raman","id":"67989537-8f92-404e-9f2e-2710d405987f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1102","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:e5","maintenances":[],"modification_date":"2025-01-27T13:52:00.801102+00:00","name":"tf-srv-bold-raman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:39.041885+00:00","export_uri":null,"id":"f1b682db-eff5-416c-80c8-168a3c883385","modification_date":"2025-01-27T13:51:39.041885+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"67989537-8f92-404e-9f2e-2710d405987f","name":"tf-srv-bold-raman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2277"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:52:16 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 9c266fd0-d3b2-4e44-9a4b-6ff3fc3d67fa
-        status: 200 OK
-        code: 200
-        duration: 210.913417ms
-    - id: 46
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2277
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:39.041885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-raman","id":"67989537-8f92-404e-9f2e-2710d405987f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1102","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:e5","maintenances":[],"modification_date":"2025-01-27T13:52:00.801102+00:00","name":"tf-srv-bold-raman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:39.041885+00:00","export_uri":null,"id":"f1b682db-eff5-416c-80c8-168a3c883385","modification_date":"2025-01-27T13:51:39.041885+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"67989537-8f92-404e-9f2e-2710d405987f","name":"tf-srv-bold-raman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2277"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:52:21 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 859bd7fa-18ea-4541-bdc2-5e1d95e9ac13
-        status: 200 OK
-        code: 200
-        duration: 173.515708ms
+        duration: 240.560166ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2368,8 +2368,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e
         method: GET
       response:
         proto: HTTP/2.0
@@ -2377,20 +2377,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2277
+        content_length: 1845
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:39.041885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-raman","id":"67989537-8f92-404e-9f2e-2710d405987f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1102","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:e5","maintenances":[],"modification_date":"2025-01-27T13:52:00.801102+00:00","name":"tf-srv-bold-raman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:39.041885+00:00","export_uri":null,"id":"f1b682db-eff5-416c-80c8-168a3c883385","modification_date":"2025-01-27T13:51:39.041885+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"67989537-8f92-404e-9f2e-2710d405987f","name":"tf-srv-bold-raman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:23.351804+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-lamport","id":"f62102df-b5f4-41a0-9f69-5f92a08bef6e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"302","node_id":"34","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:eb","maintenances":[],"modification_date":"2025-02-11T14:23:35.392486+00:00","name":"tf-srv-clever-lamport","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"id":"f2e598d4-e262-464c-8936-029ec09368c8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2277"
+                - "1845"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:26 GMT
+                - Tue, 11 Feb 2025 14:23:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2398,10 +2398,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 31ae21b9-4763-41ce-861b-7d556c8e03c0
+                - b20b737e-cb2e-417f-96e3-d94a39fef564
         status: 200 OK
         code: 200
-        duration: 230.034625ms
+        duration: 166.028417ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2417,8 +2417,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e
         method: GET
       response:
         proto: HTTP/2.0
@@ -2426,20 +2426,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2277
+        content_length: 1845
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:39.041885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-raman","id":"67989537-8f92-404e-9f2e-2710d405987f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1102","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:e5","maintenances":[],"modification_date":"2025-01-27T13:52:00.801102+00:00","name":"tf-srv-bold-raman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:39.041885+00:00","export_uri":null,"id":"f1b682db-eff5-416c-80c8-168a3c883385","modification_date":"2025-01-27T13:51:39.041885+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"67989537-8f92-404e-9f2e-2710d405987f","name":"tf-srv-bold-raman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:23.351804+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-lamport","id":"f62102df-b5f4-41a0-9f69-5f92a08bef6e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"302","node_id":"34","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:eb","maintenances":[],"modification_date":"2025-02-11T14:23:35.392486+00:00","name":"tf-srv-clever-lamport","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"id":"f2e598d4-e262-464c-8936-029ec09368c8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2277"
+                - "1845"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:31 GMT
+                - Tue, 11 Feb 2025 14:23:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2447,10 +2447,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e5c9e762-22e1-4e33-8f49-dbf2423c4c66
+                - 307d1661-6380-46a0-9d25-22b157e98dc2
         status: 200 OK
         code: 200
-        duration: 181.574792ms
+        duration: 276.125459ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2466,8 +2466,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e
         method: GET
       response:
         proto: HTTP/2.0
@@ -2475,20 +2475,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2277
+        content_length: 1845
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:39.041885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-raman","id":"67989537-8f92-404e-9f2e-2710d405987f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1102","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:e5","maintenances":[],"modification_date":"2025-01-27T13:52:00.801102+00:00","name":"tf-srv-bold-raman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:39.041885+00:00","export_uri":null,"id":"f1b682db-eff5-416c-80c8-168a3c883385","modification_date":"2025-01-27T13:51:39.041885+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"67989537-8f92-404e-9f2e-2710d405987f","name":"tf-srv-bold-raman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:23.351804+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-lamport","id":"f62102df-b5f4-41a0-9f69-5f92a08bef6e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"302","node_id":"34","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:eb","maintenances":[],"modification_date":"2025-02-11T14:23:35.392486+00:00","name":"tf-srv-clever-lamport","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"id":"f2e598d4-e262-464c-8936-029ec09368c8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2277"
+                - "1845"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:37 GMT
+                - Tue, 11 Feb 2025 14:23:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2496,10 +2496,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e5c7d684-42e2-46de-89c4-f3895e33a246
+                - b523ded4-51a2-429c-8d77-395dd630c55b
         status: 200 OK
         code: 200
-        duration: 187.487958ms
+        duration: 188.976542ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -2515,8 +2515,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e
         method: GET
       response:
         proto: HTTP/2.0
@@ -2524,20 +2524,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2277
+        content_length: 1845
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:39.041885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-raman","id":"67989537-8f92-404e-9f2e-2710d405987f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1102","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:e5","maintenances":[],"modification_date":"2025-01-27T13:52:00.801102+00:00","name":"tf-srv-bold-raman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:39.041885+00:00","export_uri":null,"id":"f1b682db-eff5-416c-80c8-168a3c883385","modification_date":"2025-01-27T13:51:39.041885+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"67989537-8f92-404e-9f2e-2710d405987f","name":"tf-srv-bold-raman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:23.351804+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-lamport","id":"f62102df-b5f4-41a0-9f69-5f92a08bef6e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"302","node_id":"34","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:eb","maintenances":[],"modification_date":"2025-02-11T14:23:35.392486+00:00","name":"tf-srv-clever-lamport","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"id":"f2e598d4-e262-464c-8936-029ec09368c8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2277"
+                - "1845"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:42 GMT
+                - Tue, 11 Feb 2025 14:23:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2545,10 +2545,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e4b039cc-f0ec-44e5-810c-fc8bbfc0bca2
+                - 5a8e81ec-ad3f-45c8-9164-f6b16e0f2ff7
         status: 200 OK
         code: 200
-        duration: 170.263709ms
+        duration: 161.754958ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2564,8 +2564,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e
         method: GET
       response:
         proto: HTTP/2.0
@@ -2573,20 +2573,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2277
+        content_length: 1845
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:39.041885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-raman","id":"67989537-8f92-404e-9f2e-2710d405987f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1102","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:e5","maintenances":[],"modification_date":"2025-01-27T13:52:00.801102+00:00","name":"tf-srv-bold-raman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:39.041885+00:00","export_uri":null,"id":"f1b682db-eff5-416c-80c8-168a3c883385","modification_date":"2025-01-27T13:51:39.041885+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"67989537-8f92-404e-9f2e-2710d405987f","name":"tf-srv-bold-raman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:23.351804+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-lamport","id":"f62102df-b5f4-41a0-9f69-5f92a08bef6e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"302","node_id":"34","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:eb","maintenances":[],"modification_date":"2025-02-11T14:23:35.392486+00:00","name":"tf-srv-clever-lamport","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"id":"f2e598d4-e262-464c-8936-029ec09368c8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2277"
+                - "1845"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:47 GMT
+                - Tue, 11 Feb 2025 14:23:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2594,10 +2594,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 20626d7d-bd34-4963-8e65-d0d61a652e23
+                - b6c96276-eb77-47bb-aa2c-89d5a388aa68
         status: 200 OK
         code: 200
-        duration: 138.27ms
+        duration: 178.970666ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -2613,8 +2613,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e
         method: GET
       response:
         proto: HTTP/2.0
@@ -2622,20 +2622,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2277
+        content_length: 1845
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:39.041885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-raman","id":"67989537-8f92-404e-9f2e-2710d405987f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1102","node_id":"43","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:e5","maintenances":[],"modification_date":"2025-01-27T13:52:00.801102+00:00","name":"tf-srv-bold-raman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:39.041885+00:00","export_uri":null,"id":"f1b682db-eff5-416c-80c8-168a3c883385","modification_date":"2025-01-27T13:51:39.041885+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"67989537-8f92-404e-9f2e-2710d405987f","name":"tf-srv-bold-raman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:23.351804+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-lamport","id":"f62102df-b5f4-41a0-9f69-5f92a08bef6e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"302","node_id":"34","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:eb","maintenances":[],"modification_date":"2025-02-11T14:23:35.392486+00:00","name":"tf-srv-clever-lamport","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"id":"f2e598d4-e262-464c-8936-029ec09368c8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2277"
+                - "1845"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:53 GMT
+                - Tue, 11 Feb 2025 14:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2643,10 +2643,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5543feea-5583-4b25-bb02-e1c14fc693e1
+                - 7129775f-1e37-423f-9e5f-79c4799d8939
         status: 200 OK
         code: 200
-        duration: 720.524208ms
+        duration: 589.021958ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -2662,8 +2662,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e
         method: GET
       response:
         proto: HTTP/2.0
@@ -2671,20 +2671,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2160
+        content_length: 1845
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:39.041885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-raman","id":"67989537-8f92-404e-9f2e-2710d405987f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:e5","maintenances":[],"modification_date":"2025-01-27T13:52:54.793613+00:00","name":"tf-srv-bold-raman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:39.041885+00:00","export_uri":null,"id":"f1b682db-eff5-416c-80c8-168a3c883385","modification_date":"2025-01-27T13:51:39.041885+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"67989537-8f92-404e-9f2e-2710d405987f","name":"tf-srv-bold-raman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:23.351804+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-lamport","id":"f62102df-b5f4-41a0-9f69-5f92a08bef6e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"302","node_id":"34","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:eb","maintenances":[],"modification_date":"2025-02-11T14:23:35.392486+00:00","name":"tf-srv-clever-lamport","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"id":"f2e598d4-e262-464c-8936-029ec09368c8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2160"
+                - "1845"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:58 GMT
+                - Tue, 11 Feb 2025 14:24:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2692,10 +2692,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 27b3206a-bf76-423a-8a22-dc3aa160b272
+                - a982861a-36fd-48a5-8b07-44e1502c1040
         status: 200 OK
         code: 200
-        duration: 157.364916ms
+        duration: 166.042333ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -2711,8 +2711,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e
         method: GET
       response:
         proto: HTTP/2.0
@@ -2720,20 +2720,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2160
+        content_length: 1729
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:51:39.041885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-raman","id":"67989537-8f92-404e-9f2e-2710d405987f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:e5","maintenances":[],"modification_date":"2025-01-27T13:52:54.793613+00:00","name":"tf-srv-bold-raman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:51:39.041885+00:00","export_uri":null,"id":"f1b682db-eff5-416c-80c8-168a3c883385","modification_date":"2025-01-27T13:51:39.041885+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"67989537-8f92-404e-9f2e-2710d405987f","name":"tf-srv-bold-raman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:23.351804+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-lamport","id":"f62102df-b5f4-41a0-9f69-5f92a08bef6e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:eb","maintenances":[],"modification_date":"2025-02-11T14:24:08.527674+00:00","name":"tf-srv-clever-lamport","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"id":"f2e598d4-e262-464c-8936-029ec09368c8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2160"
+                - "1729"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:58 GMT
+                - Tue, 11 Feb 2025 14:24:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2741,10 +2741,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ed405110-7e3d-4efd-ac6e-68b54b01d51b
+                - 9fa001da-8843-4991-910d-4cf99d884b28
         status: 200 OK
         code: 200
-        duration: 140.662417ms
+        duration: 142.15575ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -2760,27 +2760,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 1729
         uncompressed: false
-        body: ""
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:23:23.351804+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-clever-lamport","id":"f62102df-b5f4-41a0-9f69-5f92a08bef6e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:eb","maintenances":[],"modification_date":"2025-02-11T14:24:08.527674+00:00","name":"tf-srv-clever-lamport","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","user_data"],"volumes":{"0":{"boot":false,"id":"f2e598d4-e262-464c-8936-029ec09368c8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
+            Content-Length:
+                - "1729"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:58 GMT
+                - Tue, 11 Feb 2025 14:24:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2788,10 +2790,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1446ccd6-07e9-4b86-9981-a8d8b1f05336
-        status: 204 No Content
-        code: 204
-        duration: 217.258167ms
+                - 061061c0-7b82-4611-a314-4bb290942477
+        status: 200 OK
+        code: 200
+        duration: 139.591209ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2807,106 +2809,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 143
-        uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"67989537-8f92-404e-9f2e-2710d405987f","type":"not_found"}'
-        headers:
-            Content-Length:
-                - "143"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:52:59 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - be6949b2-e509-4ae6-86de-efd1c1a9cd8c
-        status: 404 Not Found
-        code: 404
-        duration: 127.55375ms
-    - id: 57
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f1b682db-eff5-416c-80c8-168a3c883385
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 446
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:51:39.041885+00:00","export_uri":null,"id":"f1b682db-eff5-416c-80c8-168a3c883385","modification_date":"2025-01-27T13:52:58.949077+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "446"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:52:58 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 86679628-1e64-4bde-82ad-95c344ad9668
-        status: 200 OK
-        code: 200
-        duration: 113.5385ms
-    - id: 58
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f1b682db-eff5-416c-80c8-168a3c883385
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2923,9 +2827,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:59 GMT
+                - Tue, 11 Feb 2025 14:24:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2933,10 +2837,108 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 185dc4b2-89ce-4e03-972c-2723b6911353
+                - 14dbfb1a-99ae-4e5e-9e0d-3d53c5dc255a
         status: 204 No Content
         code: 204
-        duration: 199.641833ms
+        duration: 243.704333ms
+    - id: 57
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"f62102df-b5f4-41a0-9f69-5f92a08bef6e","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 868ac2d0-3c20-4ad7-bd35-a76ac050fe1a
+        status: 404 Not Found
+        code: 404
+        duration: 104.24725ms
+    - id: 58
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f2e598d4-e262-464c-8936-029ec09368c8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"f2e598d4-e262-464c-8936-029ec09368c8","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 295792b6-0eec-458b-85a1-54e98bd45daa
+        status: 404 Not Found
+        code: 404
+        duration: 30.705458ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -2952,8 +2954,104 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/67989537-8f92-404e-9f2e-2710d405987f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/f2e598d4-e262-464c-8936-029ec09368c8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 494
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:23:23.559738Z","id":"f2e598d4-e262-464c-8936-029ec09368c8","last_detached_at":"2025-02-11T14:24:12.968802Z","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":20000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:24:12.968802Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "494"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:13 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 60f47304-6a27-45f7-86a5-f520e1ae7feb
+        status: 200 OK
+        code: 200
+        duration: 70.556542ms
+    - id: 60
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/f2e598d4-e262-464c-8936-029ec09368c8
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:13 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e5c59d12-d2bf-4e9b-84c4-de6c13308cc7
+        status: 204 No Content
+        code: 204
+        duration: 121.240167ms
+    - id: 61
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f62102df-b5f4-41a0-9f69-5f92a08bef6e
         method: GET
       response:
         proto: HTTP/2.0
@@ -2963,7 +3061,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"67989537-8f92-404e-9f2e-2710d405987f","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"f62102df-b5f4-41a0-9f69-5f92a08bef6e","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -2972,9 +3070,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:59 GMT
+                - Tue, 11 Feb 2025 14:24:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2982,7 +3080,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 27944029-b067-4981-a1e2-169a2ce56cfc
+                - c1252335-4dde-4972-83a1-ff1f23d06cec
         status: 404 Not Found
         code: 404
-        duration: 130.749167ms
+        duration: 96.199084ms

--- a/internal/services/instance/testdata/server-with-default-root-volume-and-additional-volume.cassette.yaml
+++ b/internal/services/instance/testdata/server-with-default-root-volume-and-additional-volume.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 124
+        content_length: 132
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-vol-jovial-roentgen","project":"105bdce1-64c0-48ab-899d-868455867ecf","volume_type":"b_ssd","size":100000000000}'
+        body: '{"name":"tf-vol-compassionate-chaplygin","project":"105bdce1-64c0-48ab-899d-868455867ecf","volume_type":"b_ssd","size":100000000000}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes
         method: POST
       response:
@@ -27,22 +27,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 445
+        content_length: 453
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:52:33.529882+00:00","export_uri":null,"id":"c1ca1e2f-e543-4ba1-b0d4-746af7c627cb","modification_date":"2025-01-27T13:52:33.529882+00:00","name":"tf-vol-jovial-roentgen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:24:36.397022+00:00","export_uri":null,"id":"b4098fa0-f77a-4033-a9f8-af5ceb81d136","modification_date":"2025-02-11T14:24:36.397022+00:00","name":"tf-vol-compassionate-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "445"
+                - "453"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:33 GMT
+                - Tue, 11 Feb 2025 14:24:36 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/c1ca1e2f-e543-4ba1-b0d4-746af7c627cb
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b4098fa0-f77a-4033-a9f8-af5ceb81d136
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -50,10 +50,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a20c6eaf-c7a3-4f11-a19a-37b95971bbbd
+                - fd8daea6-19f3-480b-9925-28a1f55b76b7
         status: 201 Created
         code: 201
-        duration: 300.348125ms
+        duration: 231.718041ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -69,8 +69,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/c1ca1e2f-e543-4ba1-b0d4-746af7c627cb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b4098fa0-f77a-4033-a9f8-af5ceb81d136
         method: GET
       response:
         proto: HTTP/2.0
@@ -78,20 +78,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 445
+        content_length: 453
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:52:33.529882+00:00","export_uri":null,"id":"c1ca1e2f-e543-4ba1-b0d4-746af7c627cb","modification_date":"2025-01-27T13:52:33.529882+00:00","name":"tf-vol-jovial-roentgen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:24:36.397022+00:00","export_uri":null,"id":"b4098fa0-f77a-4033-a9f8-af5ceb81d136","modification_date":"2025-02-11T14:24:36.397022+00:00","name":"tf-vol-compassionate-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "445"
+                - "453"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:33 GMT
+                - Tue, 11 Feb 2025 14:24:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -99,10 +99,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8b05d477-237a-417b-b4d3-1190c0efb367
+                - cea8a61e-0f5c-4115-ba93-0b2a33e760dc
         status: 200 OK
         code: 200
-        duration: 108.154583ms
+        duration: 70.491625ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -118,8 +118,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/c1ca1e2f-e543-4ba1-b0d4-746af7c627cb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b4098fa0-f77a-4033-a9f8-af5ceb81d136
         method: GET
       response:
         proto: HTTP/2.0
@@ -127,20 +127,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 445
+        content_length: 453
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:52:33.529882+00:00","export_uri":null,"id":"c1ca1e2f-e543-4ba1-b0d4-746af7c627cb","modification_date":"2025-01-27T13:52:33.529882+00:00","name":"tf-vol-jovial-roentgen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:24:36.397022+00:00","export_uri":null,"id":"b4098fa0-f77a-4033-a9f8-af5ceb81d136","modification_date":"2025-02-11T14:24:36.397022+00:00","name":"tf-vol-compassionate-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "445"
+                - "453"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:33 GMT
+                - Tue, 11 Feb 2025 14:24:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -148,10 +148,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d1ebc2d7-7987-4eab-a612-df504b802161
+                - 4ade1784-00a0-4daa-97d9-0d71dc0b48ef
         status: 200 OK
         code: 200
-        duration: 114.467ms
+        duration: 83.257583ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -167,7 +167,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
         method: GET
       response:
@@ -176,22 +176,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 38539
+        content_length: 35639
         uncompressed: false
-        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
+        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
         headers:
             Content-Length:
-                - "38539"
+                - "35639"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:33 GMT
+                - Tue, 11 Feb 2025 14:24:36 GMT
             Link:
                 - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -199,12 +199,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 99935ca0-aa71-44eb-ac81-487da484f757
+                - fbe1b741-c3c7-40a3-b9e4-d137a6e97f8c
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 53.909625ms
+        duration: 61.154417ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -220,7 +220,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
         method: GET
       response:
@@ -229,22 +229,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 14208
+        content_length: 13164
         uncompressed: false
-        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
         headers:
             Content-Length:
-                - "14208"
+                - "13164"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:33 GMT
+                - Tue, 11 Feb 2025 14:24:36 GMT
             Link:
                 - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -252,12 +252,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4c947f14-533d-4c9a-8560-a0a17094bad7
+                - 43a3748d-db60-4b94-b74c-30ad77841009
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 42.525084ms
+        duration: 59.385208ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -273,8 +273,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/c1ca1e2f-e543-4ba1-b0d4-746af7c627cb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b4098fa0-f77a-4033-a9f8-af5ceb81d136
         method: GET
       response:
         proto: HTTP/2.0
@@ -282,20 +282,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 445
+        content_length: 453
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:52:33.529882+00:00","export_uri":null,"id":"c1ca1e2f-e543-4ba1-b0d4-746af7c627cb","modification_date":"2025-01-27T13:52:33.529882+00:00","name":"tf-vol-jovial-roentgen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:24:36.397022+00:00","export_uri":null,"id":"b4098fa0-f77a-4033-a9f8-af5ceb81d136","modification_date":"2025-02-11T14:24:36.397022+00:00","name":"tf-vol-compassionate-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "445"
+                - "453"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:33 GMT
+                - Tue, 11 Feb 2025 14:24:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -303,10 +303,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 576bb7e4-4635-46e9-9c4e-7f900bfc7fe4
+                - f8fc5a4c-6bd5-4ee5-85c7-b9cc9561341d
         status: 200 OK
         code: 200
-        duration: 79.858834ms
+        duration: 95.772125ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -322,8 +322,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_bionic&order_by=type_asc&type=instance_local&zone=fr-par-1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=type_asc&type=instance_sbs&zone=fr-par-1
         method: GET
       response:
         proto: HTTP/2.0
@@ -331,20 +331,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 779
+        content_length: 1296
         uncompressed: false
-        body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","ENT1-2XL","ENT1-L","ENT1-M","ENT1-S","ENT1-XL","ENT1-XS","ENT1-XXS","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","GPU-3070-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-16C-64G","POP2-2C-8G","POP2-32C-128G","POP2-4C-16G","POP2-64C-256G","POP2-8C-32G","POP2-HC-16C-32G","POP2-HC-2C-4G","POP2-HC-32C-64G","POP2-HC-4C-8G","POP2-HC-64C-128G","POP2-HC-8C-16G","POP2-HM-16C-128G","POP2-HM-2C-16G","POP2-HM-32C-256G","POP2-HM-4C-32G","POP2-HM-64C-512G","POP2-HM-8C-64G","PRO2-L","PRO2-M","PRO2-S","PRO2-XS"],"id":"655aeea7-8a30-418a-bc2e-3c04e3fdc8aa","label":"ubuntu_bionic","type":"instance_local","zone":"fr-par-1"}],"total_count":1}'
+        body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","label":"ubuntu_jammy","type":"instance_sbs","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"7044ae1e-a35d-4364-a962-93811c845f2f","label":"ubuntu_jammy","type":"instance_sbs","zone":"fr-par-1"}],"total_count":2}'
         headers:
             Content-Length:
-                - "779"
+                - "1296"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:34 GMT
+                - Tue, 11 Feb 2025 14:24:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -352,28 +352,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3623b1bd-c32b-4c02-9885-00c0c65bc696
+                - 50841903-9176-45e5-8644-97fea3ba4311
         status: 200 OK
         code: 200
-        duration: 69.456458ms
+        duration: 85.553916ms
     - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 355
+        content_length: 326
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-srv-goofy-panini","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"655aeea7-8a30-418a-bc2e-3c04e3fdc8aa","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"},"1":{"id":"c1ca1e2f-e543-4ba1-b0d4-746af7c627cb","name":"tf-vol-jovial-roentgen"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+        body: '{"name":"tf-srv-nostalgic-pascal","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","volumes":{"0":{"boot":false},"1":{"id":"b4098fa0-f77a-4033-a9f8-af5ceb81d136","name":"tf-vol-compassionate-chaplygin"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
         method: POST
       response:
@@ -382,22 +382,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2643
+        content_length: 2220
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:34.428187+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-panini","id":"c611832b-0216-43f6-96b6-88a2f23e725b","image":{"arch":"x86_64","creation_date":"2023-08-08T13:36:04.744241+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"655aeea7-8a30-418a-bc2e-3c04e3fdc8aa","modification_date":"2023-08-08T13:36:04.744241+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"27a6459c-efe6-4327-a062-b21a17f3143d","name":"Ubuntu 18.04 Bionic Beaver","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:15","maintenances":[],"modification_date":"2025-01-27T13:52:34.428187+00:00","name":"tf-srv-goofy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:34.428187+00:00","export_uri":null,"id":"a8c1daa4-cb61-4806-8ed5-92a09e173188","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:33.529882+00:00","export_uri":null,"id":"c1ca1e2f-e543-4ba1-b0d4-746af7c627cb","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"tf-vol-jovial-roentgen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:37.478858+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-pascal","id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:11","maintenances":[],"modification_date":"2025-02-11T14:24:37.478858+00:00","name":"tf-srv-nostalgic-pascal","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"1d87a592-709c-4d49-bf14-6178781323fa","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:24:36.397022+00:00","export_uri":null,"id":"b4098fa0-f77a-4033-a9f8-af5ceb81d136","modification_date":"2025-02-11T14:24:37.478858+00:00","name":"tf-vol-compassionate-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","name":"tf-srv-nostalgic-pascal"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2643"
+                - "2220"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:34 GMT
+                - Tue, 11 Feb 2025 14:24:37 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c611832b-0216-43f6-96b6-88a2f23e725b
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/52518021-cc13-4eb4-9c7b-3a6781aeb404
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -405,10 +405,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d9a9a7a2-1276-4b55-9575-4bb4ef671213
+                - 33034b75-f1dd-4648-b7a4-7e0446f29973
         status: 201 Created
         code: 201
-        duration: 938.275542ms
+        duration: 1.103762292s
     - id: 8
       request:
         proto: HTTP/1.1
@@ -424,8 +424,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c611832b-0216-43f6-96b6-88a2f23e725b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/52518021-cc13-4eb4-9c7b-3a6781aeb404
         method: GET
       response:
         proto: HTTP/2.0
@@ -433,20 +433,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2643
+        content_length: 2220
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:34.428187+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-panini","id":"c611832b-0216-43f6-96b6-88a2f23e725b","image":{"arch":"x86_64","creation_date":"2023-08-08T13:36:04.744241+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"655aeea7-8a30-418a-bc2e-3c04e3fdc8aa","modification_date":"2023-08-08T13:36:04.744241+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"27a6459c-efe6-4327-a062-b21a17f3143d","name":"Ubuntu 18.04 Bionic Beaver","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:15","maintenances":[],"modification_date":"2025-01-27T13:52:34.428187+00:00","name":"tf-srv-goofy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:34.428187+00:00","export_uri":null,"id":"a8c1daa4-cb61-4806-8ed5-92a09e173188","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:33.529882+00:00","export_uri":null,"id":"c1ca1e2f-e543-4ba1-b0d4-746af7c627cb","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"tf-vol-jovial-roentgen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:37.478858+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-pascal","id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:11","maintenances":[],"modification_date":"2025-02-11T14:24:37.478858+00:00","name":"tf-srv-nostalgic-pascal","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"1d87a592-709c-4d49-bf14-6178781323fa","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:24:36.397022+00:00","export_uri":null,"id":"b4098fa0-f77a-4033-a9f8-af5ceb81d136","modification_date":"2025-02-11T14:24:37.478858+00:00","name":"tf-vol-compassionate-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","name":"tf-srv-nostalgic-pascal"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2643"
+                - "2220"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:35 GMT
+                - Tue, 11 Feb 2025 14:24:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -454,10 +454,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 56c0a781-b652-4ac0-87d0-b036a906687f
+                - 400e0c4e-95a2-46b0-9be0-240dacbb3b56
         status: 200 OK
         code: 200
-        duration: 225.300708ms
+        duration: 132.527083ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -473,8 +473,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c611832b-0216-43f6-96b6-88a2f23e725b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/52518021-cc13-4eb4-9c7b-3a6781aeb404
         method: GET
       response:
         proto: HTTP/2.0
@@ -482,20 +482,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2643
+        content_length: 2220
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:34.428187+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-panini","id":"c611832b-0216-43f6-96b6-88a2f23e725b","image":{"arch":"x86_64","creation_date":"2023-08-08T13:36:04.744241+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"655aeea7-8a30-418a-bc2e-3c04e3fdc8aa","modification_date":"2023-08-08T13:36:04.744241+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"27a6459c-efe6-4327-a062-b21a17f3143d","name":"Ubuntu 18.04 Bionic Beaver","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:15","maintenances":[],"modification_date":"2025-01-27T13:52:34.428187+00:00","name":"tf-srv-goofy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:34.428187+00:00","export_uri":null,"id":"a8c1daa4-cb61-4806-8ed5-92a09e173188","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:33.529882+00:00","export_uri":null,"id":"c1ca1e2f-e543-4ba1-b0d4-746af7c627cb","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"tf-vol-jovial-roentgen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:37.478858+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-pascal","id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:11","maintenances":[],"modification_date":"2025-02-11T14:24:37.478858+00:00","name":"tf-srv-nostalgic-pascal","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"1d87a592-709c-4d49-bf14-6178781323fa","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:24:36.397022+00:00","export_uri":null,"id":"b4098fa0-f77a-4033-a9f8-af5ceb81d136","modification_date":"2025-02-11T14:24:37.478858+00:00","name":"tf-vol-compassionate-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","name":"tf-srv-nostalgic-pascal"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2643"
+                - "2220"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:35 GMT
+                - Tue, 11 Feb 2025 14:24:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -503,11 +503,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 746ae673-07fd-429f-a5ee-794b57407631
+                - 7b3dadbe-721f-4832-b28b-a2d3f8a48fa9
         status: 200 OK
         code: 200
-        duration: 182.086542ms
+        duration: 148.10325ms
     - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/1d87a592-709c-4d49-bf14-6178781323fa
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 705
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:24:37.705303Z","id":"1d87a592-709c-4d49-bf14-6178781323fa","last_detached_at":null,"name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:24:37.705303Z","id":"df17331f-7592-40ba-8e5e-3bee3bef6820","product_resource_id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:24:37.705303Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "705"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:38 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 58efe613-00df-411c-b93d-2566fb97cd5b
+        status: 200 OK
+        code: 200
+        duration: 62.754959ms
+    - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -524,8 +573,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c611832b-0216-43f6-96b6-88a2f23e725b/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/52518021-cc13-4eb4-9c7b-3a6781aeb404/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -535,7 +584,7 @@ interactions:
         trailer: {}
         content_length: 357
         uncompressed: false
-        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/c611832b-0216-43f6-96b6-88a2f23e725b/action","href_result":"/servers/c611832b-0216-43f6-96b6-88a2f23e725b","id":"2134fdc2-e1aa-4ca2-834f-eee4290be176","progress":0,"started_at":"2025-01-27T13:52:35.786494+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/52518021-cc13-4eb4-9c7b-3a6781aeb404/action","href_result":"/servers/52518021-cc13-4eb4-9c7b-3a6781aeb404","id":"6fb69de9-e37b-4957-91ba-d7c20c3f3595","progress":0,"started_at":"2025-02-11T14:24:38.639831+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -544,11 +593,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:35 GMT
+                - Tue, 11 Feb 2025 14:24:38 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/2134fdc2-e1aa-4ca2-834f-eee4290be176
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/6fb69de9-e37b-4957-91ba-d7c20c3f3595
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -556,59 +605,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 307110ce-2156-47ea-9702-cef94f74ba72
+                - 653a859c-bfec-40fe-b4f6-165238da94d1
         status: 202 Accepted
         code: 202
-        duration: 499.462208ms
-    - id: 11
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c611832b-0216-43f6-96b6-88a2f23e725b
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2665
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:34.428187+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-panini","id":"c611832b-0216-43f6-96b6-88a2f23e725b","image":{"arch":"x86_64","creation_date":"2023-08-08T13:36:04.744241+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"655aeea7-8a30-418a-bc2e-3c04e3fdc8aa","modification_date":"2023-08-08T13:36:04.744241+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"27a6459c-efe6-4327-a062-b21a17f3143d","name":"Ubuntu 18.04 Bionic Beaver","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:15","maintenances":[],"modification_date":"2025-01-27T13:52:35.454243+00:00","name":"tf-srv-goofy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:34.428187+00:00","export_uri":null,"id":"a8c1daa4-cb61-4806-8ed5-92a09e173188","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:33.529882+00:00","export_uri":null,"id":"c1ca1e2f-e543-4ba1-b0d4-746af7c627cb","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"tf-vol-jovial-roentgen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2665"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:52:35 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 43985947-8ab9-40c4-8e1c-d3a4ce99998c
-        status: 200 OK
-        code: 200
-        duration: 155.833833ms
+        duration: 244.962458ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -624,8 +624,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c611832b-0216-43f6-96b6-88a2f23e725b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/52518021-cc13-4eb4-9c7b-3a6781aeb404
         method: GET
       response:
         proto: HTTP/2.0
@@ -633,20 +633,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2768
+        content_length: 2242
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:34.428187+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-panini","id":"c611832b-0216-43f6-96b6-88a2f23e725b","image":{"arch":"x86_64","creation_date":"2023-08-08T13:36:04.744241+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"655aeea7-8a30-418a-bc2e-3c04e3fdc8aa","modification_date":"2023-08-08T13:36:04.744241+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"27a6459c-efe6-4327-a062-b21a17f3143d","name":"Ubuntu 18.04 Bionic Beaver","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"401","node_id":"30","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:15","maintenances":[],"modification_date":"2025-01-27T13:52:35.454243+00:00","name":"tf-srv-goofy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:34.428187+00:00","export_uri":null,"id":"a8c1daa4-cb61-4806-8ed5-92a09e173188","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:33.529882+00:00","export_uri":null,"id":"c1ca1e2f-e543-4ba1-b0d4-746af7c627cb","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"tf-vol-jovial-roentgen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:37.478858+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-pascal","id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:11","maintenances":[],"modification_date":"2025-02-11T14:24:38.457213+00:00","name":"tf-srv-nostalgic-pascal","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"id":"1d87a592-709c-4d49-bf14-6178781323fa","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:24:36.397022+00:00","export_uri":null,"id":"b4098fa0-f77a-4033-a9f8-af5ceb81d136","modification_date":"2025-02-11T14:24:37.478858+00:00","name":"tf-vol-compassionate-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","name":"tf-srv-nostalgic-pascal"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2768"
+                - "2242"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:40 GMT
+                - Tue, 11 Feb 2025 14:24:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -654,10 +654,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7bfa1d23-7920-43e8-99d4-509f342d1e20
+                - 8e40c648-9176-4159-b5bb-c8ece8a58094
         status: 200 OK
         code: 200
-        duration: 166.398166ms
+        duration: 184.750375ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -673,8 +673,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c611832b-0216-43f6-96b6-88a2f23e725b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/52518021-cc13-4eb4-9c7b-3a6781aeb404
         method: GET
       response:
         proto: HTTP/2.0
@@ -682,20 +682,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2768
+        content_length: 2376
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:34.428187+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-panini","id":"c611832b-0216-43f6-96b6-88a2f23e725b","image":{"arch":"x86_64","creation_date":"2023-08-08T13:36:04.744241+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"655aeea7-8a30-418a-bc2e-3c04e3fdc8aa","modification_date":"2023-08-08T13:36:04.744241+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"27a6459c-efe6-4327-a062-b21a17f3143d","name":"Ubuntu 18.04 Bionic Beaver","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"401","node_id":"30","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:15","maintenances":[],"modification_date":"2025-01-27T13:52:35.454243+00:00","name":"tf-srv-goofy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:34.428187+00:00","export_uri":null,"id":"a8c1daa4-cb61-4806-8ed5-92a09e173188","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:33.529882+00:00","export_uri":null,"id":"c1ca1e2f-e543-4ba1-b0d4-746af7c627cb","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"tf-vol-jovial-roentgen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:37.478858+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-pascal","id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"802","node_id":"40","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:11","maintenances":[],"modification_date":"2025-02-11T14:24:43.728945+00:00","name":"tf-srv-nostalgic-pascal","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"1d87a592-709c-4d49-bf14-6178781323fa","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:24:36.397022+00:00","export_uri":null,"id":"b4098fa0-f77a-4033-a9f8-af5ceb81d136","modification_date":"2025-02-11T14:24:37.478858+00:00","name":"tf-vol-compassionate-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","name":"tf-srv-nostalgic-pascal"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2768"
+                - "2376"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:45 GMT
+                - Tue, 11 Feb 2025 14:24:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -703,10 +703,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1227c00f-6527-4403-baed-16d2c3d7dcbb
+                - 29b51b6f-fa59-4797-8705-39a8e7e19956
         status: 200 OK
         code: 200
-        duration: 181.521958ms
+        duration: 220.98025ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -722,8 +722,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c611832b-0216-43f6-96b6-88a2f23e725b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/52518021-cc13-4eb4-9c7b-3a6781aeb404
         method: GET
       response:
         proto: HTTP/2.0
@@ -731,20 +731,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2768
+        content_length: 2376
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:34.428187+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-panini","id":"c611832b-0216-43f6-96b6-88a2f23e725b","image":{"arch":"x86_64","creation_date":"2023-08-08T13:36:04.744241+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"655aeea7-8a30-418a-bc2e-3c04e3fdc8aa","modification_date":"2023-08-08T13:36:04.744241+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"27a6459c-efe6-4327-a062-b21a17f3143d","name":"Ubuntu 18.04 Bionic Beaver","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"401","node_id":"30","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:15","maintenances":[],"modification_date":"2025-01-27T13:52:35.454243+00:00","name":"tf-srv-goofy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:34.428187+00:00","export_uri":null,"id":"a8c1daa4-cb61-4806-8ed5-92a09e173188","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:33.529882+00:00","export_uri":null,"id":"c1ca1e2f-e543-4ba1-b0d4-746af7c627cb","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"tf-vol-jovial-roentgen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:37.478858+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-pascal","id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"802","node_id":"40","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:11","maintenances":[],"modification_date":"2025-02-11T14:24:43.728945+00:00","name":"tf-srv-nostalgic-pascal","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"1d87a592-709c-4d49-bf14-6178781323fa","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:24:36.397022+00:00","export_uri":null,"id":"b4098fa0-f77a-4033-a9f8-af5ceb81d136","modification_date":"2025-02-11T14:24:37.478858+00:00","name":"tf-vol-compassionate-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","name":"tf-srv-nostalgic-pascal"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2768"
+                - "2376"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:51 GMT
+                - Tue, 11 Feb 2025 14:24:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -752,10 +752,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 67b7a155-d78d-40bf-9d7f-14e101579c1c
+                - 52c2a8ca-3398-4c06-8cee-c3fcb6451690
         status: 200 OK
         code: 200
-        duration: 176.528542ms
+        duration: 173.26425ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -771,8 +771,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c611832b-0216-43f6-96b6-88a2f23e725b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/1d87a592-709c-4d49-bf14-6178781323fa
         method: GET
       response:
         proto: HTTP/2.0
@@ -780,20 +780,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2768
+        content_length: 143
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:34.428187+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-panini","id":"c611832b-0216-43f6-96b6-88a2f23e725b","image":{"arch":"x86_64","creation_date":"2023-08-08T13:36:04.744241+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"655aeea7-8a30-418a-bc2e-3c04e3fdc8aa","modification_date":"2023-08-08T13:36:04.744241+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"27a6459c-efe6-4327-a062-b21a17f3143d","name":"Ubuntu 18.04 Bionic Beaver","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"401","node_id":"30","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:15","maintenances":[],"modification_date":"2025-01-27T13:52:35.454243+00:00","name":"tf-srv-goofy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:34.428187+00:00","export_uri":null,"id":"a8c1daa4-cb61-4806-8ed5-92a09e173188","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:33.529882+00:00","export_uri":null,"id":"c1ca1e2f-e543-4ba1-b0d4-746af7c627cb","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"tf-vol-jovial-roentgen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"1d87a592-709c-4d49-bf14-6178781323fa","type":"not_found"}'
         headers:
             Content-Length:
-                - "2768"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:52:56 GMT
+                - Tue, 11 Feb 2025 14:24:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -801,10 +801,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - abfc8d82-1d22-420d-977b-a9ed550a588a
-        status: 200 OK
-        code: 200
-        duration: 166.335208ms
+                - fcd709e8-0c32-491f-b209-8b966735f51f
+        status: 404 Not Found
+        code: 404
+        duration: 31.732125ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -820,8 +820,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c611832b-0216-43f6-96b6-88a2f23e725b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/1d87a592-709c-4d49-bf14-6178781323fa
         method: GET
       response:
         proto: HTTP/2.0
@@ -829,20 +829,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2799
+        content_length: 705
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:34.428187+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-panini","id":"c611832b-0216-43f6-96b6-88a2f23e725b","image":{"arch":"x86_64","creation_date":"2023-08-08T13:36:04.744241+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"655aeea7-8a30-418a-bc2e-3c04e3fdc8aa","modification_date":"2023-08-08T13:36:04.744241+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"27a6459c-efe6-4327-a062-b21a17f3143d","name":"Ubuntu 18.04 Bionic Beaver","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"401","node_id":"30","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:15","maintenances":[],"modification_date":"2025-01-27T13:53:01.648508+00:00","name":"tf-srv-goofy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:34.428187+00:00","export_uri":null,"id":"a8c1daa4-cb61-4806-8ed5-92a09e173188","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:33.529882+00:00","export_uri":null,"id":"c1ca1e2f-e543-4ba1-b0d4-746af7c627cb","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"tf-vol-jovial-roentgen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T14:24:37.705303Z","id":"1d87a592-709c-4d49-bf14-6178781323fa","last_detached_at":null,"name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:24:37.705303Z","id":"df17331f-7592-40ba-8e5e-3bee3bef6820","product_resource_id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:24:37.705303Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2799"
+                - "705"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:01 GMT
+                - Tue, 11 Feb 2025 14:24:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -850,10 +850,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3f64c675-a27c-4da1-84a4-a83fe7c4248b
+                - 5e98ad20-0cb1-4b19-b4b5-19fd97e1a8bb
         status: 200 OK
         code: 200
-        duration: 195.427041ms
+        duration: 65.355083ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -869,8 +869,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c611832b-0216-43f6-96b6-88a2f23e725b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/52518021-cc13-4eb4-9c7b-3a6781aeb404/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -878,20 +878,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2799
+        content_length: 17
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:34.428187+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-panini","id":"c611832b-0216-43f6-96b6-88a2f23e725b","image":{"arch":"x86_64","creation_date":"2023-08-08T13:36:04.744241+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"655aeea7-8a30-418a-bc2e-3c04e3fdc8aa","modification_date":"2023-08-08T13:36:04.744241+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"27a6459c-efe6-4327-a062-b21a17f3143d","name":"Ubuntu 18.04 Bionic Beaver","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"401","node_id":"30","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:15","maintenances":[],"modification_date":"2025-01-27T13:53:01.648508+00:00","name":"tf-srv-goofy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:34.428187+00:00","export_uri":null,"id":"a8c1daa4-cb61-4806-8ed5-92a09e173188","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:33.529882+00:00","export_uri":null,"id":"c1ca1e2f-e543-4ba1-b0d4-746af7c627cb","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"tf-vol-jovial-roentgen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "2799"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:02 GMT
+                - Tue, 11 Feb 2025 14:24:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -899,10 +899,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0e6b627c-323f-4d9e-8482-c4a0c6ba5257
+                - 59581b9b-33b4-4ef7-9a11-39412dc89ddc
         status: 200 OK
         code: 200
-        duration: 223.2755ms
+        duration: 83.829875ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -918,8 +918,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/a8c1daa4-cb61-4806-8ed5-92a09e173188
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/52518021-cc13-4eb4-9c7b-3a6781aeb404/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -927,20 +927,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 521
+        content_length: 20
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:52:34.428187+00:00","export_uri":null,"id":"a8c1daa4-cb61-4806-8ed5-92a09e173188","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "521"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:02 GMT
+                - Tue, 11 Feb 2025 14:24:44 GMT
+            Link:
+                - </servers/52518021-cc13-4eb4-9c7b-3a6781aeb404/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -948,10 +950,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 698cd8f8-7561-4146-8ce9-aa01383ce53c
+                - 86890f20-054e-4d47-a93c-63723a184ca5
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 237.596375ms
+        duration: 89.863291ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -967,8 +971,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c611832b-0216-43f6-96b6-88a2f23e725b/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/52518021-cc13-4eb4-9c7b-3a6781aeb404
         method: GET
       response:
         proto: HTTP/2.0
@@ -976,20 +980,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 2376
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:37.478858+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-pascal","id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"802","node_id":"40","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:11","maintenances":[],"modification_date":"2025-02-11T14:24:43.728945+00:00","name":"tf-srv-nostalgic-pascal","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"1d87a592-709c-4d49-bf14-6178781323fa","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:24:36.397022+00:00","export_uri":null,"id":"b4098fa0-f77a-4033-a9f8-af5ceb81d136","modification_date":"2025-02-11T14:24:37.478858+00:00","name":"tf-vol-compassionate-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","name":"tf-srv-nostalgic-pascal"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "17"
+                - "2376"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:02 GMT
+                - Tue, 11 Feb 2025 14:24:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -997,10 +1001,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4cfba56e-d5d3-4bce-8c41-5138e902b1ad
+                - d99761e8-f6a9-424a-b782-61f4a400c813
         status: 200 OK
         code: 200
-        duration: 108.983ms
+        duration: 191.312208ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1016,8 +1020,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c611832b-0216-43f6-96b6-88a2f23e725b/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b4098fa0-f77a-4033-a9f8-af5ceb81d136
         method: GET
       response:
         proto: HTTP/2.0
@@ -1025,22 +1029,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 530
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:24:36.397022+00:00","export_uri":null,"id":"b4098fa0-f77a-4033-a9f8-af5ceb81d136","modification_date":"2025-02-11T14:24:37.478858+00:00","name":"tf-vol-compassionate-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","name":"tf-srv-nostalgic-pascal"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "20"
+                - "530"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:02 GMT
-            Link:
-                - </servers/c611832b-0216-43f6-96b6-88a2f23e725b/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:24:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1048,12 +1050,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c8083d45-96d5-4a82-bb81-32dd6acc1d75
-            X-Total-Count:
-                - "0"
+                - c81b3ddf-cc1a-4b9f-a1ef-973c7ee7b7e9
         status: 200 OK
         code: 200
-        duration: 152.650459ms
+        duration: 97.153833ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1069,8 +1069,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c611832b-0216-43f6-96b6-88a2f23e725b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/52518021-cc13-4eb4-9c7b-3a6781aeb404
         method: GET
       response:
         proto: HTTP/2.0
@@ -1078,20 +1078,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2799
+        content_length: 2376
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:34.428187+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-panini","id":"c611832b-0216-43f6-96b6-88a2f23e725b","image":{"arch":"x86_64","creation_date":"2023-08-08T13:36:04.744241+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"655aeea7-8a30-418a-bc2e-3c04e3fdc8aa","modification_date":"2023-08-08T13:36:04.744241+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"27a6459c-efe6-4327-a062-b21a17f3143d","name":"Ubuntu 18.04 Bionic Beaver","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"401","node_id":"30","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:15","maintenances":[],"modification_date":"2025-01-27T13:53:01.648508+00:00","name":"tf-srv-goofy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:34.428187+00:00","export_uri":null,"id":"a8c1daa4-cb61-4806-8ed5-92a09e173188","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:33.529882+00:00","export_uri":null,"id":"c1ca1e2f-e543-4ba1-b0d4-746af7c627cb","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"tf-vol-jovial-roentgen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:37.478858+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-pascal","id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"802","node_id":"40","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:11","maintenances":[],"modification_date":"2025-02-11T14:24:43.728945+00:00","name":"tf-srv-nostalgic-pascal","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"1d87a592-709c-4d49-bf14-6178781323fa","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:24:36.397022+00:00","export_uri":null,"id":"b4098fa0-f77a-4033-a9f8-af5ceb81d136","modification_date":"2025-02-11T14:24:37.478858+00:00","name":"tf-vol-compassionate-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","name":"tf-srv-nostalgic-pascal"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2799"
+                - "2376"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:02 GMT
+                - Tue, 11 Feb 2025 14:24:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1099,10 +1099,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 13371ae3-de45-4c47-93fe-266129c21e0f
+                - 0a46920f-4d72-4bbb-877f-5d9d04d8cae2
         status: 200 OK
         code: 200
-        duration: 199.376542ms
+        duration: 166.39125ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1118,8 +1118,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/c1ca1e2f-e543-4ba1-b0d4-746af7c627cb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/1d87a592-709c-4d49-bf14-6178781323fa
         method: GET
       response:
         proto: HTTP/2.0
@@ -1127,20 +1127,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 518
+        content_length: 143
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:52:33.529882+00:00","export_uri":null,"id":"c1ca1e2f-e543-4ba1-b0d4-746af7c627cb","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"tf-vol-jovial-roentgen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"1d87a592-709c-4d49-bf14-6178781323fa","type":"not_found"}'
         headers:
             Content-Length:
-                - "518"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:02 GMT
+                - Tue, 11 Feb 2025 14:24:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1148,10 +1148,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 02baaba9-d20e-4164-b0a3-057789fe6623
-        status: 200 OK
-        code: 200
-        duration: 207.304791ms
+                - af31f299-5334-4437-97b9-532d55fc1a08
+        status: 404 Not Found
+        code: 404
+        duration: 29.081291ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1167,8 +1167,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c611832b-0216-43f6-96b6-88a2f23e725b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/1d87a592-709c-4d49-bf14-6178781323fa
         method: GET
       response:
         proto: HTTP/2.0
@@ -1176,20 +1176,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2799
+        content_length: 705
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:34.428187+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-panini","id":"c611832b-0216-43f6-96b6-88a2f23e725b","image":{"arch":"x86_64","creation_date":"2023-08-08T13:36:04.744241+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"655aeea7-8a30-418a-bc2e-3c04e3fdc8aa","modification_date":"2023-08-08T13:36:04.744241+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"27a6459c-efe6-4327-a062-b21a17f3143d","name":"Ubuntu 18.04 Bionic Beaver","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"401","node_id":"30","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:15","maintenances":[],"modification_date":"2025-01-27T13:53:01.648508+00:00","name":"tf-srv-goofy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:34.428187+00:00","export_uri":null,"id":"a8c1daa4-cb61-4806-8ed5-92a09e173188","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:33.529882+00:00","export_uri":null,"id":"c1ca1e2f-e543-4ba1-b0d4-746af7c627cb","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"tf-vol-jovial-roentgen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T14:24:37.705303Z","id":"1d87a592-709c-4d49-bf14-6178781323fa","last_detached_at":null,"name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:24:37.705303Z","id":"df17331f-7592-40ba-8e5e-3bee3bef6820","product_resource_id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:24:37.705303Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2799"
+                - "705"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:03 GMT
+                - Tue, 11 Feb 2025 14:24:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1197,10 +1197,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1741d858-d335-41d8-b724-c1e36aa85e57
+                - 08f1f0ba-596e-44b5-807a-1350aae7ef99
         status: 200 OK
         code: 200
-        duration: 166.072875ms
+        duration: 66.975083ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1216,57 +1216,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/a8c1daa4-cb61-4806-8ed5-92a09e173188
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 521
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:52:34.428187+00:00","export_uri":null,"id":"a8c1daa4-cb61-4806-8ed5-92a09e173188","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "521"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:53:03 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 20e2bf16-67ac-4d2d-a8b1-52e66882c10c
-        status: 200 OK
-        code: 200
-        duration: 97.957083ms
-    - id: 25
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c611832b-0216-43f6-96b6-88a2f23e725b/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/52518021-cc13-4eb4-9c7b-3a6781aeb404/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1285,9 +1236,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:03 GMT
+                - Tue, 11 Feb 2025 14:24:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1295,11 +1246,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1a5fd724-b3b8-4794-a6e6-42d7ef0a95f1
+                - d38db301-cbd6-47d4-8944-d7488dcf87c0
         status: 200 OK
         code: 200
-        duration: 93.023625ms
-    - id: 26
+        duration: 78.857083ms
+    - id: 25
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1314,8 +1265,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c611832b-0216-43f6-96b6-88a2f23e725b/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/52518021-cc13-4eb4-9c7b-3a6781aeb404/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1334,11 +1285,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:03 GMT
+                - Tue, 11 Feb 2025 14:24:45 GMT
             Link:
-                - </servers/c611832b-0216-43f6-96b6-88a2f23e725b/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/52518021-cc13-4eb4-9c7b-3a6781aeb404/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1346,12 +1297,61 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0504be65-99e1-49ba-a509-14307bd80257
+                - f39542f1-4719-429a-83ff-c1bf8fd719d4
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 304.606042ms
+        duration: 74.970625ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/52518021-cc13-4eb4-9c7b-3a6781aeb404
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2376
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:37.478858+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-pascal","id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"802","node_id":"40","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:11","maintenances":[],"modification_date":"2025-02-11T14:24:43.728945+00:00","name":"tf-srv-nostalgic-pascal","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"1d87a592-709c-4d49-bf14-6178781323fa","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:24:36.397022+00:00","export_uri":null,"id":"b4098fa0-f77a-4033-a9f8-af5ceb81d136","modification_date":"2025-02-11T14:24:37.478858+00:00","name":"tf-vol-compassionate-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","name":"tf-srv-nostalgic-pascal"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2376"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:24:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 284d5737-eba0-4a6f-b930-622fca91bf9e
+        status: 200 OK
+        code: 200
+        duration: 153.055ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1367,8 +1367,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c611832b-0216-43f6-96b6-88a2f23e725b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/1d87a592-709c-4d49-bf14-6178781323fa
         method: GET
       response:
         proto: HTTP/2.0
@@ -1376,20 +1376,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2799
+        content_length: 705
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:34.428187+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-panini","id":"c611832b-0216-43f6-96b6-88a2f23e725b","image":{"arch":"x86_64","creation_date":"2023-08-08T13:36:04.744241+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"655aeea7-8a30-418a-bc2e-3c04e3fdc8aa","modification_date":"2023-08-08T13:36:04.744241+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"27a6459c-efe6-4327-a062-b21a17f3143d","name":"Ubuntu 18.04 Bionic Beaver","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"401","node_id":"30","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:15","maintenances":[],"modification_date":"2025-01-27T13:53:01.648508+00:00","name":"tf-srv-goofy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:34.428187+00:00","export_uri":null,"id":"a8c1daa4-cb61-4806-8ed5-92a09e173188","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:33.529882+00:00","export_uri":null,"id":"c1ca1e2f-e543-4ba1-b0d4-746af7c627cb","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"tf-vol-jovial-roentgen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T14:24:37.705303Z","id":"1d87a592-709c-4d49-bf14-6178781323fa","last_detached_at":null,"name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:24:37.705303Z","id":"df17331f-7592-40ba-8e5e-3bee3bef6820","product_resource_id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:24:37.705303Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2799"
+                - "705"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:04 GMT
+                - Tue, 11 Feb 2025 14:24:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1397,10 +1397,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 06bf6aa8-c685-4260-a701-a5ccb52c65f8
+                - a9c0d7f9-d2d5-4b04-bfbd-1c7ce2f4dc09
         status: 200 OK
         code: 200
-        duration: 172.557541ms
+        duration: 77.998375ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1418,8 +1418,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c611832b-0216-43f6-96b6-88a2f23e725b/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/52518021-cc13-4eb4-9c7b-3a6781aeb404/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -1429,7 +1429,7 @@ interactions:
         trailer: {}
         content_length: 352
         uncompressed: false
-        body: '{"task":{"description":"server_poweroff","href_from":"/servers/c611832b-0216-43f6-96b6-88a2f23e725b/action","href_result":"/servers/c611832b-0216-43f6-96b6-88a2f23e725b","id":"24d51a17-4eec-4325-99c9-2c5435f1dbac","progress":0,"started_at":"2025-01-27T13:53:05.451829+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_poweroff","href_from":"/servers/52518021-cc13-4eb4-9c7b-3a6781aeb404/action","href_result":"/servers/52518021-cc13-4eb4-9c7b-3a6781aeb404","id":"ad3714e5-2301-4b4f-93ea-fb5b486876a0","progress":0,"started_at":"2025-02-11T14:24:46.393799+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "352"
@@ -1438,11 +1438,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:05 GMT
+                - Tue, 11 Feb 2025 14:24:45 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/24d51a17-4eec-4325-99c9-2c5435f1dbac
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/ad3714e5-2301-4b4f-93ea-fb5b486876a0
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1450,10 +1450,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d262e103-9f9f-4315-8a2e-a1ed2e43aca5
+                - fdf2d123-21b0-4062-89e3-6836435557c0
         status: 202 Accepted
         code: 202
-        duration: 975.246958ms
+        duration: 486.720417ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1469,8 +1469,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c611832b-0216-43f6-96b6-88a2f23e725b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/52518021-cc13-4eb4-9c7b-3a6781aeb404
         method: GET
       response:
         proto: HTTP/2.0
@@ -1478,20 +1478,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2759
+        content_length: 2336
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:34.428187+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-panini","id":"c611832b-0216-43f6-96b6-88a2f23e725b","image":{"arch":"x86_64","creation_date":"2023-08-08T13:36:04.744241+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"655aeea7-8a30-418a-bc2e-3c04e3fdc8aa","modification_date":"2023-08-08T13:36:04.744241+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"27a6459c-efe6-4327-a062-b21a17f3143d","name":"Ubuntu 18.04 Bionic Beaver","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"401","node_id":"30","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:15","maintenances":[],"modification_date":"2025-01-27T13:53:04.575347+00:00","name":"tf-srv-goofy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:34.428187+00:00","export_uri":null,"id":"a8c1daa4-cb61-4806-8ed5-92a09e173188","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:33.529882+00:00","export_uri":null,"id":"c1ca1e2f-e543-4ba1-b0d4-746af7c627cb","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"tf-vol-jovial-roentgen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:37.478858+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-pascal","id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"802","node_id":"40","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:11","maintenances":[],"modification_date":"2025-02-11T14:24:46.034995+00:00","name":"tf-srv-nostalgic-pascal","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"1d87a592-709c-4d49-bf14-6178781323fa","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:24:36.397022+00:00","export_uri":null,"id":"b4098fa0-f77a-4033-a9f8-af5ceb81d136","modification_date":"2025-02-11T14:24:37.478858+00:00","name":"tf-vol-compassionate-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","name":"tf-srv-nostalgic-pascal"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2759"
+                - "2336"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:05 GMT
+                - Tue, 11 Feb 2025 14:24:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1499,10 +1499,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 731929d2-e33e-4b71-b4f6-9c03b4aafec1
+                - ff1bda82-4a95-4119-bc74-f95f397f2f8b
         status: 200 OK
         code: 200
-        duration: 209.890208ms
+        duration: 165.656959ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1518,8 +1518,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c611832b-0216-43f6-96b6-88a2f23e725b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/52518021-cc13-4eb4-9c7b-3a6781aeb404
         method: GET
       response:
         proto: HTTP/2.0
@@ -1527,20 +1527,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2759
+        content_length: 2336
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:34.428187+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-panini","id":"c611832b-0216-43f6-96b6-88a2f23e725b","image":{"arch":"x86_64","creation_date":"2023-08-08T13:36:04.744241+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"655aeea7-8a30-418a-bc2e-3c04e3fdc8aa","modification_date":"2023-08-08T13:36:04.744241+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"27a6459c-efe6-4327-a062-b21a17f3143d","name":"Ubuntu 18.04 Bionic Beaver","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"401","node_id":"30","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:15","maintenances":[],"modification_date":"2025-01-27T13:53:04.575347+00:00","name":"tf-srv-goofy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:34.428187+00:00","export_uri":null,"id":"a8c1daa4-cb61-4806-8ed5-92a09e173188","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:33.529882+00:00","export_uri":null,"id":"c1ca1e2f-e543-4ba1-b0d4-746af7c627cb","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"tf-vol-jovial-roentgen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:37.478858+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-pascal","id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"802","node_id":"40","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:11","maintenances":[],"modification_date":"2025-02-11T14:24:46.034995+00:00","name":"tf-srv-nostalgic-pascal","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"1d87a592-709c-4d49-bf14-6178781323fa","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:24:36.397022+00:00","export_uri":null,"id":"b4098fa0-f77a-4033-a9f8-af5ceb81d136","modification_date":"2025-02-11T14:24:37.478858+00:00","name":"tf-vol-compassionate-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","name":"tf-srv-nostalgic-pascal"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2759"
+                - "2336"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:10 GMT
+                - Tue, 11 Feb 2025 14:24:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1548,10 +1548,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dc1c7f4e-d5fd-4905-a2ce-23c2d18999c7
+                - 90851c22-8f59-441c-ab9c-927b558ff6c2
         status: 200 OK
         code: 200
-        duration: 236.989834ms
+        duration: 216.612209ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1567,8 +1567,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c611832b-0216-43f6-96b6-88a2f23e725b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/52518021-cc13-4eb4-9c7b-3a6781aeb404
         method: GET
       response:
         proto: HTTP/2.0
@@ -1576,20 +1576,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2759
+        content_length: 2336
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:34.428187+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-panini","id":"c611832b-0216-43f6-96b6-88a2f23e725b","image":{"arch":"x86_64","creation_date":"2023-08-08T13:36:04.744241+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"655aeea7-8a30-418a-bc2e-3c04e3fdc8aa","modification_date":"2023-08-08T13:36:04.744241+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"27a6459c-efe6-4327-a062-b21a17f3143d","name":"Ubuntu 18.04 Bionic Beaver","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"401","node_id":"30","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:15","maintenances":[],"modification_date":"2025-01-27T13:53:04.575347+00:00","name":"tf-srv-goofy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:34.428187+00:00","export_uri":null,"id":"a8c1daa4-cb61-4806-8ed5-92a09e173188","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:33.529882+00:00","export_uri":null,"id":"c1ca1e2f-e543-4ba1-b0d4-746af7c627cb","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"tf-vol-jovial-roentgen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:37.478858+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-pascal","id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"802","node_id":"40","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:11","maintenances":[],"modification_date":"2025-02-11T14:24:46.034995+00:00","name":"tf-srv-nostalgic-pascal","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"1d87a592-709c-4d49-bf14-6178781323fa","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:24:36.397022+00:00","export_uri":null,"id":"b4098fa0-f77a-4033-a9f8-af5ceb81d136","modification_date":"2025-02-11T14:24:37.478858+00:00","name":"tf-vol-compassionate-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","name":"tf-srv-nostalgic-pascal"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2759"
+                - "2336"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:15 GMT
+                - Tue, 11 Feb 2025 14:24:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1597,10 +1597,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f3f999a4-c0ee-494b-bc17-4c58cf4ee4aa
+                - 616e2ae5-1fee-48e8-aac9-1b541a3ef6d7
         status: 200 OK
         code: 200
-        duration: 174.774542ms
+        duration: 482.435417ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1616,8 +1616,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c611832b-0216-43f6-96b6-88a2f23e725b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/52518021-cc13-4eb4-9c7b-3a6781aeb404
         method: GET
       response:
         proto: HTTP/2.0
@@ -1625,20 +1625,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2759
+        content_length: 2336
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:34.428187+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-panini","id":"c611832b-0216-43f6-96b6-88a2f23e725b","image":{"arch":"x86_64","creation_date":"2023-08-08T13:36:04.744241+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"655aeea7-8a30-418a-bc2e-3c04e3fdc8aa","modification_date":"2023-08-08T13:36:04.744241+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"27a6459c-efe6-4327-a062-b21a17f3143d","name":"Ubuntu 18.04 Bionic Beaver","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"401","node_id":"30","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:15","maintenances":[],"modification_date":"2025-01-27T13:53:04.575347+00:00","name":"tf-srv-goofy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:34.428187+00:00","export_uri":null,"id":"a8c1daa4-cb61-4806-8ed5-92a09e173188","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:33.529882+00:00","export_uri":null,"id":"c1ca1e2f-e543-4ba1-b0d4-746af7c627cb","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"tf-vol-jovial-roentgen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:37.478858+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-pascal","id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"802","node_id":"40","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:11","maintenances":[],"modification_date":"2025-02-11T14:24:46.034995+00:00","name":"tf-srv-nostalgic-pascal","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"1d87a592-709c-4d49-bf14-6178781323fa","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:24:36.397022+00:00","export_uri":null,"id":"b4098fa0-f77a-4033-a9f8-af5ceb81d136","modification_date":"2025-02-11T14:24:37.478858+00:00","name":"tf-vol-compassionate-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","name":"tf-srv-nostalgic-pascal"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2759"
+                - "2336"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:21 GMT
+                - Tue, 11 Feb 2025 14:25:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1646,10 +1646,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 685a337d-ab64-48c3-9769-124f604795a7
+                - 5641b14a-ae4c-49fb-95f9-69d88700b98e
         status: 200 OK
         code: 200
-        duration: 185.264958ms
+        duration: 232.536833ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1665,8 +1665,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c611832b-0216-43f6-96b6-88a2f23e725b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/52518021-cc13-4eb4-9c7b-3a6781aeb404
         method: GET
       response:
         proto: HTTP/2.0
@@ -1674,20 +1674,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2759
+        content_length: 2336
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:34.428187+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-panini","id":"c611832b-0216-43f6-96b6-88a2f23e725b","image":{"arch":"x86_64","creation_date":"2023-08-08T13:36:04.744241+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"655aeea7-8a30-418a-bc2e-3c04e3fdc8aa","modification_date":"2023-08-08T13:36:04.744241+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"27a6459c-efe6-4327-a062-b21a17f3143d","name":"Ubuntu 18.04 Bionic Beaver","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"401","node_id":"30","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:15","maintenances":[],"modification_date":"2025-01-27T13:53:04.575347+00:00","name":"tf-srv-goofy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:34.428187+00:00","export_uri":null,"id":"a8c1daa4-cb61-4806-8ed5-92a09e173188","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:33.529882+00:00","export_uri":null,"id":"c1ca1e2f-e543-4ba1-b0d4-746af7c627cb","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"tf-vol-jovial-roentgen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:37.478858+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-pascal","id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"802","node_id":"40","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:11","maintenances":[],"modification_date":"2025-02-11T14:24:46.034995+00:00","name":"tf-srv-nostalgic-pascal","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"1d87a592-709c-4d49-bf14-6178781323fa","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:24:36.397022+00:00","export_uri":null,"id":"b4098fa0-f77a-4033-a9f8-af5ceb81d136","modification_date":"2025-02-11T14:24:37.478858+00:00","name":"tf-vol-compassionate-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","name":"tf-srv-nostalgic-pascal"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2759"
+                - "2336"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:26 GMT
+                - Tue, 11 Feb 2025 14:25:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1695,10 +1695,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0c4e5b1a-5bb9-4090-95e4-cdc1a32a149f
+                - 08c17862-c07b-42d8-b29b-72fb9663a471
         status: 200 OK
         code: 200
-        duration: 161.128ms
+        duration: 177.025167ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1714,8 +1714,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c611832b-0216-43f6-96b6-88a2f23e725b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/52518021-cc13-4eb4-9c7b-3a6781aeb404
         method: GET
       response:
         proto: HTTP/2.0
@@ -1723,20 +1723,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2759
+        content_length: 2336
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:34.428187+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-panini","id":"c611832b-0216-43f6-96b6-88a2f23e725b","image":{"arch":"x86_64","creation_date":"2023-08-08T13:36:04.744241+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"655aeea7-8a30-418a-bc2e-3c04e3fdc8aa","modification_date":"2023-08-08T13:36:04.744241+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"27a6459c-efe6-4327-a062-b21a17f3143d","name":"Ubuntu 18.04 Bionic Beaver","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"401","node_id":"30","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:15","maintenances":[],"modification_date":"2025-01-27T13:53:04.575347+00:00","name":"tf-srv-goofy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:34.428187+00:00","export_uri":null,"id":"a8c1daa4-cb61-4806-8ed5-92a09e173188","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:33.529882+00:00","export_uri":null,"id":"c1ca1e2f-e543-4ba1-b0d4-746af7c627cb","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"tf-vol-jovial-roentgen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:37.478858+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-pascal","id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"802","node_id":"40","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:11","maintenances":[],"modification_date":"2025-02-11T14:24:46.034995+00:00","name":"tf-srv-nostalgic-pascal","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"1d87a592-709c-4d49-bf14-6178781323fa","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:24:36.397022+00:00","export_uri":null,"id":"b4098fa0-f77a-4033-a9f8-af5ceb81d136","modification_date":"2025-02-11T14:24:37.478858+00:00","name":"tf-vol-compassionate-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","name":"tf-srv-nostalgic-pascal"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2759"
+                - "2336"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:31 GMT
+                - Tue, 11 Feb 2025 14:25:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1744,10 +1744,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1cd920f3-0e12-4b43-9f15-12f6a6ee5358
+                - fe71cd34-b21e-48f4-9277-c419ba4586e4
         status: 200 OK
         code: 200
-        duration: 183.912375ms
+        duration: 156.478292ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1763,8 +1763,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c611832b-0216-43f6-96b6-88a2f23e725b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/52518021-cc13-4eb4-9c7b-3a6781aeb404
         method: GET
       response:
         proto: HTTP/2.0
@@ -1772,20 +1772,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2759
+        content_length: 2336
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:34.428187+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-panini","id":"c611832b-0216-43f6-96b6-88a2f23e725b","image":{"arch":"x86_64","creation_date":"2023-08-08T13:36:04.744241+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"655aeea7-8a30-418a-bc2e-3c04e3fdc8aa","modification_date":"2023-08-08T13:36:04.744241+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"27a6459c-efe6-4327-a062-b21a17f3143d","name":"Ubuntu 18.04 Bionic Beaver","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"401","node_id":"30","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:15","maintenances":[],"modification_date":"2025-01-27T13:53:04.575347+00:00","name":"tf-srv-goofy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:34.428187+00:00","export_uri":null,"id":"a8c1daa4-cb61-4806-8ed5-92a09e173188","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:33.529882+00:00","export_uri":null,"id":"c1ca1e2f-e543-4ba1-b0d4-746af7c627cb","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"tf-vol-jovial-roentgen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:37.478858+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-pascal","id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"802","node_id":"40","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:11","maintenances":[],"modification_date":"2025-02-11T14:24:46.034995+00:00","name":"tf-srv-nostalgic-pascal","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"1d87a592-709c-4d49-bf14-6178781323fa","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:24:36.397022+00:00","export_uri":null,"id":"b4098fa0-f77a-4033-a9f8-af5ceb81d136","modification_date":"2025-02-11T14:24:37.478858+00:00","name":"tf-vol-compassionate-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","name":"tf-srv-nostalgic-pascal"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2759"
+                - "2336"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:36 GMT
+                - Tue, 11 Feb 2025 14:25:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1793,10 +1793,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7b026c32-7c23-4dea-a8d0-a22065d3cde9
+                - 8e36bc36-d823-4097-9b17-6be81d31286f
         status: 200 OK
         code: 200
-        duration: 213.604791ms
+        duration: 174.498375ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1812,8 +1812,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c611832b-0216-43f6-96b6-88a2f23e725b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/52518021-cc13-4eb4-9c7b-3a6781aeb404
         method: GET
       response:
         proto: HTTP/2.0
@@ -1821,20 +1821,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2759
+        content_length: 2336
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:34.428187+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-panini","id":"c611832b-0216-43f6-96b6-88a2f23e725b","image":{"arch":"x86_64","creation_date":"2023-08-08T13:36:04.744241+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"655aeea7-8a30-418a-bc2e-3c04e3fdc8aa","modification_date":"2023-08-08T13:36:04.744241+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"27a6459c-efe6-4327-a062-b21a17f3143d","name":"Ubuntu 18.04 Bionic Beaver","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"401","node_id":"30","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:15","maintenances":[],"modification_date":"2025-01-27T13:53:04.575347+00:00","name":"tf-srv-goofy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:34.428187+00:00","export_uri":null,"id":"a8c1daa4-cb61-4806-8ed5-92a09e173188","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:33.529882+00:00","export_uri":null,"id":"c1ca1e2f-e543-4ba1-b0d4-746af7c627cb","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"tf-vol-jovial-roentgen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:37.478858+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-pascal","id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"802","node_id":"40","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:11","maintenances":[],"modification_date":"2025-02-11T14:24:46.034995+00:00","name":"tf-srv-nostalgic-pascal","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"1d87a592-709c-4d49-bf14-6178781323fa","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:24:36.397022+00:00","export_uri":null,"id":"b4098fa0-f77a-4033-a9f8-af5ceb81d136","modification_date":"2025-02-11T14:24:37.478858+00:00","name":"tf-vol-compassionate-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","name":"tf-srv-nostalgic-pascal"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2759"
+                - "2336"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:41 GMT
+                - Tue, 11 Feb 2025 14:25:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1842,10 +1842,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0f09d3c4-ea93-4e0d-879d-a957a49910df
+                - 2d88dd7f-b22d-4bf8-829d-ff2c68e808da
         status: 200 OK
         code: 200
-        duration: 187.764833ms
+        duration: 144.702625ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1861,8 +1861,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c611832b-0216-43f6-96b6-88a2f23e725b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/52518021-cc13-4eb4-9c7b-3a6781aeb404
         method: GET
       response:
         proto: HTTP/2.0
@@ -1870,20 +1870,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2759
+        content_length: 2336
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:34.428187+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-panini","id":"c611832b-0216-43f6-96b6-88a2f23e725b","image":{"arch":"x86_64","creation_date":"2023-08-08T13:36:04.744241+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"655aeea7-8a30-418a-bc2e-3c04e3fdc8aa","modification_date":"2023-08-08T13:36:04.744241+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"27a6459c-efe6-4327-a062-b21a17f3143d","name":"Ubuntu 18.04 Bionic Beaver","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"401","node_id":"30","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:15","maintenances":[],"modification_date":"2025-01-27T13:53:04.575347+00:00","name":"tf-srv-goofy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:34.428187+00:00","export_uri":null,"id":"a8c1daa4-cb61-4806-8ed5-92a09e173188","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:33.529882+00:00","export_uri":null,"id":"c1ca1e2f-e543-4ba1-b0d4-746af7c627cb","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"tf-vol-jovial-roentgen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:37.478858+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-pascal","id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"802","node_id":"40","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:11","maintenances":[],"modification_date":"2025-02-11T14:24:46.034995+00:00","name":"tf-srv-nostalgic-pascal","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"1d87a592-709c-4d49-bf14-6178781323fa","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:24:36.397022+00:00","export_uri":null,"id":"b4098fa0-f77a-4033-a9f8-af5ceb81d136","modification_date":"2025-02-11T14:24:37.478858+00:00","name":"tf-vol-compassionate-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","name":"tf-srv-nostalgic-pascal"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2759"
+                - "2336"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:47 GMT
+                - Tue, 11 Feb 2025 14:25:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1891,10 +1891,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1251a42f-4b35-409c-9dd3-9c61384ff120
+                - 2bdc19bc-a267-41d6-9226-d5f881189044
         status: 200 OK
         code: 200
-        duration: 208.816375ms
+        duration: 166.620833ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1910,8 +1910,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c611832b-0216-43f6-96b6-88a2f23e725b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/52518021-cc13-4eb4-9c7b-3a6781aeb404
         method: GET
       response:
         proto: HTTP/2.0
@@ -1919,20 +1919,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2759
+        content_length: 2220
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:34.428187+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-panini","id":"c611832b-0216-43f6-96b6-88a2f23e725b","image":{"arch":"x86_64","creation_date":"2023-08-08T13:36:04.744241+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"655aeea7-8a30-418a-bc2e-3c04e3fdc8aa","modification_date":"2023-08-08T13:36:04.744241+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"27a6459c-efe6-4327-a062-b21a17f3143d","name":"Ubuntu 18.04 Bionic Beaver","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"401","node_id":"30","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:01:15","maintenances":[],"modification_date":"2025-01-27T13:53:04.575347+00:00","name":"tf-srv-goofy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:34.428187+00:00","export_uri":null,"id":"a8c1daa4-cb61-4806-8ed5-92a09e173188","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:33.529882+00:00","export_uri":null,"id":"c1ca1e2f-e543-4ba1-b0d4-746af7c627cb","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"tf-vol-jovial-roentgen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:37.478858+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-pascal","id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:11","maintenances":[],"modification_date":"2025-02-11T14:25:29.061323+00:00","name":"tf-srv-nostalgic-pascal","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"1d87a592-709c-4d49-bf14-6178781323fa","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:24:36.397022+00:00","export_uri":null,"id":"b4098fa0-f77a-4033-a9f8-af5ceb81d136","modification_date":"2025-02-11T14:24:37.478858+00:00","name":"tf-vol-compassionate-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","name":"tf-srv-nostalgic-pascal"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2759"
+                - "2220"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:52 GMT
+                - Tue, 11 Feb 2025 14:25:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1940,10 +1940,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 43ab20c0-2bcc-4478-b271-4eda8cd95a02
+                - 03b27b4a-1f6c-4fe8-9157-da54cdca1ee1
         status: 200 OK
         code: 200
-        duration: 163.551792ms
+        duration: 159.848792ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1959,8 +1959,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c611832b-0216-43f6-96b6-88a2f23e725b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/52518021-cc13-4eb4-9c7b-3a6781aeb404
         method: GET
       response:
         proto: HTTP/2.0
@@ -1968,20 +1968,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2643
+        content_length: 2220
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:34.428187+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-panini","id":"c611832b-0216-43f6-96b6-88a2f23e725b","image":{"arch":"x86_64","creation_date":"2023-08-08T13:36:04.744241+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"655aeea7-8a30-418a-bc2e-3c04e3fdc8aa","modification_date":"2023-08-08T13:36:04.744241+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"27a6459c-efe6-4327-a062-b21a17f3143d","name":"Ubuntu 18.04 Bionic Beaver","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:15","maintenances":[],"modification_date":"2025-01-27T13:53:52.956004+00:00","name":"tf-srv-goofy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:34.428187+00:00","export_uri":null,"id":"a8c1daa4-cb61-4806-8ed5-92a09e173188","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:33.529882+00:00","export_uri":null,"id":"c1ca1e2f-e543-4ba1-b0d4-746af7c627cb","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"tf-vol-jovial-roentgen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:24:37.478858+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-pascal","id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","image":{"arch":"x86_64","creation_date":"2024-10-07T11:39:13.069801+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0","modification_date":"2024-10-07T11:39:13.069801+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"4eb9437f-8993-444a-b564-f7654add2131","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:11","maintenances":[],"modification_date":"2025-02-11T14:25:29.061323+00:00","name":"tf-srv-nostalgic-pascal","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"1d87a592-709c-4d49-bf14-6178781323fa","volume_type":"sbs_volume","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:24:36.397022+00:00","export_uri":null,"id":"b4098fa0-f77a-4033-a9f8-af5ceb81d136","modification_date":"2025-02-11T14:24:37.478858+00:00","name":"tf-vol-compassionate-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","name":"tf-srv-nostalgic-pascal"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2643"
+                - "2220"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:59 GMT
+                - Tue, 11 Feb 2025 14:25:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1989,10 +1989,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d9a5d543-2bf5-4700-b5e4-cb57404b15b7
+                - 1428434a-65e9-4143-ab46-ee88957825f4
         status: 200 OK
         code: 200
-        duration: 143.094292ms
+        duration: 154.916292ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2008,29 +2008,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c611832b-0216-43f6-96b6-88a2f23e725b
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/52518021-cc13-4eb4-9c7b-3a6781aeb404
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2643
+        content_length: 0
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:52:34.428187+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-goofy-panini","id":"c611832b-0216-43f6-96b6-88a2f23e725b","image":{"arch":"x86_64","creation_date":"2023-08-08T13:36:04.744241+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"655aeea7-8a30-418a-bc2e-3c04e3fdc8aa","modification_date":"2023-08-08T13:36:04.744241+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"27a6459c-efe6-4327-a062-b21a17f3143d","name":"Ubuntu 18.04 Bionic Beaver","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:01:15","maintenances":[],"modification_date":"2025-01-27T13:53:52.956004+00:00","name":"tf-srv-goofy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:52:34.428187+00:00","export_uri":null,"id":"a8c1daa4-cb61-4806-8ed5-92a09e173188","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"Ubuntu 18.04 Bionic Beaver","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:52:33.529882+00:00","export_uri":null,"id":"c1ca1e2f-e543-4ba1-b0d4-746af7c627cb","modification_date":"2025-01-27T13:52:34.428187+00:00","name":"tf-vol-jovial-roentgen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c611832b-0216-43f6-96b6-88a2f23e725b","name":"tf-srv-goofy-panini"},"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: ""
         headers:
-            Content-Length:
-                - "2643"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:59 GMT
+                - Tue, 11 Feb 2025 14:25:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2038,10 +2036,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ceaa4f9e-71c2-438f-aa02-ba10c0d638fe
-        status: 200 OK
-        code: 200
-        duration: 157.87075ms
+                - 7a5b2795-fa18-4dec-8659-a0f51910ba0a
+        status: 204 No Content
+        code: 204
+        duration: 375.937083ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2057,27 +2055,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c611832b-0216-43f6-96b6-88a2f23e725b
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/52518021-cc13-4eb4-9c7b-3a6781aeb404
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 143
         uncompressed: false
-        body: ""
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","type":"not_found"}'
         headers:
+            Content-Length:
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:59 GMT
+                - Tue, 11 Feb 2025 14:25:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2085,10 +2085,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 47bb9296-9aea-42dc-a997-b48ed8f01fad
-        status: 204 No Content
-        code: 204
-        duration: 178.824833ms
+                - 977b89db-3d87-465c-a3d8-d79ba34d51cc
+        status: 404 Not Found
+        code: 404
+        duration: 164.539166ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2104,8 +2104,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c611832b-0216-43f6-96b6-88a2f23e725b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b4098fa0-f77a-4033-a9f8-af5ceb81d136
         method: GET
       response:
         proto: HTTP/2.0
@@ -2113,20 +2113,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 143
+        content_length: 453
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"c611832b-0216-43f6-96b6-88a2f23e725b","type":"not_found"}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:24:36.397022+00:00","export_uri":null,"id":"b4098fa0-f77a-4033-a9f8-af5ceb81d136","modification_date":"2025-02-11T14:25:33.818839+00:00","name":"tf-vol-compassionate-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "143"
+                - "453"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:53:59 GMT
+                - Tue, 11 Feb 2025 14:25:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2134,10 +2134,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2f385ecb-64f6-4785-92c2-6246857eeb83
-        status: 404 Not Found
-        code: 404
-        duration: 88.825209ms
+                - 043fc392-bfe2-4e9c-8adf-458f3a46ebeb
+        status: 200 OK
+        code: 200
+        duration: 78.085167ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2153,57 +2153,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/c1ca1e2f-e543-4ba1-b0d4-746af7c627cb
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 445
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:52:33.529882+00:00","export_uri":null,"id":"c1ca1e2f-e543-4ba1-b0d4-746af7c627cb","modification_date":"2025-01-27T13:53:59.733954+00:00","name":"tf-vol-jovial-roentgen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":100000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "445"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:53:59 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - a99d1560-8e60-41bc-ab97-f0789da606c4
-        status: 200 OK
-        code: 200
-        duration: 81.191458ms
-    - id: 44
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/c1ca1e2f-e543-4ba1-b0d4-746af7c627cb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b4098fa0-f77a-4033-a9f8-af5ceb81d136
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2220,9 +2171,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:00 GMT
+                - Tue, 11 Feb 2025 14:25:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2230,11 +2181,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8a2bf801-d367-46c4-9000-8f97ca3c421b
+                - ef525961-c374-4abf-90d5-c7fb5780def1
         status: 204 No Content
         code: 204
-        duration: 161.386667ms
-    - id: 45
+        duration: 188.019292ms
+    - id: 44
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2249,8 +2200,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c611832b-0216-43f6-96b6-88a2f23e725b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/52518021-cc13-4eb4-9c7b-3a6781aeb404
         method: GET
       response:
         proto: HTTP/2.0
@@ -2260,7 +2211,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"c611832b-0216-43f6-96b6-88a2f23e725b","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"52518021-cc13-4eb4-9c7b-3a6781aeb404","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -2269,9 +2220,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:54:00 GMT
+                - Tue, 11 Feb 2025 14:25:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2279,7 +2230,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6ed5f580-9e1b-4444-9337-75b2fcf77de5
+                - faa967e0-6402-46d5-be4f-c1667126ae04
         status: 404 Not Found
         code: 404
-        duration: 144.964792ms
+        duration: 88.095458ms

--- a/internal/services/instance/testdata/server-with-reserved-ip.cassette.yaml
+++ b/internal/services/instance/testdata/server-with-reserved-ip.cassette.yaml
@@ -18,7 +18,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips
         method: POST
       response:
@@ -27,22 +27,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 364
+        content_length: 365
         uncompressed: false
-        body: '{"ip":{"address":"51.158.65.65","id":"fb49b08e-51b4-45cd-a0d0-bcf156deee1b","ipam_id":"fee483d7-e770-44c5-819e-0a58a614105b","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"d2740bae-187d-42b4-ae39-7e511bc1f051","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "364"
+                - "365"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:23 GMT
+                - Tue, 11 Feb 2025 14:25:04 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/fb49b08e-51b4-45cd-a0d0-bcf156deee1b
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -50,10 +50,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 124e32f7-c3d6-46f1-82c8-1b9ae2baa923
+                - e88dba4c-b8ca-4844-bc0f-4f44318f702d
         status: 201 Created
         code: 201
-        duration: 483.027083ms
+        duration: 516.532458ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -69,8 +69,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/fb49b08e-51b4-45cd-a0d0-bcf156deee1b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
         method: GET
       response:
         proto: HTTP/2.0
@@ -78,20 +78,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 364
+        content_length: 365
         uncompressed: false
-        body: '{"ip":{"address":"51.158.65.65","id":"fb49b08e-51b4-45cd-a0d0-bcf156deee1b","ipam_id":"fee483d7-e770-44c5-819e-0a58a614105b","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"d2740bae-187d-42b4-ae39-7e511bc1f051","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "364"
+                - "365"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:23 GMT
+                - Tue, 11 Feb 2025 14:25:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -99,10 +99,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9cba62bc-3e12-46a1-aab8-94e34c66a4c6
+                - 19100bb6-4c92-4351-98bb-e1b5b19600c9
         status: 200 OK
         code: 200
-        duration: 90.694334ms
+        duration: 80.377917ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -118,7 +118,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
         method: GET
       response:
@@ -127,22 +127,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 38539
+        content_length: 35639
         uncompressed: false
-        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
+        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
         headers:
             Content-Length:
-                - "38539"
+                - "35639"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:23 GMT
+                - Tue, 11 Feb 2025 14:25:04 GMT
             Link:
                 - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -150,12 +150,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 67dc1c77-a089-416f-9562-22b7af03fe3f
+                - 63d6dbba-e9db-486a-83cf-05ea7301caeb
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 57.629333ms
+        duration: 62.530334ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -171,7 +171,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
         method: GET
       response:
@@ -180,22 +180,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 14208
+        content_length: 13164
         uncompressed: false
-        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
         headers:
             Content-Length:
-                - "14208"
+                - "13164"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:23 GMT
+                - Tue, 11 Feb 2025 14:25:04 GMT
             Link:
                 - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -203,12 +203,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8003eb48-a1b9-4f30-9b3c-35c09839455b
+                - 4bd06070-9e21-4c3b-83aa-96380609e2cd
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 50.457917ms
+        duration: 60.208084ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -224,8 +224,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_local&zone=fr-par-1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_sbs&zone=fr-par-1
         method: GET
       response:
         proto: HTTP/2.0
@@ -233,20 +233,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1300
+        content_length: 1296
         uncompressed: false
-        body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"56d4019c-8305-467a-a3f2-70498ad799df","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
+        body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"57509e82-ac3b-49b7-9970-97b60f40ff72","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"9b647e1e-253a-41e7-8c15-911c622ee2dc","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"}],"total_count":2}'
         headers:
             Content-Length:
-                - "1300"
+                - "1296"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:23 GMT
+                - Tue, 11 Feb 2025 14:25:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -254,28 +254,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2b5a500f-d14f-4b6a-93b8-b6ac60c5a6a4
+                - 63137d9d-b427-4d6d-8df2-bf9d8a0c1104
         status: 200 OK
         code: 200
-        duration: 66.099666ms
+        duration: 82.285542ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 394
+        content_length: 353
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-srv-nostalgic-gates","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"public_ip":"fb49b08e-51b4-45cd-a0d0-bcf156deee1b","boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":["terraform-test","scaleway_instance_server","reserved_ip"]}'
+        body: '{"name":"tf-srv-awesome-haslett","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"57509e82-ac3b-49b7-9970-97b60f40ff72","volumes":{"0":{"boot":false}},"public_ip":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":["terraform-test","scaleway_instance_server","reserved_ip"]}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
         method: POST
       response:
@@ -284,22 +284,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2701
+        content_length: 2259
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:24.018433+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.65.65","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"fb49b08e-51b4-45cd-a0d0-bcf156deee1b","ipam_id":"fee483d7-e770-44c5-819e-0a58a614105b","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.65.65","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"fb49b08e-51b4-45cd-a0d0-bcf156deee1b","ipam_id":"fee483d7-e770-44c5-819e-0a58a614105b","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:05.403080+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"d2740bae-187d-42b4-ae39-7e511bc1f051","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"d2740bae-187d-42b4-ae39-7e511bc1f051","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2701"
+                - "2259"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:24 GMT
+                - Tue, 11 Feb 2025 14:25:06 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -307,10 +307,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a0f1a3bb-bf02-4ae9-a8ac-9c83ee07525f
+                - c8066729-a2d4-4dd4-9333-31dd65a43267
         status: 201 Created
         code: 201
-        duration: 935.642708ms
+        duration: 1.064696166s
     - id: 6
       request:
         proto: HTTP/1.1
@@ -326,8 +326,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
         method: GET
       response:
         proto: HTTP/2.0
@@ -335,20 +335,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2701
+        content_length: 2259
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:24.018433+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.65.65","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"fb49b08e-51b4-45cd-a0d0-bcf156deee1b","ipam_id":"fee483d7-e770-44c5-819e-0a58a614105b","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.65.65","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"fb49b08e-51b4-45cd-a0d0-bcf156deee1b","ipam_id":"fee483d7-e770-44c5-819e-0a58a614105b","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:05.403080+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"d2740bae-187d-42b4-ae39-7e511bc1f051","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"d2740bae-187d-42b4-ae39-7e511bc1f051","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2701"
+                - "2259"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:24 GMT
+                - Tue, 11 Feb 2025 14:25:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -356,10 +356,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0a1ee64f-26ae-4e15-a4bb-b72c9aca518c
+                - 1861c8a0-689a-4c3f-a816-73c0d9157353
         status: 200 OK
         code: 200
-        duration: 148.399917ms
+        duration: 178.161625ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -375,8 +375,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
         method: GET
       response:
         proto: HTTP/2.0
@@ -384,20 +384,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2701
+        content_length: 2259
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:24.018433+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.65.65","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"fb49b08e-51b4-45cd-a0d0-bcf156deee1b","ipam_id":"fee483d7-e770-44c5-819e-0a58a614105b","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.65.65","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"fb49b08e-51b4-45cd-a0d0-bcf156deee1b","ipam_id":"fee483d7-e770-44c5-819e-0a58a614105b","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:05.403080+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"d2740bae-187d-42b4-ae39-7e511bc1f051","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"d2740bae-187d-42b4-ae39-7e511bc1f051","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2701"
+                - "2259"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:24 GMT
+                - Tue, 11 Feb 2025 14:25:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -405,11 +405,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ca21a97f-b221-457c-bc50-e06ef7b932ae
+                - 61da6876-f907-41c8-95d5-b6e8818fb002
         status: 200 OK
         code: 200
-        duration: 144.31ms
+        duration: 177.529833ms
     - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/0725a599-8625-404e-8c03-fc85ad86c0a8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:25:05.625577Z","id":"0725a599-8625-404e-8c03-fc85ad86c0a8","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:25:05.625577Z","id":"7cbf0cd1-960a-4808-8227-635a82c90a3e","product_resource_id":"82e67158-c544-4736-b58a-a28a0ce8892d","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:25:05.625577Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5694410b-caaf-4b99-8d98-d9b2aa78565a
+        status: 200 OK
+        code: 200
+        duration: 60.375042ms
+    - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -426,8 +475,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -437,7 +486,7 @@ interactions:
         trailer: {}
         content_length: 357
         uncompressed: false
-        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f/action","href_result":"/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f","id":"6e67efb2-af32-4a8d-9994-7700907458d7","progress":0,"started_at":"2025-01-27T13:50:25.271777+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/82e67158-c544-4736-b58a-a28a0ce8892d/action","href_result":"/servers/82e67158-c544-4736-b58a-a28a0ce8892d","id":"8ea169d2-308e-47f3-a524-44f60d245719","progress":0,"started_at":"2025-02-11T14:25:06.857425+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -446,11 +495,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:25 GMT
+                - Tue, 11 Feb 2025 14:25:06 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/6e67efb2-af32-4a8d-9994-7700907458d7
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/8ea169d2-308e-47f3-a524-44f60d245719
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -458,59 +507,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e9db2b2d-1db6-4c27-a048-4c0036283f53
+                - bf2c39e7-5c2d-456b-9dfd-62dfcd163489
         status: 202 Accepted
         code: 202
-        duration: 304.20125ms
-    - id: 9
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2723
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:25.023033+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.65.65","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"fb49b08e-51b4-45cd-a0d0-bcf156deee1b","ipam_id":"fee483d7-e770-44c5-819e-0a58a614105b","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.65.65","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"fb49b08e-51b4-45cd-a0d0-bcf156deee1b","ipam_id":"fee483d7-e770-44c5-819e-0a58a614105b","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2723"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:25 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 84c94ed5-45d3-40c8-8d69-1a62093f850b
-        status: 200 OK
-        code: 200
-        duration: 157.636166ms
+        duration: 294.967292ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -526,8 +526,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
         method: GET
       response:
         proto: HTTP/2.0
@@ -535,20 +535,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2827
+        content_length: 2281
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:25.023033+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.65.65","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"fb49b08e-51b4-45cd-a0d0-bcf156deee1b","ipam_id":"fee483d7-e770-44c5-819e-0a58a614105b","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.65.65","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"fb49b08e-51b4-45cd-a0d0-bcf156deee1b","ipam_id":"fee483d7-e770-44c5-819e-0a58a614105b","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:06.637374+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"d2740bae-187d-42b4-ae39-7e511bc1f051","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"d2740bae-187d-42b4-ae39-7e511bc1f051","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2827"
+                - "2281"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:30 GMT
+                - Tue, 11 Feb 2025 14:25:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -556,10 +556,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d06403d1-80fa-4198-baf0-8177e6dd156d
+                - 71614c15-8b91-4510-b912-4432c420ccf8
         status: 200 OK
         code: 200
-        duration: 189.295625ms
+        duration: 198.931542ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -575,8 +575,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
         method: GET
       response:
         proto: HTTP/2.0
@@ -584,20 +584,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2858
+        content_length: 2414
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:34.660280+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.65.65","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"fb49b08e-51b4-45cd-a0d0-bcf156deee1b","ipam_id":"fee483d7-e770-44c5-819e-0a58a614105b","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.65.65","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"fb49b08e-51b4-45cd-a0d0-bcf156deee1b","ipam_id":"fee483d7-e770-44c5-819e-0a58a614105b","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:10.295356+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"d2740bae-187d-42b4-ae39-7e511bc1f051","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"d2740bae-187d-42b4-ae39-7e511bc1f051","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2858"
+                - "2414"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:35 GMT
+                - Tue, 11 Feb 2025 14:25:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -605,10 +605,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 223e9a0a-271a-40c7-a2b2-a30c7415d4af
+                - db2afaea-5d2a-49f9-aba8-c633f2b3ae23
         status: 200 OK
         code: 200
-        duration: 166.655ms
+        duration: 163.318208ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -624,8 +624,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
         method: GET
       response:
         proto: HTTP/2.0
@@ -633,20 +633,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2858
+        content_length: 2414
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:34.660280+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.65.65","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"fb49b08e-51b4-45cd-a0d0-bcf156deee1b","ipam_id":"fee483d7-e770-44c5-819e-0a58a614105b","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.65.65","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"fb49b08e-51b4-45cd-a0d0-bcf156deee1b","ipam_id":"fee483d7-e770-44c5-819e-0a58a614105b","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:10.295356+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"d2740bae-187d-42b4-ae39-7e511bc1f051","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"d2740bae-187d-42b4-ae39-7e511bc1f051","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2858"
+                - "2414"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:35 GMT
+                - Tue, 11 Feb 2025 14:25:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -654,10 +654,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ac6d21be-edd0-4f1e-b21b-fc0e8a96d61f
+                - 5f552721-73bd-4783-9d74-ddb68c1bfe01
         status: 200 OK
         code: 200
-        duration: 193.429208ms
+        duration: 177.753292ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -673,8 +673,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b4ae101e-1819-4dd8-8d8d-184ab3546b36
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0725a599-8625-404e-8c03-fc85ad86c0a8
         method: GET
       response:
         proto: HTTP/2.0
@@ -682,20 +682,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 522
+        content_length: 143
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"0725a599-8625-404e-8c03-fc85ad86c0a8","type":"not_found"}'
         headers:
             Content-Length:
-                - "522"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:35 GMT
+                - Tue, 11 Feb 2025 14:25:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -703,10 +703,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 96352424-6caf-4c32-9450-0c7b31e3b1fc
-        status: 200 OK
-        code: 200
-        duration: 98.162542ms
+                - afa5976c-4c7f-4042-b3d5-3d5af2235e0d
+        status: 404 Not Found
+        code: 404
+        duration: 38.5145ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -722,8 +722,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/0725a599-8625-404e-8c03-fc85ad86c0a8
         method: GET
       response:
         proto: HTTP/2.0
@@ -731,20 +731,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 701
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"created_at":"2025-02-11T14:25:05.625577Z","id":"0725a599-8625-404e-8c03-fc85ad86c0a8","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:25:05.625577Z","id":"7cbf0cd1-960a-4808-8227-635a82c90a3e","product_resource_id":"82e67158-c544-4736-b58a-a28a0ce8892d","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:25:05.625577Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "17"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:35 GMT
+                - Tue, 11 Feb 2025 14:25:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -752,10 +752,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 20b5e80f-07bb-4694-890e-ce5084283958
+                - f8a9684f-d31c-4479-81f4-8091cb648e96
         status: 200 OK
         code: 200
-        duration: 93.088375ms
+        duration: 96.964208ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -771,8 +771,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -780,22 +780,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 17
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "20"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:36 GMT
-            Link:
-                - </servers/151ea383-08c6-41ce-8c6d-e81466eeda0f/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:25:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -803,12 +801,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2483eaeb-1c94-4b4c-98ee-782fe2285559
-            X-Total-Count:
-                - "0"
+                - fac9f415-e0c2-4d76-9e30-7750877971d7
         status: 200 OK
         code: 200
-        duration: 91.562125ms
+        duration: 84.435ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -824,8 +820,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -833,20 +829,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2858
+        content_length: 20
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:34.660280+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.65.65","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"fb49b08e-51b4-45cd-a0d0-bcf156deee1b","ipam_id":"fee483d7-e770-44c5-819e-0a58a614105b","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.65.65","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"fb49b08e-51b4-45cd-a0d0-bcf156deee1b","ipam_id":"fee483d7-e770-44c5-819e-0a58a614105b","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "2858"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:36 GMT
+                - Tue, 11 Feb 2025 14:25:12 GMT
+            Link:
+                - </servers/82e67158-c544-4736-b58a-a28a0ce8892d/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -854,10 +852,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0971efa5-0af3-47f9-aacd-f9949f4ef2f6
+                - 9d70e2f1-5471-41c9-b793-61eef43f1f67
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 162.311208ms
+        duration: 117.755833ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -873,8 +873,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/fb49b08e-51b4-45cd-a0d0-bcf156deee1b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
         method: GET
       response:
         proto: HTTP/2.0
@@ -882,20 +882,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 440
+        content_length: 2414
         uncompressed: false
-        body: '{"ip":{"address":"51.158.65.65","id":"fb49b08e-51b4-45cd-a0d0-bcf156deee1b","ipam_id":"fee483d7-e770-44c5-819e-0a58a614105b","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"state":"attached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:10.295356+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"d2740bae-187d-42b4-ae39-7e511bc1f051","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"d2740bae-187d-42b4-ae39-7e511bc1f051","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "440"
+                - "2414"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:36 GMT
+                - Tue, 11 Feb 2025 14:25:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -903,10 +903,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 429e7adb-4701-4e80-8884-b6874e23df5b
+                - cdfef61a-dadc-4c5f-a51b-d10ccb61f82b
         status: 200 OK
         code: 200
-        duration: 103.397042ms
+        duration: 191.843375ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -922,8 +922,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
         method: GET
       response:
         proto: HTTP/2.0
@@ -931,20 +931,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2858
+        content_length: 441
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:34.660280+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.65.65","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"fb49b08e-51b4-45cd-a0d0-bcf156deee1b","ipam_id":"fee483d7-e770-44c5-819e-0a58a614105b","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.65.65","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"fb49b08e-51b4-45cd-a0d0-bcf156deee1b","ipam_id":"fee483d7-e770-44c5-819e-0a58a614105b","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"d2740bae-187d-42b4-ae39-7e511bc1f051","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"82e67158-c544-4736-b58a-a28a0ce8892d","name":"tf-srv-awesome-haslett"},"state":"attached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2858"
+                - "441"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:36 GMT
+                - Tue, 11 Feb 2025 14:25:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -952,10 +952,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 703410d6-b65b-41fc-b7cd-bee2b4d683ee
+                - e182727c-9b49-49bf-89c0-218e1b066c05
         status: 200 OK
         code: 200
-        duration: 165.264ms
+        duration: 89.420083ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -971,8 +971,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b4ae101e-1819-4dd8-8d8d-184ab3546b36
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
         method: GET
       response:
         proto: HTTP/2.0
@@ -980,20 +980,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 522
+        content_length: 2414
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:10.295356+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"d2740bae-187d-42b4-ae39-7e511bc1f051","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"d2740bae-187d-42b4-ae39-7e511bc1f051","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "522"
+                - "2414"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:36 GMT
+                - Tue, 11 Feb 2025 14:25:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1001,10 +1001,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f98bd8b2-7f59-4ea0-8d96-86d71eead732
+                - 1891741c-be49-42da-bab9-219c6cb1b06f
         status: 200 OK
         code: 200
-        duration: 77.976375ms
+        duration: 188.760167ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1020,8 +1020,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0725a599-8625-404e-8c03-fc85ad86c0a8
         method: GET
       response:
         proto: HTTP/2.0
@@ -1029,20 +1029,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 143
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"0725a599-8625-404e-8c03-fc85ad86c0a8","type":"not_found"}'
         headers:
             Content-Length:
-                - "17"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:36 GMT
+                - Tue, 11 Feb 2025 14:25:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1050,10 +1050,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 28753c46-e679-47be-84f9-995b6464237b
-        status: 200 OK
-        code: 200
-        duration: 76.171042ms
+                - 1c5d7cc4-5cc1-4dee-9a48-664c0c947a82
+        status: 404 Not Found
+        code: 404
+        duration: 33.179166ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1069,8 +1069,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/0725a599-8625-404e-8c03-fc85ad86c0a8
         method: GET
       response:
         proto: HTTP/2.0
@@ -1078,22 +1078,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 701
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"created_at":"2025-02-11T14:25:05.625577Z","id":"0725a599-8625-404e-8c03-fc85ad86c0a8","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:25:05.625577Z","id":"7cbf0cd1-960a-4808-8227-635a82c90a3e","product_resource_id":"82e67158-c544-4736-b58a-a28a0ce8892d","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:25:05.625577Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "20"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:36 GMT
-            Link:
-                - </servers/151ea383-08c6-41ce-8c6d-e81466eeda0f/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:25:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1101,12 +1099,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e21cb2f7-45d0-4647-90ed-4c5dec94aef0
-            X-Total-Count:
-                - "0"
+                - 471102fa-e5d0-42d1-8400-fa3f657406cf
         status: 200 OK
         code: 200
-        duration: 84.902791ms
+        duration: 65.567708ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1122,155 +1118,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/fb49b08e-51b4-45cd-a0d0-bcf156deee1b
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 440
-        uncompressed: false
-        body: '{"ip":{"address":"51.158.65.65","id":"fb49b08e-51b4-45cd-a0d0-bcf156deee1b","ipam_id":"fee483d7-e770-44c5-819e-0a58a614105b","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"state":"attached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "440"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:37 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 5ff1ae81-2711-4fe9-9edb-153ddfdb1ddd
-        status: 200 OK
-        code: 200
-        duration: 96.499125ms
-    - id: 23
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2858
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:34.660280+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.65.65","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"fb49b08e-51b4-45cd-a0d0-bcf156deee1b","ipam_id":"fee483d7-e770-44c5-819e-0a58a614105b","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.65.65","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"fb49b08e-51b4-45cd-a0d0-bcf156deee1b","ipam_id":"fee483d7-e770-44c5-819e-0a58a614105b","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2858"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:37 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 2543dcb2-a030-4ef6-805c-504ca98d5055
-        status: 200 OK
-        code: 200
-        duration: 158.097834ms
-    - id: 24
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b4ae101e-1819-4dd8-8d8d-184ab3546b36
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 522
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "522"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:37 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - f2f1d567-b887-48a5-a755-b9cbfe4fa8f6
-        status: 200 OK
-        code: 200
-        duration: 90.754709ms
-    - id: 25
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1289,9 +1138,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:37 GMT
+                - Tue, 11 Feb 2025 14:25:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1299,11 +1148,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7c107a68-4a89-4795-97d9-273e2d6636ed
+                - ac15234d-7dc2-4d71-8265-fe905eadddcf
         status: 200 OK
         code: 200
-        duration: 115.890583ms
-    - id: 26
+        duration: 94.630333ms
+    - id: 23
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1318,8 +1167,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1338,11 +1187,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:37 GMT
+                - Tue, 11 Feb 2025 14:25:13 GMT
             Link:
-                - </servers/151ea383-08c6-41ce-8c6d-e81466eeda0f/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/82e67158-c544-4736-b58a-a28a0ce8892d/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1350,13 +1199,311 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f83fa408-0449-4bce-9b6d-d5e3ceaa0b0d
+                - 639db121-bed8-4694-95cf-e1b7a48e500a
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 80.441042ms
+        duration: 117.533542ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 441
+        uncompressed: false
+        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"d2740bae-187d-42b4-ae39-7e511bc1f051","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"82e67158-c544-4736-b58a-a28a0ce8892d","name":"tf-srv-awesome-haslett"},"state":"attached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "441"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:13 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 02e24d86-6535-418e-86ac-b0dc19bcc958
+        status: 200 OK
+        code: 200
+        duration: 94.6945ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2414
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:10.295356+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"d2740bae-187d-42b4-ae39-7e511bc1f051","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"d2740bae-187d-42b4-ae39-7e511bc1f051","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2414"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:13 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - bf76ad4e-e8b7-42ec-915e-fa5d6663da56
+        status: 200 OK
+        code: 200
+        duration: 194.060916ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0725a599-8625-404e-8c03-fc85ad86c0a8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"0725a599-8625-404e-8c03-fc85ad86c0a8","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:13 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 50a1c40e-1098-4556-9363-c0038cd66f60
+        status: 404 Not Found
+        code: 404
+        duration: 33.485209ms
     - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/0725a599-8625-404e-8c03-fc85ad86c0a8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:25:05.625577Z","id":"0725a599-8625-404e-8c03-fc85ad86c0a8","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:25:05.625577Z","id":"7cbf0cd1-960a-4808-8227-635a82c90a3e","product_resource_id":"82e67158-c544-4736-b58a-a28a0ce8892d","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:25:05.625577Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:14 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 00fd2d1e-5e79-474f-b696-a9418375b3a2
+        status: 200 OK
+        code: 200
+        duration: 79.827583ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d/user_data
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 17
+        uncompressed: false
+        body: '{"user_data":[]}'
+        headers:
+            Content-Length:
+                - "17"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:14 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 74a1a292-e6b9-40b0-9d62-b017e75a265f
+        status: 200 OK
+        code: 200
+        duration: 95.420625ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 20
+        uncompressed: false
+        body: '{"private_nics":[]}'
+        headers:
+            Content-Length:
+                - "20"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:14 GMT
+            Link:
+                - </servers/82e67158-c544-4736-b58a-a28a0ce8892d/private_nics?page=0&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - bfb01d39-48c3-4a50-85f7-534710fa6786
+            X-Total-Count:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 81.523083ms
+    - id: 30
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1373,7 +1520,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips
         method: POST
       response:
@@ -1382,22 +1529,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 365
+        content_length: 364
         uncompressed: false
-        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"47c67a80-eb9f-4c3e-a4cf-1b475a27b411","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        body: '{"ip":{"address":"51.158.107.2","id":"43e95675-93d8-4109-b6bd-3f5ab30b7754","ipam_id":"40610e47-44a6-4808-bb35-e26d14fb02f9","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "365"
+                - "364"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:38 GMT
+                - Tue, 11 Feb 2025 14:25:15 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/43e95675-93d8-4109-b6bd-3f5ab30b7754
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1405,197 +1552,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f576d0fa-4777-43a8-85e6-70156ff1a5c7
+                - f3632686-e10c-480d-bf62-7cf059bc94f3
         status: 201 Created
         code: 201
-        duration: 508.238166ms
-    - id: 28
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 365
-        uncompressed: false
-        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"47c67a80-eb9f-4c3e-a4cf-1b475a27b411","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "365"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:38 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - a5b4e607-1839-4ba9-9ede-ae9c85d24d0c
-        status: 200 OK
-        code: 200
-        duration: 83.2435ms
-    - id: 29
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2858
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:34.660280+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.65.65","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"fb49b08e-51b4-45cd-a0d0-bcf156deee1b","ipam_id":"fee483d7-e770-44c5-819e-0a58a614105b","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.65.65","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"fb49b08e-51b4-45cd-a0d0-bcf156deee1b","ipam_id":"fee483d7-e770-44c5-819e-0a58a614105b","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2858"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:38 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - ddc49384-8c39-470a-99e5-a5838c10562a
-        status: 200 OK
-        code: 200
-        duration: 149.614041ms
-    - id: 30
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2858
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:34.660280+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.65.65","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"fb49b08e-51b4-45cd-a0d0-bcf156deee1b","ipam_id":"fee483d7-e770-44c5-819e-0a58a614105b","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.65.65","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"fb49b08e-51b4-45cd-a0d0-bcf156deee1b","ipam_id":"fee483d7-e770-44c5-819e-0a58a614105b","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2858"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:38 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 9ce55f67-3525-4bd2-937b-fac3529c7b7b
-        status: 200 OK
-        code: 200
-        duration: 170.575292ms
+        duration: 490.669416ms
     - id: 31
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 15
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"server":null}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/fb49b08e-51b4-45cd-a0d0-bcf156deee1b
-        method: PATCH
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/43e95675-93d8-4109-b6bd-3f5ab30b7754
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 363
+        content_length: 364
         uncompressed: false
-        body: '{"ip":{"address":"51.158.65.65","id":"fb49b08e-51b4-45cd-a0d0-bcf156deee1b","ipam_id":"fee483d7-e770-44c5-819e-0a58a614105b","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"pending","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        body: '{"ip":{"address":"51.158.107.2","id":"43e95675-93d8-4109-b6bd-3f5ab30b7754","ipam_id":"40610e47-44a6-4808-bb35-e26d14fb02f9","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "363"
+                - "364"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:39 GMT
+                - Tue, 11 Feb 2025 14:25:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1603,10 +1601,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 05f5303f-509e-4585-b0c1-353da0087988
+                - 642a4223-1603-4c2c-b684-aa8f59aec813
         status: 200 OK
         code: 200
-        duration: 396.614542ms
+        duration: 79.144208ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1622,8 +1620,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1631,20 +1629,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2334
+        content_length: 2414
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:34.660280+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:10.295356+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"d2740bae-187d-42b4-ae39-7e511bc1f051","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"d2740bae-187d-42b4-ae39-7e511bc1f051","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2334"
+                - "2414"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:39 GMT
+                - Tue, 11 Feb 2025 14:25:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1652,10 +1650,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f56f5dea-9de9-4fde-b193-e657135052b4
+                - 3f18e702-b08e-4804-9876-ead6a11dbc74
         status: 200 OK
         code: 200
-        duration: 305.209542ms
+        duration: 193.544375ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1671,8 +1669,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1680,20 +1678,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2334
+        content_length: 2414
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:34.660280+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:10.295356+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"d2740bae-187d-42b4-ae39-7e511bc1f051","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"d2740bae-187d-42b4-ae39-7e511bc1f051","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2334"
+                - "2414"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:39 GMT
+                - Tue, 11 Feb 2025 14:25:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1701,1201 +1699,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7809f327-2ad6-4a45-a661-3b64c5782a49
+                - f20940e9-763f-42de-ba63-feb7e7cd248e
         status: 200 OK
         code: 200
-        duration: 204.833ms
+        duration: 181.62925ms
     - id: 34
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 49
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"server":"151ea383-08c6-41ce-8c6d-e81466eeda0f"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
-        method: PATCH
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 440
-        uncompressed: false
-        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"47c67a80-eb9f-4c3e-a4cf-1b475a27b411","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"state":"pending","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "440"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:40 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - b3956cae-f020-48fa-8c73-ba363f27c059
-        status: 200 OK
-        code: 200
-        duration: 529.7455ms
-    - id: 35
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2858
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:34.660280+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"47c67a80-eb9f-4c3e-a4cf-1b475a27b411","netmask":"32","provisioning_mode":"dhcp","state":"pending","tags":[]},"public_ips":[{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"47c67a80-eb9f-4c3e-a4cf-1b475a27b411","netmask":"32","provisioning_mode":"dhcp","state":"pending","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2858"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:40 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 59df764e-843a-4efc-9087-984ec9afb39f
-        status: 200 OK
-        code: 200
-        duration: 181.811584ms
-    - id: 36
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2858
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:34.660280+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"47c67a80-eb9f-4c3e-a4cf-1b475a27b411","netmask":"32","provisioning_mode":"dhcp","state":"pending","tags":[]},"public_ips":[{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"47c67a80-eb9f-4c3e-a4cf-1b475a27b411","netmask":"32","provisioning_mode":"dhcp","state":"pending","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2858"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:40 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - a152232d-9221-4988-a1aa-cb372f578b20
-        status: 200 OK
-        code: 200
-        duration: 212.188291ms
-    - id: 37
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2858
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:34.660280+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"47c67a80-eb9f-4c3e-a4cf-1b475a27b411","netmask":"32","provisioning_mode":"dhcp","state":"pending","tags":[]},"public_ips":[{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"47c67a80-eb9f-4c3e-a4cf-1b475a27b411","netmask":"32","provisioning_mode":"dhcp","state":"pending","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2858"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:40 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 9f63156e-903c-4a9c-b332-e88b54f1dfd2
-        status: 200 OK
-        code: 200
-        duration: 189.367709ms
-    - id: 38
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b4ae101e-1819-4dd8-8d8d-184ab3546b36
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 522
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "522"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:41 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 566d6e08-ac7f-4e40-bcfd-2c597ec567ab
-        status: 200 OK
-        code: 200
-        duration: 72.947833ms
-    - id: 39
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f/user_data
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 17
-        uncompressed: false
-        body: '{"user_data":[]}'
-        headers:
-            Content-Length:
-                - "17"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:41 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 9714f932-7482-46bd-9ff0-9d7e0de7ffc9
-        status: 200 OK
-        code: 200
-        duration: 93.324083ms
-    - id: 40
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f/private_nics
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 20
-        uncompressed: false
-        body: '{"private_nics":[]}'
-        headers:
-            Content-Length:
-                - "20"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:41 GMT
-            Link:
-                - </servers/151ea383-08c6-41ce-8c6d-e81466eeda0f/private_nics?page=0&per_page=50&>; rel="last"
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - a3892e24-e735-4605-a673-6eeae8b9d9e5
-            X-Total-Count:
-                - "0"
-        status: 200 OK
-        code: 200
-        duration: 84.631333ms
-    - id: 41
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2858
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:34.660280+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"47c67a80-eb9f-4c3e-a4cf-1b475a27b411","netmask":"32","provisioning_mode":"dhcp","state":"pending","tags":[]},"public_ips":[{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"47c67a80-eb9f-4c3e-a4cf-1b475a27b411","netmask":"32","provisioning_mode":"dhcp","state":"pending","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2858"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:41 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 3f2aae9a-6169-4cdd-a240-0f9e76f0721b
-        status: 200 OK
-        code: 200
-        duration: 190.907208ms
-    - id: 42
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2858
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:34.660280+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"47c67a80-eb9f-4c3e-a4cf-1b475a27b411","netmask":"32","provisioning_mode":"dhcp","state":"pending","tags":[]},"public_ips":[{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"47c67a80-eb9f-4c3e-a4cf-1b475a27b411","netmask":"32","provisioning_mode":"dhcp","state":"pending","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2858"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:41 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 22750626-44c8-406e-beab-7c48e172ddb2
-        status: 200 OK
-        code: 200
-        duration: 190.939333ms
-    - id: 43
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 440
-        uncompressed: false
-        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"47c67a80-eb9f-4c3e-a4cf-1b475a27b411","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"state":"pending","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "440"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:41 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 464ef0dc-d03d-411b-9b8a-64dd5996072c
-        status: 200 OK
-        code: 200
-        duration: 92.032458ms
-    - id: 44
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 440
-        uncompressed: false
-        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"47c67a80-eb9f-4c3e-a4cf-1b475a27b411","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"state":"pending","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "440"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:41 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 617cd6f2-72aa-4824-8ea9-7eedc305294f
-        status: 200 OK
-        code: 200
-        duration: 86.663166ms
-    - id: 45
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/fb49b08e-51b4-45cd-a0d0-bcf156deee1b
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 364
-        uncompressed: false
-        body: '{"ip":{"address":"51.158.65.65","id":"fb49b08e-51b4-45cd-a0d0-bcf156deee1b","ipam_id":"fee483d7-e770-44c5-819e-0a58a614105b","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "364"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:41 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - c5472586-49f2-4424-ae93-740ed0f8aeca
-        status: 200 OK
-        code: 200
-        duration: 86.693292ms
-    - id: 46
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2858
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:34.660280+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"47c67a80-eb9f-4c3e-a4cf-1b475a27b411","netmask":"32","provisioning_mode":"dhcp","state":"pending","tags":[]},"public_ips":[{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"47c67a80-eb9f-4c3e-a4cf-1b475a27b411","netmask":"32","provisioning_mode":"dhcp","state":"pending","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2858"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:42 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - d149a23e-3f17-41f1-b820-6329b3fabcdd
-        status: 200 OK
-        code: 200
-        duration: 175.830584ms
-    - id: 47
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b4ae101e-1819-4dd8-8d8d-184ab3546b36
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 522
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "522"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:42 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 05a09c0f-7e6f-4924-9b6c-07ef20f17634
-        status: 200 OK
-        code: 200
-        duration: 82.011041ms
-    - id: 48
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f/user_data
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 17
-        uncompressed: false
-        body: '{"user_data":[]}'
-        headers:
-            Content-Length:
-                - "17"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:42 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 5e45f7a2-7a6f-4d0a-9080-13e740c64261
-        status: 200 OK
-        code: 200
-        duration: 78.879417ms
-    - id: 49
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f/private_nics
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 20
-        uncompressed: false
-        body: '{"private_nics":[]}'
-        headers:
-            Content-Length:
-                - "20"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:42 GMT
-            Link:
-                - </servers/151ea383-08c6-41ce-8c6d-e81466eeda0f/private_nics?page=0&per_page=50&>; rel="last"
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - d2bf1d37-9e97-4bb8-ac19-25c6289669b1
-            X-Total-Count:
-                - "0"
-        status: 200 OK
-        code: 200
-        duration: 95.002834ms
-    - id: 50
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/fb49b08e-51b4-45cd-a0d0-bcf156deee1b
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 364
-        uncompressed: false
-        body: '{"ip":{"address":"51.158.65.65","id":"fb49b08e-51b4-45cd-a0d0-bcf156deee1b","ipam_id":"fee483d7-e770-44c5-819e-0a58a614105b","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "364"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:42 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 2f109e6d-b8cc-4f0c-b5ee-e0847baa70e4
-        status: 200 OK
-        code: 200
-        duration: 80.989833ms
-    - id: 51
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 440
-        uncompressed: false
-        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"47c67a80-eb9f-4c3e-a4cf-1b475a27b411","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"state":"pending","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "440"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:42 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - c75bb0cb-2ab7-4299-a5cf-7cf6b87cc7a9
-        status: 200 OK
-        code: 200
-        duration: 98.594083ms
-    - id: 52
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2858
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:34.660280+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"47c67a80-eb9f-4c3e-a4cf-1b475a27b411","netmask":"32","provisioning_mode":"dhcp","state":"pending","tags":[]},"public_ips":[{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"47c67a80-eb9f-4c3e-a4cf-1b475a27b411","netmask":"32","provisioning_mode":"dhcp","state":"pending","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2858"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:42 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - b5531fb6-d204-40e4-8ff7-ad0a502ba9e1
-        status: 200 OK
-        code: 200
-        duration: 185.495541ms
-    - id: 53
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b4ae101e-1819-4dd8-8d8d-184ab3546b36
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 522
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "522"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:42 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 8662ac91-e833-47b8-abae-a3a8ab432c92
-        status: 200 OK
-        code: 200
-        duration: 76.038125ms
-    - id: 54
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f/user_data
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 17
-        uncompressed: false
-        body: '{"user_data":[]}'
-        headers:
-            Content-Length:
-                - "17"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:42 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - c9016892-87d0-4cbe-9042-215ae9f31e24
-        status: 200 OK
-        code: 200
-        duration: 86.718458ms
-    - id: 55
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f/private_nics
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 20
-        uncompressed: false
-        body: '{"private_nics":[]}'
-        headers:
-            Content-Length:
-                - "20"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:43 GMT
-            Link:
-                - </servers/151ea383-08c6-41ce-8c6d-e81466eeda0f/private_nics?page=0&per_page=50&>; rel="last"
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 46b42373-0de1-45e8-9e2a-f167b939d54d
-            X-Total-Count:
-                - "0"
-        status: 200 OK
-        code: 200
-        duration: 76.07025ms
-    - id: 56
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2858
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:34.660280+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"47c67a80-eb9f-4c3e-a4cf-1b475a27b411","netmask":"32","provisioning_mode":"dhcp","state":"pending","tags":[]},"public_ips":[{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"47c67a80-eb9f-4c3e-a4cf-1b475a27b411","netmask":"32","provisioning_mode":"dhcp","state":"pending","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2858"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:43 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 86c49735-6f58-4fc0-8092-9f04a30cb99c
-        status: 200 OK
-        code: 200
-        duration: 162.689834ms
-    - id: 57
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2858
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:34.660280+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"47c67a80-eb9f-4c3e-a4cf-1b475a27b411","netmask":"32","provisioning_mode":"dhcp","state":"pending","tags":[]},"public_ips":[{"address":"51.15.236.240","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"47c67a80-eb9f-4c3e-a4cf-1b475a27b411","netmask":"32","provisioning_mode":"dhcp","state":"pending","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2858"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:43 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 52d669ca-14f5-4e31-aa7f-be71fc75da45
-        status: 200 OK
-        code: 200
-        duration: 182.487583ms
-    - id: 58
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2912,7 +1720,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
         method: PATCH
       response:
@@ -2923,7 +1731,7 @@ interactions:
         trailer: {}
         content_length: 364
         uncompressed: false
-        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"47c67a80-eb9f-4c3e-a4cf-1b475a27b411","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"pending","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"d2740bae-187d-42b4-ae39-7e511bc1f051","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"pending","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "364"
@@ -2932,9 +1740,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:43 GMT
+                - Tue, 11 Feb 2025 14:25:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2942,10 +1750,1196 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d421f924-b96a-4442-bc01-53c2295ec02d
+                - b82adb7d-a65d-4b0d-80ba-850d45008229
         status: 200 OK
         code: 200
-        duration: 493.997458ms
+        duration: 446.341709ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1888
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:10.295356+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1888"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:16 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4cda9131-c4ac-4940-9892-f5d6e5025c76
+        status: 200 OK
+        code: 200
+        duration: 197.543292ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1888
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:10.295356+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1888"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:16 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 688d3ff3-2eeb-41ac-8d8c-82f49c40521a
+        status: 200 OK
+        code: 200
+        duration: 173.077792ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 49
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"server":"82e67158-c544-4736-b58a-a28a0ce8892d"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/43e95675-93d8-4109-b6bd-3f5ab30b7754
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 439
+        uncompressed: false
+        body: '{"ip":{"address":"51.158.107.2","id":"43e95675-93d8-4109-b6bd-3f5ab30b7754","ipam_id":"40610e47-44a6-4808-bb35-e26d14fb02f9","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"82e67158-c544-4736-b58a-a28a0ce8892d","name":"tf-srv-awesome-haslett"},"state":"pending","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "439"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a1c511ca-af33-4121-b00d-035c7ac904cc
+        status: 200 OK
+        code: 200
+        duration: 679.888458ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2410
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:10.295356+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.107.2","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"43e95675-93d8-4109-b6bd-3f5ab30b7754","ipam_id":"40610e47-44a6-4808-bb35-e26d14fb02f9","netmask":"32","provisioning_mode":"dhcp","state":"pending","tags":[]},"public_ips":[{"address":"51.158.107.2","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"43e95675-93d8-4109-b6bd-3f5ab30b7754","ipam_id":"40610e47-44a6-4808-bb35-e26d14fb02f9","netmask":"32","provisioning_mode":"dhcp","state":"pending","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2410"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1802b57b-5c94-4452-ad69-766d6236bb91
+        status: 200 OK
+        code: 200
+        duration: 196.553709ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2410
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:10.295356+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.107.2","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"43e95675-93d8-4109-b6bd-3f5ab30b7754","ipam_id":"40610e47-44a6-4808-bb35-e26d14fb02f9","netmask":"32","provisioning_mode":"dhcp","state":"pending","tags":[]},"public_ips":[{"address":"51.158.107.2","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"43e95675-93d8-4109-b6bd-3f5ab30b7754","ipam_id":"40610e47-44a6-4808-bb35-e26d14fb02f9","netmask":"32","provisioning_mode":"dhcp","state":"pending","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2410"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c2643458-3ec5-44c5-96a7-043f105761a7
+        status: 200 OK
+        code: 200
+        duration: 182.936792ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2410
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:10.295356+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.107.2","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"43e95675-93d8-4109-b6bd-3f5ab30b7754","ipam_id":"40610e47-44a6-4808-bb35-e26d14fb02f9","netmask":"32","provisioning_mode":"dhcp","state":"pending","tags":[]},"public_ips":[{"address":"51.158.107.2","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"43e95675-93d8-4109-b6bd-3f5ab30b7754","ipam_id":"40610e47-44a6-4808-bb35-e26d14fb02f9","netmask":"32","provisioning_mode":"dhcp","state":"pending","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2410"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0dfde1c8-e265-4929-a361-f8ec7a9aefc9
+        status: 200 OK
+        code: 200
+        duration: 207.799208ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0725a599-8625-404e-8c03-fc85ad86c0a8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"0725a599-8625-404e-8c03-fc85ad86c0a8","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d3d12af1-15f5-4e1f-b1c7-0fab1a17f964
+        status: 404 Not Found
+        code: 404
+        duration: 36.502334ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/0725a599-8625-404e-8c03-fc85ad86c0a8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:25:05.625577Z","id":"0725a599-8625-404e-8c03-fc85ad86c0a8","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:25:05.625577Z","id":"7cbf0cd1-960a-4808-8227-635a82c90a3e","product_resource_id":"82e67158-c544-4736-b58a-a28a0ce8892d","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:25:05.625577Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 29f020ee-f7c1-49cd-8f56-c82e3f755b76
+        status: 200 OK
+        code: 200
+        duration: 70.524666ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d/user_data
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 17
+        uncompressed: false
+        body: '{"user_data":[]}'
+        headers:
+            Content-Length:
+                - "17"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fca28979-127c-4fa0-b22a-571cf6ab5fa8
+        status: 200 OK
+        code: 200
+        duration: 85.683625ms
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 20
+        uncompressed: false
+        body: '{"private_nics":[]}'
+        headers:
+            Content-Length:
+                - "20"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:17 GMT
+            Link:
+                - </servers/82e67158-c544-4736-b58a-a28a0ce8892d/private_nics?page=0&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 243423d2-1089-4658-b15a-6affd069e489
+            X-Total-Count:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 100.177208ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2410
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:10.295356+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.107.2","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"43e95675-93d8-4109-b6bd-3f5ab30b7754","ipam_id":"40610e47-44a6-4808-bb35-e26d14fb02f9","netmask":"32","provisioning_mode":"dhcp","state":"pending","tags":[]},"public_ips":[{"address":"51.158.107.2","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"43e95675-93d8-4109-b6bd-3f5ab30b7754","ipam_id":"40610e47-44a6-4808-bb35-e26d14fb02f9","netmask":"32","provisioning_mode":"dhcp","state":"pending","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2410"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 03172edf-4112-45ee-857b-94530c99b6e2
+        status: 200 OK
+        code: 200
+        duration: 209.746125ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2410
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:10.295356+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.107.2","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"43e95675-93d8-4109-b6bd-3f5ab30b7754","ipam_id":"40610e47-44a6-4808-bb35-e26d14fb02f9","netmask":"32","provisioning_mode":"dhcp","state":"pending","tags":[]},"public_ips":[{"address":"51.158.107.2","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"43e95675-93d8-4109-b6bd-3f5ab30b7754","ipam_id":"40610e47-44a6-4808-bb35-e26d14fb02f9","netmask":"32","provisioning_mode":"dhcp","state":"pending","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2410"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 58023082-82ee-4aae-a8a6-6fd999f1c46e
+        status: 200 OK
+        code: 200
+        duration: 184.527209ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/43e95675-93d8-4109-b6bd-3f5ab30b7754
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 439
+        uncompressed: false
+        body: '{"ip":{"address":"51.158.107.2","id":"43e95675-93d8-4109-b6bd-3f5ab30b7754","ipam_id":"40610e47-44a6-4808-bb35-e26d14fb02f9","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"82e67158-c544-4736-b58a-a28a0ce8892d","name":"tf-srv-awesome-haslett"},"state":"pending","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "439"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 299ff83b-8ada-4873-a9f6-d16ba8c0ef38
+        status: 200 OK
+        code: 200
+        duration: 98.708417ms
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 365
+        uncompressed: false
+        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"d2740bae-187d-42b4-ae39-7e511bc1f051","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "365"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 55275cf2-2542-4926-b9d5-d499d2584036
+        status: 200 OK
+        code: 200
+        duration: 72.033708ms
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/43e95675-93d8-4109-b6bd-3f5ab30b7754
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 439
+        uncompressed: false
+        body: '{"ip":{"address":"51.158.107.2","id":"43e95675-93d8-4109-b6bd-3f5ab30b7754","ipam_id":"40610e47-44a6-4808-bb35-e26d14fb02f9","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"82e67158-c544-4736-b58a-a28a0ce8892d","name":"tf-srv-awesome-haslett"},"state":"pending","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "439"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e5f89b12-faa2-4a69-ab21-9467501897d0
+        status: 200 OK
+        code: 200
+        duration: 96.904167ms
+    - id: 50
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2410
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:10.295356+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.107.2","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"43e95675-93d8-4109-b6bd-3f5ab30b7754","ipam_id":"40610e47-44a6-4808-bb35-e26d14fb02f9","netmask":"32","provisioning_mode":"dhcp","state":"pending","tags":[]},"public_ips":[{"address":"51.158.107.2","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"43e95675-93d8-4109-b6bd-3f5ab30b7754","ipam_id":"40610e47-44a6-4808-bb35-e26d14fb02f9","netmask":"32","provisioning_mode":"dhcp","state":"pending","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2410"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 95f3f069-19f6-44e0-badf-df01138fedec
+        status: 200 OK
+        code: 200
+        duration: 212.397042ms
+    - id: 51
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0725a599-8625-404e-8c03-fc85ad86c0a8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"0725a599-8625-404e-8c03-fc85ad86c0a8","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:19 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2fbac762-30c6-4447-8a6b-3d610d108d11
+        status: 404 Not Found
+        code: 404
+        duration: 31.907583ms
+    - id: 52
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/0725a599-8625-404e-8c03-fc85ad86c0a8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:25:05.625577Z","id":"0725a599-8625-404e-8c03-fc85ad86c0a8","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:25:05.625577Z","id":"7cbf0cd1-960a-4808-8227-635a82c90a3e","product_resource_id":"82e67158-c544-4736-b58a-a28a0ce8892d","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:25:05.625577Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:19 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4c640a19-42bf-4476-985a-e9d7dc7af4c8
+        status: 200 OK
+        code: 200
+        duration: 71.639333ms
+    - id: 53
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d/user_data
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 17
+        uncompressed: false
+        body: '{"user_data":[]}'
+        headers:
+            Content-Length:
+                - "17"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:19 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4a1681eb-c953-4876-8877-9bcd3bd62da2
+        status: 200 OK
+        code: 200
+        duration: 86.977417ms
+    - id: 54
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 20
+        uncompressed: false
+        body: '{"private_nics":[]}'
+        headers:
+            Content-Length:
+                - "20"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:19 GMT
+            Link:
+                - </servers/82e67158-c544-4736-b58a-a28a0ce8892d/private_nics?page=0&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c75d04b4-5a7f-4a95-8c30-b8235c939c3e
+            X-Total-Count:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 85.464125ms
+    - id: 55
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 365
+        uncompressed: false
+        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"d2740bae-187d-42b4-ae39-7e511bc1f051","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "365"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:19 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 136d0897-9686-4192-8902-eddf5cb55d74
+        status: 200 OK
+        code: 200
+        duration: 93.258333ms
+    - id: 56
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/43e95675-93d8-4109-b6bd-3f5ab30b7754
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 439
+        uncompressed: false
+        body: '{"ip":{"address":"51.158.107.2","id":"43e95675-93d8-4109-b6bd-3f5ab30b7754","ipam_id":"40610e47-44a6-4808-bb35-e26d14fb02f9","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"82e67158-c544-4736-b58a-a28a0ce8892d","name":"tf-srv-awesome-haslett"},"state":"pending","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "439"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:19 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5c22e9e5-8ab6-4c91-9e93-511cf246d7b0
+        status: 200 OK
+        code: 200
+        duration: 103.111041ms
+    - id: 57
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2410
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:10.295356+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.107.2","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"43e95675-93d8-4109-b6bd-3f5ab30b7754","ipam_id":"40610e47-44a6-4808-bb35-e26d14fb02f9","netmask":"32","provisioning_mode":"dhcp","state":"pending","tags":[]},"public_ips":[{"address":"51.158.107.2","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"43e95675-93d8-4109-b6bd-3f5ab30b7754","ipam_id":"40610e47-44a6-4808-bb35-e26d14fb02f9","netmask":"32","provisioning_mode":"dhcp","state":"pending","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2410"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:19 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a30311af-f500-4ca3-83bb-20734ef7687c
+        status: 200 OK
+        code: 200
+        duration: 182.836458ms
+    - id: 58
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0725a599-8625-404e-8c03-fc85ad86c0a8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"0725a599-8625-404e-8c03-fc85ad86c0a8","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:19 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a1be5ad8-0688-46a1-a54d-f75d70997115
+        status: 404 Not Found
+        code: 404
+        duration: 36.324625ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -2961,8 +2955,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/0725a599-8625-404e-8c03-fc85ad86c0a8
         method: GET
       response:
         proto: HTTP/2.0
@@ -2970,20 +2964,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2334
+        content_length: 701
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:34.660280+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T14:25:05.625577Z","id":"0725a599-8625-404e-8c03-fc85ad86c0a8","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:25:05.625577Z","id":"7cbf0cd1-960a-4808-8227-635a82c90a3e","product_resource_id":"82e67158-c544-4736-b58a-a28a0ce8892d","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:25:05.625577Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2334"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:44 GMT
+                - Tue, 11 Feb 2025 14:25:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2991,10 +2985,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e07847f9-a3b6-40eb-9a96-b2319e64a758
+                - 55ced274-da7b-4fde-ba16-4d38116c17f5
         status: 200 OK
         code: 200
-        duration: 154.35775ms
+        duration: 62.040625ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -3010,8 +3004,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -3019,20 +3013,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2334
+        content_length: 17
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:34.660280+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "2334"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:44 GMT
+                - Tue, 11 Feb 2025 14:25:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3040,10 +3034,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7fe99434-3522-4c0d-ad82-7705d69c4a28
+                - fdcdb62e-911e-4f84-a169-b4893c9262b2
         status: 200 OK
         code: 200
-        duration: 191.504625ms
+        duration: 74.31725ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -3059,8 +3053,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -3068,20 +3062,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2334
+        content_length: 20
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:34.660280+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "2334"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:44 GMT
+                - Tue, 11 Feb 2025 14:25:20 GMT
+            Link:
+                - </servers/82e67158-c544-4736-b58a-a28a0ce8892d/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3089,10 +3085,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6df53dfd-75f1-4662-8458-1c33e2dbca09
+                - fefd433d-a1f8-445c-9e71-7ff890c29c3a
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 188.012208ms
+        duration: 101.984584ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -3108,8 +3106,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b4ae101e-1819-4dd8-8d8d-184ab3546b36
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
         method: GET
       response:
         proto: HTTP/2.0
@@ -3117,20 +3115,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 522
+        content_length: 2410
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:10.295356+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.107.2","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"43e95675-93d8-4109-b6bd-3f5ab30b7754","ipam_id":"40610e47-44a6-4808-bb35-e26d14fb02f9","netmask":"32","provisioning_mode":"dhcp","state":"pending","tags":[]},"public_ips":[{"address":"51.158.107.2","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"43e95675-93d8-4109-b6bd-3f5ab30b7754","ipam_id":"40610e47-44a6-4808-bb35-e26d14fb02f9","netmask":"32","provisioning_mode":"dhcp","state":"pending","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "522"
+                - "2410"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:44 GMT
+                - Tue, 11 Feb 2025 14:25:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3138,10 +3136,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1ef78170-e06e-4b12-a355-79b6a2e751e1
+                - a89835a4-02a4-464d-8239-49c023fcf13d
         status: 200 OK
         code: 200
-        duration: 91.954667ms
+        duration: 186.921208ms
     - id: 63
       request:
         proto: HTTP/1.1
@@ -3157,8 +3155,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
         method: GET
       response:
         proto: HTTP/2.0
@@ -3166,20 +3164,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 2410
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:10.295356+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.107.2","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"43e95675-93d8-4109-b6bd-3f5ab30b7754","ipam_id":"40610e47-44a6-4808-bb35-e26d14fb02f9","netmask":"32","provisioning_mode":"dhcp","state":"pending","tags":[]},"public_ips":[{"address":"51.158.107.2","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"43e95675-93d8-4109-b6bd-3f5ab30b7754","ipam_id":"40610e47-44a6-4808-bb35-e26d14fb02f9","netmask":"32","provisioning_mode":"dhcp","state":"pending","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "17"
+                - "2410"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:45 GMT
+                - Tue, 11 Feb 2025 14:25:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3187,50 +3185,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 066fa1d1-3554-4671-b469-f4d3c0295662
+                - aaedc16e-dcec-4852-b8d1-d9faa6518ff5
         status: 200 OK
         code: 200
-        duration: 147.768125ms
+        duration: 166.7955ms
     - id: 64
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 15
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"server":null}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f/private_nics
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/43e95675-93d8-4109-b6bd-3f5ab30b7754
+        method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 363
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"ip":{"address":"51.158.107.2","id":"43e95675-93d8-4109-b6bd-3f5ab30b7754","ipam_id":"40610e47-44a6-4808-bb35-e26d14fb02f9","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"pending","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "20"
+                - "363"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:45 GMT
-            Link:
-                - </servers/151ea383-08c6-41ce-8c6d-e81466eeda0f/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:25:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3238,12 +3236,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 27c81e1e-ed86-4a9d-beca-ada08a4c4bdd
-            X-Total-Count:
-                - "0"
+                - dff7cd9f-5322-40dc-b760-64682c2c9173
         status: 200 OK
         code: 200
-        duration: 109.941167ms
+        duration: 404.32425ms
     - id: 65
       request:
         proto: HTTP/1.1
@@ -3259,8 +3255,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
         method: GET
       response:
         proto: HTTP/2.0
@@ -3268,20 +3264,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2334
+        content_length: 1888
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:34.660280+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:10.295356+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2334"
+                - "1888"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:45 GMT
+                - Tue, 11 Feb 2025 14:25:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3289,10 +3285,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1c021ec9-ac76-4898-b8dd-20ca694ea67a
+                - 1f72e318-2d99-48c3-994b-8b7c7d7df053
         status: 200 OK
         code: 200
-        duration: 144.97925ms
+        duration: 190.212375ms
     - id: 66
       request:
         proto: HTTP/1.1
@@ -3308,8 +3304,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
         method: GET
       response:
         proto: HTTP/2.0
@@ -3317,20 +3313,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2334
+        content_length: 1888
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:34.660280+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:10.295356+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2334"
+                - "1888"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:45 GMT
+                - Tue, 11 Feb 2025 14:25:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3338,10 +3334,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 25bcedd9-5588-4412-aa06-7d952278823d
+                - c66206a6-936d-4045-bf2a-781c6fde0d3e
         status: 200 OK
         code: 200
-        duration: 172.474833ms
+        duration: 164.316125ms
     - id: 67
       request:
         proto: HTTP/1.1
@@ -3357,8 +3353,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
         method: GET
       response:
         proto: HTTP/2.0
@@ -3366,20 +3362,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 365
+        content_length: 1888
         uncompressed: false
-        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"47c67a80-eb9f-4c3e-a4cf-1b475a27b411","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:10.295356+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "365"
+                - "1888"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:45 GMT
+                - Tue, 11 Feb 2025 14:25:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3387,10 +3383,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3d552db7-7db5-4e21-a604-15d4170bc7f1
+                - 53a49678-f0ba-4b1e-9756-42f45d060092
         status: 200 OK
         code: 200
-        duration: 116.176292ms
+        duration: 183.293166ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -3406,8 +3402,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/fb49b08e-51b4-45cd-a0d0-bcf156deee1b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0725a599-8625-404e-8c03-fc85ad86c0a8
         method: GET
       response:
         proto: HTTP/2.0
@@ -3415,20 +3411,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 364
+        content_length: 143
         uncompressed: false
-        body: '{"ip":{"address":"51.158.65.65","id":"fb49b08e-51b4-45cd-a0d0-bcf156deee1b","ipam_id":"fee483d7-e770-44c5-819e-0a58a614105b","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"0725a599-8625-404e-8c03-fc85ad86c0a8","type":"not_found"}'
         headers:
             Content-Length:
-                - "364"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:45 GMT
+                - Tue, 11 Feb 2025 14:25:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3436,10 +3432,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 011293bb-0924-444e-a967-2ab794cc2bbf
-        status: 200 OK
-        code: 200
-        duration: 122.257875ms
+                - e6cef1a5-40ee-4b4c-aa0a-75aeda38205c
+        status: 404 Not Found
+        code: 404
+        duration: 54.5655ms
     - id: 69
       request:
         proto: HTTP/1.1
@@ -3455,8 +3451,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/0725a599-8625-404e-8c03-fc85ad86c0a8
         method: GET
       response:
         proto: HTTP/2.0
@@ -3464,20 +3460,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2334
+        content_length: 701
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:34.660280+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-11T14:25:05.625577Z","id":"0725a599-8625-404e-8c03-fc85ad86c0a8","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:25:05.625577Z","id":"7cbf0cd1-960a-4808-8227-635a82c90a3e","product_resource_id":"82e67158-c544-4736-b58a-a28a0ce8892d","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:25:05.625577Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2334"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:45 GMT
+                - Tue, 11 Feb 2025 14:25:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3485,10 +3481,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e4d92652-481a-4c92-851e-c78b6747bee6
+                - 3fc01796-1b55-43ba-b133-9527892e42d3
         status: 200 OK
         code: 200
-        duration: 197.693292ms
+        duration: 69.530375ms
     - id: 70
       request:
         proto: HTTP/1.1
@@ -3504,8 +3500,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b4ae101e-1819-4dd8-8d8d-184ab3546b36
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -3513,20 +3509,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 522
+        content_length: 17
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "522"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:45 GMT
+                - Tue, 11 Feb 2025 14:25:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3534,10 +3530,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dce8e6fd-8207-429f-ba8d-64af218ea2ea
+                - 49913d15-1adb-4508-9547-5b3ce09bdecc
         status: 200 OK
         code: 200
-        duration: 102.14125ms
+        duration: 101.540125ms
     - id: 71
       request:
         proto: HTTP/1.1
@@ -3553,8 +3549,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -3562,20 +3558,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 20
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"private_nics":[]}'
         headers:
             Content-Length:
-                - "17"
+                - "20"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:46 GMT
+                - Tue, 11 Feb 2025 14:25:21 GMT
+            Link:
+                - </servers/82e67158-c544-4736-b58a-a28a0ce8892d/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3583,10 +3581,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 62dd405f-3edf-49ed-b600-3514bf66449c
+                - f1ce5844-b177-477c-a799-ec6e06765599
+            X-Total-Count:
+                - "0"
         status: 200 OK
         code: 200
-        duration: 87.341833ms
+        duration: 86.012833ms
     - id: 72
       request:
         proto: HTTP/1.1
@@ -3602,8 +3602,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
         method: GET
       response:
         proto: HTTP/2.0
@@ -3611,22 +3611,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 1888
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:10.295356+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "20"
+                - "1888"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:46 GMT
-            Link:
-                - </servers/151ea383-08c6-41ce-8c6d-e81466eeda0f/private_nics?page=0&per_page=50&>; rel="last"
+                - Tue, 11 Feb 2025 14:25:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3634,12 +3632,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ab368b85-863e-4da7-b82c-6b33f292998e
-            X-Total-Count:
-                - "0"
+                - 0d0e156f-9103-4596-96bf-eb540bcf75bc
         status: 200 OK
         code: 200
-        duration: 90.63025ms
+        duration: 159.892458ms
     - id: 73
       request:
         proto: HTTP/1.1
@@ -3655,8 +3651,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
         method: GET
       response:
         proto: HTTP/2.0
@@ -3664,20 +3660,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 365
+        content_length: 1888
         uncompressed: false
-        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"47c67a80-eb9f-4c3e-a4cf-1b475a27b411","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:10.295356+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "365"
+                - "1888"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:46 GMT
+                - Tue, 11 Feb 2025 14:25:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3685,10 +3681,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5d79e4bf-f30f-46f0-8ad5-32cb6b2c1354
+                - e4dec868-83d4-4fec-99ea-79a33c0161cd
         status: 200 OK
         code: 200
-        duration: 77.588125ms
+        duration: 172.52025ms
     - id: 74
       request:
         proto: HTTP/1.1
@@ -3704,8 +3700,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/fb49b08e-51b4-45cd-a0d0-bcf156deee1b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
         method: GET
       response:
         proto: HTTP/2.0
@@ -3713,20 +3709,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 364
+        content_length: 365
         uncompressed: false
-        body: '{"ip":{"address":"51.158.65.65","id":"fb49b08e-51b4-45cd-a0d0-bcf156deee1b","ipam_id":"fee483d7-e770-44c5-819e-0a58a614105b","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"d2740bae-187d-42b4-ae39-7e511bc1f051","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "364"
+                - "365"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:46 GMT
+                - Tue, 11 Feb 2025 14:25:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3734,10 +3730,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 664ce4ba-a839-442f-af32-bcdac658011b
+                - 8ed686c7-762f-422d-84b5-11b4582ce363
         status: 200 OK
         code: 200
-        duration: 90.156416ms
+        duration: 76.682334ms
     - id: 75
       request:
         proto: HTTP/1.1
@@ -3753,8 +3749,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/43e95675-93d8-4109-b6bd-3f5ab30b7754
         method: GET
       response:
         proto: HTTP/2.0
@@ -3762,20 +3758,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2334
+        content_length: 364
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:34.660280+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"ip":{"address":"51.158.107.2","id":"43e95675-93d8-4109-b6bd-3f5ab30b7754","ipam_id":"40610e47-44a6-4808-bb35-e26d14fb02f9","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2334"
+                - "364"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:46 GMT
+                - Tue, 11 Feb 2025 14:25:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3783,10 +3779,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5972babd-def5-4acc-af56-9b7b47e4400d
+                - a36232d3-a6fc-46a8-abad-7449e4f76b27
         status: 200 OK
         code: 200
-        duration: 145.155458ms
+        duration: 78.332ms
     - id: 76
       request:
         proto: HTTP/1.1
@@ -3802,8 +3798,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b4ae101e-1819-4dd8-8d8d-184ab3546b36
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
         method: GET
       response:
         proto: HTTP/2.0
@@ -3811,20 +3807,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 522
+        content_length: 1888
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:10.295356+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "522"
+                - "1888"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:46 GMT
+                - Tue, 11 Feb 2025 14:25:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3832,10 +3828,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8351a5e1-ce2c-416d-b5cf-8b8c12a17b70
+                - 8a455d68-dba8-45a5-9155-beb7dbb76c37
         status: 200 OK
         code: 200
-        duration: 99.669166ms
+        duration: 181.428584ms
     - id: 77
       request:
         proto: HTTP/1.1
@@ -3851,8 +3847,106 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0725a599-8625-404e-8c03-fc85ad86c0a8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"0725a599-8625-404e-8c03-fc85ad86c0a8","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f9d3db6a-9c04-46aa-b7bb-6a6fb1da40ae
+        status: 404 Not Found
+        code: 404
+        duration: 37.7955ms
+    - id: 78
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/0725a599-8625-404e-8c03-fc85ad86c0a8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:25:05.625577Z","id":"0725a599-8625-404e-8c03-fc85ad86c0a8","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:25:05.625577Z","id":"7cbf0cd1-960a-4808-8227-635a82c90a3e","product_resource_id":"82e67158-c544-4736-b58a-a28a0ce8892d","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:25:05.625577Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f2e0b6f9-0744-4800-8d1c-937c8db7ae14
+        status: 200 OK
+        code: 200
+        duration: 57.357584ms
+    - id: 79
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -3871,9 +3965,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:46 GMT
+                - Tue, 11 Feb 2025 14:25:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3881,11 +3975,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b96f38a1-2414-42bc-bceb-6eb680abe346
+                - b9315d44-017d-4111-ba18-53cad77c45e2
         status: 200 OK
         code: 200
-        duration: 107.445375ms
-    - id: 78
+        duration: 76.739375ms
+    - id: 80
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3900,8 +3994,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -3920,11 +4014,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:46 GMT
+                - Tue, 11 Feb 2025 14:25:22 GMT
             Link:
-                - </servers/151ea383-08c6-41ce-8c6d-e81466eeda0f/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/82e67158-c544-4736-b58a-a28a0ce8892d/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3932,13 +4026,13 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9e8f798b-8d23-4b4e-b893-ee2bda28824b
+                - cfe12f44-d567-4482-ba2e-da66d86416a0
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 89.07225ms
-    - id: 79
+        duration: 73.875875ms
+    - id: 81
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3953,8 +4047,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
         method: GET
       response:
         proto: HTTP/2.0
@@ -3962,20 +4056,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2334
+        content_length: 365
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:34.660280+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"d2740bae-187d-42b4-ae39-7e511bc1f051","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2334"
+                - "365"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:47 GMT
+                - Tue, 11 Feb 2025 14:25:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3983,11 +4077,358 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 960281a2-099a-46a4-9acd-f370192027f7
+                - 1f1fbdf8-c0dd-4c58-8273-e1b11dbc589f
         status: 200 OK
         code: 200
-        duration: 176.568792ms
-    - id: 80
+        duration: 76.255542ms
+    - id: 82
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/43e95675-93d8-4109-b6bd-3f5ab30b7754
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 364
+        uncompressed: false
+        body: '{"ip":{"address":"51.158.107.2","id":"43e95675-93d8-4109-b6bd-3f5ab30b7754","ipam_id":"40610e47-44a6-4808-bb35-e26d14fb02f9","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "364"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 630bb03f-0c73-4e85-a894-0b7211c73ba4
+        status: 200 OK
+        code: 200
+        duration: 80.716416ms
+    - id: 83
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1888
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:10.295356+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1888"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e7006214-5e77-4f4c-8288-931f8b7bda5b
+        status: 200 OK
+        code: 200
+        duration: 154.729542ms
+    - id: 84
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0725a599-8625-404e-8c03-fc85ad86c0a8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"0725a599-8625-404e-8c03-fc85ad86c0a8","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 63226302-3ac8-4535-b7c4-fd2233357e0d
+        status: 404 Not Found
+        code: 404
+        duration: 33.39675ms
+    - id: 85
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/0725a599-8625-404e-8c03-fc85ad86c0a8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:25:05.625577Z","id":"0725a599-8625-404e-8c03-fc85ad86c0a8","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:25:05.625577Z","id":"7cbf0cd1-960a-4808-8227-635a82c90a3e","product_resource_id":"82e67158-c544-4736-b58a-a28a0ce8892d","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:25:05.625577Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d83612bd-60b6-4d3b-9c60-f60a798a1b05
+        status: 200 OK
+        code: 200
+        duration: 68.864209ms
+    - id: 86
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d/user_data
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 17
+        uncompressed: false
+        body: '{"user_data":[]}'
+        headers:
+            Content-Length:
+                - "17"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3c4ad145-0890-4220-a952-88b86f6c6750
+        status: 200 OK
+        code: 200
+        duration: 81.318042ms
+    - id: 87
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 20
+        uncompressed: false
+        body: '{"private_nics":[]}'
+        headers:
+            Content-Length:
+                - "20"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:23 GMT
+            Link:
+                - </servers/82e67158-c544-4736-b58a-a28a0ce8892d/private_nics?page=0&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e4b4df65-4e81-4fc5-8c5a-412efe863142
+            X-Total-Count:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 88.384625ms
+    - id: 88
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1888
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:10.295356+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1888"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:24 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c17c6319-2aeb-4ad7-a197-423104a40ef8
+        status: 200 OK
+        code: 200
+        duration: 187.822083ms
+    - id: 89
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4004,8 +4445,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -4013,20 +4454,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2861
+        content_length: 2411
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:47.552245+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"2a082169-532b-42cf-a942-1b6f7c2b3ef2","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"2a082169-532b-42cf-a942-1b6f7c2b3ef2","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:24.582534+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"df9d9996-1bb7-4c13-9971-e3c3b9dae088","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"df9d9996-1bb7-4c13-9971-e3c3b9dae088","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2861"
+                - "2411"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:48 GMT
+                - Tue, 11 Feb 2025 14:25:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4034,455 +4475,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 693e705d-5823-4e79-ac39-6dbf844c283a
+                - 8c62b703-a4af-4fc3-adc7-eb08a4f821d3
         status: 200 OK
         code: 200
-        duration: 827.626792ms
-    - id: 81
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2861
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:47.552245+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"2a082169-532b-42cf-a942-1b6f7c2b3ef2","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"2a082169-532b-42cf-a942-1b6f7c2b3ef2","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2861"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:48 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 379d03eb-b690-4b50-9d63-02ac5db14b71
-        status: 200 OK
-        code: 200
-        duration: 177.332125ms
-    - id: 82
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2861
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:47.552245+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"2a082169-532b-42cf-a942-1b6f7c2b3ef2","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"2a082169-532b-42cf-a942-1b6f7c2b3ef2","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2861"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:48 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 6ef24ceb-080b-4763-9d75-4a647ff5913c
-        status: 200 OK
-        code: 200
-        duration: 180.128291ms
-    - id: 83
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b4ae101e-1819-4dd8-8d8d-184ab3546b36
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 522
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "522"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:48 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - bdacad21-835d-4a70-9ed0-d69675064b2b
-        status: 200 OK
-        code: 200
-        duration: 73.726958ms
-    - id: 84
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f/user_data
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 17
-        uncompressed: false
-        body: '{"user_data":[]}'
-        headers:
-            Content-Length:
-                - "17"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:48 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 4827258b-dbf8-42ce-b557-821540f51746
-        status: 200 OK
-        code: 200
-        duration: 100.652042ms
-    - id: 85
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f/private_nics
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 20
-        uncompressed: false
-        body: '{"private_nics":[]}'
-        headers:
-            Content-Length:
-                - "20"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:48 GMT
-            Link:
-                - </servers/151ea383-08c6-41ce-8c6d-e81466eeda0f/private_nics?page=0&per_page=50&>; rel="last"
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 6cf322a7-4e3a-4482-a579-c99260d43e91
-            X-Total-Count:
-                - "0"
-        status: 200 OK
-        code: 200
-        duration: 82.851125ms
-    - id: 86
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2861
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:47.552245+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"2a082169-532b-42cf-a942-1b6f7c2b3ef2","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"2a082169-532b-42cf-a942-1b6f7c2b3ef2","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2861"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:49 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - f3e1807e-b7b0-4f23-a9a4-8159c2282043
-        status: 200 OK
-        code: 200
-        duration: 169.899875ms
-    - id: 87
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2861
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:47.552245+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"2a082169-532b-42cf-a942-1b6f7c2b3ef2","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"2a082169-532b-42cf-a942-1b6f7c2b3ef2","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2861"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:49 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - dcb2ab5d-e796-4af5-a309-88785b33e126
-        status: 200 OK
-        code: 200
-        duration: 206.377167ms
-    - id: 88
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/fb49b08e-51b4-45cd-a0d0-bcf156deee1b
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 364
-        uncompressed: false
-        body: '{"ip":{"address":"51.158.65.65","id":"fb49b08e-51b4-45cd-a0d0-bcf156deee1b","ipam_id":"fee483d7-e770-44c5-819e-0a58a614105b","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "364"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:49 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - b2cd5b80-dd22-405c-a06d-1521ebe7574d
-        status: 200 OK
-        code: 200
-        duration: 77.86825ms
-    - id: 89
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 365
-        uncompressed: false
-        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"47c67a80-eb9f-4c3e-a4cf-1b475a27b411","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "365"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:49 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - fc0387e3-4510-4531-9496-2d30e6d99770
-        status: 200 OK
-        code: 200
-        duration: 85.181625ms
+        duration: 1.125490541s
     - id: 90
       request:
         proto: HTTP/1.1
@@ -4498,8 +4494,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
         method: GET
       response:
         proto: HTTP/2.0
@@ -4507,20 +4503,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2861
+        content_length: 2411
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:47.552245+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"2a082169-532b-42cf-a942-1b6f7c2b3ef2","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"2a082169-532b-42cf-a942-1b6f7c2b3ef2","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:24.582534+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"df9d9996-1bb7-4c13-9971-e3c3b9dae088","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"df9d9996-1bb7-4c13-9971-e3c3b9dae088","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2861"
+                - "2411"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:49 GMT
+                - Tue, 11 Feb 2025 14:25:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4528,10 +4524,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 598966d3-0808-4c28-9f84-56e9f8fc1de1
+                - 086366aa-6ff1-4c69-a1a7-233738e92787
         status: 200 OK
         code: 200
-        duration: 155.812292ms
+        duration: 195.747834ms
     - id: 91
       request:
         proto: HTTP/1.1
@@ -4547,8 +4543,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b4ae101e-1819-4dd8-8d8d-184ab3546b36
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
         method: GET
       response:
         proto: HTTP/2.0
@@ -4556,20 +4552,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 522
+        content_length: 2411
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:24.582534+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"df9d9996-1bb7-4c13-9971-e3c3b9dae088","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"df9d9996-1bb7-4c13-9971-e3c3b9dae088","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "522"
+                - "2411"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:49 GMT
+                - Tue, 11 Feb 2025 14:25:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4577,10 +4573,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 240b3627-6191-4ee2-873c-0c4e699a399a
+                - 5b636ec4-98fd-4e37-bae6-e59adaf5a09f
         status: 200 OK
         code: 200
-        duration: 99.415334ms
+        duration: 193.410833ms
     - id: 92
       request:
         proto: HTTP/1.1
@@ -4596,8 +4592,106 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0725a599-8625-404e-8c03-fc85ad86c0a8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"0725a599-8625-404e-8c03-fc85ad86c0a8","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2222ae8e-aff2-40d8-874a-025faf2667f5
+        status: 404 Not Found
+        code: 404
+        duration: 29.460833ms
+    - id: 93
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/0725a599-8625-404e-8c03-fc85ad86c0a8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:25:05.625577Z","id":"0725a599-8625-404e-8c03-fc85ad86c0a8","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:25:05.625577Z","id":"7cbf0cd1-960a-4808-8227-635a82c90a3e","product_resource_id":"82e67158-c544-4736-b58a-a28a0ce8892d","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:25:05.625577Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f201ef90-fbbd-4a97-9362-2a4c0d437cc3
+        status: 200 OK
+        code: 200
+        duration: 62.965584ms
+    - id: 94
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -4616,9 +4710,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:49 GMT
+                - Tue, 11 Feb 2025 14:25:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4626,11 +4720,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6e3c1486-24f4-4366-ba39-c5da7875e1eb
+                - f8939ea2-6b0d-45a2-ad65-27affa3deae0
         status: 200 OK
         code: 200
-        duration: 106.468125ms
-    - id: 93
+        duration: 88.601167ms
+    - id: 95
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4645,8 +4739,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -4665,11 +4759,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:49 GMT
+                - Tue, 11 Feb 2025 14:25:25 GMT
             Link:
-                - </servers/151ea383-08c6-41ce-8c6d-e81466eeda0f/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/82e67158-c544-4736-b58a-a28a0ce8892d/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4677,13 +4771,13 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0e521b1f-6bf1-43af-8147-25e62ccd2a86
+                - 3a8d4fc6-4c05-4611-a310-f435e6ec3ea0
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 82.169083ms
-    - id: 94
+        duration: 78.12275ms
+    - id: 96
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4698,8 +4792,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
         method: GET
       response:
         proto: HTTP/2.0
@@ -4707,20 +4801,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2861
+        content_length: 2411
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:47.552245+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"2a082169-532b-42cf-a942-1b6f7c2b3ef2","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"2a082169-532b-42cf-a942-1b6f7c2b3ef2","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:24.582534+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"df9d9996-1bb7-4c13-9971-e3c3b9dae088","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"df9d9996-1bb7-4c13-9971-e3c3b9dae088","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2861"
+                - "2411"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:50 GMT
+                - Tue, 11 Feb 2025 14:25:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4728,11 +4822,505 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7e60a3a0-b8be-4c0c-8bc5-3e9872a81321
+                - 93ae1583-c4a8-4d62-abd8-b88c3b04af5a
         status: 200 OK
         code: 200
-        duration: 132.363375ms
-    - id: 95
+        duration: 200.882875ms
+    - id: 97
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2411
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:24.582534+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"df9d9996-1bb7-4c13-9971-e3c3b9dae088","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"df9d9996-1bb7-4c13-9971-e3c3b9dae088","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2411"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4e996197-b694-40db-bed2-dbfa2ca8a503
+        status: 200 OK
+        code: 200
+        duration: 210.171292ms
+    - id: 98
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 365
+        uncompressed: false
+        body: '{"ip":{"address":"51.15.236.240","id":"65a60f6b-fa89-4e49-bc25-fced17fa3df3","ipam_id":"d2740bae-187d-42b4-ae39-7e511bc1f051","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "365"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 91a360d3-875b-4b10-8e6f-046622910fd5
+        status: 200 OK
+        code: 200
+        duration: 75.656292ms
+    - id: 99
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/43e95675-93d8-4109-b6bd-3f5ab30b7754
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 364
+        uncompressed: false
+        body: '{"ip":{"address":"51.158.107.2","id":"43e95675-93d8-4109-b6bd-3f5ab30b7754","ipam_id":"40610e47-44a6-4808-bb35-e26d14fb02f9","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "364"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6c1a92b8-dfd6-4154-b2b7-60e223d0764d
+        status: 200 OK
+        code: 200
+        duration: 80.815709ms
+    - id: 100
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2411
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:24.582534+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"df9d9996-1bb7-4c13-9971-e3c3b9dae088","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"df9d9996-1bb7-4c13-9971-e3c3b9dae088","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2411"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - bf57a510-9b1c-46dd-89df-ff983c8d7325
+        status: 200 OK
+        code: 200
+        duration: 145.167458ms
+    - id: 101
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0725a599-8625-404e-8c03-fc85ad86c0a8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"0725a599-8625-404e-8c03-fc85ad86c0a8","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a118f797-e693-4bea-b07f-bc166edad93c
+        status: 404 Not Found
+        code: 404
+        duration: 28.283875ms
+    - id: 102
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/0725a599-8625-404e-8c03-fc85ad86c0a8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:25:05.625577Z","id":"0725a599-8625-404e-8c03-fc85ad86c0a8","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:25:05.625577Z","id":"7cbf0cd1-960a-4808-8227-635a82c90a3e","product_resource_id":"82e67158-c544-4736-b58a-a28a0ce8892d","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:25:05.625577Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 000a6250-8f8c-42cb-9994-da4c7eaf2fa6
+        status: 200 OK
+        code: 200
+        duration: 56.18375ms
+    - id: 103
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d/user_data
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 17
+        uncompressed: false
+        body: '{"user_data":[]}'
+        headers:
+            Content-Length:
+                - "17"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8530d327-d633-44b8-af2b-55ae028ff7a4
+        status: 200 OK
+        code: 200
+        duration: 94.825667ms
+    - id: 104
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 20
+        uncompressed: false
+        body: '{"private_nics":[]}'
+        headers:
+            Content-Length:
+                - "20"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:26 GMT
+            Link:
+                - </servers/82e67158-c544-4736-b58a-a28a0ce8892d/private_nics?page=0&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 238b9797-54b6-48f9-8166-767824baf9ea
+            X-Total-Count:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 84.070667ms
+    - id: 105
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2411
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:24.582534+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"df9d9996-1bb7-4c13-9971-e3c3b9dae088","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"df9d9996-1bb7-4c13-9971-e3c3b9dae088","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2411"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3eff839d-9659-4baf-9519-74693767b212
+        status: 200 OK
+        code: 200
+        duration: 154.880166ms
+    - id: 106
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/0725a599-8625-404e-8c03-fc85ad86c0a8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:25:05.625577Z","id":"0725a599-8625-404e-8c03-fc85ad86c0a8","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-11T14:25:05.625577Z","id":"7cbf0cd1-960a-4808-8227-635a82c90a3e","product_resource_id":"82e67158-c544-4736-b58a-a28a0ce8892d","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:25:05.625577Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d063378e-7a46-41b7-a1b7-64440effe786
+        status: 200 OK
+        code: 200
+        duration: 59.252375ms
+    - id: 107
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4749,8 +5337,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -4760,7 +5348,7 @@ interactions:
         trailer: {}
         content_length: 352
         uncompressed: false
-        body: '{"task":{"description":"server_poweroff","href_from":"/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f/action","href_result":"/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f","id":"3c244c47-c895-444d-8995-4e4d69ecb096","progress":0,"started_at":"2025-01-27T13:50:50.623333+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_poweroff","href_from":"/servers/82e67158-c544-4736-b58a-a28a0ce8892d/action","href_result":"/servers/82e67158-c544-4736-b58a-a28a0ce8892d","id":"6aceed3c-eb4e-40a7-b764-e6dd720379b2","progress":0,"started_at":"2025-02-11T14:25:27.789594+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "352"
@@ -4769,11 +5357,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:50 GMT
+                - Tue, 11 Feb 2025 14:25:27 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/3c244c47-c895-444d-8995-4e4d69ecb096
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/6aceed3c-eb4e-40a7-b764-e6dd720379b2
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4781,11 +5369,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d3a0a57d-956e-4963-a1d2-70b0b64d784e
+                - 1b299366-9c26-4b98-b664-3f3dd491629a
         status: 202 Accepted
         code: 202
-        duration: 222.2785ms
-    - id: 96
+        duration: 243.947375ms
+    - id: 108
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4800,7 +5388,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/65a60f6b-fa89-4e49-bc25-fced17fa3df3
         method: DELETE
       response:
@@ -4818,9 +5406,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:50:50 GMT
+                - Tue, 11 Feb 2025 14:25:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4828,596 +5416,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4b25036a-36d4-4b2c-8809-e6ef461d01df
+                - f95d09cc-5856-462c-bb91-5880a203b3be
         status: 204 No Content
         code: 204
-        duration: 444.511167ms
-    - id: 97
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/fb49b08e-51b4-45cd-a0d0-bcf156deee1b
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:50 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 9c3ea82d-e9b2-4777-a90f-0bead16b1524
-        status: 204 No Content
-        code: 204
-        duration: 487.774292ms
-    - id: 98
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2821
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:50.460897+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"2a082169-532b-42cf-a942-1b6f7c2b3ef2","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.145.106","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"780585ed-d10d-45e0-a5a4-9cce36efefd9","ipam_id":"2a082169-532b-42cf-a942-1b6f7c2b3ef2","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2821"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:50 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 3419dbe5-0ac0-4cbc-afc3-4d47a68342a4
-        status: 200 OK
-        code: 200
-        duration: 139.737292ms
-    - id: 99
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2293
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:50.460897+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2293"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:50:55 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 45ee24d2-2488-4509-ba7d-cf47e517c39b
-        status: 200 OK
-        code: 200
-        duration: 153.260791ms
-    - id: 100
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2293
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:50.460897+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2293"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:01 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 64032949-d0d5-43ad-bc17-e0886c0df77d
-        status: 200 OK
-        code: 200
-        duration: 385.540708ms
-    - id: 101
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2293
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:50.460897+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2293"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:06 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 49b4576e-0307-49e4-8b45-5a27f7a7be71
-        status: 200 OK
-        code: 200
-        duration: 174.458625ms
-    - id: 102
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2293
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:50.460897+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2293"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:11 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - f8cf93c3-1f13-4a63-a6d2-4ce97cfc64fe
-        status: 200 OK
-        code: 200
-        duration: 145.238625ms
-    - id: 103
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2293
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:50.460897+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2293"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:16 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 998d4263-4060-4c82-bb14-e2b979eb19a8
-        status: 200 OK
-        code: 200
-        duration: 152.720708ms
-    - id: 104
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2293
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:50.460897+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2293"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:21 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 1a7df07c-bb25-4cb7-8afd-d7f2de0486aa
-        status: 200 OK
-        code: 200
-        duration: 160.856583ms
-    - id: 105
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2293
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:50.460897+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2293"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:26 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 2d9832ee-fdad-4383-af26-e743e8a9ec43
-        status: 200 OK
-        code: 200
-        duration: 178.801792ms
-    - id: 106
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2293
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"1202","node_id":"18","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:50:50.460897+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2293"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:32 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - de0e7042-7ae5-4a16-bb85-78e4c50c4762
-        status: 200 OK
-        code: 200
-        duration: 171.665959ms
-    - id: 107
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2176
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:51:33.535296+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2176"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:37 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 71be0017-f563-43b6-b6f7-12ea41a8e9d4
-        status: 200 OK
-        code: 200
-        duration: 145.218292ms
-    - id: 108
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2176
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:50:24.018433+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nostalgic-gates","id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:90:00:81","maintenances":[],"modification_date":"2025-01-27T13:51:33.535296+00:00","name":"tf-srv-nostalgic-gates","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:50:24.018433+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","name":"tf-srv-nostalgic-gates"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2176"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:51:37 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 5f228a8f-5c68-48f3-84e1-fb219e4d2d81
-        status: 200 OK
-        code: 200
-        duration: 140.082292ms
+        duration: 520.594208ms
     - id: 109
       request:
         proto: HTTP/1.1
@@ -5433,8 +5435,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/43e95675-93d8-4109-b6bd-3f5ab30b7754
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5451,9 +5453,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:37 GMT
+                - Tue, 11 Feb 2025 14:25:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5461,10 +5463,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ce00a302-117a-4ea9-88f6-e5140f6642ce
+                - 48eba93a-279c-4985-9609-6935e671a4a6
         status: 204 No Content
         code: 204
-        duration: 162.584625ms
+        duration: 587.191542ms
     - id: 110
       request:
         proto: HTTP/1.1
@@ -5480,8 +5482,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
         method: GET
       response:
         proto: HTTP/2.0
@@ -5489,20 +5491,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 143
+        content_length: 2371
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","type":"not_found"}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:27.592495+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"df9d9996-1bb7-4c13-9971-e3c3b9dae088","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.219.146","dynamic":true,"family":"inet","gateway":"62.210.0.1","id":"090b718f-a41b-45ad-9bdb-0514effd355c","ipam_id":"df9d9996-1bb7-4c13-9971-e3c3b9dae088","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "143"
+                - "2371"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:37 GMT
+                - Tue, 11 Feb 2025 14:25:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5510,10 +5512,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5a08eb56-1396-46b8-86ec-a341f3fbb10c
-        status: 404 Not Found
-        code: 404
-        duration: 89.207292ms
+                - 75e95aa9-1f96-437e-a570-42597423c234
+        status: 200 OK
+        code: 200
+        duration: 165.248667ms
     - id: 111
       request:
         proto: HTTP/1.1
@@ -5529,8 +5531,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b4ae101e-1819-4dd8-8d8d-184ab3546b36
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
         method: GET
       response:
         proto: HTTP/2.0
@@ -5538,20 +5540,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 446
+        content_length: 1847
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:50:24.018433+00:00","export_uri":null,"id":"b4ae101e-1819-4dd8-8d8d-184ab3546b36","modification_date":"2025-01-27T13:51:37.643967+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:27.592495+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "446"
+                - "1847"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:37 GMT
+                - Tue, 11 Feb 2025 14:25:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5559,10 +5561,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 62327511-fa10-4fb8-901a-de5c0dda3728
+                - 1a19a1cb-fcd5-47b5-9833-5450f424788d
         status: 200 OK
         code: 200
-        duration: 90.571292ms
+        duration: 201.774875ms
     - id: 112
       request:
         proto: HTTP/1.1
@@ -5578,8 +5580,351 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b4ae101e-1819-4dd8-8d8d-184ab3546b36
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1847
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:27.592495+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1847"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 622f6b55-2659-4bc9-ad23-35a8381618df
+        status: 200 OK
+        code: 200
+        duration: 174.946959ms
+    - id: 113
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1847
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:27.592495+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1847"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:43 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5e9075ee-4f97-4b9d-a5a0-aa82de4c19f1
+        status: 200 OK
+        code: 200
+        duration: 165.2315ms
+    - id: 114
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1847
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:27.592495+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1847"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b472c217-e07c-4f91-956e-9441c0cfacb2
+        status: 200 OK
+        code: 200
+        duration: 197.63625ms
+    - id: 115
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1847
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:27.592495+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1847"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2d5ab1c5-5550-4233-bcea-df8407ff627e
+        status: 200 OK
+        code: 200
+        duration: 175.614416ms
+    - id: 116
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1847
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"103","node_id":"5","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:25:27.592495+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1847"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:25:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b0e03fc9-f30b-4bd2-9aa2-700358b4f623
+        status: 200 OK
+        code: 200
+        duration: 186.840042ms
+    - id: 117
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1732
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:26:01.066313+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1732"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:26:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2fdda297-b49d-4085-aedc-9c5c5032e558
+        status: 200 OK
+        code: 200
+        duration: 204.205417ms
+    - id: 118
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1732
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:25:05.403080+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-haslett","id":"82e67158-c544-4736-b58a-a28a0ce8892d","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6e:15","maintenances":[],"modification_date":"2025-02-11T14:26:01.066313+00:00","name":"tf-srv-awesome-haslett","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"id":"0725a599-8625-404e-8c03-fc85ad86c0a8","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1732"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:26:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - edd80472-8d92-4cd5-b4ec-bb66973be202
+        status: 200 OK
+        code: 200
+        duration: 163.422042ms
+    - id: 119
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5596,9 +5941,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:37 GMT
+                - Tue, 11 Feb 2025 14:26:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5606,11 +5951,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8c34b148-583b-46df-a4bc-93accb8d3017
+                - ba45fa24-83a6-47b7-9f64-ab53a63e7034
         status: 204 No Content
         code: 204
-        duration: 140.490042ms
-    - id: 113
+        duration: 770.999583ms
+    - id: 120
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -5625,8 +5970,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/151ea383-08c6-41ce-8c6d-e81466eeda0f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
         method: GET
       response:
         proto: HTTP/2.0
@@ -5636,7 +5981,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"151ea383-08c6-41ce-8c6d-e81466eeda0f","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"82e67158-c544-4736-b58a-a28a0ce8892d","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -5645,9 +5990,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:51:37 GMT
+                - Tue, 11 Feb 2025 14:26:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5655,7 +6000,201 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 37deb863-c443-4471-92f4-9e94320694c3
+                - 37ba6b1f-b4bf-4744-b784-4f8d7cc88fcc
         status: 404 Not Found
         code: 404
-        duration: 86.732083ms
+        duration: 84.870709ms
+    - id: 121
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0725a599-8625-404e-8c03-fc85ad86c0a8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"0725a599-8625-404e-8c03-fc85ad86c0a8","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:26:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e0610d5f-0131-428b-bc8c-94fe2905d217
+        status: 404 Not Found
+        code: 404
+        duration: 45.632625ms
+    - id: 122
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/0725a599-8625-404e-8c03-fc85ad86c0a8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 494
+        uncompressed: false
+        body: '{"created_at":"2025-02-11T14:25:05.625577Z","id":"0725a599-8625-404e-8c03-fc85ad86c0a8","last_detached_at":"2025-02-11T14:26:05.285885Z","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-11T14:26:05.285885Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "494"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:26:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a6ac8886-808c-4211-81a0-c199b0f85911
+        status: 200 OK
+        code: 200
+        duration: 64.916666ms
+    - id: 123
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/0725a599-8625-404e-8c03-fc85ad86c0a8
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:26:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - dc4372e5-2797-4175-a2b1-d254f6db60de
+        status: 204 No Content
+        code: 204
+        duration: 120.744834ms
+    - id: 124
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/82e67158-c544-4736-b58a-a28a0ce8892d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"82e67158-c544-4736-b58a-a28a0ce8892d","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:26:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - aa861f74-52a1-45b3-ba6e-7beab56fc2bd
+        status: 404 Not Found
+        code: 404
+        duration: 102.176125ms

--- a/internal/services/instance/testdata/snapshot-server-with-block-volume.cassette.yaml
+++ b/internal/services/instance/testdata/snapshot-server-with-block-volume.cassette.yaml
@@ -6,19 +6,19 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 119
+        content_length: 122
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-vol-nice-bhabha","project":"105bdce1-64c0-48ab-899d-868455867ecf","volume_type":"b_ssd","size":10000000000}'
+        body: '{"name":"tf-vol-youthful-fermi","project":"105bdce1-64c0-48ab-899d-868455867ecf","volume_type":"b_ssd","size":10000000000}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes
         method: POST
       response:
@@ -27,22 +27,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 440
+        content_length: 443
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:18.113957+00:00","export_uri":null,"id":"817ef76c-fa77-4898-b677-8bb0712019fb","modification_date":"2025-01-27T13:48:18.113957+00:00","name":"tf-vol-nice-bhabha","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:36.140054+00:00","export_uri":null,"id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","modification_date":"2025-02-11T14:22:36.140054+00:00","name":"tf-vol-youthful-fermi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "440"
+                - "443"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:18 GMT
+                - Tue, 11 Feb 2025 14:22:35 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/817ef76c-fa77-4898-b677-8bb0712019fb
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -50,10 +50,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7a2f9e97-75cf-48c1-b500-be7ef0472ab7
+                - 39353e93-40d5-4b78-862d-61f590c09f97
         status: 201 Created
         code: 201
-        duration: 198.903792ms
+        duration: 475.848ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -69,8 +69,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/817ef76c-fa77-4898-b677-8bb0712019fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1
         method: GET
       response:
         proto: HTTP/2.0
@@ -78,20 +78,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 440
+        content_length: 443
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:18.113957+00:00","export_uri":null,"id":"817ef76c-fa77-4898-b677-8bb0712019fb","modification_date":"2025-01-27T13:48:18.113957+00:00","name":"tf-vol-nice-bhabha","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:36.140054+00:00","export_uri":null,"id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","modification_date":"2025-02-11T14:22:36.140054+00:00","name":"tf-vol-youthful-fermi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "440"
+                - "443"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:18 GMT
+                - Tue, 11 Feb 2025 14:22:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -99,10 +99,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f58b608a-a39d-42b9-9604-e4b8cd890160
+                - e003b4b7-5261-45aa-87a1-4e561bf2ea41
         status: 200 OK
         code: 200
-        duration: 73.45975ms
+        duration: 107.156625ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -118,8 +118,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/817ef76c-fa77-4898-b677-8bb0712019fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1
         method: GET
       response:
         proto: HTTP/2.0
@@ -127,20 +127,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 440
+        content_length: 443
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:18.113957+00:00","export_uri":null,"id":"817ef76c-fa77-4898-b677-8bb0712019fb","modification_date":"2025-01-27T13:48:18.113957+00:00","name":"tf-vol-nice-bhabha","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:36.140054+00:00","export_uri":null,"id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","modification_date":"2025-02-11T14:22:36.140054+00:00","name":"tf-vol-youthful-fermi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "440"
+                - "443"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:17 GMT
+                - Tue, 11 Feb 2025 14:22:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -148,10 +148,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2726e098-370f-4eac-865b-5c497532030d
+                - ffac1f5f-22a1-4be3-b321-cb64826b9b8b
         status: 200 OK
         code: 200
-        duration: 77.869417ms
+        duration: 93.310542ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -167,7 +167,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
         method: GET
       response:
@@ -176,22 +176,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 38539
+        content_length: 35639
         uncompressed: false
-        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
+        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
         headers:
             Content-Length:
-                - "38539"
+                - "35639"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:17 GMT
+                - Tue, 11 Feb 2025 14:22:36 GMT
             Link:
                 - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -199,12 +199,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 244e1d43-3547-47cd-a966-87d658284342
+                - b35ff6b4-de60-426c-9197-a4ee29948745
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 50.708375ms
+        duration: 45.528833ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -220,7 +220,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
         method: GET
       response:
@@ -229,22 +229,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 14208
+        content_length: 13164
         uncompressed: false
-        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
         headers:
             Content-Length:
-                - "14208"
+                - "13164"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:18 GMT
+                - Tue, 11 Feb 2025 14:22:36 GMT
             Link:
                 - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -252,12 +252,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 919f233f-1aeb-4d7d-bb68-1e2dcc13488d
+                - 34680322-495e-4dcb-9ec3-286b4d6de000
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 41.755125ms
+        duration: 49.739917ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -273,8 +273,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/817ef76c-fa77-4898-b677-8bb0712019fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1
         method: GET
       response:
         proto: HTTP/2.0
@@ -282,20 +282,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 440
+        content_length: 443
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:18.113957+00:00","export_uri":null,"id":"817ef76c-fa77-4898-b677-8bb0712019fb","modification_date":"2025-01-27T13:48:18.113957+00:00","name":"tf-vol-nice-bhabha","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:36.140054+00:00","export_uri":null,"id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","modification_date":"2025-02-11T14:22:36.140054+00:00","name":"tf-vol-youthful-fermi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "440"
+                - "443"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:18 GMT
+                - Tue, 11 Feb 2025 14:22:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -303,10 +303,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d2e6bef2-1762-45ec-ac84-f8d65b2dad62
+                - 058f3b78-0278-4ea9-8a2e-ae23f149c1f9
         status: 200 OK
         code: 200
-        duration: 81.609542ms
+        duration: 91.809916ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -322,7 +322,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_local&zone=fr-par-1
         method: GET
       response:
@@ -342,9 +342,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:18 GMT
+                - Tue, 11 Feb 2025 14:22:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -352,28 +352,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b33c227f-3a05-4ec4-8f50-754e8b7bd50e
+                - 61579048-5d0c-4cdc-87e7-bc285181de80
         status: 200 OK
         code: 200
-        duration: 76.165375ms
+        duration: 85.8435ms
     - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 135
+        content_length: 131
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-snap-vigorous-khorana","volume_id":"817ef76c-fa77-4898-b677-8bb0712019fb","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+        body: '{"name":"tf-snap-awesome-benz","volume_id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
         method: POST
       response:
@@ -382,20 +382,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 842
+        content_length: 841
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"817ef76c-fa77-4898-b677-8bb0712019fb","name":"tf-vol-nice-bhabha"},"creation_date":"2025-01-27T13:48:18.460767+00:00","error_details":null,"id":"40dbe32f-3bb2-48e3-9115-ccb957845697","modification_date":"2025-01-27T13:48:18.460767+00:00","name":"tf-snap-vigorous-khorana","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"},"task":{"description":"volume_snapshot","href_from":"/snapshots","href_result":"snapshots/40dbe32f-3bb2-48e3-9115-ccb957845697","id":"98d4a144-511a-4fdc-9885-c7434559ee0c","progress":0,"started_at":"2025-01-27T13:48:18.618787+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","name":"tf-vol-youthful-fermi"},"creation_date":"2025-02-11T14:22:36.578181+00:00","error_details":null,"id":"444bfd94-a046-48ee-b4ce-bdbfa50aad1a","modification_date":"2025-02-11T14:22:36.578181+00:00","name":"tf-snap-awesome-benz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"},"task":{"description":"volume_snapshot","href_from":"/snapshots","href_result":"snapshots/444bfd94-a046-48ee-b4ce-bdbfa50aad1a","id":"7e79d7f1-e546-48a8-84e2-1b74cd58438f","progress":0,"started_at":"2025-02-11T14:22:36.754392+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "842"
+                - "841"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:18 GMT
+                - Tue, 11 Feb 2025 14:22:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -403,10 +403,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b9bbeca2-16e5-428b-a31e-65c8bc657055
+                - cadde7f2-964b-4835-ae7a-0a9274537407
         status: 201 Created
         code: 201
-        duration: 427.96275ms
+        duration: 478.76975ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -422,8 +422,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/40dbe32f-3bb2-48e3-9115-ccb957845697
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/444bfd94-a046-48ee-b4ce-bdbfa50aad1a
         method: GET
       response:
         proto: HTTP/2.0
@@ -431,20 +431,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 531
+        content_length: 530
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"817ef76c-fa77-4898-b677-8bb0712019fb","name":"tf-vol-nice-bhabha"},"creation_date":"2025-01-27T13:48:18.460767+00:00","error_details":null,"id":"40dbe32f-3bb2-48e3-9115-ccb957845697","modification_date":"2025-01-27T13:48:18.460767+00:00","name":"tf-snap-vigorous-khorana","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","name":"tf-vol-youthful-fermi"},"creation_date":"2025-02-11T14:22:36.578181+00:00","error_details":null,"id":"444bfd94-a046-48ee-b4ce-bdbfa50aad1a","modification_date":"2025-02-11T14:22:36.578181+00:00","name":"tf-snap-awesome-benz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "531"
+                - "530"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:18 GMT
+                - Tue, 11 Feb 2025 14:22:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -452,28 +452,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b3c1d526-acf4-4417-9ebb-bf8e3e73d4f0
+                - 018709db-36d3-4f88-a10d-0e3c3d1b05af
         status: 200 OK
         code: 200
-        duration: 87.917583ms
+        duration: 99.092ms
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 356
+        content_length: 354
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-srv-strange-blackburn","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","volumes":{"0":{"boot":false,"size":10000000000,"volume_type":"l_ssd"},"1":{"id":"817ef76c-fa77-4898-b677-8bb0712019fb","name":"tf-vol-nice-bhabha"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+        body: '{"name":"tf-srv-frosty-gould","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","volumes":{"0":{"boot":false,"size":10000000000,"volume_type":"l_ssd"},"1":{"id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","name":"tf-vol-youthful-fermi"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
         method: POST
       response:
@@ -482,22 +482,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2636
+        content_length: 2619
         uncompressed: false
-        body: '{"server":{"allowed_actions":[],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:18.833411+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-blackburn","id":"00478d4e-a51c-4ea1-a991-ad3deea73514","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:cf","maintenances":[],"modification_date":"2025-01-27T13:48:18.833411+00:00","name":"tf-srv-strange-blackburn","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:18.833411+00:00","export_uri":null,"id":"baed541a-7caa-437a-90d4-7f10d775e6ef","modification_date":"2025-01-27T13:48:18.833411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:48:18.113957+00:00","export_uri":null,"id":"817ef76c-fa77-4898-b677-8bb0712019fb","modification_date":"2025-01-27T13:48:18.833411+00:00","name":"tf-vol-nice-bhabha","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":[],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.050336+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-frosty-gould","id":"3de4c610-2143-4305-a211-9c4098e590f9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:d9","maintenances":[],"modification_date":"2025-02-11T14:22:37.050336+00:00","name":"tf-srv-frosty-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:22:37.050336+00:00","export_uri":null,"id":"4e63a045-02a7-4ad3-bb80-477e9dbb0490","modification_date":"2025-02-11T14:22:37.050336+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140054+00:00","export_uri":null,"id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","modification_date":"2025-02-11T14:22:37.050336+00:00","name":"tf-vol-youthful-fermi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2636"
+                - "2619"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:19 GMT
+                - Tue, 11 Feb 2025 14:22:37 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/00478d4e-a51c-4ea1-a991-ad3deea73514
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3de4c610-2143-4305-a211-9c4098e590f9
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -505,10 +505,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5f0a5608-de6e-462a-940f-69b841fe73e6
+                - b5fbc628-37dd-4714-a814-c3d23cced90f
         status: 201 Created
         code: 201
-        duration: 545.292208ms
+        duration: 885.437666ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -524,8 +524,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/00478d4e-a51c-4ea1-a991-ad3deea73514
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3de4c610-2143-4305-a211-9c4098e590f9
         method: GET
       response:
         proto: HTTP/2.0
@@ -533,20 +533,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2636
+        content_length: 2619
         uncompressed: false
-        body: '{"server":{"allowed_actions":[],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:18.833411+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-blackburn","id":"00478d4e-a51c-4ea1-a991-ad3deea73514","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:cf","maintenances":[],"modification_date":"2025-01-27T13:48:18.833411+00:00","name":"tf-srv-strange-blackburn","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:18.833411+00:00","export_uri":null,"id":"baed541a-7caa-437a-90d4-7f10d775e6ef","modification_date":"2025-01-27T13:48:18.833411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:48:18.113957+00:00","export_uri":null,"id":"817ef76c-fa77-4898-b677-8bb0712019fb","modification_date":"2025-01-27T13:48:18.833411+00:00","name":"tf-vol-nice-bhabha","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":[],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.050336+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-frosty-gould","id":"3de4c610-2143-4305-a211-9c4098e590f9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:d9","maintenances":[],"modification_date":"2025-02-11T14:22:37.050336+00:00","name":"tf-srv-frosty-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:22:37.050336+00:00","export_uri":null,"id":"4e63a045-02a7-4ad3-bb80-477e9dbb0490","modification_date":"2025-02-11T14:22:37.050336+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140054+00:00","export_uri":null,"id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","modification_date":"2025-02-11T14:22:37.050336+00:00","name":"tf-vol-youthful-fermi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2636"
+                - "2619"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:19 GMT
+                - Tue, 11 Feb 2025 14:22:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -554,10 +554,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 310ac2bd-c701-49de-b95e-00023eb11942
+                - d1db7aa5-bbee-4b3c-a23c-f5692ae2137d
         status: 200 OK
         code: 200
-        duration: 215.771667ms
+        duration: 124.634292ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -573,8 +573,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/00478d4e-a51c-4ea1-a991-ad3deea73514
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3de4c610-2143-4305-a211-9c4098e590f9
         method: GET
       response:
         proto: HTTP/2.0
@@ -582,20 +582,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2636
+        content_length: 2619
         uncompressed: false
-        body: '{"server":{"allowed_actions":[],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:18.833411+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-blackburn","id":"00478d4e-a51c-4ea1-a991-ad3deea73514","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:cf","maintenances":[],"modification_date":"2025-01-27T13:48:18.833411+00:00","name":"tf-srv-strange-blackburn","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:18.833411+00:00","export_uri":null,"id":"baed541a-7caa-437a-90d4-7f10d775e6ef","modification_date":"2025-01-27T13:48:18.833411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:48:18.113957+00:00","export_uri":null,"id":"817ef76c-fa77-4898-b677-8bb0712019fb","modification_date":"2025-01-27T13:48:18.833411+00:00","name":"tf-vol-nice-bhabha","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":[],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.050336+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-frosty-gould","id":"3de4c610-2143-4305-a211-9c4098e590f9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:d9","maintenances":[],"modification_date":"2025-02-11T14:22:37.050336+00:00","name":"tf-srv-frosty-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:22:37.050336+00:00","export_uri":null,"id":"4e63a045-02a7-4ad3-bb80-477e9dbb0490","modification_date":"2025-02-11T14:22:37.050336+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140054+00:00","export_uri":null,"id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","modification_date":"2025-02-11T14:22:37.050336+00:00","name":"tf-vol-youthful-fermi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2636"
+                - "2619"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:19 GMT
+                - Tue, 11 Feb 2025 14:22:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -603,10 +603,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ec029a34-c52a-475c-98bb-6c46e8a4b7c5
+                - 8afc9d53-30a8-40d5-8a02-75124881f37e
         status: 200 OK
         code: 200
-        duration: 157.04925ms
+        duration: 155.616ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -622,8 +622,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/817ef76c-fa77-4898-b677-8bb0712019fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1
         method: GET
       response:
         proto: HTTP/2.0
@@ -631,20 +631,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 521
+        content_length: 519
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:18.113957+00:00","export_uri":null,"id":"817ef76c-fa77-4898-b677-8bb0712019fb","modification_date":"2025-01-27T13:48:18.833411+00:00","name":"tf-vol-nice-bhabha","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:36.140054+00:00","export_uri":null,"id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","modification_date":"2025-02-11T14:22:37.050336+00:00","name":"tf-vol-youthful-fermi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "521"
+                - "519"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:19 GMT
+                - Tue, 11 Feb 2025 14:22:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -652,10 +652,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cd2060b9-a140-4f6f-be8d-61980f17a209
+                - aa9a9f8e-2444-4546-9d10-971f29d171c0
         status: 200 OK
         code: 200
-        duration: 78.61925ms
+        duration: 107.840292ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -671,8 +671,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/817ef76c-fa77-4898-b677-8bb0712019fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/444bfd94-a046-48ee-b4ce-bdbfa50aad1a
         method: GET
       response:
         proto: HTTP/2.0
@@ -680,20 +680,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 518
+        content_length: 527
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:18.113957+00:00","export_uri":null,"id":"817ef76c-fa77-4898-b677-8bb0712019fb","modification_date":"2025-01-27T13:48:21.346538+00:00","name":"tf-vol-nice-bhabha","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","name":"tf-vol-youthful-fermi"},"creation_date":"2025-02-11T14:22:36.578181+00:00","error_details":null,"id":"444bfd94-a046-48ee-b4ce-bdbfa50aad1a","modification_date":"2025-02-11T14:22:39.266244+00:00","name":"tf-snap-awesome-benz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "518"
+                - "527"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:37 GMT
+                - Tue, 11 Feb 2025 14:22:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -701,10 +701,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9806c99d-0c69-4dff-a8c9-4aef1cbd63ea
+                - 430970c7-5b7d-4692-b17a-67a1226bd5bc
         status: 200 OK
         code: 200
-        duration: 13.599030583s
+        duration: 81.714958ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -720,8 +720,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/40dbe32f-3bb2-48e3-9115-ccb957845697
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/444bfd94-a046-48ee-b4ce-bdbfa50aad1a
         method: GET
       response:
         proto: HTTP/2.0
@@ -729,20 +729,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 528
+        content_length: 527
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"817ef76c-fa77-4898-b677-8bb0712019fb","name":"tf-vol-nice-bhabha"},"creation_date":"2025-01-27T13:48:18.460767+00:00","error_details":null,"id":"40dbe32f-3bb2-48e3-9115-ccb957845697","modification_date":"2025-01-27T13:48:21.346538+00:00","name":"tf-snap-vigorous-khorana","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","name":"tf-vol-youthful-fermi"},"creation_date":"2025-02-11T14:22:36.578181+00:00","error_details":null,"id":"444bfd94-a046-48ee-b4ce-bdbfa50aad1a","modification_date":"2025-02-11T14:22:39.266244+00:00","name":"tf-snap-awesome-benz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "528"
+                - "527"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:37 GMT
+                - Tue, 11 Feb 2025 14:22:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -750,10 +750,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a7aa9344-e8e0-4045-892b-5b44e7c2c801
+                - 3344fb9a-1943-4c49-9ea4-43b6710b33a0
         status: 200 OK
         code: 200
-        duration: 14.370031083s
+        duration: 92.654541ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -769,8 +769,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/40dbe32f-3bb2-48e3-9115-ccb957845697
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1
         method: GET
       response:
         proto: HTTP/2.0
@@ -778,20 +778,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 528
+        content_length: 516
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"817ef76c-fa77-4898-b677-8bb0712019fb","name":"tf-vol-nice-bhabha"},"creation_date":"2025-01-27T13:48:18.460767+00:00","error_details":null,"id":"40dbe32f-3bb2-48e3-9115-ccb957845697","modification_date":"2025-01-27T13:48:21.346538+00:00","name":"tf-snap-vigorous-khorana","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:36.140054+00:00","export_uri":null,"id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","modification_date":"2025-02-11T14:22:39.266244+00:00","name":"tf-vol-youthful-fermi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "528"
+                - "516"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:37 GMT
+                - Tue, 11 Feb 2025 14:22:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -799,10 +799,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f2056ee7-ec35-457a-8267-dc8de667d05c
+                - 4b4f9d85-1ad4-4f11-840d-dae4b3df28e0
         status: 200 OK
         code: 200
-        duration: 1.618769916s
+        duration: 86.712292ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -820,8 +820,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/00478d4e-a51c-4ea1-a991-ad3deea73514/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3de4c610-2143-4305-a211-9c4098e590f9/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -831,7 +831,7 @@ interactions:
         trailer: {}
         content_length: 357
         uncompressed: false
-        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/00478d4e-a51c-4ea1-a991-ad3deea73514/action","href_result":"/servers/00478d4e-a51c-4ea1-a991-ad3deea73514","id":"b946d886-a4f6-401d-9f86-3e02b7586f3c","progress":0,"started_at":"2025-01-27T13:48:38.447722+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/3de4c610-2143-4305-a211-9c4098e590f9/action","href_result":"/servers/3de4c610-2143-4305-a211-9c4098e590f9","id":"82bf28ad-5ab6-42fb-935d-a6ed4e161f26","progress":0,"started_at":"2025-02-11T14:22:43.236758+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -840,11 +840,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:38 GMT
+                - Tue, 11 Feb 2025 14:22:42 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/b946d886-a4f6-401d-9f86-3e02b7586f3c
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/82bf28ad-5ab6-42fb-935d-a6ed4e161f26
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -852,10 +852,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6b6e19af-78fe-462c-87f2-3aaf9d1858e0
+                - 2778fa5f-c689-48ca-9677-3d58eb6ebc73
         status: 202 Accepted
         code: 202
-        duration: 1.647827458s
+        duration: 202.460334ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -871,8 +871,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/00478d4e-a51c-4ea1-a991-ad3deea73514
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3de4c610-2143-4305-a211-9c4098e590f9
         method: GET
       response:
         proto: HTTP/2.0
@@ -880,20 +880,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2674
+        content_length: 2657
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:18.833411+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-blackburn","id":"00478d4e-a51c-4ea1-a991-ad3deea73514","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:cf","maintenances":[],"modification_date":"2025-01-27T13:48:38.205420+00:00","name":"tf-srv-strange-blackburn","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:18.833411+00:00","export_uri":null,"id":"baed541a-7caa-437a-90d4-7f10d775e6ef","modification_date":"2025-01-27T13:48:18.833411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:48:18.113957+00:00","export_uri":null,"id":"817ef76c-fa77-4898-b677-8bb0712019fb","modification_date":"2025-01-27T13:48:21.346538+00:00","name":"tf-vol-nice-bhabha","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.050336+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-frosty-gould","id":"3de4c610-2143-4305-a211-9c4098e590f9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:d9","maintenances":[],"modification_date":"2025-02-11T14:22:43.072489+00:00","name":"tf-srv-frosty-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:22:37.050336+00:00","export_uri":null,"id":"4e63a045-02a7-4ad3-bb80-477e9dbb0490","modification_date":"2025-02-11T14:22:37.050336+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140054+00:00","export_uri":null,"id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","modification_date":"2025-02-11T14:22:39.266244+00:00","name":"tf-vol-youthful-fermi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2674"
+                - "2657"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:39 GMT
+                - Tue, 11 Feb 2025 14:22:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -901,10 +901,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e2e7b09c-11be-4cc5-aa0b-6fe7d13fd5c4
+                - f31d0dc8-52ca-4a3d-a25f-932b24fb3021
         status: 200 OK
         code: 200
-        duration: 1.267649625s
+        duration: 138.725125ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -920,8 +920,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/00478d4e-a51c-4ea1-a991-ad3deea73514
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3de4c610-2143-4305-a211-9c4098e590f9
         method: GET
       response:
         proto: HTTP/2.0
@@ -929,20 +929,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2778
+        content_length: 2759
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:18.833411+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-blackburn","id":"00478d4e-a51c-4ea1-a991-ad3deea73514","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"1701","node_id":"17","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:cf","maintenances":[],"modification_date":"2025-01-27T13:48:38.205420+00:00","name":"tf-srv-strange-blackburn","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:18.833411+00:00","export_uri":null,"id":"baed541a-7caa-437a-90d4-7f10d775e6ef","modification_date":"2025-01-27T13:48:18.833411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:48:18.113957+00:00","export_uri":null,"id":"817ef76c-fa77-4898-b677-8bb0712019fb","modification_date":"2025-01-27T13:48:21.346538+00:00","name":"tf-vol-nice-bhabha","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.050336+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-frosty-gould","id":"3de4c610-2143-4305-a211-9c4098e590f9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"202","node_id":"8","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:d9","maintenances":[],"modification_date":"2025-02-11T14:22:43.072489+00:00","name":"tf-srv-frosty-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:22:37.050336+00:00","export_uri":null,"id":"4e63a045-02a7-4ad3-bb80-477e9dbb0490","modification_date":"2025-02-11T14:22:37.050336+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140054+00:00","export_uri":null,"id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","modification_date":"2025-02-11T14:22:39.266244+00:00","name":"tf-vol-youthful-fermi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2778"
+                - "2759"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:45 GMT
+                - Tue, 11 Feb 2025 14:22:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -950,10 +950,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dde2fff9-dc06-4938-b29e-c08377e278d5
+                - 3c057752-b41a-4cee-a597-791980f7559f
         status: 200 OK
         code: 200
-        duration: 137.890291ms
+        duration: 191.788167ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -969,8 +969,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/00478d4e-a51c-4ea1-a991-ad3deea73514
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3de4c610-2143-4305-a211-9c4098e590f9
         method: GET
       response:
         proto: HTTP/2.0
@@ -978,20 +978,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2778
+        content_length: 2759
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:18.833411+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-blackburn","id":"00478d4e-a51c-4ea1-a991-ad3deea73514","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"1701","node_id":"17","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:cf","maintenances":[],"modification_date":"2025-01-27T13:48:38.205420+00:00","name":"tf-srv-strange-blackburn","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:18.833411+00:00","export_uri":null,"id":"baed541a-7caa-437a-90d4-7f10d775e6ef","modification_date":"2025-01-27T13:48:18.833411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:48:18.113957+00:00","export_uri":null,"id":"817ef76c-fa77-4898-b677-8bb0712019fb","modification_date":"2025-01-27T13:48:21.346538+00:00","name":"tf-vol-nice-bhabha","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.050336+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-frosty-gould","id":"3de4c610-2143-4305-a211-9c4098e590f9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"202","node_id":"8","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:d9","maintenances":[],"modification_date":"2025-02-11T14:22:43.072489+00:00","name":"tf-srv-frosty-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:22:37.050336+00:00","export_uri":null,"id":"4e63a045-02a7-4ad3-bb80-477e9dbb0490","modification_date":"2025-02-11T14:22:37.050336+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140054+00:00","export_uri":null,"id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","modification_date":"2025-02-11T14:22:39.266244+00:00","name":"tf-vol-youthful-fermi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2778"
+                - "2759"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:51 GMT
+                - Tue, 11 Feb 2025 14:22:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -999,10 +999,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d4e67a5c-1390-4ee9-9474-8966825f14a5
+                - 1beacd0f-b300-4039-b1ab-16778b6e91fe
         status: 200 OK
         code: 200
-        duration: 178.093875ms
+        duration: 135.288916ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1018,8 +1018,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/00478d4e-a51c-4ea1-a991-ad3deea73514
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3de4c610-2143-4305-a211-9c4098e590f9
         method: GET
       response:
         proto: HTTP/2.0
@@ -1027,20 +1027,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2809
+        content_length: 2790
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:18.833411+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-blackburn","id":"00478d4e-a51c-4ea1-a991-ad3deea73514","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"1701","node_id":"17","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:cf","maintenances":[],"modification_date":"2025-01-27T13:48:54.194214+00:00","name":"tf-srv-strange-blackburn","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:18.833411+00:00","export_uri":null,"id":"baed541a-7caa-437a-90d4-7f10d775e6ef","modification_date":"2025-01-27T13:48:18.833411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:48:18.113957+00:00","export_uri":null,"id":"817ef76c-fa77-4898-b677-8bb0712019fb","modification_date":"2025-01-27T13:48:21.346538+00:00","name":"tf-vol-nice-bhabha","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.050336+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-frosty-gould","id":"3de4c610-2143-4305-a211-9c4098e590f9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"202","node_id":"8","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:d9","maintenances":[],"modification_date":"2025-02-11T14:22:58.247587+00:00","name":"tf-srv-frosty-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:22:37.050336+00:00","export_uri":null,"id":"4e63a045-02a7-4ad3-bb80-477e9dbb0490","modification_date":"2025-02-11T14:22:37.050336+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140054+00:00","export_uri":null,"id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","modification_date":"2025-02-11T14:22:39.266244+00:00","name":"tf-vol-youthful-fermi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2809"
+                - "2790"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:56 GMT
+                - Tue, 11 Feb 2025 14:22:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1048,10 +1048,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 039a908b-6c39-46b2-a70a-104b48a21e64
+                - a4694006-db68-49e9-89f1-fc5707ffeb4b
         status: 200 OK
         code: 200
-        duration: 169.270416ms
+        duration: 151.454625ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1067,8 +1067,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/00478d4e-a51c-4ea1-a991-ad3deea73514
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3de4c610-2143-4305-a211-9c4098e590f9
         method: GET
       response:
         proto: HTTP/2.0
@@ -1076,20 +1076,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2809
+        content_length: 2790
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:18.833411+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-blackburn","id":"00478d4e-a51c-4ea1-a991-ad3deea73514","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"1701","node_id":"17","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:cf","maintenances":[],"modification_date":"2025-01-27T13:48:54.194214+00:00","name":"tf-srv-strange-blackburn","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:18.833411+00:00","export_uri":null,"id":"baed541a-7caa-437a-90d4-7f10d775e6ef","modification_date":"2025-01-27T13:48:18.833411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:48:18.113957+00:00","export_uri":null,"id":"817ef76c-fa77-4898-b677-8bb0712019fb","modification_date":"2025-01-27T13:48:21.346538+00:00","name":"tf-vol-nice-bhabha","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.050336+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-frosty-gould","id":"3de4c610-2143-4305-a211-9c4098e590f9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"202","node_id":"8","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:d9","maintenances":[],"modification_date":"2025-02-11T14:22:58.247587+00:00","name":"tf-srv-frosty-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:22:37.050336+00:00","export_uri":null,"id":"4e63a045-02a7-4ad3-bb80-477e9dbb0490","modification_date":"2025-02-11T14:22:37.050336+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140054+00:00","export_uri":null,"id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","modification_date":"2025-02-11T14:22:39.266244+00:00","name":"tf-vol-youthful-fermi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2809"
+                - "2790"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:56 GMT
+                - Tue, 11 Feb 2025 14:22:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1097,10 +1097,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9b7d02e1-ad4d-4b83-a0da-5ef5b22c7df6
+                - b682718a-f96b-4366-9844-721fd7bc649a
         status: 200 OK
         code: 200
-        duration: 190.987958ms
+        duration: 137.413541ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1116,8 +1116,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/baed541a-7caa-437a-90d4-7f10d775e6ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/4e63a045-02a7-4ad3-bb80-477e9dbb0490
         method: GET
       response:
         proto: HTTP/2.0
@@ -1125,20 +1125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 524
+        content_length: 519
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:18.833411+00:00","export_uri":null,"id":"baed541a-7caa-437a-90d4-7f10d775e6ef","modification_date":"2025-01-27T13:48:18.833411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:37.050336+00:00","export_uri":null,"id":"4e63a045-02a7-4ad3-bb80-477e9dbb0490","modification_date":"2025-02-11T14:22:37.050336+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "524"
+                - "519"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:56 GMT
+                - Tue, 11 Feb 2025 14:22:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1146,10 +1146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0154b0a9-0c11-4662-8fbb-996a656d3c10
+                - 1c9b3d63-e290-4e1a-ba5d-3ac97008e54e
         status: 200 OK
         code: 200
-        duration: 91.088125ms
+        duration: 99.7335ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1165,8 +1165,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/00478d4e-a51c-4ea1-a991-ad3deea73514/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3de4c610-2143-4305-a211-9c4098e590f9/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1185,9 +1185,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:56 GMT
+                - Tue, 11 Feb 2025 14:22:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1195,10 +1195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 61fd8204-0d96-4957-894d-25d8d27dc226
+                - d349b7bc-1ac2-47fd-81b9-20030550dc0f
         status: 200 OK
         code: 200
-        duration: 121.942167ms
+        duration: 85.277666ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1214,8 +1214,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/00478d4e-a51c-4ea1-a991-ad3deea73514/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3de4c610-2143-4305-a211-9c4098e590f9/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1234,11 +1234,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:56 GMT
+                - Tue, 11 Feb 2025 14:22:59 GMT
             Link:
-                - </servers/00478d4e-a51c-4ea1-a991-ad3deea73514/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/3de4c610-2143-4305-a211-9c4098e590f9/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1246,12 +1246,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 34d903d0-2610-43d9-9011-80ce8e4f597c
+                - f397f4dc-fd76-4a2f-a089-87cb6400a954
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 149.41475ms
+        duration: 119.814709ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1267,8 +1267,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/40dbe32f-3bb2-48e3-9115-ccb957845697
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/444bfd94-a046-48ee-b4ce-bdbfa50aad1a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1276,20 +1276,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 528
+        content_length: 527
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"817ef76c-fa77-4898-b677-8bb0712019fb","name":"tf-vol-nice-bhabha"},"creation_date":"2025-01-27T13:48:18.460767+00:00","error_details":null,"id":"40dbe32f-3bb2-48e3-9115-ccb957845697","modification_date":"2025-01-27T13:48:21.346538+00:00","name":"tf-snap-vigorous-khorana","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","name":"tf-vol-youthful-fermi"},"creation_date":"2025-02-11T14:22:36.578181+00:00","error_details":null,"id":"444bfd94-a046-48ee-b4ce-bdbfa50aad1a","modification_date":"2025-02-11T14:22:39.266244+00:00","name":"tf-snap-awesome-benz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "528"
+                - "527"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:57 GMT
+                - Tue, 11 Feb 2025 14:22:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1297,10 +1297,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9499063d-8784-4589-abff-ab46a56c7163
+                - 10928650-f8b8-436e-a609-92636c3d2b52
         status: 200 OK
         code: 200
-        duration: 160.1295ms
+        duration: 88.85075ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1316,8 +1316,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/817ef76c-fa77-4898-b677-8bb0712019fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1325,20 +1325,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 518
+        content_length: 516
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:18.113957+00:00","export_uri":null,"id":"817ef76c-fa77-4898-b677-8bb0712019fb","modification_date":"2025-01-27T13:48:21.346538+00:00","name":"tf-vol-nice-bhabha","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:36.140054+00:00","export_uri":null,"id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","modification_date":"2025-02-11T14:22:39.266244+00:00","name":"tf-vol-youthful-fermi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "518"
+                - "516"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:57 GMT
+                - Tue, 11 Feb 2025 14:22:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1346,10 +1346,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1893ca1d-0cdc-4ec9-bab9-acc0f8685c8d
+                - 9fed931c-7f86-4260-ba34-94756c87c9d5
         status: 200 OK
         code: 200
-        duration: 133.9235ms
+        duration: 73.539667ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1365,8 +1365,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/40dbe32f-3bb2-48e3-9115-ccb957845697
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/444bfd94-a046-48ee-b4ce-bdbfa50aad1a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1374,20 +1374,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 528
+        content_length: 527
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"817ef76c-fa77-4898-b677-8bb0712019fb","name":"tf-vol-nice-bhabha"},"creation_date":"2025-01-27T13:48:18.460767+00:00","error_details":null,"id":"40dbe32f-3bb2-48e3-9115-ccb957845697","modification_date":"2025-01-27T13:48:21.346538+00:00","name":"tf-snap-vigorous-khorana","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","name":"tf-vol-youthful-fermi"},"creation_date":"2025-02-11T14:22:36.578181+00:00","error_details":null,"id":"444bfd94-a046-48ee-b4ce-bdbfa50aad1a","modification_date":"2025-02-11T14:22:39.266244+00:00","name":"tf-snap-awesome-benz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "528"
+                - "527"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:57 GMT
+                - Tue, 11 Feb 2025 14:22:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1395,10 +1395,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6c96688f-f068-4f79-8a4c-124ddd04e225
+                - 80abc9b8-3b21-44a1-844d-5313506d10c4
         status: 200 OK
         code: 200
-        duration: 173.42925ms
+        duration: 83.088917ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1414,8 +1414,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/00478d4e-a51c-4ea1-a991-ad3deea73514
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3de4c610-2143-4305-a211-9c4098e590f9
         method: GET
       response:
         proto: HTTP/2.0
@@ -1423,20 +1423,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2809
+        content_length: 2790
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:18.833411+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-blackburn","id":"00478d4e-a51c-4ea1-a991-ad3deea73514","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"1701","node_id":"17","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:cf","maintenances":[],"modification_date":"2025-01-27T13:48:54.194214+00:00","name":"tf-srv-strange-blackburn","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:18.833411+00:00","export_uri":null,"id":"baed541a-7caa-437a-90d4-7f10d775e6ef","modification_date":"2025-01-27T13:48:18.833411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:48:18.113957+00:00","export_uri":null,"id":"817ef76c-fa77-4898-b677-8bb0712019fb","modification_date":"2025-01-27T13:48:21.346538+00:00","name":"tf-vol-nice-bhabha","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.050336+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-frosty-gould","id":"3de4c610-2143-4305-a211-9c4098e590f9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"202","node_id":"8","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:d9","maintenances":[],"modification_date":"2025-02-11T14:22:58.247587+00:00","name":"tf-srv-frosty-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:22:37.050336+00:00","export_uri":null,"id":"4e63a045-02a7-4ad3-bb80-477e9dbb0490","modification_date":"2025-02-11T14:22:37.050336+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140054+00:00","export_uri":null,"id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","modification_date":"2025-02-11T14:22:39.266244+00:00","name":"tf-vol-youthful-fermi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2809"
+                - "2790"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:57 GMT
+                - Tue, 11 Feb 2025 14:22:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1444,10 +1444,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 07e2933d-f791-435f-840c-8ba11d55cf6d
+                - dd8da062-a2c1-4030-a956-d35ca0d2c926
         status: 200 OK
         code: 200
-        duration: 186.598125ms
+        duration: 128.641959ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1463,8 +1463,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/baed541a-7caa-437a-90d4-7f10d775e6ef
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/4e63a045-02a7-4ad3-bb80-477e9dbb0490
         method: GET
       response:
         proto: HTTP/2.0
@@ -1472,20 +1472,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 524
+        content_length: 519
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:18.833411+00:00","export_uri":null,"id":"baed541a-7caa-437a-90d4-7f10d775e6ef","modification_date":"2025-01-27T13:48:18.833411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:37.050336+00:00","export_uri":null,"id":"4e63a045-02a7-4ad3-bb80-477e9dbb0490","modification_date":"2025-02-11T14:22:37.050336+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "524"
+                - "519"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:57 GMT
+                - Tue, 11 Feb 2025 14:22:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1493,10 +1493,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 856a5e95-885d-4e4b-bd16-1b2b500cfa4d
+                - b3e76de2-d6d1-4af2-b932-3949107e71ce
         status: 200 OK
         code: 200
-        duration: 162.993875ms
+        duration: 89.460541ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1512,8 +1512,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/00478d4e-a51c-4ea1-a991-ad3deea73514/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3de4c610-2143-4305-a211-9c4098e590f9/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1532,9 +1532,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:57 GMT
+                - Tue, 11 Feb 2025 14:22:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1542,10 +1542,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 17a7e077-7d9b-4154-a676-0d4d0bec65e6
+                - ccea0dd1-fef5-4c62-b37d-2be471a0ccd1
         status: 200 OK
         code: 200
-        duration: 123.808125ms
+        duration: 87.95525ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1561,8 +1561,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/00478d4e-a51c-4ea1-a991-ad3deea73514/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3de4c610-2143-4305-a211-9c4098e590f9/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1581,11 +1581,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:58 GMT
+                - Tue, 11 Feb 2025 14:23:00 GMT
             Link:
-                - </servers/00478d4e-a51c-4ea1-a991-ad3deea73514/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/3de4c610-2143-4305-a211-9c4098e590f9/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1593,12 +1593,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 52f40237-f214-4916-845b-7f93bfb541a7
+                - d189ab82-8642-427a-a6a4-7c4399e51bc2
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 180.900834ms
+        duration: 77.500417ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1614,8 +1614,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/40dbe32f-3bb2-48e3-9115-ccb957845697
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/444bfd94-a046-48ee-b4ce-bdbfa50aad1a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1623,20 +1623,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 528
+        content_length: 527
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"817ef76c-fa77-4898-b677-8bb0712019fb","name":"tf-vol-nice-bhabha"},"creation_date":"2025-01-27T13:48:18.460767+00:00","error_details":null,"id":"40dbe32f-3bb2-48e3-9115-ccb957845697","modification_date":"2025-01-27T13:48:21.346538+00:00","name":"tf-snap-vigorous-khorana","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","name":"tf-vol-youthful-fermi"},"creation_date":"2025-02-11T14:22:36.578181+00:00","error_details":null,"id":"444bfd94-a046-48ee-b4ce-bdbfa50aad1a","modification_date":"2025-02-11T14:22:39.266244+00:00","name":"tf-snap-awesome-benz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "528"
+                - "527"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:58 GMT
+                - Tue, 11 Feb 2025 14:23:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1644,10 +1644,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bebbbd34-5cf5-4aee-b353-a2035bb7b28e
+                - 9803e21e-cd1c-4013-9680-bd19feb79c27
         status: 200 OK
         code: 200
-        duration: 202.653917ms
+        duration: 96.663333ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1663,8 +1663,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/00478d4e-a51c-4ea1-a991-ad3deea73514
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3de4c610-2143-4305-a211-9c4098e590f9
         method: GET
       response:
         proto: HTTP/2.0
@@ -1672,20 +1672,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2809
+        content_length: 2790
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:18.833411+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-blackburn","id":"00478d4e-a51c-4ea1-a991-ad3deea73514","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"1701","node_id":"17","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:cf","maintenances":[],"modification_date":"2025-01-27T13:48:54.194214+00:00","name":"tf-srv-strange-blackburn","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:18.833411+00:00","export_uri":null,"id":"baed541a-7caa-437a-90d4-7f10d775e6ef","modification_date":"2025-01-27T13:48:18.833411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:48:18.113957+00:00","export_uri":null,"id":"817ef76c-fa77-4898-b677-8bb0712019fb","modification_date":"2025-01-27T13:48:21.346538+00:00","name":"tf-vol-nice-bhabha","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.050336+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-frosty-gould","id":"3de4c610-2143-4305-a211-9c4098e590f9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"202","node_id":"8","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:d9","maintenances":[],"modification_date":"2025-02-11T14:22:58.247587+00:00","name":"tf-srv-frosty-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:22:37.050336+00:00","export_uri":null,"id":"4e63a045-02a7-4ad3-bb80-477e9dbb0490","modification_date":"2025-02-11T14:22:37.050336+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140054+00:00","export_uri":null,"id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","modification_date":"2025-02-11T14:22:39.266244+00:00","name":"tf-vol-youthful-fermi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2809"
+                - "2790"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:58 GMT
+                - Tue, 11 Feb 2025 14:23:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1693,10 +1693,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0ab3b516-380e-4f9b-a2c8-9f5279ab11e7
+                - 229ff02a-d404-424a-a66d-0beb86f301cd
         status: 200 OK
         code: 200
-        duration: 201.931917ms
+        duration: 134.795125ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1712,8 +1712,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/40dbe32f-3bb2-48e3-9115-ccb957845697
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/444bfd94-a046-48ee-b4ce-bdbfa50aad1a
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1730,9 +1730,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:58 GMT
+                - Tue, 11 Feb 2025 14:23:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1740,10 +1740,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3f89fece-9049-475f-bb61-f0f3cc0ccfd1
+                - d52fb9c0-02bc-4d02-8884-a3bb603fa120
         status: 204 No Content
         code: 204
-        duration: 176.1335ms
+        duration: 165.589ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1759,8 +1759,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/40dbe32f-3bb2-48e3-9115-ccb957845697
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/444bfd94-a046-48ee-b4ce-bdbfa50aad1a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1770,7 +1770,7 @@ interactions:
         trailer: {}
         content_length: 145
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"40dbe32f-3bb2-48e3-9115-ccb957845697","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"444bfd94-a046-48ee-b4ce-bdbfa50aad1a","type":"not_found"}'
         headers:
             Content-Length:
                 - "145"
@@ -1779,9 +1779,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:59 GMT
+                - Tue, 11 Feb 2025 14:23:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1789,10 +1789,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b15d7745-2bef-4c47-9f91-46caf58a5350
+                - 939d824a-cd02-48de-8fe8-59db60458f7a
         status: 404 Not Found
         code: 404
-        duration: 133.478375ms
+        duration: 38.781334ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1810,8 +1810,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/00478d4e-a51c-4ea1-a991-ad3deea73514/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3de4c610-2143-4305-a211-9c4098e590f9/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -1821,7 +1821,7 @@ interactions:
         trailer: {}
         content_length: 352
         uncompressed: false
-        body: '{"task":{"description":"server_poweroff","href_from":"/servers/00478d4e-a51c-4ea1-a991-ad3deea73514/action","href_result":"/servers/00478d4e-a51c-4ea1-a991-ad3deea73514","id":"3baaf47f-e509-4f48-b066-3ee0ad528068","progress":0,"started_at":"2025-01-27T13:48:59.133985+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_poweroff","href_from":"/servers/3de4c610-2143-4305-a211-9c4098e590f9/action","href_result":"/servers/3de4c610-2143-4305-a211-9c4098e590f9","id":"a814462a-0187-401b-b555-8aa1defcb93b","progress":0,"started_at":"2025-02-11T14:23:00.795762+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "352"
@@ -1830,11 +1830,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:58 GMT
+                - Tue, 11 Feb 2025 14:23:00 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/3baaf47f-e509-4f48-b066-3ee0ad528068
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/a814462a-0187-401b-b555-8aa1defcb93b
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1842,10 +1842,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c7b7bc3f-5c4b-4edb-a408-326718a18472
+                - 77191095-e465-4aef-9d33-5f603e64f758
         status: 202 Accepted
         code: 202
-        duration: 309.912083ms
+        duration: 253.27425ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1861,8 +1861,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/00478d4e-a51c-4ea1-a991-ad3deea73514
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3de4c610-2143-4305-a211-9c4098e590f9
         method: GET
       response:
         proto: HTTP/2.0
@@ -1870,20 +1870,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2769
+        content_length: 2750
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:18.833411+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-blackburn","id":"00478d4e-a51c-4ea1-a991-ad3deea73514","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"1701","node_id":"17","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:cf","maintenances":[],"modification_date":"2025-01-27T13:48:58.920206+00:00","name":"tf-srv-strange-blackburn","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:18.833411+00:00","export_uri":null,"id":"baed541a-7caa-437a-90d4-7f10d775e6ef","modification_date":"2025-01-27T13:48:18.833411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:48:18.113957+00:00","export_uri":null,"id":"817ef76c-fa77-4898-b677-8bb0712019fb","modification_date":"2025-01-27T13:48:21.346538+00:00","name":"tf-vol-nice-bhabha","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.050336+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-frosty-gould","id":"3de4c610-2143-4305-a211-9c4098e590f9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"202","node_id":"8","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:d9","maintenances":[],"modification_date":"2025-02-11T14:23:00.591750+00:00","name":"tf-srv-frosty-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:22:37.050336+00:00","export_uri":null,"id":"4e63a045-02a7-4ad3-bb80-477e9dbb0490","modification_date":"2025-02-11T14:22:37.050336+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140054+00:00","export_uri":null,"id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","modification_date":"2025-02-11T14:22:39.266244+00:00","name":"tf-vol-youthful-fermi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2769"
+                - "2750"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:59 GMT
+                - Tue, 11 Feb 2025 14:23:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1891,10 +1891,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c5ba79c5-644e-4473-8d8d-f1d3b2ea2400
+                - 42c7cea7-3e8c-40fc-8f95-505d12738ae6
         status: 200 OK
         code: 200
-        duration: 186.510167ms
+        duration: 163.575833ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1910,8 +1910,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/00478d4e-a51c-4ea1-a991-ad3deea73514
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3de4c610-2143-4305-a211-9c4098e590f9
         method: GET
       response:
         proto: HTTP/2.0
@@ -1919,20 +1919,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2769
+        content_length: 2750
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:18.833411+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-blackburn","id":"00478d4e-a51c-4ea1-a991-ad3deea73514","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"1701","node_id":"17","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:cf","maintenances":[],"modification_date":"2025-01-27T13:48:58.920206+00:00","name":"tf-srv-strange-blackburn","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:18.833411+00:00","export_uri":null,"id":"baed541a-7caa-437a-90d4-7f10d775e6ef","modification_date":"2025-01-27T13:48:18.833411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:48:18.113957+00:00","export_uri":null,"id":"817ef76c-fa77-4898-b677-8bb0712019fb","modification_date":"2025-01-27T13:48:21.346538+00:00","name":"tf-vol-nice-bhabha","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.050336+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-frosty-gould","id":"3de4c610-2143-4305-a211-9c4098e590f9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"202","node_id":"8","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:d9","maintenances":[],"modification_date":"2025-02-11T14:23:00.591750+00:00","name":"tf-srv-frosty-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:22:37.050336+00:00","export_uri":null,"id":"4e63a045-02a7-4ad3-bb80-477e9dbb0490","modification_date":"2025-02-11T14:22:37.050336+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140054+00:00","export_uri":null,"id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","modification_date":"2025-02-11T14:22:39.266244+00:00","name":"tf-vol-youthful-fermi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2769"
+                - "2750"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:04 GMT
+                - Tue, 11 Feb 2025 14:23:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1940,10 +1940,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5e76118c-3168-4fd9-b1b3-b9b3250ce561
+                - 60c77ea8-8f6a-49bc-9a5b-1f05939c0d49
         status: 200 OK
         code: 200
-        duration: 157.957958ms
+        duration: 134.040708ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1959,8 +1959,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/00478d4e-a51c-4ea1-a991-ad3deea73514
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3de4c610-2143-4305-a211-9c4098e590f9
         method: GET
       response:
         proto: HTTP/2.0
@@ -1968,20 +1968,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2769
+        content_length: 2750
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:18.833411+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-blackburn","id":"00478d4e-a51c-4ea1-a991-ad3deea73514","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"1701","node_id":"17","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:cf","maintenances":[],"modification_date":"2025-01-27T13:48:58.920206+00:00","name":"tf-srv-strange-blackburn","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:18.833411+00:00","export_uri":null,"id":"baed541a-7caa-437a-90d4-7f10d775e6ef","modification_date":"2025-01-27T13:48:18.833411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:48:18.113957+00:00","export_uri":null,"id":"817ef76c-fa77-4898-b677-8bb0712019fb","modification_date":"2025-01-27T13:48:21.346538+00:00","name":"tf-vol-nice-bhabha","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.050336+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-frosty-gould","id":"3de4c610-2143-4305-a211-9c4098e590f9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"202","node_id":"8","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:d9","maintenances":[],"modification_date":"2025-02-11T14:23:00.591750+00:00","name":"tf-srv-frosty-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:22:37.050336+00:00","export_uri":null,"id":"4e63a045-02a7-4ad3-bb80-477e9dbb0490","modification_date":"2025-02-11T14:22:37.050336+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140054+00:00","export_uri":null,"id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","modification_date":"2025-02-11T14:22:39.266244+00:00","name":"tf-vol-youthful-fermi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2769"
+                - "2750"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:09 GMT
+                - Tue, 11 Feb 2025 14:23:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1989,10 +1989,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b713eede-e534-4243-ace9-bfc909c2a501
+                - 7de99992-2f16-4938-97f2-d81e86764ac9
         status: 200 OK
         code: 200
-        duration: 248.290542ms
+        duration: 164.448417ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2008,8 +2008,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/00478d4e-a51c-4ea1-a991-ad3deea73514
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3de4c610-2143-4305-a211-9c4098e590f9
         method: GET
       response:
         proto: HTTP/2.0
@@ -2017,20 +2017,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2769
+        content_length: 2750
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:18.833411+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-blackburn","id":"00478d4e-a51c-4ea1-a991-ad3deea73514","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"1701","node_id":"17","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:cf","maintenances":[],"modification_date":"2025-01-27T13:48:58.920206+00:00","name":"tf-srv-strange-blackburn","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:18.833411+00:00","export_uri":null,"id":"baed541a-7caa-437a-90d4-7f10d775e6ef","modification_date":"2025-01-27T13:48:18.833411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:48:18.113957+00:00","export_uri":null,"id":"817ef76c-fa77-4898-b677-8bb0712019fb","modification_date":"2025-01-27T13:48:21.346538+00:00","name":"tf-vol-nice-bhabha","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.050336+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-frosty-gould","id":"3de4c610-2143-4305-a211-9c4098e590f9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"202","node_id":"8","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:d9","maintenances":[],"modification_date":"2025-02-11T14:23:00.591750+00:00","name":"tf-srv-frosty-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:22:37.050336+00:00","export_uri":null,"id":"4e63a045-02a7-4ad3-bb80-477e9dbb0490","modification_date":"2025-02-11T14:22:37.050336+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140054+00:00","export_uri":null,"id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","modification_date":"2025-02-11T14:22:39.266244+00:00","name":"tf-vol-youthful-fermi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2769"
+                - "2750"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:14 GMT
+                - Tue, 11 Feb 2025 14:23:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2038,10 +2038,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 36c7b563-b9af-409f-9ea1-2c25a214cc89
+                - 7b4fbcae-3055-42ea-bebd-703de99e4aa0
         status: 200 OK
         code: 200
-        duration: 148.346958ms
+        duration: 123.218916ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2057,8 +2057,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/00478d4e-a51c-4ea1-a991-ad3deea73514
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3de4c610-2143-4305-a211-9c4098e590f9
         method: GET
       response:
         proto: HTTP/2.0
@@ -2066,20 +2066,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2769
+        content_length: 2750
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:18.833411+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-blackburn","id":"00478d4e-a51c-4ea1-a991-ad3deea73514","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"1701","node_id":"17","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:cf","maintenances":[],"modification_date":"2025-01-27T13:48:58.920206+00:00","name":"tf-srv-strange-blackburn","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:18.833411+00:00","export_uri":null,"id":"baed541a-7caa-437a-90d4-7f10d775e6ef","modification_date":"2025-01-27T13:48:18.833411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:48:18.113957+00:00","export_uri":null,"id":"817ef76c-fa77-4898-b677-8bb0712019fb","modification_date":"2025-01-27T13:48:21.346538+00:00","name":"tf-vol-nice-bhabha","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.050336+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-frosty-gould","id":"3de4c610-2143-4305-a211-9c4098e590f9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"202","node_id":"8","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:d9","maintenances":[],"modification_date":"2025-02-11T14:23:00.591750+00:00","name":"tf-srv-frosty-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:22:37.050336+00:00","export_uri":null,"id":"4e63a045-02a7-4ad3-bb80-477e9dbb0490","modification_date":"2025-02-11T14:22:37.050336+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140054+00:00","export_uri":null,"id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","modification_date":"2025-02-11T14:22:39.266244+00:00","name":"tf-vol-youthful-fermi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2769"
+                - "2750"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:20 GMT
+                - Tue, 11 Feb 2025 14:23:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2087,10 +2087,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 56aa38ef-a0c7-4c39-9a0b-e93b9aa842a9
+                - 90212c14-678f-4917-a62a-cb5bfea90f31
         status: 200 OK
         code: 200
-        duration: 203.6045ms
+        duration: 154.305375ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2106,8 +2106,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/00478d4e-a51c-4ea1-a991-ad3deea73514
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3de4c610-2143-4305-a211-9c4098e590f9
         method: GET
       response:
         proto: HTTP/2.0
@@ -2115,20 +2115,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2769
+        content_length: 2750
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:18.833411+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-blackburn","id":"00478d4e-a51c-4ea1-a991-ad3deea73514","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"1701","node_id":"17","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:cf","maintenances":[],"modification_date":"2025-01-27T13:48:58.920206+00:00","name":"tf-srv-strange-blackburn","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:18.833411+00:00","export_uri":null,"id":"baed541a-7caa-437a-90d4-7f10d775e6ef","modification_date":"2025-01-27T13:48:18.833411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:48:18.113957+00:00","export_uri":null,"id":"817ef76c-fa77-4898-b677-8bb0712019fb","modification_date":"2025-01-27T13:48:21.346538+00:00","name":"tf-vol-nice-bhabha","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.050336+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-frosty-gould","id":"3de4c610-2143-4305-a211-9c4098e590f9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"202","node_id":"8","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:d9","maintenances":[],"modification_date":"2025-02-11T14:23:00.591750+00:00","name":"tf-srv-frosty-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:22:37.050336+00:00","export_uri":null,"id":"4e63a045-02a7-4ad3-bb80-477e9dbb0490","modification_date":"2025-02-11T14:22:37.050336+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140054+00:00","export_uri":null,"id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","modification_date":"2025-02-11T14:22:39.266244+00:00","name":"tf-vol-youthful-fermi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2769"
+                - "2750"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:24 GMT
+                - Tue, 11 Feb 2025 14:23:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2136,10 +2136,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 49bc5b6c-9cc0-4e7f-8ae2-d1d672598c69
+                - 5194a451-416d-4081-828a-9715e6d2050d
         status: 200 OK
         code: 200
-        duration: 145.309ms
+        duration: 146.315458ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2155,8 +2155,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/00478d4e-a51c-4ea1-a991-ad3deea73514
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3de4c610-2143-4305-a211-9c4098e590f9
         method: GET
       response:
         proto: HTTP/2.0
@@ -2164,20 +2164,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2769
+        content_length: 2750
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:18.833411+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-blackburn","id":"00478d4e-a51c-4ea1-a991-ad3deea73514","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"1701","node_id":"17","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:cf","maintenances":[],"modification_date":"2025-01-27T13:48:58.920206+00:00","name":"tf-srv-strange-blackburn","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:18.833411+00:00","export_uri":null,"id":"baed541a-7caa-437a-90d4-7f10d775e6ef","modification_date":"2025-01-27T13:48:18.833411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:48:18.113957+00:00","export_uri":null,"id":"817ef76c-fa77-4898-b677-8bb0712019fb","modification_date":"2025-01-27T13:48:21.346538+00:00","name":"tf-vol-nice-bhabha","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.050336+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-frosty-gould","id":"3de4c610-2143-4305-a211-9c4098e590f9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"202","node_id":"8","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:d9","maintenances":[],"modification_date":"2025-02-11T14:23:00.591750+00:00","name":"tf-srv-frosty-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:22:37.050336+00:00","export_uri":null,"id":"4e63a045-02a7-4ad3-bb80-477e9dbb0490","modification_date":"2025-02-11T14:22:37.050336+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140054+00:00","export_uri":null,"id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","modification_date":"2025-02-11T14:22:39.266244+00:00","name":"tf-vol-youthful-fermi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2769"
+                - "2750"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:29 GMT
+                - Tue, 11 Feb 2025 14:23:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2185,10 +2185,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4924c08d-49e7-4c8a-bd19-aa5251e7cb2e
+                - 7255de32-78e7-4484-af04-57a280b86719
         status: 200 OK
         code: 200
-        duration: 146.557833ms
+        duration: 146.692875ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2204,8 +2204,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/00478d4e-a51c-4ea1-a991-ad3deea73514
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3de4c610-2143-4305-a211-9c4098e590f9
         method: GET
       response:
         proto: HTTP/2.0
@@ -2213,20 +2213,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2769
+        content_length: 2750
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:18.833411+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-blackburn","id":"00478d4e-a51c-4ea1-a991-ad3deea73514","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"1701","node_id":"17","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:cf","maintenances":[],"modification_date":"2025-01-27T13:48:58.920206+00:00","name":"tf-srv-strange-blackburn","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:18.833411+00:00","export_uri":null,"id":"baed541a-7caa-437a-90d4-7f10d775e6ef","modification_date":"2025-01-27T13:48:18.833411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:48:18.113957+00:00","export_uri":null,"id":"817ef76c-fa77-4898-b677-8bb0712019fb","modification_date":"2025-01-27T13:48:21.346538+00:00","name":"tf-vol-nice-bhabha","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.050336+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-frosty-gould","id":"3de4c610-2143-4305-a211-9c4098e590f9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"202","node_id":"8","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:6d:d9","maintenances":[],"modification_date":"2025-02-11T14:23:00.591750+00:00","name":"tf-srv-frosty-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:22:37.050336+00:00","export_uri":null,"id":"4e63a045-02a7-4ad3-bb80-477e9dbb0490","modification_date":"2025-02-11T14:22:37.050336+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140054+00:00","export_uri":null,"id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","modification_date":"2025-02-11T14:22:39.266244+00:00","name":"tf-vol-youthful-fermi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2769"
+                - "2750"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:35 GMT
+                - Tue, 11 Feb 2025 14:23:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2234,10 +2234,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0f226a90-5fca-4540-80d2-22356328c665
+                - 94cc2064-ada3-4f6e-9acc-0bc7c4b1ad1a
         status: 200 OK
         code: 200
-        duration: 180.54925ms
+        duration: 187.412667ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2253,8 +2253,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/00478d4e-a51c-4ea1-a991-ad3deea73514
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3de4c610-2143-4305-a211-9c4098e590f9
         method: GET
       response:
         proto: HTTP/2.0
@@ -2262,20 +2262,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2769
+        content_length: 2635
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:18.833411+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-blackburn","id":"00478d4e-a51c-4ea1-a991-ad3deea73514","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"19","hypervisor_id":"1701","node_id":"17","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:cf","maintenances":[],"modification_date":"2025-01-27T13:48:58.920206+00:00","name":"tf-srv-strange-blackburn","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:18.833411+00:00","export_uri":null,"id":"baed541a-7caa-437a-90d4-7f10d775e6ef","modification_date":"2025-01-27T13:48:18.833411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:48:18.113957+00:00","export_uri":null,"id":"817ef76c-fa77-4898-b677-8bb0712019fb","modification_date":"2025-01-27T13:48:21.346538+00:00","name":"tf-vol-nice-bhabha","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.050336+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-frosty-gould","id":"3de4c610-2143-4305-a211-9c4098e590f9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:d9","maintenances":[],"modification_date":"2025-02-11T14:23:41.955606+00:00","name":"tf-srv-frosty-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:22:37.050336+00:00","export_uri":null,"id":"4e63a045-02a7-4ad3-bb80-477e9dbb0490","modification_date":"2025-02-11T14:22:37.050336+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140054+00:00","export_uri":null,"id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","modification_date":"2025-02-11T14:22:39.266244+00:00","name":"tf-vol-youthful-fermi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2769"
+                - "2635"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:40 GMT
+                - Tue, 11 Feb 2025 14:23:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2283,10 +2283,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 32987ea7-fb1e-4f7c-8f52-5b5e9f965a5e
+                - 52cc7a1b-b9a3-417d-8e7a-923416068bab
         status: 200 OK
         code: 200
-        duration: 209.288958ms
+        duration: 151.003667ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2302,8 +2302,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/00478d4e-a51c-4ea1-a991-ad3deea73514
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3de4c610-2143-4305-a211-9c4098e590f9
         method: GET
       response:
         proto: HTTP/2.0
@@ -2311,20 +2311,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2652
+        content_length: 2635
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:18.833411+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-blackburn","id":"00478d4e-a51c-4ea1-a991-ad3deea73514","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:cf","maintenances":[],"modification_date":"2025-01-27T13:49:42.586977+00:00","name":"tf-srv-strange-blackburn","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:18.833411+00:00","export_uri":null,"id":"baed541a-7caa-437a-90d4-7f10d775e6ef","modification_date":"2025-01-27T13:48:18.833411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:48:18.113957+00:00","export_uri":null,"id":"817ef76c-fa77-4898-b677-8bb0712019fb","modification_date":"2025-01-27T13:48:21.346538+00:00","name":"tf-vol-nice-bhabha","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-11T14:22:37.050336+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-frosty-gould","id":"3de4c610-2143-4305-a211-9c4098e590f9","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:6d:d9","maintenances":[],"modification_date":"2025-02-11T14:23:41.955606+00:00","name":"tf-srv-frosty-gould","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-11T14:22:37.050336+00:00","export_uri":null,"id":"4e63a045-02a7-4ad3-bb80-477e9dbb0490","modification_date":"2025-02-11T14:22:37.050336+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-02-11T14:22:36.140054+00:00","export_uri":null,"id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","modification_date":"2025-02-11T14:22:39.266244+00:00","name":"tf-vol-youthful-fermi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3de4c610-2143-4305-a211-9c4098e590f9","name":"tf-srv-frosty-gould"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2652"
+                - "2635"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:45 GMT
+                - Tue, 11 Feb 2025 14:23:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2332,10 +2332,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 71fa4ca9-0fab-4794-a12a-bec826a18240
+                - 670cb569-46b4-473e-9959-c69bfa0ff7ec
         status: 200 OK
         code: 200
-        duration: 139.067458ms
+        duration: 135.497792ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2351,29 +2351,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/00478d4e-a51c-4ea1-a991-ad3deea73514
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3de4c610-2143-4305-a211-9c4098e590f9
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2652
+        content_length: 0
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:18.833411+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-blackburn","id":"00478d4e-a51c-4ea1-a991-ad3deea73514","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:cf","maintenances":[],"modification_date":"2025-01-27T13:49:42.586977+00:00","name":"tf-srv-strange-blackburn","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:18.833411+00:00","export_uri":null,"id":"baed541a-7caa-437a-90d4-7f10d775e6ef","modification_date":"2025-01-27T13:48:18.833411+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2025-01-27T13:48:18.113957+00:00","export_uri":null,"id":"817ef76c-fa77-4898-b677-8bb0712019fb","modification_date":"2025-01-27T13:48:21.346538+00:00","name":"tf-vol-nice-bhabha","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00478d4e-a51c-4ea1-a991-ad3deea73514","name":"tf-srv-strange-blackburn"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: ""
         headers:
-            Content-Length:
-                - "2652"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:46 GMT
+                - Tue, 11 Feb 2025 14:23:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2381,10 +2379,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 43320896-f0cc-4c3c-b1f9-84225ff8dc02
-        status: 200 OK
-        code: 200
-        duration: 138.205167ms
+                - 50247b00-eea5-4e00-9757-12e0a009de9b
+        status: 204 No Content
+        code: 204
+        duration: 189.222291ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2400,27 +2398,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/00478d4e-a51c-4ea1-a991-ad3deea73514
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3de4c610-2143-4305-a211-9c4098e590f9
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 143
         uncompressed: false
-        body: ""
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"3de4c610-2143-4305-a211-9c4098e590f9","type":"not_found"}'
         headers:
+            Content-Length:
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:46 GMT
+                - Tue, 11 Feb 2025 14:23:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2428,10 +2428,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f09edf8b-d6a8-4f3b-9af1-afb1078788a6
-        status: 204 No Content
-        code: 204
-        duration: 190.605375ms
+                - f9a63624-71ec-435c-8887-4001b3d7204d
+        status: 404 Not Found
+        code: 404
+        duration: 67.58775ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2447,8 +2447,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/00478d4e-a51c-4ea1-a991-ad3deea73514
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/4e63a045-02a7-4ad3-bb80-477e9dbb0490
         method: GET
       response:
         proto: HTTP/2.0
@@ -2456,20 +2456,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 143
+        content_length: 446
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"00478d4e-a51c-4ea1-a991-ad3deea73514","type":"not_found"}'
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:37.050336+00:00","export_uri":null,"id":"4e63a045-02a7-4ad3-bb80-477e9dbb0490","modification_date":"2025-02-11T14:23:42.367318+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "143"
+                - "446"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:46 GMT
+                - Tue, 11 Feb 2025 14:23:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2477,10 +2477,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3414a966-bf2a-4ff4-a68c-e90f088e875a
-        status: 404 Not Found
-        code: 404
-        duration: 104.898417ms
+                - a99270a9-a94c-46d6-9ac8-2236e0fed10d
+        status: 200 OK
+        code: 200
+        duration: 73.887125ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -2496,29 +2496,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/baed541a-7caa-437a-90d4-7f10d775e6ef
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/4e63a045-02a7-4ad3-bb80-477e9dbb0490
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 446
+        content_length: 0
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:18.833411+00:00","export_uri":null,"id":"baed541a-7caa-437a-90d4-7f10d775e6ef","modification_date":"2025-01-27T13:49:46.187958+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: ""
         headers:
-            Content-Length:
-                - "446"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:46 GMT
+                - Tue, 11 Feb 2025 14:23:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2526,10 +2524,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e691a794-81f0-4f54-a3e2-babaf42c2dcd
-        status: 200 OK
-        code: 200
-        duration: 88.038208ms
+                - 763d98fd-c655-4465-8d8e-364fd4b50132
+        status: 204 No Content
+        code: 204
+        duration: 160.328042ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2545,27 +2543,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/baed541a-7caa-437a-90d4-7f10d775e6ef
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 443
         uncompressed: false
-        body: ""
+        body: '{"volume":{"creation_date":"2025-02-11T14:22:36.140054+00:00","export_uri":null,"id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","modification_date":"2025-02-11T14:23:42.367318+00:00","name":"tf-vol-youthful-fermi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
         headers:
+            Content-Length:
+                - "443"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:46 GMT
+                - Tue, 11 Feb 2025 14:23:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2573,10 +2573,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ead2b68b-cf29-4160-96ee-a1fd36d8f216
-        status: 204 No Content
-        code: 204
-        duration: 173.858417ms
+                - fbe8ad91-52b3-4f98-89b7-be2c215cdc59
+        status: 200 OK
+        code: 200
+        duration: 80.197834ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -2592,57 +2592,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/817ef76c-fa77-4898-b677-8bb0712019fb
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 440
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:18.113957+00:00","export_uri":null,"id":"817ef76c-fa77-4898-b677-8bb0712019fb","modification_date":"2025-01-27T13:49:46.187958+00:00","name":"tf-vol-nice-bhabha","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "440"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:49:46 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 5e9feec8-4577-4a47-9697-070ca95e3253
-        status: 200 OK
-        code: 200
-        duration: 108.652417ms
-    - id: 53
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/817ef76c-fa77-4898-b677-8bb0712019fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2659,9 +2610,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:46 GMT
+                - Tue, 11 Feb 2025 14:23:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2669,10 +2620,59 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 549d6640-72ef-48b0-8d4b-59b7ce63d048
+                - b5b2c95e-0268-4519-ab57-3b3ef23cbe90
         status: 204 No Content
         code: 204
-        duration: 168.357875ms
+        duration: 176.197166ms
+    - id: 53
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"55e5eb1c-b7e1-467c-b8d7-6cc7a42f5bf1","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 11 Feb 2025 14:23:43 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 890e5630-556b-4192-be58-1f93a99b5cb7
+        status: 404 Not Found
+        code: 404
+        duration: 872.114542ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -2688,8 +2688,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/817ef76c-fa77-4898-b677-8bb0712019fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3de4c610-2143-4305-a211-9c4098e590f9
         method: GET
       response:
         proto: HTTP/2.0
@@ -2699,7 +2699,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"817ef76c-fa77-4898-b677-8bb0712019fb","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"3de4c610-2143-4305-a211-9c4098e590f9","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -2708,9 +2708,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:46 GMT
+                - Tue, 11 Feb 2025 14:23:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2718,10 +2718,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - aed04f94-e62e-4d84-b008-a1706c2782a6
+                - 36812921-1d25-4152-a924-7fd1b6c66766
         status: 404 Not Found
         code: 404
-        duration: 27.081834ms
+        duration: 83.50275ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -2737,57 +2737,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/00478d4e-a51c-4ea1-a991-ad3deea73514
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 143
-        uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"00478d4e-a51c-4ea1-a991-ad3deea73514","type":"not_found"}'
-        headers:
-            Content-Length:
-                - "143"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:49:47 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - ca9028ca-fbc6-4801-90f0-75f9a4ea16bd
-        status: 404 Not Found
-        code: 404
-        duration: 175.724375ms
-    - id: 56
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/40dbe32f-3bb2-48e3-9115-ccb957845697
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/444bfd94-a046-48ee-b4ce-bdbfa50aad1a
         method: GET
       response:
         proto: HTTP/2.0
@@ -2797,7 +2748,7 @@ interactions:
         trailer: {}
         content_length: 145
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"40dbe32f-3bb2-48e3-9115-ccb957845697","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"444bfd94-a046-48ee-b4ce-bdbfa50aad1a","type":"not_found"}'
         headers:
             Content-Length:
                 - "145"
@@ -2806,9 +2757,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:46 GMT
+                - Tue, 11 Feb 2025 14:23:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-1;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2816,7 +2767,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a8e9c8fc-ebab-43da-813d-317b3bbf86ed
+                - b38a3c04-2736-4446-95f6-0adcf2d8c6c1
         status: 404 Not Found
         code: 404
-        duration: 52.968792ms
+        duration: 41.193625ms

--- a/internal/services/instance/testdata/snapshot-server.cassette.yaml
+++ b/internal/services/instance/testdata/snapshot-server.cassette.yaml
@@ -16,7 +16,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
         method: GET
       response:
@@ -25,22 +25,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 38539
+        content_length: 35639
         uncompressed: false
-        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
+        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
         headers:
             Content-Length:
-                - "38539"
+                - "35639"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:19 GMT
+                - Wed, 12 Feb 2025 15:00:24 GMT
             Link:
                 - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,12 +48,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6571b56c-f6a5-415a-898d-13d8ca72ae8a
+                - 28a30ace-59b2-4411-a1e2-a6fc612c152e
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 39.177875ms
+        duration: 348.815417ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -69,7 +69,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
         method: GET
       response:
@@ -78,22 +78,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 14208
+        content_length: 13164
         uncompressed: false
-        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
         headers:
             Content-Length:
-                - "14208"
+                - "13164"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:19 GMT
+                - Wed, 12 Feb 2025 15:00:24 GMT
             Link:
                 - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -101,12 +101,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9e0af562-1ff7-462e-9832-fde4877f10fa
+                - 27ab5cc5-cca2-4f83-b3a8-6093a06c06c0
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 63.631625ms
+        duration: 63.6445ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -122,7 +122,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_local&zone=fr-par-1
         method: GET
       response:
@@ -142,9 +142,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:20 GMT
+                - Wed, 12 Feb 2025 15:00:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -152,28 +152,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 64238e21-a2ea-4b2f-9dac-b994026cc8e4
+                - b9a00f2c-297e-4619-a508-f05a997d9446
         status: 200 OK
         code: 200
-        duration: 72.361875ms
+        duration: 96.681417ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 276
+        content_length: 271
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-srv-awesome-bardeen","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+        body: '{"name":"tf-srv-angry-wing","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
         method: POST
       response:
@@ -182,22 +182,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2118
+        content_length: 2103
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:20.295686+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-bardeen","id":"c6fd4733-bf24-4bc2-b94c-ab2ed17a656b","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:d3","maintenances":[],"modification_date":"2025-01-27T13:48:20.295686+00:00","name":"tf-srv-awesome-bardeen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:20.295686+00:00","export_uri":null,"id":"8f5869c8-8e4c-445d-9dbe-37f47aa0a318","modification_date":"2025-01-27T13:48:20.295686+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c6fd4733-bf24-4bc2-b94c-ab2ed17a656b","name":"tf-srv-awesome-bardeen"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:00:25.242726+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-angry-wing","id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c2:bd","maintenances":[],"modification_date":"2025-02-12T15:00:25.242726+00:00","name":"tf-srv-angry-wing","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:00:25.242726+00:00","export_uri":null,"id":"18766887-538a-418b-856c-ea9a92807d65","modification_date":"2025-02-12T15:00:25.242726+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","name":"tf-srv-angry-wing"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2118"
+                - "2103"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:20 GMT
+                - Wed, 12 Feb 2025 15:00:25 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c6fd4733-bf24-4bc2-b94c-ab2ed17a656b
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d4d6af7-481d-45b4-a1de-af5fe7fa05eb
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -205,10 +205,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 04fe2421-caee-4b5e-bf43-afcded7c6f65
+                - 59346505-9bf2-41d2-a3d1-d82ab9266711
         status: 201 Created
         code: 201
-        duration: 550.233167ms
+        duration: 757.071125ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -224,8 +224,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c6fd4733-bf24-4bc2-b94c-ab2ed17a656b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d4d6af7-481d-45b4-a1de-af5fe7fa05eb
         method: GET
       response:
         proto: HTTP/2.0
@@ -233,20 +233,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2118
+        content_length: 2103
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:20.295686+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-bardeen","id":"c6fd4733-bf24-4bc2-b94c-ab2ed17a656b","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:d3","maintenances":[],"modification_date":"2025-01-27T13:48:20.295686+00:00","name":"tf-srv-awesome-bardeen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:20.295686+00:00","export_uri":null,"id":"8f5869c8-8e4c-445d-9dbe-37f47aa0a318","modification_date":"2025-01-27T13:48:20.295686+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c6fd4733-bf24-4bc2-b94c-ab2ed17a656b","name":"tf-srv-awesome-bardeen"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:00:25.242726+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-angry-wing","id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c2:bd","maintenances":[],"modification_date":"2025-02-12T15:00:25.242726+00:00","name":"tf-srv-angry-wing","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:00:25.242726+00:00","export_uri":null,"id":"18766887-538a-418b-856c-ea9a92807d65","modification_date":"2025-02-12T15:00:25.242726+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","name":"tf-srv-angry-wing"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2118"
+                - "2103"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:20 GMT
+                - Wed, 12 Feb 2025 15:00:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -254,10 +254,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dc43dcb1-d45f-4e9c-9902-9c38f02bccbe
+                - b0eff407-6714-4dd7-a372-e7ff603fcf96
         status: 200 OK
         code: 200
-        duration: 131.598542ms
+        duration: 203.327375ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -273,8 +273,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c6fd4733-bf24-4bc2-b94c-ab2ed17a656b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d4d6af7-481d-45b4-a1de-af5fe7fa05eb
         method: GET
       response:
         proto: HTTP/2.0
@@ -282,20 +282,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2118
+        content_length: 2103
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:20.295686+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-bardeen","id":"c6fd4733-bf24-4bc2-b94c-ab2ed17a656b","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:d3","maintenances":[],"modification_date":"2025-01-27T13:48:20.295686+00:00","name":"tf-srv-awesome-bardeen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:20.295686+00:00","export_uri":null,"id":"8f5869c8-8e4c-445d-9dbe-37f47aa0a318","modification_date":"2025-01-27T13:48:20.295686+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c6fd4733-bf24-4bc2-b94c-ab2ed17a656b","name":"tf-srv-awesome-bardeen"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:00:25.242726+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-angry-wing","id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c2:bd","maintenances":[],"modification_date":"2025-02-12T15:00:25.242726+00:00","name":"tf-srv-angry-wing","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:00:25.242726+00:00","export_uri":null,"id":"18766887-538a-418b-856c-ea9a92807d65","modification_date":"2025-02-12T15:00:25.242726+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","name":"tf-srv-angry-wing"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2118"
+                - "2103"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:20 GMT
+                - Wed, 12 Feb 2025 15:00:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -303,10 +303,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9501b946-cff9-467a-8e28-298dcb998348
+                - 3284952d-538e-4af6-a26f-6eaea51f1ba2
         status: 200 OK
         code: 200
-        duration: 160.529708ms
+        duration: 303.142875ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -324,8 +324,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c6fd4733-bf24-4bc2-b94c-ab2ed17a656b/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d4d6af7-481d-45b4-a1de-af5fe7fa05eb/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -335,7 +335,7 @@ interactions:
         trailer: {}
         content_length: 357
         uncompressed: false
-        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/c6fd4733-bf24-4bc2-b94c-ab2ed17a656b/action","href_result":"/servers/c6fd4733-bf24-4bc2-b94c-ab2ed17a656b","id":"bfb3daf9-dce1-4b94-8ded-0c88c40bb2b3","progress":0,"started_at":"2025-01-27T13:48:21.120135+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/1d4d6af7-481d-45b4-a1de-af5fe7fa05eb/action","href_result":"/servers/1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","id":"dbd782aa-47db-41f5-b27a-7cdfbc3e0ab9","progress":0,"started_at":"2025-02-12T15:00:26.575591+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -344,11 +344,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:20 GMT
+                - Wed, 12 Feb 2025 15:00:26 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/bfb3daf9-dce1-4b94-8ded-0c88c40bb2b3
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/dbd782aa-47db-41f5-b27a-7cdfbc3e0ab9
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -356,10 +356,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bade6d93-162e-4a34-b4ec-4b3c65488b9e
+                - 826b1968-e1c4-4bbd-8ea6-3ea025ad335a
         status: 202 Accepted
         code: 202
-        duration: 273.36525ms
+        duration: 511.911375ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -375,8 +375,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c6fd4733-bf24-4bc2-b94c-ab2ed17a656b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d4d6af7-481d-45b4-a1de-af5fe7fa05eb
         method: GET
       response:
         proto: HTTP/2.0
@@ -384,20 +384,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2140
+        content_length: 2125
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:20.295686+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-bardeen","id":"c6fd4733-bf24-4bc2-b94c-ab2ed17a656b","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:d3","maintenances":[],"modification_date":"2025-01-27T13:48:20.903207+00:00","name":"tf-srv-awesome-bardeen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:20.295686+00:00","export_uri":null,"id":"8f5869c8-8e4c-445d-9dbe-37f47aa0a318","modification_date":"2025-01-27T13:48:20.295686+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c6fd4733-bf24-4bc2-b94c-ab2ed17a656b","name":"tf-srv-awesome-bardeen"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:00:25.242726+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-angry-wing","id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c2:bd","maintenances":[],"modification_date":"2025-02-12T15:00:26.322482+00:00","name":"tf-srv-angry-wing","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:00:25.242726+00:00","export_uri":null,"id":"18766887-538a-418b-856c-ea9a92807d65","modification_date":"2025-02-12T15:00:25.242726+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","name":"tf-srv-angry-wing"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2140"
+                - "2125"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:20 GMT
+                - Wed, 12 Feb 2025 15:00:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -405,10 +405,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 304a8c8b-0666-4cd4-bd85-634c1ef1eac9
+                - 1e653af8-624d-4ddd-901c-e0c6e45193c5
         status: 200 OK
         code: 200
-        duration: 123.787667ms
+        duration: 193.040959ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -424,8 +424,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c6fd4733-bf24-4bc2-b94c-ab2ed17a656b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d4d6af7-481d-45b4-a1de-af5fe7fa05eb
         method: GET
       response:
         proto: HTTP/2.0
@@ -433,20 +433,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2273
+        content_length: 2228
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:20.295686+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-bardeen","id":"c6fd4733-bf24-4bc2-b94c-ab2ed17a656b","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"43","hypervisor_id":"804","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:d3","maintenances":[],"modification_date":"2025-01-27T13:48:29.966487+00:00","name":"tf-srv-awesome-bardeen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:20.295686+00:00","export_uri":null,"id":"8f5869c8-8e4c-445d-9dbe-37f47aa0a318","modification_date":"2025-01-27T13:48:20.295686+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c6fd4733-bf24-4bc2-b94c-ab2ed17a656b","name":"tf-srv-awesome-bardeen"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:00:25.242726+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-angry-wing","id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1202","node_id":"2","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c2:bd","maintenances":[],"modification_date":"2025-02-12T15:00:26.322482+00:00","name":"tf-srv-angry-wing","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:00:25.242726+00:00","export_uri":null,"id":"18766887-538a-418b-856c-ea9a92807d65","modification_date":"2025-02-12T15:00:25.242726+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","name":"tf-srv-angry-wing"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2273"
+                - "2228"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:38 GMT
+                - Wed, 12 Feb 2025 15:00:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -454,10 +454,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1f229544-150b-408b-b74f-9788626e98a9
+                - 76d5a5ca-9984-471d-b5c0-5a6a3687aa97
         status: 200 OK
         code: 200
-        duration: 13.550487167s
+        duration: 205.42225ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -473,8 +473,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c6fd4733-bf24-4bc2-b94c-ab2ed17a656b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d4d6af7-481d-45b4-a1de-af5fe7fa05eb
         method: GET
       response:
         proto: HTTP/2.0
@@ -482,20 +482,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2273
+        content_length: 2228
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:20.295686+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-bardeen","id":"c6fd4733-bf24-4bc2-b94c-ab2ed17a656b","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"43","hypervisor_id":"804","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:d3","maintenances":[],"modification_date":"2025-01-27T13:48:29.966487+00:00","name":"tf-srv-awesome-bardeen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:20.295686+00:00","export_uri":null,"id":"8f5869c8-8e4c-445d-9dbe-37f47aa0a318","modification_date":"2025-01-27T13:48:20.295686+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c6fd4733-bf24-4bc2-b94c-ab2ed17a656b","name":"tf-srv-awesome-bardeen"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:00:25.242726+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-angry-wing","id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1202","node_id":"2","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c2:bd","maintenances":[],"modification_date":"2025-02-12T15:00:26.322482+00:00","name":"tf-srv-angry-wing","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:00:25.242726+00:00","export_uri":null,"id":"18766887-538a-418b-856c-ea9a92807d65","modification_date":"2025-02-12T15:00:25.242726+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","name":"tf-srv-angry-wing"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2273"
+                - "2228"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:39 GMT
+                - Wed, 12 Feb 2025 15:00:37 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -503,10 +503,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8f4bff4b-a269-4a64-b3db-9964e5b70b0c
+                - 28c2b7b9-34da-4524-b41a-8c75729ae6d4
         status: 200 OK
         code: 200
-        duration: 1.273192541s
+        duration: 552.376458ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -522,8 +522,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/8f5869c8-8e4c-445d-9dbe-37f47aa0a318
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d4d6af7-481d-45b4-a1de-af5fe7fa05eb
         method: GET
       response:
         proto: HTTP/2.0
@@ -531,20 +531,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 522
+        content_length: 2228
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:20.295686+00:00","export_uri":null,"id":"8f5869c8-8e4c-445d-9dbe-37f47aa0a318","modification_date":"2025-01-27T13:48:20.295686+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c6fd4733-bf24-4bc2-b94c-ab2ed17a656b","name":"tf-srv-awesome-bardeen"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:00:25.242726+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-angry-wing","id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1202","node_id":"2","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c2:bd","maintenances":[],"modification_date":"2025-02-12T15:00:26.322482+00:00","name":"tf-srv-angry-wing","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:00:25.242726+00:00","export_uri":null,"id":"18766887-538a-418b-856c-ea9a92807d65","modification_date":"2025-02-12T15:00:25.242726+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","name":"tf-srv-angry-wing"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "522"
+                - "2228"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:41 GMT
+                - Wed, 12 Feb 2025 15:00:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -552,10 +552,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6ad436b2-adb5-4303-a093-9b93ec65619f
+                - d7ba11a8-7b20-44b0-9054-461d8a72c3c4
         status: 200 OK
         code: 200
-        duration: 97.900208ms
+        duration: 209.937125ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -571,8 +571,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c6fd4733-bf24-4bc2-b94c-ab2ed17a656b/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d4d6af7-481d-45b4-a1de-af5fe7fa05eb
         method: GET
       response:
         proto: HTTP/2.0
@@ -580,20 +580,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 2259
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:00:25.242726+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-angry-wing","id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1202","node_id":"2","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c2:bd","maintenances":[],"modification_date":"2025-02-12T15:00:45.290151+00:00","name":"tf-srv-angry-wing","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:00:25.242726+00:00","export_uri":null,"id":"18766887-538a-418b-856c-ea9a92807d65","modification_date":"2025-02-12T15:00:25.242726+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","name":"tf-srv-angry-wing"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "17"
+                - "2259"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:40 GMT
+                - Wed, 12 Feb 2025 15:00:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -601,10 +601,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c5f89289-1ee0-4286-87ea-e10c109352fa
+                - 7b1a7035-9d6b-4e87-acb8-ec489fb881b1
         status: 200 OK
         code: 200
-        duration: 82.959042ms
+        duration: 405.06925ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -620,8 +620,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c6fd4733-bf24-4bc2-b94c-ab2ed17a656b/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d4d6af7-481d-45b4-a1de-af5fe7fa05eb
         method: GET
       response:
         proto: HTTP/2.0
@@ -629,22 +629,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20
+        content_length: 2259
         uncompressed: false
-        body: '{"private_nics":[]}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:00:25.242726+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-angry-wing","id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1202","node_id":"2","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c2:bd","maintenances":[],"modification_date":"2025-02-12T15:00:45.290151+00:00","name":"tf-srv-angry-wing","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:00:25.242726+00:00","export_uri":null,"id":"18766887-538a-418b-856c-ea9a92807d65","modification_date":"2025-02-12T15:00:25.242726+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","name":"tf-srv-angry-wing"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "20"
+                - "2259"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:41 GMT
-            Link:
-                - </servers/c6fd4733-bf24-4bc2-b94c-ab2ed17a656b/private_nics?page=0&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 15:00:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -652,52 +650,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2e42fce3-b498-45ac-be63-1f79aa347973
-            X-Total-Count:
-                - "0"
+                - 4cb347a1-4597-4c1c-9ddc-c54f5412444e
         status: 200 OK
         code: 200
-        duration: 98.627875ms
+        duration: 230.101583ms
     - id: 13
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 137
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-snap-gallant-goldwasser","volume_id":"8f5869c8-8e4c-445d-9dbe-37f47aa0a318","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/18766887-538a-418b-856c-ea9a92807d65
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 850
+        content_length: 517
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"8f5869c8-8e4c-445d-9dbe-37f47aa0a318","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:48:41.530616+00:00","error_details":null,"id":"b5f721ef-1f1c-4406-8d88-b82f0d38150e","modification_date":"2025-01-27T13:48:41.530616+00:00","name":"tf-snap-gallant-goldwasser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"task":{"description":"volume_snapshot","href_from":"/snapshots","href_result":"snapshots/b5f721ef-1f1c-4406-8d88-b82f0d38150e","id":"1ab0f87c-d14e-4d64-b377-5fe502827f00","progress":0,"started_at":"2025-01-27T13:48:41.842331+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"volume":{"creation_date":"2025-02-12T15:00:25.242726+00:00","export_uri":null,"id":"18766887-538a-418b-856c-ea9a92807d65","modification_date":"2025-02-12T15:00:25.242726+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","name":"tf-srv-angry-wing"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "850"
+                - "517"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:48:41 GMT
+                - Wed, 12 Feb 2025 15:00:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -705,10 +699,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d611dd64-7152-4fd2-86fa-d9c8f0018b02
-        status: 201 Created
-        code: 201
-        duration: 572.050709ms
+                - 2fb36f3b-5551-4fc6-a6b9-d96e913687f1
+        status: 200 OK
+        code: 200
+        duration: 310.748ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -724,498 +718,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/b5f721ef-1f1c-4406-8d88-b82f0d38150e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 539
-        uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"8f5869c8-8e4c-445d-9dbe-37f47aa0a318","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:48:41.530616+00:00","error_details":null,"id":"b5f721ef-1f1c-4406-8d88-b82f0d38150e","modification_date":"2025-01-27T13:48:41.530616+00:00","name":"tf-snap-gallant-goldwasser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "539"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:48:41 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 7517534a-7dcb-44bc-bf99-9674e0cff295
-        status: 200 OK
-        code: 200
-        duration: 90.363334ms
-    - id: 15
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/b5f721ef-1f1c-4406-8d88-b82f0d38150e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 539
-        uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"8f5869c8-8e4c-445d-9dbe-37f47aa0a318","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:48:41.530616+00:00","error_details":null,"id":"b5f721ef-1f1c-4406-8d88-b82f0d38150e","modification_date":"2025-01-27T13:48:41.530616+00:00","name":"tf-snap-gallant-goldwasser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "539"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:48:46 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 2dd9b23b-3d44-43e5-948c-36718e3a7142
-        status: 200 OK
-        code: 200
-        duration: 83.110625ms
-    - id: 16
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/b5f721ef-1f1c-4406-8d88-b82f0d38150e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 539
-        uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"8f5869c8-8e4c-445d-9dbe-37f47aa0a318","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:48:41.530616+00:00","error_details":null,"id":"b5f721ef-1f1c-4406-8d88-b82f0d38150e","modification_date":"2025-01-27T13:48:41.530616+00:00","name":"tf-snap-gallant-goldwasser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "539"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:48:51 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 54e7f565-c552-43bb-b4c7-18c49fc804ad
-        status: 200 OK
-        code: 200
-        duration: 74.883084ms
-    - id: 17
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/b5f721ef-1f1c-4406-8d88-b82f0d38150e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 539
-        uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"8f5869c8-8e4c-445d-9dbe-37f47aa0a318","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:48:41.530616+00:00","error_details":null,"id":"b5f721ef-1f1c-4406-8d88-b82f0d38150e","modification_date":"2025-01-27T13:48:41.530616+00:00","name":"tf-snap-gallant-goldwasser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "539"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:48:56 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 7dfb77a2-632c-4897-976d-cf0a5a2f1b81
-        status: 200 OK
-        code: 200
-        duration: 162.387208ms
-    - id: 18
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/b5f721ef-1f1c-4406-8d88-b82f0d38150e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 539
-        uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"8f5869c8-8e4c-445d-9dbe-37f47aa0a318","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:48:41.530616+00:00","error_details":null,"id":"b5f721ef-1f1c-4406-8d88-b82f0d38150e","modification_date":"2025-01-27T13:48:41.530616+00:00","name":"tf-snap-gallant-goldwasser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "539"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:49:02 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - a7387a88-cb70-4326-9839-905ff8995487
-        status: 200 OK
-        code: 200
-        duration: 97.248417ms
-    - id: 19
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/b5f721ef-1f1c-4406-8d88-b82f0d38150e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 536
-        uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"8f5869c8-8e4c-445d-9dbe-37f47aa0a318","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:48:41.530616+00:00","error_details":null,"id":"b5f721ef-1f1c-4406-8d88-b82f0d38150e","modification_date":"2025-01-27T13:49:06.022372+00:00","name":"tf-snap-gallant-goldwasser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "536"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:49:07 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 747c1768-32fb-48af-a7fb-eb90f963db74
-        status: 200 OK
-        code: 200
-        duration: 102.018667ms
-    - id: 20
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/b5f721ef-1f1c-4406-8d88-b82f0d38150e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 536
-        uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"8f5869c8-8e4c-445d-9dbe-37f47aa0a318","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:48:41.530616+00:00","error_details":null,"id":"b5f721ef-1f1c-4406-8d88-b82f0d38150e","modification_date":"2025-01-27T13:49:06.022372+00:00","name":"tf-snap-gallant-goldwasser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "536"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:49:07 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - deccb06b-0c4e-4b83-94e2-24342627e055
-        status: 200 OK
-        code: 200
-        duration: 128.460167ms
-    - id: 21
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/b5f721ef-1f1c-4406-8d88-b82f0d38150e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 536
-        uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"8f5869c8-8e4c-445d-9dbe-37f47aa0a318","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:48:41.530616+00:00","error_details":null,"id":"b5f721ef-1f1c-4406-8d88-b82f0d38150e","modification_date":"2025-01-27T13:49:06.022372+00:00","name":"tf-snap-gallant-goldwasser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "536"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:49:07 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 551095a6-f73c-40c3-9167-0fe34fbb881d
-        status: 200 OK
-        code: 200
-        duration: 97.121583ms
-    - id: 22
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c6fd4733-bf24-4bc2-b94c-ab2ed17a656b
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2273
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:20.295686+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-bardeen","id":"c6fd4733-bf24-4bc2-b94c-ab2ed17a656b","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"43","hypervisor_id":"804","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:d3","maintenances":[],"modification_date":"2025-01-27T13:48:29.966487+00:00","name":"tf-srv-awesome-bardeen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:20.295686+00:00","export_uri":null,"id":"8f5869c8-8e4c-445d-9dbe-37f47aa0a318","modification_date":"2025-01-27T13:49:06.022372+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c6fd4733-bf24-4bc2-b94c-ab2ed17a656b","name":"tf-srv-awesome-bardeen"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2273"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:49:08 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - a18fd443-1488-4852-9b40-0a27661ec415
-        status: 200 OK
-        code: 200
-        duration: 173.779416ms
-    - id: 23
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/8f5869c8-8e4c-445d-9dbe-37f47aa0a318
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 522
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:20.295686+00:00","export_uri":null,"id":"8f5869c8-8e4c-445d-9dbe-37f47aa0a318","modification_date":"2025-01-27T13:49:06.022372+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c6fd4733-bf24-4bc2-b94c-ab2ed17a656b","name":"tf-srv-awesome-bardeen"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "522"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:49:07 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 86d1d2ab-ef52-490d-88fa-b68227e5fe01
-        status: 200 OK
-        code: 200
-        duration: 136.637583ms
-    - id: 24
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c6fd4733-bf24-4bc2-b94c-ab2ed17a656b/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d4d6af7-481d-45b4-a1de-af5fe7fa05eb/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -1234,9 +738,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:08 GMT
+                - Wed, 12 Feb 2025 15:00:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1244,11 +748,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 09a86510-e1ec-49e3-b3f8-732ccf78d30a
+                - cb4de2d9-3ffc-4f3d-ab04-1357fc058cb4
         status: 200 OK
         code: 200
-        duration: 88.550417ms
-    - id: 25
+        duration: 113.584417ms
+    - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1263,8 +767,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c6fd4733-bf24-4bc2-b94c-ab2ed17a656b/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d4d6af7-481d-45b4-a1de-af5fe7fa05eb/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -1283,11 +787,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:08 GMT
+                - Wed, 12 Feb 2025 15:00:48 GMT
             Link:
-                - </servers/c6fd4733-bf24-4bc2-b94c-ab2ed17a656b/private_nics?page=0&per_page=50&>; rel="last"
+                - </servers/1d4d6af7-481d-45b4-a1de-af5fe7fa05eb/private_nics?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1295,12 +799,504 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - de7bf46c-8a44-47fb-bf4d-f783a51a6144
+                - d75da8e3-efa1-4b1c-921d-4f273d1f1a7d
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 82.493625ms
+        duration: 125.23225ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 131
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf-snap-silly-shtern","volume_id":"18766887-538a-418b-856c-ea9a92807d65","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 844
+        uncompressed: false
+        body: '{"snapshot":{"base_volume":{"id":"18766887-538a-418b-856c-ea9a92807d65","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:00:49.268988+00:00","error_details":null,"id":"8aa1b0c1-7e2d-4202-9ae7-c6f6d45b3be5","modification_date":"2025-02-12T15:00:49.268988+00:00","name":"tf-snap-silly-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"task":{"description":"volume_snapshot","href_from":"/snapshots","href_result":"snapshots/8aa1b0c1-7e2d-4202-9ae7-c6f6d45b3be5","id":"4faf3bb1-d14c-4554-b466-01f6b68896ea","progress":0,"started_at":"2025-02-12T15:00:49.591439+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "844"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:00:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 54e9ba52-8c88-45f9-8ee8-3dcc69968820
+        status: 201 Created
+        code: 201
+        duration: 877.22875ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/8aa1b0c1-7e2d-4202-9ae7-c6f6d45b3be5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 533
+        uncompressed: false
+        body: '{"snapshot":{"base_volume":{"id":"18766887-538a-418b-856c-ea9a92807d65","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:00:49.268988+00:00","error_details":null,"id":"8aa1b0c1-7e2d-4202-9ae7-c6f6d45b3be5","modification_date":"2025-02-12T15:00:49.268988+00:00","name":"tf-snap-silly-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "533"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:00:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 588901d8-2786-4092-906c-86da57057b45
+        status: 200 OK
+        code: 200
+        duration: 143.368042ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/8aa1b0c1-7e2d-4202-9ae7-c6f6d45b3be5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 533
+        uncompressed: false
+        body: '{"snapshot":{"base_volume":{"id":"18766887-538a-418b-856c-ea9a92807d65","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:00:49.268988+00:00","error_details":null,"id":"8aa1b0c1-7e2d-4202-9ae7-c6f6d45b3be5","modification_date":"2025-02-12T15:00:49.268988+00:00","name":"tf-snap-silly-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "533"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:00:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 08e9af29-9125-40e9-b29d-24e33ae08b06
+        status: 200 OK
+        code: 200
+        duration: 119.211416ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/8aa1b0c1-7e2d-4202-9ae7-c6f6d45b3be5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 533
+        uncompressed: false
+        body: '{"snapshot":{"base_volume":{"id":"18766887-538a-418b-856c-ea9a92807d65","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:00:49.268988+00:00","error_details":null,"id":"8aa1b0c1-7e2d-4202-9ae7-c6f6d45b3be5","modification_date":"2025-02-12T15:00:49.268988+00:00","name":"tf-snap-silly-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "533"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:00:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9a17bb32-736e-4f4e-aa8e-b39c93509cf9
+        status: 200 OK
+        code: 200
+        duration: 110.799917ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/8aa1b0c1-7e2d-4202-9ae7-c6f6d45b3be5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 533
+        uncompressed: false
+        body: '{"snapshot":{"base_volume":{"id":"18766887-538a-418b-856c-ea9a92807d65","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:00:49.268988+00:00","error_details":null,"id":"8aa1b0c1-7e2d-4202-9ae7-c6f6d45b3be5","modification_date":"2025-02-12T15:00:49.268988+00:00","name":"tf-snap-silly-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "533"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:01:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 608aa9e2-fc5b-497b-882b-846ac1263d06
+        status: 200 OK
+        code: 200
+        duration: 112.348709ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/8aa1b0c1-7e2d-4202-9ae7-c6f6d45b3be5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 533
+        uncompressed: false
+        body: '{"snapshot":{"base_volume":{"id":"18766887-538a-418b-856c-ea9a92807d65","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:00:49.268988+00:00","error_details":null,"id":"8aa1b0c1-7e2d-4202-9ae7-c6f6d45b3be5","modification_date":"2025-02-12T15:00:49.268988+00:00","name":"tf-snap-silly-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "533"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:01:10 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 892a86d8-783a-47b7-8c29-0a8e666a735e
+        status: 200 OK
+        code: 200
+        duration: 97.328334ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/8aa1b0c1-7e2d-4202-9ae7-c6f6d45b3be5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 533
+        uncompressed: false
+        body: '{"snapshot":{"base_volume":{"id":"18766887-538a-418b-856c-ea9a92807d65","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:00:49.268988+00:00","error_details":null,"id":"8aa1b0c1-7e2d-4202-9ae7-c6f6d45b3be5","modification_date":"2025-02-12T15:00:49.268988+00:00","name":"tf-snap-silly-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "533"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:01:15 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1e2a3e81-d0af-419d-8aa0-819c48f278cc
+        status: 200 OK
+        code: 200
+        duration: 128.089958ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/8aa1b0c1-7e2d-4202-9ae7-c6f6d45b3be5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 533
+        uncompressed: false
+        body: '{"snapshot":{"base_volume":{"id":"18766887-538a-418b-856c-ea9a92807d65","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:00:49.268988+00:00","error_details":null,"id":"8aa1b0c1-7e2d-4202-9ae7-c6f6d45b3be5","modification_date":"2025-02-12T15:00:49.268988+00:00","name":"tf-snap-silly-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "533"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:01:20 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4d3f47bd-c72b-469b-8c51-dd1d600bc6c8
+        status: 200 OK
+        code: 200
+        duration: 117.130083ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/8aa1b0c1-7e2d-4202-9ae7-c6f6d45b3be5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 533
+        uncompressed: false
+        body: '{"snapshot":{"base_volume":{"id":"18766887-538a-418b-856c-ea9a92807d65","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:00:49.268988+00:00","error_details":null,"id":"8aa1b0c1-7e2d-4202-9ae7-c6f6d45b3be5","modification_date":"2025-02-12T15:00:49.268988+00:00","name":"tf-snap-silly-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "533"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:01:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b783cbd1-93a4-4f07-81a2-3c101a27246e
+        status: 200 OK
+        code: 200
+        duration: 108.697792ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/8aa1b0c1-7e2d-4202-9ae7-c6f6d45b3be5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 530
+        uncompressed: false
+        body: '{"snapshot":{"base_volume":{"id":"18766887-538a-418b-856c-ea9a92807d65","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:00:49.268988+00:00","error_details":null,"id":"8aa1b0c1-7e2d-4202-9ae7-c6f6d45b3be5","modification_date":"2025-02-12T15:01:27.457730+00:00","name":"tf-snap-silly-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "530"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:01:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3565ad93-bb8e-4c1e-8497-4fd216ec15a8
+        status: 200 OK
+        code: 200
+        duration: 144.784917ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1316,8 +1312,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/b5f721ef-1f1c-4406-8d88-b82f0d38150e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/8aa1b0c1-7e2d-4202-9ae7-c6f6d45b3be5
         method: GET
       response:
         proto: HTTP/2.0
@@ -1325,20 +1321,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 536
+        content_length: 530
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"8f5869c8-8e4c-445d-9dbe-37f47aa0a318","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:48:41.530616+00:00","error_details":null,"id":"b5f721ef-1f1c-4406-8d88-b82f0d38150e","modification_date":"2025-01-27T13:49:06.022372+00:00","name":"tf-snap-gallant-goldwasser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"18766887-538a-418b-856c-ea9a92807d65","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:00:49.268988+00:00","error_details":null,"id":"8aa1b0c1-7e2d-4202-9ae7-c6f6d45b3be5","modification_date":"2025-02-12T15:01:27.457730+00:00","name":"tf-snap-silly-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "536"
+                - "530"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:08 GMT
+                - Wed, 12 Feb 2025 15:01:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1346,10 +1342,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 60aae503-0199-4696-9724-30008e390482
+                - 19615e4a-0471-4b3d-9f6f-e5032af17a55
         status: 200 OK
         code: 200
-        duration: 76.904458ms
+        duration: 572.530417ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1365,8 +1361,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/b5f721ef-1f1c-4406-8d88-b82f0d38150e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/8aa1b0c1-7e2d-4202-9ae7-c6f6d45b3be5
         method: GET
       response:
         proto: HTTP/2.0
@@ -1374,20 +1370,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 536
+        content_length: 530
         uncompressed: false
-        body: '{"snapshot":{"base_volume":{"id":"8f5869c8-8e4c-445d-9dbe-37f47aa0a318","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-01-27T13:48:41.530616+00:00","error_details":null,"id":"b5f721ef-1f1c-4406-8d88-b82f0d38150e","modification_date":"2025-01-27T13:49:06.022372+00:00","name":"tf-snap-gallant-goldwasser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"snapshot":{"base_volume":{"id":"18766887-538a-418b-856c-ea9a92807d65","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:00:49.268988+00:00","error_details":null,"id":"8aa1b0c1-7e2d-4202-9ae7-c6f6d45b3be5","modification_date":"2025-02-12T15:01:27.457730+00:00","name":"tf-snap-silly-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "536"
+                - "530"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:09 GMT
+                - Wed, 12 Feb 2025 15:01:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1395,10 +1391,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 44aa762b-4225-4122-b837-9e5ae9f5b933
+                - b605c3e9-4ec8-40a8-916d-ff86d2795040
         status: 200 OK
         code: 200
-        duration: 110.935333ms
+        duration: 116.195041ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1414,8 +1410,306 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/b5f721ef-1f1c-4406-8d88-b82f0d38150e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d4d6af7-481d-45b4-a1de-af5fe7fa05eb
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2259
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:00:25.242726+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-angry-wing","id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1202","node_id":"2","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c2:bd","maintenances":[],"modification_date":"2025-02-12T15:00:45.290151+00:00","name":"tf-srv-angry-wing","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:00:25.242726+00:00","export_uri":null,"id":"18766887-538a-418b-856c-ea9a92807d65","modification_date":"2025-02-12T15:01:27.457730+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","name":"tf-srv-angry-wing"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2259"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:01:31 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - cc5db8ec-0f18-44da-95d7-7f50a31be7a7
+        status: 200 OK
+        code: 200
+        duration: 144.598542ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/18766887-538a-418b-856c-ea9a92807d65
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 517
+        uncompressed: false
+        body: '{"volume":{"creation_date":"2025-02-12T15:00:25.242726+00:00","export_uri":null,"id":"18766887-538a-418b-856c-ea9a92807d65","modification_date":"2025-02-12T15:01:27.457730+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","name":"tf-srv-angry-wing"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "517"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:01:31 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8af4f0c0-bfa8-4a53-8ff4-0afedf24d08f
+        status: 200 OK
+        code: 200
+        duration: 113.894792ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d4d6af7-481d-45b4-a1de-af5fe7fa05eb/user_data
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 17
+        uncompressed: false
+        body: '{"user_data":[]}'
+        headers:
+            Content-Length:
+                - "17"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:01:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 71173f0c-5542-4d39-a0d7-b59c78b162cd
+        status: 200 OK
+        code: 200
+        duration: 122.66225ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d4d6af7-481d-45b4-a1de-af5fe7fa05eb/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 20
+        uncompressed: false
+        body: '{"private_nics":[]}'
+        headers:
+            Content-Length:
+                - "20"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:01:32 GMT
+            Link:
+                - </servers/1d4d6af7-481d-45b4-a1de-af5fe7fa05eb/private_nics?page=0&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - cc34f09b-17e7-4f97-8970-9325339aa4c3
+            X-Total-Count:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 115.915958ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/8aa1b0c1-7e2d-4202-9ae7-c6f6d45b3be5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 530
+        uncompressed: false
+        body: '{"snapshot":{"base_volume":{"id":"18766887-538a-418b-856c-ea9a92807d65","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:00:49.268988+00:00","error_details":null,"id":"8aa1b0c1-7e2d-4202-9ae7-c6f6d45b3be5","modification_date":"2025-02-12T15:01:27.457730+00:00","name":"tf-snap-silly-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "530"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:01:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fcb32c70-19b1-4173-8fcd-1f773fd37ef0
+        status: 200 OK
+        code: 200
+        duration: 107.717667ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/8aa1b0c1-7e2d-4202-9ae7-c6f6d45b3be5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 530
+        uncompressed: false
+        body: '{"snapshot":{"base_volume":{"id":"18766887-538a-418b-856c-ea9a92807d65","name":"Ubuntu 20.04 Focal Fossa"},"creation_date":"2025-02-12T15:00:49.268988+00:00","error_details":null,"id":"8aa1b0c1-7e2d-4202-9ae7-c6f6d45b3be5","modification_date":"2025-02-12T15:01:27.457730+00:00","name":"tf-snap-silly-shtern","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "530"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:01:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6d17337b-cb7d-4337-abeb-56723c66c64d
+        status: 200 OK
+        code: 200
+        duration: 530.790583ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/8aa1b0c1-7e2d-4202-9ae7-c6f6d45b3be5
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1432,9 +1726,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:08 GMT
+                - Wed, 12 Feb 2025 15:01:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1442,11 +1736,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 40aafc1e-b9e5-499f-b430-b9bcbd70db5b
+                - a1f0d09f-47fe-4187-8121-04b0ada4cb2f
         status: 204 No Content
         code: 204
-        duration: 181.146333ms
-    - id: 29
+        duration: 306.450959ms
+    - id: 35
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1461,8 +1755,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/b5f721ef-1f1c-4406-8d88-b82f0d38150e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/8aa1b0c1-7e2d-4202-9ae7-c6f6d45b3be5
         method: GET
       response:
         proto: HTTP/2.0
@@ -1472,7 +1766,7 @@ interactions:
         trailer: {}
         content_length: 145
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"b5f721ef-1f1c-4406-8d88-b82f0d38150e","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"8aa1b0c1-7e2d-4202-9ae7-c6f6d45b3be5","type":"not_found"}'
         headers:
             Content-Length:
                 - "145"
@@ -1481,9 +1775,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:08 GMT
+                - Wed, 12 Feb 2025 15:01:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1491,11 +1785,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a37adf9c-cec5-4071-a046-86aae6332319
+                - fbb4b5e0-9eab-4702-9f87-744e82954fa9
         status: 404 Not Found
         code: 404
-        duration: 36.2365ms
-    - id: 30
+        duration: 50.532417ms
+    - id: 36
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1510,8 +1804,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c6fd4733-bf24-4bc2-b94c-ab2ed17a656b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d4d6af7-481d-45b4-a1de-af5fe7fa05eb
         method: GET
       response:
         proto: HTTP/2.0
@@ -1519,20 +1813,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2273
+        content_length: 2259
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:20.295686+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-bardeen","id":"c6fd4733-bf24-4bc2-b94c-ab2ed17a656b","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"43","hypervisor_id":"804","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:d3","maintenances":[],"modification_date":"2025-01-27T13:48:29.966487+00:00","name":"tf-srv-awesome-bardeen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:20.295686+00:00","export_uri":null,"id":"8f5869c8-8e4c-445d-9dbe-37f47aa0a318","modification_date":"2025-01-27T13:49:06.022372+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c6fd4733-bf24-4bc2-b94c-ab2ed17a656b","name":"tf-srv-awesome-bardeen"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:00:25.242726+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-angry-wing","id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1202","node_id":"2","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c2:bd","maintenances":[],"modification_date":"2025-02-12T15:00:45.290151+00:00","name":"tf-srv-angry-wing","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:00:25.242726+00:00","export_uri":null,"id":"18766887-538a-418b-856c-ea9a92807d65","modification_date":"2025-02-12T15:01:27.457730+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","name":"tf-srv-angry-wing"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2273"
+                - "2259"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:08 GMT
+                - Wed, 12 Feb 2025 15:01:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1540,11 +1834,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f6c7eb8c-911d-444b-b4dd-accf69154448
+                - f8caed0a-22ef-44cf-851f-bc9647e28a01
         status: 200 OK
         code: 200
-        duration: 208.9785ms
-    - id: 31
+        duration: 556.001791ms
+    - id: 37
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1561,8 +1855,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c6fd4733-bf24-4bc2-b94c-ab2ed17a656b/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d4d6af7-481d-45b4-a1de-af5fe7fa05eb/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -1572,7 +1866,7 @@ interactions:
         trailer: {}
         content_length: 352
         uncompressed: false
-        body: '{"task":{"description":"server_poweroff","href_from":"/servers/c6fd4733-bf24-4bc2-b94c-ab2ed17a656b/action","href_result":"/servers/c6fd4733-bf24-4bc2-b94c-ab2ed17a656b","id":"111cffe0-e2e6-443b-8710-fde55786f5e3","progress":0,"started_at":"2025-01-27T13:49:09.734390+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_poweroff","href_from":"/servers/1d4d6af7-481d-45b4-a1de-af5fe7fa05eb/action","href_result":"/servers/1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","id":"6d39e905-e287-499d-803e-5a09da5fc90b","progress":0,"started_at":"2025-02-12T15:01:34.746233+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "352"
@@ -1581,11 +1875,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:09 GMT
+                - Wed, 12 Feb 2025 15:01:34 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/111cffe0-e2e6-443b-8710-fde55786f5e3
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/6d39e905-e287-499d-803e-5a09da5fc90b
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1593,304 +1887,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1b5a949b-d432-486e-8695-79b739cc8b53
+                - db604f1b-9e75-4922-ad4d-528f3c7f5e99
         status: 202 Accepted
         code: 202
-        duration: 323.396208ms
-    - id: 32
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c6fd4733-bf24-4bc2-b94c-ab2ed17a656b
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2233
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:20.295686+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-bardeen","id":"c6fd4733-bf24-4bc2-b94c-ab2ed17a656b","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"43","hypervisor_id":"804","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:d3","maintenances":[],"modification_date":"2025-01-27T13:49:09.480411+00:00","name":"tf-srv-awesome-bardeen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:20.295686+00:00","export_uri":null,"id":"8f5869c8-8e4c-445d-9dbe-37f47aa0a318","modification_date":"2025-01-27T13:49:06.022372+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c6fd4733-bf24-4bc2-b94c-ab2ed17a656b","name":"tf-srv-awesome-bardeen"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2233"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:49:09 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 669b08e7-ff72-4446-87d0-1fbe2fcf3f26
-        status: 200 OK
-        code: 200
-        duration: 156.312125ms
-    - id: 33
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c6fd4733-bf24-4bc2-b94c-ab2ed17a656b
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2233
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:20.295686+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-bardeen","id":"c6fd4733-bf24-4bc2-b94c-ab2ed17a656b","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"43","hypervisor_id":"804","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:d3","maintenances":[],"modification_date":"2025-01-27T13:49:09.480411+00:00","name":"tf-srv-awesome-bardeen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:20.295686+00:00","export_uri":null,"id":"8f5869c8-8e4c-445d-9dbe-37f47aa0a318","modification_date":"2025-01-27T13:49:06.022372+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c6fd4733-bf24-4bc2-b94c-ab2ed17a656b","name":"tf-srv-awesome-bardeen"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2233"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:49:14 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 9a5791d8-5811-4e54-93a7-b5fd2095fa39
-        status: 200 OK
-        code: 200
-        duration: 150.551375ms
-    - id: 34
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c6fd4733-bf24-4bc2-b94c-ab2ed17a656b
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2233
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:20.295686+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-bardeen","id":"c6fd4733-bf24-4bc2-b94c-ab2ed17a656b","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"43","hypervisor_id":"804","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:d3","maintenances":[],"modification_date":"2025-01-27T13:49:09.480411+00:00","name":"tf-srv-awesome-bardeen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:20.295686+00:00","export_uri":null,"id":"8f5869c8-8e4c-445d-9dbe-37f47aa0a318","modification_date":"2025-01-27T13:49:06.022372+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c6fd4733-bf24-4bc2-b94c-ab2ed17a656b","name":"tf-srv-awesome-bardeen"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2233"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:49:20 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 0a35c5e1-5d24-430c-8eda-436c251bb849
-        status: 200 OK
-        code: 200
-        duration: 164.140625ms
-    - id: 35
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c6fd4733-bf24-4bc2-b94c-ab2ed17a656b
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2233
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:20.295686+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-bardeen","id":"c6fd4733-bf24-4bc2-b94c-ab2ed17a656b","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"43","hypervisor_id":"804","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:d3","maintenances":[],"modification_date":"2025-01-27T13:49:09.480411+00:00","name":"tf-srv-awesome-bardeen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:20.295686+00:00","export_uri":null,"id":"8f5869c8-8e4c-445d-9dbe-37f47aa0a318","modification_date":"2025-01-27T13:49:06.022372+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c6fd4733-bf24-4bc2-b94c-ab2ed17a656b","name":"tf-srv-awesome-bardeen"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2233"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:49:25 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 28e59e65-307a-4654-9408-c36b517780ec
-        status: 200 OK
-        code: 200
-        duration: 159.976083ms
-    - id: 36
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c6fd4733-bf24-4bc2-b94c-ab2ed17a656b
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2233
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:20.295686+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-bardeen","id":"c6fd4733-bf24-4bc2-b94c-ab2ed17a656b","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"43","hypervisor_id":"804","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:d3","maintenances":[],"modification_date":"2025-01-27T13:49:09.480411+00:00","name":"tf-srv-awesome-bardeen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:20.295686+00:00","export_uri":null,"id":"8f5869c8-8e4c-445d-9dbe-37f47aa0a318","modification_date":"2025-01-27T13:49:06.022372+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c6fd4733-bf24-4bc2-b94c-ab2ed17a656b","name":"tf-srv-awesome-bardeen"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2233"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:49:30 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 9d1706fd-fb20-439e-8e87-7afc733623fa
-        status: 200 OK
-        code: 200
-        duration: 159.660833ms
-    - id: 37
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c6fd4733-bf24-4bc2-b94c-ab2ed17a656b
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2233
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:20.295686+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-bardeen","id":"c6fd4733-bf24-4bc2-b94c-ab2ed17a656b","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"43","hypervisor_id":"804","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ff:d3","maintenances":[],"modification_date":"2025-01-27T13:49:09.480411+00:00","name":"tf-srv-awesome-bardeen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:20.295686+00:00","export_uri":null,"id":"8f5869c8-8e4c-445d-9dbe-37f47aa0a318","modification_date":"2025-01-27T13:49:06.022372+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c6fd4733-bf24-4bc2-b94c-ab2ed17a656b","name":"tf-srv-awesome-bardeen"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2233"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 13:49:35 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - ed635d4a-30f7-4a75-88af-7914092afa39
-        status: 200 OK
-        code: 200
-        duration: 137.042041ms
+        duration: 376.756333ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1906,8 +1906,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c6fd4733-bf24-4bc2-b94c-ab2ed17a656b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d4d6af7-481d-45b4-a1de-af5fe7fa05eb
         method: GET
       response:
         proto: HTTP/2.0
@@ -1915,20 +1915,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2118
+        content_length: 2219
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:20.295686+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-bardeen","id":"c6fd4733-bf24-4bc2-b94c-ab2ed17a656b","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:d3","maintenances":[],"modification_date":"2025-01-27T13:49:38.293669+00:00","name":"tf-srv-awesome-bardeen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:20.295686+00:00","export_uri":null,"id":"8f5869c8-8e4c-445d-9dbe-37f47aa0a318","modification_date":"2025-01-27T13:49:06.022372+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c6fd4733-bf24-4bc2-b94c-ab2ed17a656b","name":"tf-srv-awesome-bardeen"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:00:25.242726+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-angry-wing","id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1202","node_id":"2","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c2:bd","maintenances":[],"modification_date":"2025-02-12T15:01:34.510419+00:00","name":"tf-srv-angry-wing","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:00:25.242726+00:00","export_uri":null,"id":"18766887-538a-418b-856c-ea9a92807d65","modification_date":"2025-02-12T15:01:27.457730+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","name":"tf-srv-angry-wing"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2118"
+                - "2219"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:40 GMT
+                - Wed, 12 Feb 2025 15:01:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1936,10 +1936,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1beb2a66-f46d-4e13-99c3-3ec4e4aac2bd
+                - 0a2d2288-5e32-4b45-85f8-7a878c615bab
         status: 200 OK
         code: 200
-        duration: 130.279125ms
+        duration: 168.428458ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1955,8 +1955,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c6fd4733-bf24-4bc2-b94c-ab2ed17a656b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d4d6af7-481d-45b4-a1de-af5fe7fa05eb
         method: GET
       response:
         proto: HTTP/2.0
@@ -1964,20 +1964,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2118
+        content_length: 2219
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T13:48:20.295686+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-bardeen","id":"c6fd4733-bf24-4bc2-b94c-ab2ed17a656b","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ff:d3","maintenances":[],"modification_date":"2025-01-27T13:49:38.293669+00:00","name":"tf-srv-awesome-bardeen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T13:48:20.295686+00:00","export_uri":null,"id":"8f5869c8-8e4c-445d-9dbe-37f47aa0a318","modification_date":"2025-01-27T13:49:06.022372+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c6fd4733-bf24-4bc2-b94c-ab2ed17a656b","name":"tf-srv-awesome-bardeen"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:00:25.242726+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-angry-wing","id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1202","node_id":"2","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c2:bd","maintenances":[],"modification_date":"2025-02-12T15:01:34.510419+00:00","name":"tf-srv-angry-wing","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:00:25.242726+00:00","export_uri":null,"id":"18766887-538a-418b-856c-ea9a92807d65","modification_date":"2025-02-12T15:01:27.457730+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","name":"tf-srv-angry-wing"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2118"
+                - "2219"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:42 GMT
+                - Wed, 12 Feb 2025 15:01:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1985,10 +1985,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0ee9d9b2-e245-461e-ae73-ec4505d369c6
+                - bd4177b9-6829-48ca-81f2-e03a63da7eb4
         status: 200 OK
         code: 200
-        duration: 2.167355875s
+        duration: 215.963458ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2004,27 +2004,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c6fd4733-bf24-4bc2-b94c-ab2ed17a656b
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d4d6af7-481d-45b4-a1de-af5fe7fa05eb
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 2219
         uncompressed: false
-        body: ""
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:00:25.242726+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-angry-wing","id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1202","node_id":"2","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c2:bd","maintenances":[],"modification_date":"2025-02-12T15:01:34.510419+00:00","name":"tf-srv-angry-wing","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:00:25.242726+00:00","export_uri":null,"id":"18766887-538a-418b-856c-ea9a92807d65","modification_date":"2025-02-12T15:01:27.457730+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","name":"tf-srv-angry-wing"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
+            Content-Length:
+                - "2219"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:43 GMT
+                - Wed, 12 Feb 2025 15:01:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2032,10 +2034,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c825d6ef-64e8-4385-889c-83f6561cb60d
-        status: 204 No Content
-        code: 204
-        duration: 185.02ms
+                - 6b11e00e-6839-442b-a0a6-b7ac611545b9
+        status: 200 OK
+        code: 200
+        duration: 168.998167ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2051,8 +2053,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c6fd4733-bf24-4bc2-b94c-ab2ed17a656b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d4d6af7-481d-45b4-a1de-af5fe7fa05eb
         method: GET
       response:
         proto: HTTP/2.0
@@ -2060,20 +2062,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 143
+        content_length: 2219
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"c6fd4733-bf24-4bc2-b94c-ab2ed17a656b","type":"not_found"}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:00:25.242726+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-angry-wing","id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1202","node_id":"2","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c2:bd","maintenances":[],"modification_date":"2025-02-12T15:01:34.510419+00:00","name":"tf-srv-angry-wing","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:00:25.242726+00:00","export_uri":null,"id":"18766887-538a-418b-856c-ea9a92807d65","modification_date":"2025-02-12T15:01:27.457730+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","name":"tf-srv-angry-wing"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "143"
+                - "2219"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:43 GMT
+                - Wed, 12 Feb 2025 15:01:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2081,10 +2083,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d872ba35-f2f3-4001-bcc2-5f9ae311a186
-        status: 404 Not Found
-        code: 404
-        duration: 141.50925ms
+                - 19908b18-bfb4-4079-8b4e-d3194bebc76b
+        status: 200 OK
+        code: 200
+        duration: 652.430042ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2100,8 +2102,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/8f5869c8-8e4c-445d-9dbe-37f47aa0a318
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d4d6af7-481d-45b4-a1de-af5fe7fa05eb
         method: GET
       response:
         proto: HTTP/2.0
@@ -2109,20 +2111,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 446
+        content_length: 2219
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T13:48:20.295686+00:00","export_uri":null,"id":"8f5869c8-8e4c-445d-9dbe-37f47aa0a318","modification_date":"2025-01-27T13:49:43.075540+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:00:25.242726+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-angry-wing","id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1202","node_id":"2","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c2:bd","maintenances":[],"modification_date":"2025-02-12T15:01:34.510419+00:00","name":"tf-srv-angry-wing","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:00:25.242726+00:00","export_uri":null,"id":"18766887-538a-418b-856c-ea9a92807d65","modification_date":"2025-02-12T15:01:27.457730+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","name":"tf-srv-angry-wing"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "446"
+                - "2219"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:43 GMT
+                - Wed, 12 Feb 2025 15:01:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2130,10 +2132,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 59cb9992-1cf4-49b0-a2b4-c7c8cbb3ab83
+                - 867066a3-2951-4492-b068-ebe5e39afba2
         status: 200 OK
         code: 200
-        duration: 87.80625ms
+        duration: 194.979916ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2149,8 +2151,155 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/8f5869c8-8e4c-445d-9dbe-37f47aa0a318
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d4d6af7-481d-45b4-a1de-af5fe7fa05eb
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2219
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:00:25.242726+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-angry-wing","id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1202","node_id":"2","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c2:bd","maintenances":[],"modification_date":"2025-02-12T15:01:34.510419+00:00","name":"tf-srv-angry-wing","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:00:25.242726+00:00","export_uri":null,"id":"18766887-538a-418b-856c-ea9a92807d65","modification_date":"2025-02-12T15:01:27.457730+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","name":"tf-srv-angry-wing"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2219"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:02:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 249ccb6c-c69e-42ab-a1a3-30ef92dcbcc9
+        status: 200 OK
+        code: 200
+        duration: 225.383792ms
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d4d6af7-481d-45b4-a1de-af5fe7fa05eb
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2103
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:00:25.242726+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-angry-wing","id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c2:bd","maintenances":[],"modification_date":"2025-02-12T15:02:01.563233+00:00","name":"tf-srv-angry-wing","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:00:25.242726+00:00","export_uri":null,"id":"18766887-538a-418b-856c-ea9a92807d65","modification_date":"2025-02-12T15:01:27.457730+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","name":"tf-srv-angry-wing"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2103"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:02:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 275574e6-d364-4522-8b12-42610031721b
+        status: 200 OK
+        code: 200
+        duration: 139.883792ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d4d6af7-481d-45b4-a1de-af5fe7fa05eb
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2103
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T15:00:25.242726+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-angry-wing","id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c2:bd","maintenances":[],"modification_date":"2025-02-12T15:02:01.563233+00:00","name":"tf-srv-angry-wing","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-02-12T15:00:25.242726+00:00","export_uri":null,"id":"18766887-538a-418b-856c-ea9a92807d65","modification_date":"2025-02-12T15:01:27.457730+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","name":"tf-srv-angry-wing"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2103"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:02:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5505d62c-2943-4120-8d94-2e39c8c77aad
+        status: 200 OK
+        code: 200
+        duration: 187.927167ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d4d6af7-481d-45b4-a1de-af5fe7fa05eb
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2167,9 +2316,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 13:49:43 GMT
+                - Wed, 12 Feb 2025 15:02:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2177,7 +2326,152 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4b2268b3-cc04-405d-a49d-0ce7e862202b
+                - 26b555e1-4793-4a68-abd7-01be85889189
         status: 204 No Content
         code: 204
-        duration: 139.659084ms
+        duration: 196.180125ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d4d6af7-481d-45b4-a1de-af5fe7fa05eb
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"1d4d6af7-481d-45b4-a1de-af5fe7fa05eb","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:02:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 07948846-4d5f-43d4-ac5c-4cd672f9f6b3
+        status: 404 Not Found
+        code: 404
+        duration: 87.413167ms
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/18766887-538a-418b-856c-ea9a92807d65
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 446
+        uncompressed: false
+        body: '{"volume":{"creation_date":"2025-02-12T15:00:25.242726+00:00","export_uri":null,"id":"18766887-538a-418b-856c-ea9a92807d65","modification_date":"2025-02-12T15:02:06.789734+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "446"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:02:07 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b9458e49-da32-4770-82a8-e408204f5e1e
+        status: 200 OK
+        code: 200
+        duration: 99.79525ms
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/18766887-538a-418b-856c-ea9a92807d65
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 15:02:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fba5aea9-4df9-4083-9574-3634267082cf
+        status: 204 No Content
+        code: 204
+        duration: 237.063708ms

--- a/internal/services/lb/testdata/lb-with-private-networks-on-dhcp-config.cassette.yaml
+++ b/internal/services/lb/testdata/lb-with-private-networks-on-dhcp-config.cassette.yaml
@@ -18,7 +18,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps
         method: POST
       response:
@@ -27,20 +27,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 556
+        content_length: 574
         uncompressed: false
-        body: '{"address":"10.0.0.1","created_at":"2025-01-24T14:15:20.581273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"48b28823-2ed8-4a73-82a5-752bc9447518","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-24T14:15:20.581273Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+        body: '{"address":"10.0.0.1","created_at":"2025-02-12T16:10:33.561435Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1248e521-f708-4f4a-80ee-9d3084b0616f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:10:33.561435Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "556"
+                - "574"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:20 GMT
+                - Wed, 12 Feb 2025 16:10:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fdff9fca-b3dd-4f3a-b225-5c280fdc34ec
+                - 45340638-5063-4102-918c-cfc63804b226
         status: 200 OK
         code: 200
-        duration: 262.098833ms
+        duration: 522.021ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -69,7 +69,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips
         method: POST
       response:
@@ -78,20 +78,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 286
+        content_length: 294
         uncompressed: false
-        body: '{"id":"df74cb2c-3245-49d9-b592-e67c753e77ac","ip_address":"51.159.25.55","lb_id":null,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-25-55.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}'
+        body: '{"id":"d44cc37b-f392-46c9-a576-e42711323050","ip_address":"51.159.9.241","lb_id":null,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-9-241.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "286"
+                - "294"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:20 GMT
+                - Wed, 12 Feb 2025 16:10:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -99,10 +99,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2926cc60-6f20-4cd6-bc5e-16c5c51ee07a
+                - 8d850d49-cb68-493f-82bf-62383ec01c10
         status: 200 OK
         code: 200
-        duration: 269.797875ms
+        duration: 531.279959ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -118,8 +118,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/48b28823-2ed8-4a73-82a5-752bc9447518
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/1248e521-f708-4f4a-80ee-9d3084b0616f
         method: GET
       response:
         proto: HTTP/2.0
@@ -127,20 +127,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 556
+        content_length: 574
         uncompressed: false
-        body: '{"address":"10.0.0.1","created_at":"2025-01-24T14:15:20.581273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"48b28823-2ed8-4a73-82a5-752bc9447518","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-24T14:15:20.581273Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+        body: '{"address":"10.0.0.1","created_at":"2025-02-12T16:10:33.561435Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1248e521-f708-4f4a-80ee-9d3084b0616f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:10:33.561435Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "556"
+                - "574"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:20 GMT
+                - Wed, 12 Feb 2025 16:10:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -148,10 +148,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 856c9ace-2c6c-4198-9445-c6b403c50992
+                - e83e64c3-a7db-4649-a723-cfd1db64fd52
         status: 200 OK
         code: 200
-        duration: 29.485875ms
+        duration: 98.991875ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -167,8 +167,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/df74cb2c-3245-49d9-b592-e67c753e77ac
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/d44cc37b-f392-46c9-a576-e42711323050
         method: GET
       response:
         proto: HTTP/2.0
@@ -176,20 +176,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 286
+        content_length: 294
         uncompressed: false
-        body: '{"id":"df74cb2c-3245-49d9-b592-e67c753e77ac","ip_address":"51.159.25.55","lb_id":null,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-25-55.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}'
+        body: '{"id":"d44cc37b-f392-46c9-a576-e42711323050","ip_address":"51.159.9.241","lb_id":null,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-9-241.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "286"
+                - "294"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:20 GMT
+                - Wed, 12 Feb 2025 16:10:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -197,10 +197,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 126c88f4-acd4-4a20-a3f3-8a1602f96510
+                - d8bfc582-3c6a-41e4-a500-e9b4249755c3
         status: 200 OK
         code: 200
-        duration: 76.181959ms
+        duration: 89.595416ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -218,7 +218,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
         method: POST
       response:
@@ -227,20 +227,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1038
+        content_length: 1060
         uncompressed: false
-        body: '{"created_at":"2025-01-24T14:15:20.580798Z","dhcp_enabled":true,"id":"57acd471-d6d6-471a-be4f-6464a3976f5b","name":"private network with a DHCP config","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-24T14:15:20.580798Z","id":"f6142587-74eb-45b3-a361-72fa990fcec1","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.40.0/22","updated_at":"2025-01-24T14:15:20.580798Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-24T14:15:20.580798Z","id":"ed64f437-e22a-454d-8f4c-34b7c0a996d3","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:cece::/64","updated_at":"2025-01-24T14:15:20.580798Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-24T14:15:20.580798Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"created_at":"2025-02-12T16:10:33.577102Z","dhcp_enabled":true,"id":"7abd3366-919a-46e1-88ad-af224037959a","name":"private network with a DHCP config","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:10:33.577102Z","id":"eca4e6e3-9dfa-4837-a839-b6506b1f69e7","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.16.0/22","updated_at":"2025-02-12T16:10:33.577102Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-12T16:10:33.577102Z","id":"afcdeb34-4c8b-495d-98ca-5c35531d6fed","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:4ef::/64","updated_at":"2025-02-12T16:10:33.577102Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-12T16:10:33.577102Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "1038"
+                - "1060"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:21 GMT
+                - Wed, 12 Feb 2025 16:10:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -248,10 +248,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7f0d6a15-9f71-4a6d-9f7e-8b8d40b5e75b
+                - f1739bc6-d351-4433-baa9-3a40e36916a5
         status: 200 OK
         code: 200
-        duration: 1.079562667s
+        duration: 1.030238292s
     - id: 5
       request:
         proto: HTTP/1.1
@@ -267,8 +267,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/57acd471-d6d6-471a-be4f-6464a3976f5b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7abd3366-919a-46e1-88ad-af224037959a
         method: GET
       response:
         proto: HTTP/2.0
@@ -276,20 +276,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1038
+        content_length: 1060
         uncompressed: false
-        body: '{"created_at":"2025-01-24T14:15:20.580798Z","dhcp_enabled":true,"id":"57acd471-d6d6-471a-be4f-6464a3976f5b","name":"private network with a DHCP config","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-24T14:15:20.580798Z","id":"f6142587-74eb-45b3-a361-72fa990fcec1","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.40.0/22","updated_at":"2025-01-24T14:15:20.580798Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-24T14:15:20.580798Z","id":"ed64f437-e22a-454d-8f4c-34b7c0a996d3","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:cece::/64","updated_at":"2025-01-24T14:15:20.580798Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-24T14:15:20.580798Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"created_at":"2025-02-12T16:10:33.577102Z","dhcp_enabled":true,"id":"7abd3366-919a-46e1-88ad-af224037959a","name":"private network with a DHCP config","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:10:33.577102Z","id":"eca4e6e3-9dfa-4837-a839-b6506b1f69e7","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.16.0/22","updated_at":"2025-02-12T16:10:33.577102Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-12T16:10:33.577102Z","id":"afcdeb34-4c8b-495d-98ca-5c35531d6fed","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:4ef::/64","updated_at":"2025-02-12T16:10:33.577102Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-12T16:10:33.577102Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "1038"
+                - "1060"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:21 GMT
+                - Wed, 12 Feb 2025 16:10:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -297,10 +297,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bc651cd7-9653-49ee-b819-4c1e83bef80f
+                - 6f81c11c-29ea-4d56-b0c2-059f9fb58a5e
         status: 200 OK
         code: 200
-        duration: 30.867958ms
+        duration: 97.863416ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -316,7 +316,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
         method: GET
       response:
@@ -325,22 +325,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 38539
+        content_length: 35639
         uncompressed: false
-        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
+        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
         headers:
             Content-Length:
-                - "38539"
+                - "35639"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:21 GMT
+                - Wed, 12 Feb 2025 16:10:33 GMT
             Link:
                 - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -348,12 +348,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8a5af463-3cd8-45b0-80ca-40a268f5d782
+                - db98f762-2193-46a4-9c93-96096c6b8958
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 57.313792ms
+        duration: 56.971375ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -369,7 +369,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
         method: GET
       response:
@@ -378,22 +378,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 14208
+        content_length: 13164
         uncompressed: false
-        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
         headers:
             Content-Length:
-                - "14208"
+                - "13164"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:21 GMT
+                - Wed, 12 Feb 2025 16:10:34 GMT
             Link:
                 - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -401,12 +401,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - aebcae5b-1d42-4d25-b438-143fd9958fa5
+                - 48dcb41c-1169-46ba-bd68-6b0c0415d592
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 54.365125ms
+        duration: 69.462625ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -422,8 +422,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=debian_bullseye&order_by=type_asc&type=instance_local&zone=fr-par-1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=debian_bullseye&order_by=type_asc&type=instance_sbs&zone=fr-par-1
         method: GET
       response:
         proto: HTTP/2.0
@@ -431,20 +431,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1226
+        content_length: 1302
         uncompressed: false
-        body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"dfed234f-dfb9-4269-aec1-91f355527c0d","label":"debian_bullseye","type":"instance_local","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"ed780432-12f8-4c42-b689-b99aa920af27","label":"debian_bullseye","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
+        body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"a805381b-7ce6-425f-a108-96d9ee019135","label":"debian_bullseye","type":"instance_sbs","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"ffd21d6b-939a-48b2-a100-ab0030fe0ec9","label":"debian_bullseye","type":"instance_sbs","zone":"fr-par-1"}],"total_count":2}'
         headers:
             Content-Length:
-                - "1226"
+                - "1302"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:21 GMT
+                - Wed, 12 Feb 2025 16:10:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -452,10 +452,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7dbba082-1416-4e44-b43c-e61d50f8fee4
+                - 9b8181ed-ecdc-46c5-b68a-44b9ad7a2f9e
         status: 200 OK
         code: 200
-        duration: 89.626125ms
+        duration: 111.965458ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -473,7 +473,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips
         method: POST
       response:
@@ -482,20 +482,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 360
+        content_length: 371
         uncompressed: false
-        body: '{"address":"51.158.121.168","created_at":"2025-01-24T14:15:22.212402Z","gateway_id":null,"id":"5e32e435-6bf9-4406-8f72-8f76be892a2f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"168-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-24T14:15:22.212402Z","zone":"fr-par-1"}'
+        body: '{"address":"163.172.162.186","created_at":"2025-02-12T16:10:34.957253Z","gateway_id":null,"id":"d217409e-10e1-4bbc-97d6-1daedb998b38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:10:34.957253Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "360"
+                - "371"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:22 GMT
+                - Wed, 12 Feb 2025 16:10:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -503,10 +503,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4f2797ce-3791-42da-bb5a-11df6366d228
+                - 1932cbed-49f9-442b-bac2-90cc9b160e15
         status: 200 OK
         code: 200
-        duration: 1.952357458s
+        duration: 2.053414667s
     - id: 10
       request:
         proto: HTTP/1.1
@@ -522,8 +522,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/5e32e435-6bf9-4406-8f72-8f76be892a2f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/d217409e-10e1-4bbc-97d6-1daedb998b38
         method: GET
       response:
         proto: HTTP/2.0
@@ -531,20 +531,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 360
+        content_length: 371
         uncompressed: false
-        body: '{"address":"51.158.121.168","created_at":"2025-01-24T14:15:22.212402Z","gateway_id":null,"id":"5e32e435-6bf9-4406-8f72-8f76be892a2f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"168-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-24T14:15:22.212402Z","zone":"fr-par-1"}'
+        body: '{"address":"163.172.162.186","created_at":"2025-02-12T16:10:34.957253Z","gateway_id":null,"id":"d217409e-10e1-4bbc-97d6-1daedb998b38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:10:34.957253Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "360"
+                - "371"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:22 GMT
+                - Wed, 12 Feb 2025 16:10:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -552,10 +552,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b1c3df7f-6537-492e-b60a-db28dbf99106
+                - 835429d9-33c1-4a99-9225-541f5b959613
         status: 200 OK
         code: 200
-        duration: 81.996792ms
+        duration: 102.85725ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -567,13 +567,13 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-public-gw","tags":[],"type":"VPC-GW-S","upstream_dns_servers":[],"ip_id":"5e32e435-6bf9-4406-8f72-8f76be892a2f","enable_smtp":false,"enable_bastion":false}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-public-gw","tags":[],"type":"VPC-GW-S","upstream_dns_servers":[],"ip_id":"d217409e-10e1-4bbc-97d6-1daedb998b38","enable_smtp":false,"enable_bastion":false}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
         method: POST
       response:
@@ -582,20 +582,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 981
+        content_length: 1013
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-24T14:15:22.458029Z","gateway_networks":[],"id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","ip":{"address":"51.158.121.168","created_at":"2025-01-24T14:15:22.212402Z","gateway_id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","id":"5e32e435-6bf9-4406-8f72-8f76be892a2f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"168-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-24T14:15:22.212402Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-24T14:15:22.458029Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:10:35.342174Z","gateway_networks":[],"id":"8ebafec9-15fb-496d-b212-1719a0311c3b","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:10:34.957253Z","gateway_id":"8ebafec9-15fb-496d-b212-1719a0311c3b","id":"d217409e-10e1-4bbc-97d6-1daedb998b38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:10:34.957253Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:10:35.342174Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "981"
+                - "1013"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:22 GMT
+                - Wed, 12 Feb 2025 16:10:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -603,10 +603,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a7f860b8-4b5e-4abe-a924-bbd01af46119
+                - df799714-c75d-4e95-ad76-5fe30d229529
         status: 200 OK
         code: 200
-        duration: 183.4805ms
+        duration: 153.250542ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -622,8 +622,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0cdaf520-f0e0-46ed-b197-36c28975d51c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/8ebafec9-15fb-496d-b212-1719a0311c3b
         method: GET
       response:
         proto: HTTP/2.0
@@ -631,20 +631,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 981
+        content_length: 1015
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-24T14:15:22.458029Z","gateway_networks":[],"id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","ip":{"address":"51.158.121.168","created_at":"2025-01-24T14:15:22.212402Z","gateway_id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","id":"5e32e435-6bf9-4406-8f72-8f76be892a2f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"168-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-24T14:15:22.212402Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-24T14:15:22.458029Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:10:35.342174Z","gateway_networks":[],"id":"8ebafec9-15fb-496d-b212-1719a0311c3b","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:10:34.957253Z","gateway_id":"8ebafec9-15fb-496d-b212-1719a0311c3b","id":"d217409e-10e1-4bbc-97d6-1daedb998b38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:10:34.957253Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:10:35.395476Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "981"
+                - "1015"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:22 GMT
+                - Wed, 12 Feb 2025 16:10:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -652,28 +652,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 277bc7a3-ad6f-48c5-b0c1-02b17b98a18e
+                - d9783b0a-eb9a-4993-b9dc-6652f0dcab09
         status: 200 OK
         code: 200
-        duration: 59.931792ms
+        duration: 93.929541ms
     - id: 13
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 281
+        content_length: 240
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"Scaleway Terraform Provider","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"dfed234f-dfb9-4269-aec1-91f355527c0d","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+        body: '{"name":"Scaleway Terraform Provider","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"a805381b-7ce6-425f-a108-96d9ee019135","volumes":{"0":{"boot":false}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
         method: POST
       response:
@@ -682,22 +682,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2106
+        content_length: 1675
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-24T14:15:22.371679+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"8b61785d-9e59-462c-8c73-602613da26ec","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:83:d3","maintenances":[],"modification_date":"2025-01-24T14:15:22.371679+00:00","name":"Scaleway Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-24T14:15:22.371679+00:00","export_uri":null,"id":"bdaabaac-1ef9-4b2b-9f03-f8a6e88a1135","modification_date":"2025-01-24T14:15:22.371679+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"8b61785d-9e59-462c-8c73-602613da26ec","name":"Scaleway Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:10:34.904348+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:9d","maintenances":[],"modification_date":"2025-02-12T16:10:34.904348+00:00","name":"Scaleway Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"6b9656e5-88c1-4a8f-af6a-01ecf39a238a","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2106"
+                - "1675"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:22 GMT
+                - Wed, 12 Feb 2025 16:10:35 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -705,10 +705,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bceb7929-08f1-4f74-9b2d-e72c8b19bb51
+                - f2615719-5ea5-48f1-86e1-7426dd570602
         status: 201 Created
         code: 201
-        duration: 1.166338s
+        duration: 1.171242875s
     - id: 14
       request:
         proto: HTTP/1.1
@@ -724,8 +724,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -733,20 +733,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2106
+        content_length: 1675
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-24T14:15:22.371679+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"8b61785d-9e59-462c-8c73-602613da26ec","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:83:d3","maintenances":[],"modification_date":"2025-01-24T14:15:22.371679+00:00","name":"Scaleway Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-24T14:15:22.371679+00:00","export_uri":null,"id":"bdaabaac-1ef9-4b2b-9f03-f8a6e88a1135","modification_date":"2025-01-24T14:15:22.371679+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"8b61785d-9e59-462c-8c73-602613da26ec","name":"Scaleway Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:10:34.904348+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:9d","maintenances":[],"modification_date":"2025-02-12T16:10:34.904348+00:00","name":"Scaleway Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"6b9656e5-88c1-4a8f-af6a-01ecf39a238a","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2106"
+                - "1675"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:22 GMT
+                - Wed, 12 Feb 2025 16:10:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -754,10 +754,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d3b4fdcd-8f2c-4a6e-8b00-ded3186ca7c7
+                - a7e6a7ab-519d-4d47-b513-6112d1fe61f3
         status: 200 OK
         code: 200
-        duration: 123.532666ms
+        duration: 186.24775ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -773,8 +773,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -782,20 +782,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2106
+        content_length: 1675
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-24T14:15:22.371679+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"8b61785d-9e59-462c-8c73-602613da26ec","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:83:d3","maintenances":[],"modification_date":"2025-01-24T14:15:22.371679+00:00","name":"Scaleway Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-24T14:15:22.371679+00:00","export_uri":null,"id":"bdaabaac-1ef9-4b2b-9f03-f8a6e88a1135","modification_date":"2025-01-24T14:15:22.371679+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"8b61785d-9e59-462c-8c73-602613da26ec","name":"Scaleway Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:10:34.904348+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:9d","maintenances":[],"modification_date":"2025-02-12T16:10:34.904348+00:00","name":"Scaleway Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"6b9656e5-88c1-4a8f-af6a-01ecf39a238a","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2106"
+                - "1675"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:23 GMT
+                - Wed, 12 Feb 2025 16:10:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -803,11 +803,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 47ab892f-0315-4639-8d09-adb6bfd5d8b8
+                - ffc7adf0-3582-49c9-b452-3b360363234d
         status: 200 OK
         code: 200
-        duration: 131.584959ms
+        duration: 186.018958ms
     - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/6b9656e5-88c1-4a8f-af6a-01ecf39a238a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 692
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:10:35.127132Z","id":"6b9656e5-88c1-4a8f-af6a-01ecf39a238a","last_detached_at":null,"name":"Debian Bullseye_sbs_volume_0","parent_snapshot_id":"a50e6921-21b9-4a69-83cc-191359208d4c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:10:35.127132Z","id":"8bc47366-83a8-4780-a8b2-b589142d9451","product_resource_id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:10:35.127132Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "692"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:10:36 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e3325688-b1f5-4e56-a454-2f48a0a67c5c
+        status: 200 OK
+        code: 200
+        duration: 78.659291ms
+    - id: 17
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -824,8 +873,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -835,7 +884,7 @@ interactions:
         trailer: {}
         content_length: 357
         uncompressed: false
-        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/8b61785d-9e59-462c-8c73-602613da26ec/action","href_result":"/servers/8b61785d-9e59-462c-8c73-602613da26ec","id":"f9e903e0-af67-497e-9c14-7b8afd8138c3","progress":0,"started_at":"2025-01-24T14:15:23.464718+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f/action","href_result":"/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f","id":"083929ab-4db5-491a-a6cf-25021d556c03","progress":0,"started_at":"2025-02-12T16:10:36.365645+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -844,11 +893,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:23 GMT
+                - Wed, 12 Feb 2025 16:10:36 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/f9e903e0-af67-497e-9c14-7b8afd8138c3
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/083929ab-4db5-491a-a6cf-25021d556c03
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -856,59 +905,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - af826abe-d998-4213-a13e-969e7fc5a067
+                - 72d8fa4c-67f3-4301-b040-4ccdf3eac749
         status: 202 Accepted
         code: 202
-        duration: 412.659292ms
-    - id: 17
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2128
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-24T14:15:22.371679+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"8b61785d-9e59-462c-8c73-602613da26ec","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:83:d3","maintenances":[],"modification_date":"2025-01-24T14:15:23.125552+00:00","name":"Scaleway Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-24T14:15:22.371679+00:00","export_uri":null,"id":"bdaabaac-1ef9-4b2b-9f03-f8a6e88a1135","modification_date":"2025-01-24T14:15:22.371679+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"8b61785d-9e59-462c-8c73-602613da26ec","name":"Scaleway Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2128"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 14:15:23 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 30328725-7384-4e2f-9cab-94ca5c73b530
-        status: 200 OK
-        code: 200
-        duration: 175.688708ms
+        duration: 338.08875ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -924,8 +924,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0cdaf520-f0e0-46ed-b197-36c28975d51c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -933,20 +933,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 984
+        content_length: 1697
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-24T14:15:22.458029Z","gateway_networks":[],"id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","ip":{"address":"51.158.121.168","created_at":"2025-01-24T14:15:22.212402Z","gateway_id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","id":"5e32e435-6bf9-4406-8f72-8f76be892a2f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"168-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-24T14:15:22.212402Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-24T14:15:22.827326Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:10:34.904348+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:9d","maintenances":[],"modification_date":"2025-02-12T16:10:36.156614+00:00","name":"Scaleway Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"id":"6b9656e5-88c1-4a8f-af6a-01ecf39a238a","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "984"
+                - "1697"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:27 GMT
+                - Wed, 12 Feb 2025 16:10:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -954,10 +954,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 309613ab-a130-4069-b762-d89130f238ab
+                - dabbdfe2-6040-4980-b9a2-30fcbdbd2081
         status: 200 OK
         code: 200
-        duration: 27.104084ms
+        duration: 198.705708ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -973,8 +973,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/8ebafec9-15fb-496d-b212-1719a0311c3b
         method: GET
       response:
         proto: HTTP/2.0
@@ -982,20 +982,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2232
+        content_length: 1016
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-24T14:15:22.371679+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"8b61785d-9e59-462c-8c73-602613da26ec","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1802","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:83:d3","maintenances":[],"modification_date":"2025-01-24T14:15:23.125552+00:00","name":"Scaleway Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-24T14:15:22.371679+00:00","export_uri":null,"id":"bdaabaac-1ef9-4b2b-9f03-f8a6e88a1135","modification_date":"2025-01-24T14:15:22.371679+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"8b61785d-9e59-462c-8c73-602613da26ec","name":"Scaleway Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:10:35.342174Z","gateway_networks":[],"id":"8ebafec9-15fb-496d-b212-1719a0311c3b","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:10:34.957253Z","gateway_id":"8ebafec9-15fb-496d-b212-1719a0311c3b","id":"d217409e-10e1-4bbc-97d6-1daedb998b38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:10:34.957253Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:10:35.568178Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2232"
+                - "1016"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:28 GMT
+                - Wed, 12 Feb 2025 16:10:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1003,10 +1003,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1376618f-8df3-420f-9547-7d53fa3dce71
+                - 6295cec6-98b9-41ca-94d6-67602945f81e
         status: 200 OK
         code: 200
-        duration: 199.163709ms
+        duration: 55.02275ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1022,8 +1022,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0cdaf520-f0e0-46ed-b197-36c28975d51c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1031,20 +1031,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 980
+        content_length: 1831
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-24T14:15:22.458029Z","gateway_networks":[],"id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","ip":{"address":"51.158.121.168","created_at":"2025-01-24T14:15:22.212402Z","gateway_id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","id":"5e32e435-6bf9-4406-8f72-8f76be892a2f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"168-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-24T14:15:22.212402Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-24T14:15:27.807785Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:10:34.904348+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"701","node_id":"23","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:9d","maintenances":[],"modification_date":"2025-02-12T16:10:41.323660+00:00","name":"Scaleway Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"6b9656e5-88c1-4a8f-af6a-01ecf39a238a","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "980"
+                - "1831"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:32 GMT
+                - Wed, 12 Feb 2025 16:10:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1052,10 +1052,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 92683421-df6b-49dd-9d36-17139b124c40
+                - 51e41fd9-fd5b-4e93-b635-87ce9d28f034
         status: 200 OK
         code: 200
-        duration: 30.834875ms
+        duration: 213.564833ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1071,8 +1071,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0cdaf520-f0e0-46ed-b197-36c28975d51c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7abd3366-919a-46e1-88ad-af224037959a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1080,20 +1080,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 980
+        content_length: 1060
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-24T14:15:22.458029Z","gateway_networks":[],"id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","ip":{"address":"51.158.121.168","created_at":"2025-01-24T14:15:22.212402Z","gateway_id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","id":"5e32e435-6bf9-4406-8f72-8f76be892a2f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"168-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-24T14:15:22.212402Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-24T14:15:27.807785Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:10:33.577102Z","dhcp_enabled":true,"id":"7abd3366-919a-46e1-88ad-af224037959a","name":"private network with a DHCP config","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:10:33.577102Z","id":"eca4e6e3-9dfa-4837-a839-b6506b1f69e7","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.16.0/22","updated_at":"2025-02-12T16:10:33.577102Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-12T16:10:33.577102Z","id":"afcdeb34-4c8b-495d-98ca-5c35531d6fed","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:4ef::/64","updated_at":"2025-02-12T16:10:33.577102Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-12T16:10:33.577102Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "980"
+                - "1060"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:32 GMT
+                - Wed, 12 Feb 2025 16:10:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1101,10 +1101,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 89364819-f8a4-4b1a-8a6a-322580ed4b9b
+                - 9fec3d56-4bcc-4279-b9ee-cb1f43da1044
         status: 200 OK
         code: 200
-        duration: 27.613541ms
+        duration: 89.605291ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1120,8 +1120,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0cdaf520-f0e0-46ed-b197-36c28975d51c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1129,20 +1129,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 980
+        content_length: 1831
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-24T14:15:22.458029Z","gateway_networks":[],"id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","ip":{"address":"51.158.121.168","created_at":"2025-01-24T14:15:22.212402Z","gateway_id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","id":"5e32e435-6bf9-4406-8f72-8f76be892a2f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"168-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-24T14:15:22.212402Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-24T14:15:27.807785Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:10:34.904348+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"701","node_id":"23","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:9d","maintenances":[],"modification_date":"2025-02-12T16:10:41.323660+00:00","name":"Scaleway Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"6b9656e5-88c1-4a8f-af6a-01ecf39a238a","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "980"
+                - "1831"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:32 GMT
+                - Wed, 12 Feb 2025 16:10:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1150,29 +1150,29 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5a651484-a48c-49a3-ad05-444ac0b242e4
+                - 8be8d488-40fd-4697-a109-50d138a2e99b
         status: 200 OK
         code: 200
-        duration: 32.635292ms
+        duration: 195.099125ms
     - id: 23
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 266
+        content_length: 61
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-lb-with-private-network-configs","description":"","ip_id":"df74cb2c-3245-49d9-b592-e67c753e77ac","ip_ids":[],"tags":null,"type":"LB-S","ssl_compatibility_level":"ssl_compatibility_level_intermediate"}'
+        body: '{"private_network_id":"7abd3366-919a-46e1-88ad-af224037959a"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f/private_nics
         method: POST
       response:
         proto: HTTP/2.0
@@ -1180,20 +1180,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 895
+        content_length: 473
         uncompressed: false
-        body: '{"backend_count":0,"created_at":"2025-01-24T14:15:32.867434935Z","description":"","frontend_count":0,"id":"74eabe50-405f-4517-9bd6-2540dafd4f89","instances":[],"ip":[{"id":"df74cb2c-3245-49d9-b592-e67c753e77ac","ip_address":"51.159.25.55","lb_id":"74eabe50-405f-4517-9bd6-2540dafd4f89","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-25-55.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"to_create","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2025-01-24T14:15:32.867434935Z","zone":"fr-par-1"}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:10:42.196064+00:00","id":"cd2ffe8a-cda4-4325-8df1-e348145dcbf5","ipam_ip_ids":["8f0f24a6-2948-4029-94cf-8f7783d650d0","481a5ee7-ae89-4dc2-b0d2-95e88d40bb84"],"mac_address":"02:00:00:16:45:44","modification_date":"2025-02-12T16:10:42.414398+00:00","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","server_id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "895"
+                - "473"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:33 GMT
+                - Wed, 12 Feb 2025 16:10:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1201,10 +1201,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6bf18900-c130-43cd-a3c9-29b2209fbe2b
-        status: 200 OK
-        code: 200
-        duration: 389.10325ms
+                - d6abf40f-09e6-45f1-b779-11d924ebfeee
+        status: 201 Created
+        code: 201
+        duration: 1.150458083s
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1220,8 +1220,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/74eabe50-405f-4517-9bd6-2540dafd4f89
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f/private_nics/cd2ffe8a-cda4-4325-8df1-e348145dcbf5
         method: GET
       response:
         proto: HTTP/2.0
@@ -1229,20 +1229,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 889
+        content_length: 473
         uncompressed: false
-        body: '{"backend_count":0,"created_at":"2025-01-24T14:15:32.867435Z","description":"","frontend_count":0,"id":"74eabe50-405f-4517-9bd6-2540dafd4f89","instances":[],"ip":[{"id":"df74cb2c-3245-49d9-b592-e67c753e77ac","ip_address":"51.159.25.55","lb_id":"74eabe50-405f-4517-9bd6-2540dafd4f89","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-25-55.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"to_create","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2025-01-24T14:15:32.867435Z","zone":"fr-par-1"}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:10:42.196064+00:00","id":"cd2ffe8a-cda4-4325-8df1-e348145dcbf5","ipam_ip_ids":["8f0f24a6-2948-4029-94cf-8f7783d650d0","481a5ee7-ae89-4dc2-b0d2-95e88d40bb84"],"mac_address":"02:00:00:16:45:44","modification_date":"2025-02-12T16:10:42.414398+00:00","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","server_id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "889"
+                - "473"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:33 GMT
+                - Wed, 12 Feb 2025 16:10:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1250,10 +1250,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4e661a9c-1e0d-480f-a76b-a227797c0555
+                - b55cbcad-be00-4595-b64e-dd37ee9aaf61
         status: 200 OK
         code: 200
-        duration: 95.938042ms
+        duration: 540.960791ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1269,8 +1269,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/8ebafec9-15fb-496d-b212-1719a0311c3b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1278,20 +1278,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2232
+        content_length: 1012
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-24T14:15:22.371679+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"8b61785d-9e59-462c-8c73-602613da26ec","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1802","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:83:d3","maintenances":[],"modification_date":"2025-01-24T14:15:23.125552+00:00","name":"Scaleway Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-24T14:15:22.371679+00:00","export_uri":null,"id":"bdaabaac-1ef9-4b2b-9f03-f8a6e88a1135","modification_date":"2025-01-24T14:15:22.371679+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"8b61785d-9e59-462c-8c73-602613da26ec","name":"Scaleway Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:10:35.342174Z","gateway_networks":[],"id":"8ebafec9-15fb-496d-b212-1719a0311c3b","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:10:34.957253Z","gateway_id":"8ebafec9-15fb-496d-b212-1719a0311c3b","id":"d217409e-10e1-4bbc-97d6-1daedb998b38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:10:34.957253Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:10:40.925398Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2232"
+                - "1012"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:33 GMT
+                - Wed, 12 Feb 2025 16:10:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1299,50 +1299,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 123d25c7-0b05-45ea-a391-b43100d47cb1
+                - 20ce7b47-547a-4f79-a3d8-139ee78fed13
         status: 200 OK
         code: 200
-        duration: 160.0155ms
+        duration: 108.923ms
     - id: 26
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 206
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"gateway_id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"48b28823-2ed8-4a73-82a5-752bc9447518"}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/8ebafec9-15fb-496d-b212-1719a0311c3b
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 941
+        content_length: 1012
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-24T14:15:34.959930Z","dhcp":{"address":"10.0.0.1","created_at":"2025-01-24T14:15:20.581273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"48b28823-2ed8-4a73-82a5-752bc9447518","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-24T14:15:20.581273Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","id":"92b71032-5580-4650-bd52-b63253bcc3b5","ipam_config":null,"mac_address":null,"private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","status":"created","updated_at":"2025-01-24T14:15:34.959930Z","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:10:35.342174Z","gateway_networks":[],"id":"8ebafec9-15fb-496d-b212-1719a0311c3b","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:10:34.957253Z","gateway_id":"8ebafec9-15fb-496d-b212-1719a0311c3b","id":"d217409e-10e1-4bbc-97d6-1daedb998b38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:10:34.957253Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:10:40.925398Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "941"
+                - "1012"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:35 GMT
+                - Wed, 12 Feb 2025 16:10:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1350,10 +1348,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7ce8f0ae-a4b4-4ba0-9d4f-3e34c631a934
+                - 2dd962d9-e70e-406c-bfb9-4fa4ec003fd3
         status: 200 OK
         code: 200
-        duration: 2.443523833s
+        duration: 57.301375ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1369,8 +1367,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0cdaf520-f0e0-46ed-b197-36c28975d51c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/8ebafec9-15fb-496d-b212-1719a0311c3b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1378,20 +1376,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1924
+        content_length: 1012
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-24T14:15:22.458029Z","gateway_networks":[{"address":null,"created_at":"2025-01-24T14:15:34.959930Z","dhcp":{"address":"10.0.0.1","created_at":"2025-01-24T14:15:20.581273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"48b28823-2ed8-4a73-82a5-752bc9447518","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-24T14:15:20.581273Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","id":"92b71032-5580-4650-bd52-b63253bcc3b5","ipam_config":null,"mac_address":null,"private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","status":"created","updated_at":"2025-01-24T14:15:34.959930Z","zone":"fr-par-1"}],"id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","ip":{"address":"51.158.121.168","created_at":"2025-01-24T14:15:22.212402Z","gateway_id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","id":"5e32e435-6bf9-4406-8f72-8f76be892a2f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"168-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-24T14:15:22.212402Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-24T14:15:35.126649Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:10:35.342174Z","gateway_networks":[],"id":"8ebafec9-15fb-496d-b212-1719a0311c3b","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:10:34.957253Z","gateway_id":"8ebafec9-15fb-496d-b212-1719a0311c3b","id":"d217409e-10e1-4bbc-97d6-1daedb998b38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:10:34.957253Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:10:40.925398Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1924"
+                - "1012"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:35 GMT
+                - Wed, 12 Feb 2025 16:10:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1399,48 +1397,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 479f92a8-968e-4359-a1fe-f2886350a6a3
+                - ea6f38c3-b030-4a83-a083-8cf6b623c188
         status: 200 OK
         code: 200
-        duration: 31.358541ms
+        duration: 50.001458ms
     - id: 28
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 266
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-lb-with-private-network-configs","description":"","ip_id":"d44cc37b-f392-46c9-a576-e42711323050","ip_ids":[],"tags":null,"type":"LB-S","ssl_compatibility_level":"ssl_compatibility_level_intermediate"}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2232
+        content_length: 922
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-24T14:15:22.371679+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"8b61785d-9e59-462c-8c73-602613da26ec","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1802","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:83:d3","maintenances":[],"modification_date":"2025-01-24T14:15:23.125552+00:00","name":"Scaleway Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-24T14:15:22.371679+00:00","export_uri":null,"id":"bdaabaac-1ef9-4b2b-9f03-f8a6e88a1135","modification_date":"2025-01-24T14:15:22.371679+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"8b61785d-9e59-462c-8c73-602613da26ec","name":"Scaleway Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"backend_count":0,"created_at":"2025-02-12T16:10:45.871196939Z","description":"","frontend_count":0,"id":"d774a252-83bc-4ff8-93d0-770d444a0574","instances":[],"ip":[{"id":"d44cc37b-f392-46c9-a576-e42711323050","ip_address":"51.159.9.241","lb_id":"d774a252-83bc-4ff8-93d0-770d444a0574","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-9-241.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"to_create","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2025-02-12T16:10:45.871196939Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2232"
+                - "922"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:38 GMT
+                - Wed, 12 Feb 2025 16:10:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1448,10 +1448,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fafc2837-ae91-4834-8727-4e18311732cc
+                - eeb3f88e-bfa1-4ac4-9b6b-546709f74e19
         status: 200 OK
         code: 200
-        duration: 200.783666ms
+        duration: 352.625583ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1467,8 +1467,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0cdaf520-f0e0-46ed-b197-36c28975d51c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/d774a252-83bc-4ff8-93d0-770d444a0574
         method: GET
       response:
         proto: HTTP/2.0
@@ -1476,20 +1476,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1924
+        content_length: 1123
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-24T14:15:22.458029Z","gateway_networks":[{"address":null,"created_at":"2025-01-24T14:15:34.959930Z","dhcp":{"address":"10.0.0.1","created_at":"2025-01-24T14:15:20.581273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"48b28823-2ed8-4a73-82a5-752bc9447518","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-24T14:15:20.581273Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","id":"92b71032-5580-4650-bd52-b63253bcc3b5","ipam_config":null,"mac_address":null,"private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","status":"created","updated_at":"2025-01-24T14:15:34.959930Z","zone":"fr-par-1"}],"id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","ip":{"address":"51.158.121.168","created_at":"2025-01-24T14:15:22.212402Z","gateway_id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","id":"5e32e435-6bf9-4406-8f72-8f76be892a2f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"168-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-24T14:15:22.212402Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-24T14:15:35.126649Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"backend_count":0,"created_at":"2025-02-12T16:10:45.871197Z","description":"","frontend_count":0,"id":"d774a252-83bc-4ff8-93d0-770d444a0574","instances":[{"created_at":"2025-02-12T16:06:55.264058Z","id":"e43221b3-c700-4951-b53d-cf6ad775b8c0","ip_address":"","region":"fr-par","status":"unknown","updated_at":"2025-02-12T16:10:46.087676Z","zone":"fr-par-1"}],"ip":[{"id":"d44cc37b-f392-46c9-a576-e42711323050","ip_address":"51.159.9.241","lb_id":"d774a252-83bc-4ff8-93d0-770d444a0574","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-9-241.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"creating","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2025-02-12T16:10:46.092748Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1924"
+                - "1123"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:40 GMT
+                - Wed, 12 Feb 2025 16:10:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1497,48 +1497,50 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b965fa89-c419-4996-851f-6a645b25b14c
+                - c0380407-b4ff-4ead-b8e5-d511e9d64474
         status: 200 OK
         code: 200
-        duration: 47.242083ms
+        duration: 106.860625ms
     - id: 30
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 206
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"gateway_id":"8ebafec9-15fb-496d-b212-1719a0311c3b","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"1248e521-f708-4f4a-80ee-9d3084b0616f"}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2263
+        content_length: 971
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-24T14:15:22.371679+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"8b61785d-9e59-462c-8c73-602613da26ec","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1802","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:83:d3","maintenances":[],"modification_date":"2025-01-24T14:15:39.592074+00:00","name":"Scaleway Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-24T14:15:22.371679+00:00","export_uri":null,"id":"bdaabaac-1ef9-4b2b-9f03-f8a6e88a1135","modification_date":"2025-01-24T14:15:22.371679+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"8b61785d-9e59-462c-8c73-602613da26ec","name":"Scaleway Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"address":null,"created_at":"2025-02-12T16:10:48.362447Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:10:33.561435Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1248e521-f708-4f4a-80ee-9d3084b0616f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:10:33.561435Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8ebafec9-15fb-496d-b212-1719a0311c3b","id":"fa8d0cb8-6e84-4edf-beba-cfefaa1bd81c","ipam_config":null,"mac_address":null,"private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","status":"created","updated_at":"2025-02-12T16:10:48.362447Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2263"
+                - "971"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:44 GMT
+                - Wed, 12 Feb 2025 16:10:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1546,10 +1548,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0fb2b411-0887-4c25-b0b4-12ae54ba82fe
+                - 02dbf8e8-9737-4a10-8e0a-8dfea551043f
         status: 200 OK
         code: 200
-        duration: 215.106209ms
+        duration: 2.788290709s
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1565,8 +1567,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/57acd471-d6d6-471a-be4f-6464a3976f5b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/8ebafec9-15fb-496d-b212-1719a0311c3b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1574,20 +1576,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1035
+        content_length: 1986
         uncompressed: false
-        body: '{"created_at":"2025-01-24T14:15:20.580798Z","dhcp_enabled":true,"id":"57acd471-d6d6-471a-be4f-6464a3976f5b","name":"private network with a DHCP config","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-24T14:15:20.580798Z","id":"f6142587-74eb-45b3-a361-72fa990fcec1","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"10.0.0.0/24","updated_at":"2025-01-24T14:15:33.062704Z","vpc_id":"bf83c6f6-2f6d-48ef-b59c-ae8086b2bb1c"},{"created_at":"2025-01-24T14:15:20.580798Z","id":"ed64f437-e22a-454d-8f4c-34b7c0a996d3","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:cece::/64","updated_at":"2025-01-24T14:15:33.065902Z","vpc_id":"bf83c6f6-2f6d-48ef-b59c-ae8086b2bb1c"}],"tags":[],"updated_at":"2025-01-24T14:15:41.703440Z","vpc_id":"bf83c6f6-2f6d-48ef-b59c-ae8086b2bb1c"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:10:35.342174Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:10:48.362447Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:10:33.561435Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1248e521-f708-4f4a-80ee-9d3084b0616f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:10:33.561435Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8ebafec9-15fb-496d-b212-1719a0311c3b","id":"fa8d0cb8-6e84-4edf-beba-cfefaa1bd81c","ipam_config":null,"mac_address":null,"private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","status":"created","updated_at":"2025-02-12T16:10:48.362447Z","zone":"fr-par-1"}],"id":"8ebafec9-15fb-496d-b212-1719a0311c3b","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:10:34.957253Z","gateway_id":"8ebafec9-15fb-496d-b212-1719a0311c3b","id":"d217409e-10e1-4bbc-97d6-1daedb998b38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:10:34.957253Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:10:48.544723Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1035"
+                - "1986"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:44 GMT
+                - Wed, 12 Feb 2025 16:10:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1595,10 +1597,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 10d1e3a0-b968-4bbb-bb14-ebc4bd5895a3
+                - 7e3b6d66-e8a7-4ffc-bf14-b4258053d302
         status: 200 OK
         code: 200
-        duration: 26.423625ms
+        duration: 55.113042ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1614,8 +1616,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f/private_nics/cd2ffe8a-cda4-4325-8df1-e348145dcbf5
         method: GET
       response:
         proto: HTTP/2.0
@@ -1623,20 +1625,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2263
+        content_length: 473
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-24T14:15:22.371679+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"8b61785d-9e59-462c-8c73-602613da26ec","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1802","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:83:d3","maintenances":[],"modification_date":"2025-01-24T14:15:39.592074+00:00","name":"Scaleway Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-24T14:15:22.371679+00:00","export_uri":null,"id":"bdaabaac-1ef9-4b2b-9f03-f8a6e88a1135","modification_date":"2025-01-24T14:15:22.371679+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"8b61785d-9e59-462c-8c73-602613da26ec","name":"Scaleway Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:10:42.196064+00:00","id":"cd2ffe8a-cda4-4325-8df1-e348145dcbf5","ipam_ip_ids":["8f0f24a6-2948-4029-94cf-8f7783d650d0","481a5ee7-ae89-4dc2-b0d2-95e88d40bb84"],"mac_address":"02:00:00:16:45:44","modification_date":"2025-02-12T16:10:42.414398+00:00","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","server_id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2263"
+                - "473"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:44 GMT
+                - Wed, 12 Feb 2025 16:10:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1644,10 +1646,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ceee6f8f-2340-46dc-bd9a-7b94a677e0fb
+                - da2c37d5-10c7-4822-9ed0-9773c122117b
         status: 200 OK
         code: 200
-        duration: 161.751083ms
+        duration: 112.835625ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1663,8 +1665,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0cdaf520-f0e0-46ed-b197-36c28975d51c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/8ebafec9-15fb-496d-b212-1719a0311c3b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1672,20 +1674,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1933
+        content_length: 1986
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-24T14:15:22.458029Z","gateway_networks":[{"address":null,"created_at":"2025-01-24T14:15:34.959930Z","dhcp":{"address":"10.0.0.1","created_at":"2025-01-24T14:15:20.581273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"48b28823-2ed8-4a73-82a5-752bc9447518","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-24T14:15:20.581273Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","id":"92b71032-5580-4650-bd52-b63253bcc3b5","ipam_config":null,"mac_address":"02:00:00:17:E0:4B","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","status":"ready","updated_at":"2025-01-24T14:15:43.507917Z","zone":"fr-par-1"}],"id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","ip":{"address":"51.158.121.168","created_at":"2025-01-24T14:15:22.212402Z","gateway_id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","id":"5e32e435-6bf9-4406-8f72-8f76be892a2f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"168-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-24T14:15:22.212402Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-24T14:15:43.659223Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:10:35.342174Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:10:48.362447Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:10:33.561435Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1248e521-f708-4f4a-80ee-9d3084b0616f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:10:33.561435Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8ebafec9-15fb-496d-b212-1719a0311c3b","id":"fa8d0cb8-6e84-4edf-beba-cfefaa1bd81c","ipam_config":null,"mac_address":null,"private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","status":"created","updated_at":"2025-02-12T16:10:48.362447Z","zone":"fr-par-1"}],"id":"8ebafec9-15fb-496d-b212-1719a0311c3b","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:10:34.957253Z","gateway_id":"8ebafec9-15fb-496d-b212-1719a0311c3b","id":"d217409e-10e1-4bbc-97d6-1daedb998b38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:10:34.957253Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:10:48.544723Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1933"
+                - "1986"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:45 GMT
+                - Wed, 12 Feb 2025 16:10:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1693,10 +1695,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f6ccfd55-4059-4f45-90c0-b313ffb1d8ba
+                - e9900f66-a238-4d2b-a580-7bd23aa5860d
         status: 200 OK
         code: 200
-        duration: 30.026459ms
+        duration: 64.197583ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1712,8 +1714,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/92b71032-5580-4650-bd52-b63253bcc3b5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f/private_nics/cd2ffe8a-cda4-4325-8df1-e348145dcbf5
         method: GET
       response:
         proto: HTTP/2.0
@@ -1721,20 +1723,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 954
+        content_length: 473
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-24T14:15:34.959930Z","dhcp":{"address":"10.0.0.1","created_at":"2025-01-24T14:15:20.581273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"48b28823-2ed8-4a73-82a5-752bc9447518","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-24T14:15:20.581273Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","id":"92b71032-5580-4650-bd52-b63253bcc3b5","ipam_config":null,"mac_address":"02:00:00:17:E0:4B","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","status":"ready","updated_at":"2025-01-24T14:15:43.507917Z","zone":"fr-par-1"}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:10:42.196064+00:00","id":"cd2ffe8a-cda4-4325-8df1-e348145dcbf5","ipam_ip_ids":["8f0f24a6-2948-4029-94cf-8f7783d650d0","481a5ee7-ae89-4dc2-b0d2-95e88d40bb84"],"mac_address":"02:00:00:16:45:44","modification_date":"2025-02-12T16:10:42.414398+00:00","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","server_id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "954"
+                - "473"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:45 GMT
+                - Wed, 12 Feb 2025 16:10:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1742,10 +1744,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e60687b2-0d9e-4b57-9e53-2049bcf87724
+                - 03b2b48e-e6dc-4087-8053-a7a3a21a8e2b
         status: 200 OK
         code: 200
-        duration: 67.214541ms
+        duration: 113.142375ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1761,8 +1763,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/92b71032-5580-4650-bd52-b63253bcc3b5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/8ebafec9-15fb-496d-b212-1719a0311c3b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1770,20 +1772,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 954
+        content_length: 2005
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-24T14:15:34.959930Z","dhcp":{"address":"10.0.0.1","created_at":"2025-01-24T14:15:20.581273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"48b28823-2ed8-4a73-82a5-752bc9447518","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-24T14:15:20.581273Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","id":"92b71032-5580-4650-bd52-b63253bcc3b5","ipam_config":null,"mac_address":"02:00:00:17:E0:4B","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","status":"ready","updated_at":"2025-01-24T14:15:43.507917Z","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:10:35.342174Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:10:48.362447Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:10:33.561435Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1248e521-f708-4f4a-80ee-9d3084b0616f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:10:33.561435Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8ebafec9-15fb-496d-b212-1719a0311c3b","id":"fa8d0cb8-6e84-4edf-beba-cfefaa1bd81c","ipam_config":null,"mac_address":"02:00:00:18:61:C7","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","status":"configuring","updated_at":"2025-02-12T16:10:54.228713Z","zone":"fr-par-1"}],"id":"8ebafec9-15fb-496d-b212-1719a0311c3b","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:10:34.957253Z","gateway_id":"8ebafec9-15fb-496d-b212-1719a0311c3b","id":"d217409e-10e1-4bbc-97d6-1daedb998b38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:10:34.957253Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:10:48.544723Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "954"
+                - "2005"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:45 GMT
+                - Wed, 12 Feb 2025 16:10:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1791,10 +1793,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a7d46a80-a83c-45fb-94fc-4f5cca1c9af5
+                - 06152b4a-8850-4328-b7ab-b6ec95885a18
         status: 200 OK
         code: 200
-        duration: 47.959375ms
+        duration: 54.098666ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1810,8 +1812,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0cdaf520-f0e0-46ed-b197-36c28975d51c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f/private_nics/cd2ffe8a-cda4-4325-8df1-e348145dcbf5
         method: GET
       response:
         proto: HTTP/2.0
@@ -1819,20 +1821,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1933
+        content_length: 473
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-24T14:15:22.458029Z","gateway_networks":[{"address":null,"created_at":"2025-01-24T14:15:34.959930Z","dhcp":{"address":"10.0.0.1","created_at":"2025-01-24T14:15:20.581273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"48b28823-2ed8-4a73-82a5-752bc9447518","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-24T14:15:20.581273Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","id":"92b71032-5580-4650-bd52-b63253bcc3b5","ipam_config":null,"mac_address":"02:00:00:17:E0:4B","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","status":"ready","updated_at":"2025-01-24T14:15:43.507917Z","zone":"fr-par-1"}],"id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","ip":{"address":"51.158.121.168","created_at":"2025-01-24T14:15:22.212402Z","gateway_id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","id":"5e32e435-6bf9-4406-8f72-8f76be892a2f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"168-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-24T14:15:22.212402Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-24T14:15:43.659223Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:10:42.196064+00:00","id":"cd2ffe8a-cda4-4325-8df1-e348145dcbf5","ipam_ip_ids":["8f0f24a6-2948-4029-94cf-8f7783d650d0","481a5ee7-ae89-4dc2-b0d2-95e88d40bb84"],"mac_address":"02:00:00:16:45:44","modification_date":"2025-02-12T16:10:42.414398+00:00","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","server_id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1933"
+                - "473"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:45 GMT
+                - Wed, 12 Feb 2025 16:10:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1840,10 +1842,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4ee3c234-1af5-4fa2-8c61-03264d14f39b
+                - edc86364-7e99-48fb-8e12-2d5b34f3963c
         status: 200 OK
         code: 200
-        duration: 31.534625ms
+        duration: 120.832542ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1859,8 +1861,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/92b71032-5580-4650-bd52-b63253bcc3b5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/8ebafec9-15fb-496d-b212-1719a0311c3b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1868,20 +1870,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 954
+        content_length: 1995
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-24T14:15:34.959930Z","dhcp":{"address":"10.0.0.1","created_at":"2025-01-24T14:15:20.581273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"48b28823-2ed8-4a73-82a5-752bc9447518","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-24T14:15:20.581273Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","id":"92b71032-5580-4650-bd52-b63253bcc3b5","ipam_config":null,"mac_address":"02:00:00:17:E0:4B","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","status":"ready","updated_at":"2025-01-24T14:15:43.507917Z","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:10:35.342174Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:10:48.362447Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:10:33.561435Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1248e521-f708-4f4a-80ee-9d3084b0616f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:10:33.561435Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8ebafec9-15fb-496d-b212-1719a0311c3b","id":"fa8d0cb8-6e84-4edf-beba-cfefaa1bd81c","ipam_config":null,"mac_address":"02:00:00:18:61:C7","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","status":"ready","updated_at":"2025-02-12T16:10:59.506156Z","zone":"fr-par-1"}],"id":"8ebafec9-15fb-496d-b212-1719a0311c3b","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:10:34.957253Z","gateway_id":"8ebafec9-15fb-496d-b212-1719a0311c3b","id":"d217409e-10e1-4bbc-97d6-1daedb998b38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:10:34.957253Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:10:59.705659Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "954"
+                - "1995"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:45 GMT
+                - Wed, 12 Feb 2025 16:11:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1889,50 +1891,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 76e8a2a5-700a-497e-a936-812b76b4033d
+                - 607b4af1-36f5-48f4-b28b-7ff18d647285
         status: 200 OK
         code: 200
-        duration: 50.07975ms
+        duration: 49.225167ms
     - id: 38
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 61
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b"}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec/private_nics
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/fa8d0cb8-6e84-4edf-beba-cfefaa1bd81c
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 473
+        content_length: 984
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-24T14:15:44.689986+00:00","id":"9046d524-d6a4-49ac-93cc-7dc56744d7ee","ipam_ip_ids":["2434ba0e-6dd2-4176-adca-a051205c78e8","bbadcc9e-16cd-475d-9167-9728c06de445"],"mac_address":"02:00:00:10:c8:b7","modification_date":"2025-01-24T14:15:44.930528+00:00","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","server_id":"8b61785d-9e59-462c-8c73-602613da26ec","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"address":null,"created_at":"2025-02-12T16:10:48.362447Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:10:33.561435Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1248e521-f708-4f4a-80ee-9d3084b0616f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:10:33.561435Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8ebafec9-15fb-496d-b212-1719a0311c3b","id":"fa8d0cb8-6e84-4edf-beba-cfefaa1bd81c","ipam_config":null,"mac_address":"02:00:00:18:61:C7","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","status":"ready","updated_at":"2025-02-12T16:10:59.506156Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "473"
+                - "984"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:45 GMT
+                - Wed, 12 Feb 2025 16:11:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1940,10 +1940,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - da2ef179-f47f-481b-af20-0102103176e8
-        status: 201 Created
-        code: 201
-        duration: 1.308148708s
+                - fe069a5d-5709-4a36-9c46-97b064cb5c0b
+        status: 200 OK
+        code: 200
+        duration: 116.842625ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1959,8 +1959,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec/private_nics/9046d524-d6a4-49ac-93cc-7dc56744d7ee
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/fa8d0cb8-6e84-4edf-beba-cfefaa1bd81c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1968,20 +1968,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 473
+        content_length: 984
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-24T14:15:44.689986+00:00","id":"9046d524-d6a4-49ac-93cc-7dc56744d7ee","ipam_ip_ids":["2434ba0e-6dd2-4176-adca-a051205c78e8","bbadcc9e-16cd-475d-9167-9728c06de445"],"mac_address":"02:00:00:10:c8:b7","modification_date":"2025-01-24T14:15:44.930528+00:00","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","server_id":"8b61785d-9e59-462c-8c73-602613da26ec","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"address":null,"created_at":"2025-02-12T16:10:48.362447Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:10:33.561435Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1248e521-f708-4f4a-80ee-9d3084b0616f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:10:33.561435Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8ebafec9-15fb-496d-b212-1719a0311c3b","id":"fa8d0cb8-6e84-4edf-beba-cfefaa1bd81c","ipam_config":null,"mac_address":"02:00:00:18:61:C7","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","status":"ready","updated_at":"2025-02-12T16:10:59.506156Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "473"
+                - "984"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:46 GMT
+                - Wed, 12 Feb 2025 16:11:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1989,10 +1989,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d4ad8270-d00a-45cd-82a8-671bb231ebef
+                - 9dac06f7-6db3-4be9-985f-79498aa24ccb
         status: 200 OK
         code: 200
-        duration: 90.241708ms
+        duration: 106.707084ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2008,8 +2008,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec/private_nics/9046d524-d6a4-49ac-93cc-7dc56744d7ee
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/8ebafec9-15fb-496d-b212-1719a0311c3b
         method: GET
       response:
         proto: HTTP/2.0
@@ -2017,20 +2017,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 473
+        content_length: 1995
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-24T14:15:44.689986+00:00","id":"9046d524-d6a4-49ac-93cc-7dc56744d7ee","ipam_ip_ids":["2434ba0e-6dd2-4176-adca-a051205c78e8","bbadcc9e-16cd-475d-9167-9728c06de445"],"mac_address":"02:00:00:10:c8:b7","modification_date":"2025-01-24T14:15:44.930528+00:00","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","server_id":"8b61785d-9e59-462c-8c73-602613da26ec","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:10:35.342174Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:10:48.362447Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:10:33.561435Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1248e521-f708-4f4a-80ee-9d3084b0616f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:10:33.561435Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8ebafec9-15fb-496d-b212-1719a0311c3b","id":"fa8d0cb8-6e84-4edf-beba-cfefaa1bd81c","ipam_config":null,"mac_address":"02:00:00:18:61:C7","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","status":"ready","updated_at":"2025-02-12T16:10:59.506156Z","zone":"fr-par-1"}],"id":"8ebafec9-15fb-496d-b212-1719a0311c3b","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:10:34.957253Z","gateway_id":"8ebafec9-15fb-496d-b212-1719a0311c3b","id":"d217409e-10e1-4bbc-97d6-1daedb998b38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:10:34.957253Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:10:59.705659Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "473"
+                - "1995"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:51 GMT
+                - Wed, 12 Feb 2025 16:11:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2038,10 +2038,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 89d43e72-0ff7-4148-8187-4ebe5cea61db
+                - b5f97f18-9920-4bc7-b22c-862ed930d50e
         status: 200 OK
         code: 200
-        duration: 74.815542ms
+        duration: 48.201834ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2057,8 +2057,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec/private_nics/9046d524-d6a4-49ac-93cc-7dc56744d7ee
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/fa8d0cb8-6e84-4edf-beba-cfefaa1bd81c
         method: GET
       response:
         proto: HTTP/2.0
@@ -2066,20 +2066,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 473
+        content_length: 984
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-24T14:15:44.689986+00:00","id":"9046d524-d6a4-49ac-93cc-7dc56744d7ee","ipam_ip_ids":["2434ba0e-6dd2-4176-adca-a051205c78e8","bbadcc9e-16cd-475d-9167-9728c06de445"],"mac_address":"02:00:00:10:c8:b7","modification_date":"2025-01-24T14:15:44.930528+00:00","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","server_id":"8b61785d-9e59-462c-8c73-602613da26ec","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"address":null,"created_at":"2025-02-12T16:10:48.362447Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:10:33.561435Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1248e521-f708-4f4a-80ee-9d3084b0616f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:10:33.561435Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8ebafec9-15fb-496d-b212-1719a0311c3b","id":"fa8d0cb8-6e84-4edf-beba-cfefaa1bd81c","ipam_config":null,"mac_address":"02:00:00:18:61:C7","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","status":"ready","updated_at":"2025-02-12T16:10:59.506156Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "473"
+                - "984"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:15:56 GMT
+                - Wed, 12 Feb 2025 16:11:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2087,10 +2087,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6807bb80-33fe-4b40-af66-488579b163df
+                - 177603df-2d8a-4cd1-999d-8997248f458d
         status: 200 OK
         code: 200
-        duration: 85.660709ms
+        duration: 69.35725ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2106,8 +2106,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec/private_nics/9046d524-d6a4-49ac-93cc-7dc56744d7ee
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f/private_nics/cd2ffe8a-cda4-4325-8df1-e348145dcbf5
         method: GET
       response:
         proto: HTTP/2.0
@@ -2117,7 +2117,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-24T14:15:44.689986+00:00","id":"9046d524-d6a4-49ac-93cc-7dc56744d7ee","ipam_ip_ids":["2434ba0e-6dd2-4176-adca-a051205c78e8","bbadcc9e-16cd-475d-9167-9728c06de445"],"mac_address":"02:00:00:10:c8:b7","modification_date":"2025-01-24T14:15:44.930528+00:00","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","server_id":"8b61785d-9e59-462c-8c73-602613da26ec","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:10:42.196064+00:00","id":"cd2ffe8a-cda4-4325-8df1-e348145dcbf5","ipam_ip_ids":["8f0f24a6-2948-4029-94cf-8f7783d650d0","481a5ee7-ae89-4dc2-b0d2-95e88d40bb84"],"mac_address":"02:00:00:16:45:44","modification_date":"2025-02-12T16:10:42.414398+00:00","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","server_id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -2126,9 +2126,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:00 GMT
+                - Wed, 12 Feb 2025 16:11:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2136,10 +2136,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ecdbd0e3-4a5b-417b-957d-b67d4210062a
+                - 9358151b-e5d1-438a-b446-baebe49a0932
         status: 200 OK
         code: 200
-        duration: 107.115583ms
+        duration: 122.884333ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2155,8 +2155,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/74eabe50-405f-4517-9bd6-2540dafd4f89
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f/private_nics/cd2ffe8a-cda4-4325-8df1-e348145dcbf5
         method: GET
       response:
         proto: HTTP/2.0
@@ -2164,20 +2164,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1085
+        content_length: 473
         uncompressed: false
-        body: '{"backend_count":0,"created_at":"2025-01-24T14:15:32.867435Z","description":"","frontend_count":0,"id":"74eabe50-405f-4517-9bd6-2540dafd4f89","instances":[{"created_at":"2025-01-24T14:11:38.800501Z","id":"db97ec97-2d4e-4ffe-9447-7fa34e014506","ip_address":"","region":"fr-par","status":"ready","updated_at":"2025-01-24T14:15:35.244866Z","zone":"fr-par-1"}],"ip":[{"id":"df74cb2c-3245-49d9-b592-e67c753e77ac","ip_address":"51.159.25.55","lb_id":"74eabe50-405f-4517-9bd6-2540dafd4f89","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-25-55.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2025-01-24T14:15:36.612864Z","zone":"fr-par-1"}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:10:42.196064+00:00","id":"cd2ffe8a-cda4-4325-8df1-e348145dcbf5","ipam_ip_ids":["8f0f24a6-2948-4029-94cf-8f7783d650d0","481a5ee7-ae89-4dc2-b0d2-95e88d40bb84"],"mac_address":"02:00:00:16:45:44","modification_date":"2025-02-12T16:10:42.414398+00:00","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","server_id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1085"
+                - "473"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:03 GMT
+                - Wed, 12 Feb 2025 16:11:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2185,11 +2185,407 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b8445a12-71ad-4562-adf4-9528fb8dd0ae
+                - 3b925f21-fdaf-4544-8895-23d91668db02
         status: 200 OK
         code: 200
-        duration: 89.821792ms
+        duration: 122.624375ms
     - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f/private_nics/cd2ffe8a-cda4-4325-8df1-e348145dcbf5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 475
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:10:42.196064+00:00","id":"cd2ffe8a-cda4-4325-8df1-e348145dcbf5","ipam_ip_ids":["8f0f24a6-2948-4029-94cf-8f7783d650d0","481a5ee7-ae89-4dc2-b0d2-95e88d40bb84"],"mac_address":"02:00:00:16:45:44","modification_date":"2025-02-12T16:11:14.306581+00:00","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","server_id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","state":"available","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "475"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:11:14 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fb77e250-ea5e-4832-ba6e-e8cd84353688
+        status: 200 OK
+        code: 200
+        duration: 102.000292ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f/private_nics/cd2ffe8a-cda4-4325-8df1-e348145dcbf5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 475
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:10:42.196064+00:00","id":"cd2ffe8a-cda4-4325-8df1-e348145dcbf5","ipam_ip_ids":["8f0f24a6-2948-4029-94cf-8f7783d650d0","481a5ee7-ae89-4dc2-b0d2-95e88d40bb84"],"mac_address":"02:00:00:16:45:44","modification_date":"2025-02-12T16:11:14.306581+00:00","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","server_id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","state":"available","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "475"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:11:14 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5830ab0b-1f1a-411e-a91b-58435f31d9bc
+        status: 200 OK
+        code: 200
+        duration: 98.061958ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2289
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:10:34.904348+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"701","node_id":"23","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:9d","maintenances":[],"modification_date":"2025-02-12T16:10:41.323660+00:00","name":"Scaleway Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:10:42.196064+00:00","id":"cd2ffe8a-cda4-4325-8df1-e348145dcbf5","ipam_ip_ids":["8f0f24a6-2948-4029-94cf-8f7783d650d0","481a5ee7-ae89-4dc2-b0d2-95e88d40bb84"],"mac_address":"02:00:00:16:45:44","modification_date":"2025-02-12T16:11:14.306581+00:00","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","server_id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"6b9656e5-88c1-4a8f-af6a-01ecf39a238a","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2289"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:11:14 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8f289741-8607-45af-b686-fbef4a10defe
+        status: 200 OK
+        code: 200
+        duration: 231.895166ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/6b9656e5-88c1-4a8f-af6a-01ecf39a238a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"6b9656e5-88c1-4a8f-af6a-01ecf39a238a","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:11:14 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0f5cb59d-2c90-4f0f-b726-846bbf4ddd9c
+        status: 404 Not Found
+        code: 404
+        duration: 68.997708ms
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/6b9656e5-88c1-4a8f-af6a-01ecf39a238a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 692
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:10:35.127132Z","id":"6b9656e5-88c1-4a8f-af6a-01ecf39a238a","last_detached_at":null,"name":"Debian Bullseye_sbs_volume_0","parent_snapshot_id":"a50e6921-21b9-4a69-83cc-191359208d4c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:10:35.127132Z","id":"8bc47366-83a8-4780-a8b2-b589142d9451","product_resource_id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:10:35.127132Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "692"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:11:15 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - bbb152be-52e7-4249-ad10-02668f0e1317
+        status: 200 OK
+        code: 200
+        duration: 92.577042ms
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f/user_data
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 17
+        uncompressed: false
+        body: '{"user_data":[]}'
+        headers:
+            Content-Length:
+                - "17"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:11:15 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3f1fa105-b232-4e2d-a876-7a659fce0f72
+        status: 200 OK
+        code: 200
+        duration: 102.783208ms
+    - id: 50
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 478
+        uncompressed: false
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:10:42.196064+00:00","id":"cd2ffe8a-cda4-4325-8df1-e348145dcbf5","ipam_ip_ids":["8f0f24a6-2948-4029-94cf-8f7783d650d0","481a5ee7-ae89-4dc2-b0d2-95e88d40bb84"],"mac_address":"02:00:00:16:45:44","modification_date":"2025-02-12T16:11:14.306581+00:00","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","server_id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        headers:
+            Content-Length:
+                - "478"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:11:14 GMT
+            Link:
+                - </servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f/private_nics?page=1&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 38e65b20-0b77-437d-8ac5-13c356e594dd
+            X-Total-Count:
+                - "1"
+        status: 200 OK
+        code: 200
+        duration: 94.466125ms
+    - id: 51
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/d774a252-83bc-4ff8-93d0-770d444a0574
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1118
+        uncompressed: false
+        body: '{"backend_count":0,"created_at":"2025-02-12T16:10:45.871197Z","description":"","frontend_count":0,"id":"d774a252-83bc-4ff8-93d0-770d444a0574","instances":[{"created_at":"2025-02-12T16:06:55.264058Z","id":"e43221b3-c700-4951-b53d-cf6ad775b8c0","ip_address":"","region":"fr-par","status":"ready","updated_at":"2025-02-12T16:10:47.729725Z","zone":"fr-par-1"}],"ip":[{"id":"d44cc37b-f392-46c9-a576-e42711323050","ip_address":"51.159.9.241","lb_id":"d774a252-83bc-4ff8-93d0-770d444a0574","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-9-241.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2025-02-12T16:10:49.157407Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "1118"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:11:16 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b00a284d-b170-4b60-8ab8-a67c792f4ae1
+        status: 200 OK
+        code: 200
+        duration: 114.143792ms
+    - id: 52
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2206,8 +2602,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/74eabe50-405f-4517-9bd6-2540dafd4f89/private-networks/57acd471-d6d6-471a-be4f-6464a3976f5b/attach
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/d774a252-83bc-4ff8-93d0-770d444a0574/private-networks/7abd3366-919a-46e1-88ad-af224037959a/attach
         method: POST
       response:
         proto: HTTP/2.0
@@ -2215,20 +2611,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1306
+        content_length: 1345
         uncompressed: false
-        body: '{"created_at":"2025-01-24T14:16:03.474743321Z","dhcp_config":{"ip_id":null},"ipam_ids":[],"lb":{"backend_count":0,"created_at":"2025-01-24T14:15:32.867435Z","description":"","frontend_count":0,"id":"74eabe50-405f-4517-9bd6-2540dafd4f89","instances":[{"created_at":"2025-01-24T14:11:38.800501Z","id":"db97ec97-2d4e-4ffe-9447-7fa34e014506","ip_address":"","region":"fr-par","status":"ready","updated_at":"2025-01-24T14:15:35.244866Z","zone":"fr-par-1"}],"ip":[{"id":"df74cb2c-3245-49d9-b592-e67c753e77ac","ip_address":"51.159.25.55","lb_id":"74eabe50-405f-4517-9bd6-2540dafd4f89","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-25-55.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2025-01-24T14:15:36.612864Z","zone":"fr-par-1"},"private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","status":"pending","updated_at":"2025-01-24T14:16:03.474743321Z"}'
+        body: '{"created_at":"2025-02-12T16:11:16.557208333Z","dhcp_config":{"ip_id":null},"ipam_ids":[],"lb":{"backend_count":0,"created_at":"2025-02-12T16:10:45.871197Z","description":"","frontend_count":0,"id":"d774a252-83bc-4ff8-93d0-770d444a0574","instances":[{"created_at":"2025-02-12T16:06:55.264058Z","id":"e43221b3-c700-4951-b53d-cf6ad775b8c0","ip_address":"","region":"fr-par","status":"ready","updated_at":"2025-02-12T16:10:47.729725Z","zone":"fr-par-1"}],"ip":[{"id":"d44cc37b-f392-46c9-a576-e42711323050","ip_address":"51.159.9.241","lb_id":"d774a252-83bc-4ff8-93d0-770d444a0574","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-9-241.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2025-02-12T16:10:49.157407Z","zone":"fr-par-1"},"private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","status":"pending","updated_at":"2025-02-12T16:11:16.557208333Z"}'
         headers:
             Content-Length:
-                - "1306"
+                - "1345"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:03 GMT
+                - Wed, 12 Feb 2025 16:11:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2236,402 +2632,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fd77bee9-a5e5-4c5e-9ecb-731118cc8ba9
+                - 14ad7df1-88e7-4025-bc55-14b6c992243e
         status: 200 OK
         code: 200
-        duration: 347.464542ms
-    - id: 45
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/74eabe50-405f-4517-9bd6-2540dafd4f89/private-networks?order_by=created_at_asc
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1138
-        uncompressed: false
-        body: '{"private_network":[{"created_at":"2025-01-24T14:16:03.474743Z","dhcp_config":{"ip_id":null},"ipam_ids":[],"lb":{"backend_count":0,"created_at":"2025-01-24T14:15:32.867435Z","description":"","frontend_count":0,"id":"74eabe50-405f-4517-9bd6-2540dafd4f89","instances":[],"ip":[{"id":"df74cb2c-3245-49d9-b592-e67c753e77ac","ip_address":"51.159.25.55","lb_id":"74eabe50-405f-4517-9bd6-2540dafd4f89","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-25-55.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2025-01-24T14:15:36.612864Z","zone":"fr-par-1"},"private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","status":"pending","updated_at":"2025-01-24T14:16:03.474743Z"}],"total_count":1}'
-        headers:
-            Content-Length:
-                - "1138"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 14:16:03 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - f1d49b90-6c72-4e9e-a32a-34105b6d3c7a
-        status: 200 OK
-        code: 200
-        duration: 99.717375ms
-    - id: 46
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec/private_nics/9046d524-d6a4-49ac-93cc-7dc56744d7ee
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 473
-        uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-24T14:15:44.689986+00:00","id":"9046d524-d6a4-49ac-93cc-7dc56744d7ee","ipam_ip_ids":["2434ba0e-6dd2-4176-adca-a051205c78e8","bbadcc9e-16cd-475d-9167-9728c06de445"],"mac_address":"02:00:00:10:c8:b7","modification_date":"2025-01-24T14:15:44.930528+00:00","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","server_id":"8b61785d-9e59-462c-8c73-602613da26ec","state":"syncing","tags":[],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "473"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 14:16:06 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 82550d46-e781-40fb-9794-ee42867a0e0e
-        status: 200 OK
-        code: 200
-        duration: 97.562917ms
-    - id: 47
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec/private_nics/9046d524-d6a4-49ac-93cc-7dc56744d7ee
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 473
-        uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-24T14:15:44.689986+00:00","id":"9046d524-d6a4-49ac-93cc-7dc56744d7ee","ipam_ip_ids":["2434ba0e-6dd2-4176-adca-a051205c78e8","bbadcc9e-16cd-475d-9167-9728c06de445"],"mac_address":"02:00:00:10:c8:b7","modification_date":"2025-01-24T14:15:44.930528+00:00","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","server_id":"8b61785d-9e59-462c-8c73-602613da26ec","state":"syncing","tags":[],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "473"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 14:16:11 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 515aa36c-c187-40e9-9b35-f3ffdce4e025
-        status: 200 OK
-        code: 200
-        duration: 83.048625ms
-    - id: 48
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec/private_nics/9046d524-d6a4-49ac-93cc-7dc56744d7ee
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 473
-        uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-24T14:15:44.689986+00:00","id":"9046d524-d6a4-49ac-93cc-7dc56744d7ee","ipam_ip_ids":["2434ba0e-6dd2-4176-adca-a051205c78e8","bbadcc9e-16cd-475d-9167-9728c06de445"],"mac_address":"02:00:00:10:c8:b7","modification_date":"2025-01-24T14:15:44.930528+00:00","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","server_id":"8b61785d-9e59-462c-8c73-602613da26ec","state":"syncing","tags":[],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "473"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 14:16:16 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 9368269e-4ce1-4efb-9d7f-bdfc9ee6df45
-        status: 200 OK
-        code: 200
-        duration: 97.952792ms
-    - id: 49
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec/private_nics/9046d524-d6a4-49ac-93cc-7dc56744d7ee
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 475
-        uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-24T14:15:44.689986+00:00","id":"9046d524-d6a4-49ac-93cc-7dc56744d7ee","ipam_ip_ids":["2434ba0e-6dd2-4176-adca-a051205c78e8","bbadcc9e-16cd-475d-9167-9728c06de445"],"mac_address":"02:00:00:10:c8:b7","modification_date":"2025-01-24T14:16:16.703652+00:00","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","server_id":"8b61785d-9e59-462c-8c73-602613da26ec","state":"available","tags":[],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "475"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 14:16:21 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 744b327b-2a4d-4714-b5bc-adef9010b9f2
-        status: 200 OK
-        code: 200
-        duration: 97.84925ms
-    - id: 50
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec/private_nics/9046d524-d6a4-49ac-93cc-7dc56744d7ee
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 475
-        uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-24T14:15:44.689986+00:00","id":"9046d524-d6a4-49ac-93cc-7dc56744d7ee","ipam_ip_ids":["2434ba0e-6dd2-4176-adca-a051205c78e8","bbadcc9e-16cd-475d-9167-9728c06de445"],"mac_address":"02:00:00:10:c8:b7","modification_date":"2025-01-24T14:16:16.703652+00:00","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","server_id":"8b61785d-9e59-462c-8c73-602613da26ec","state":"available","tags":[],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "475"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 14:16:21 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - ae1a71c5-441c-4911-b9c3-ff4f06f2b7e5
-        status: 200 OK
-        code: 200
-        duration: 80.372583ms
-    - id: 51
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2721
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-24T14:15:22.371679+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"8b61785d-9e59-462c-8c73-602613da26ec","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1802","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:83:d3","maintenances":[],"modification_date":"2025-01-24T14:15:39.592074+00:00","name":"Scaleway Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-24T14:15:44.689986+00:00","id":"9046d524-d6a4-49ac-93cc-7dc56744d7ee","ipam_ip_ids":["2434ba0e-6dd2-4176-adca-a051205c78e8","bbadcc9e-16cd-475d-9167-9728c06de445"],"mac_address":"02:00:00:10:c8:b7","modification_date":"2025-01-24T14:16:16.703652+00:00","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","server_id":"8b61785d-9e59-462c-8c73-602613da26ec","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-24T14:15:22.371679+00:00","export_uri":null,"id":"bdaabaac-1ef9-4b2b-9f03-f8a6e88a1135","modification_date":"2025-01-24T14:15:22.371679+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"8b61785d-9e59-462c-8c73-602613da26ec","name":"Scaleway Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2721"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 14:16:21 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 7bb1b286-7c67-45b3-a040-8a6da3cf40c0
-        status: 200 OK
-        code: 200
-        duration: 158.243083ms
-    - id: 52
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/bdaabaac-1ef9-4b2b-9f03-f8a6e88a1135
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 518
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-24T14:15:22.371679+00:00","export_uri":null,"id":"bdaabaac-1ef9-4b2b-9f03-f8a6e88a1135","modification_date":"2025-01-24T14:15:22.371679+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"8b61785d-9e59-462c-8c73-602613da26ec","name":"Scaleway Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "518"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 14:16:21 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - b474345e-bb2a-4f76-8ed0-3f619212e7d0
-        status: 200 OK
-        code: 200
-        duration: 77.191625ms
+        duration: 496.971125ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -2647,8 +2651,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/d774a252-83bc-4ff8-93d0-770d444a0574/private-networks?order_by=created_at_asc
         method: GET
       response:
         proto: HTTP/2.0
@@ -2656,20 +2660,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 1172
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"private_network":[{"created_at":"2025-02-12T16:11:16.557208Z","dhcp_config":{"ip_id":null},"ipam_ids":[],"lb":{"backend_count":0,"created_at":"2025-02-12T16:10:45.871197Z","description":"","frontend_count":0,"id":"d774a252-83bc-4ff8-93d0-770d444a0574","instances":[],"ip":[{"id":"d44cc37b-f392-46c9-a576-e42711323050","ip_address":"51.159.9.241","lb_id":"d774a252-83bc-4ff8-93d0-770d444a0574","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-9-241.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2025-02-12T16:10:49.157407Z","zone":"fr-par-1"},"private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","status":"pending","updated_at":"2025-02-12T16:11:16.557208Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "17"
+                - "1172"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:22 GMT
+                - Wed, 12 Feb 2025 16:11:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2677,10 +2681,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ab5b4ea9-1f55-4ff5-8be4-784b0dd56119
+                - a7591b99-efbc-405f-a21e-d1b88646ac3a
         status: 200 OK
         code: 200
-        duration: 66.1885ms
+        duration: 189.248083ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -2696,8 +2700,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/d774a252-83bc-4ff8-93d0-770d444a0574/private-networks?order_by=created_at_asc
         method: GET
       response:
         proto: HTTP/2.0
@@ -2705,22 +2709,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 478
+        content_length: 1242
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-24T14:15:44.689986+00:00","id":"9046d524-d6a4-49ac-93cc-7dc56744d7ee","ipam_ip_ids":["2434ba0e-6dd2-4176-adca-a051205c78e8","bbadcc9e-16cd-475d-9167-9728c06de445"],"mac_address":"02:00:00:10:c8:b7","modification_date":"2025-01-24T14:16:16.703652+00:00","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","server_id":"8b61785d-9e59-462c-8c73-602613da26ec","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"private_network":[{"created_at":"2025-02-12T16:11:16.557208Z","dhcp_config":{"ip_id":"ce282ae5-f717-4ba1-a026-40754d835ca6"},"ipam_ids":["ce282ae5-f717-4ba1-a026-40754d835ca6"],"lb":{"backend_count":0,"created_at":"2025-02-12T16:10:45.871197Z","description":"","frontend_count":0,"id":"d774a252-83bc-4ff8-93d0-770d444a0574","instances":[],"ip":[{"id":"d44cc37b-f392-46c9-a576-e42711323050","ip_address":"51.159.9.241","lb_id":"d774a252-83bc-4ff8-93d0-770d444a0574","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-9-241.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2025-02-12T16:10:49.157407Z","zone":"fr-par-1"},"private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","status":"ready","updated_at":"2025-02-12T16:11:19.154906Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "478"
+                - "1242"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:21 GMT
-            Link:
-                - </servers/8b61785d-9e59-462c-8c73-602613da26ec/private_nics?page=1&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 16:11:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2728,12 +2730,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 01538812-9627-48d0-9b3d-ff3283b94c90
-            X-Total-Count:
-                - "1"
+                - 9146aa89-7d11-43bd-a93d-209d339c9c1d
         status: 200 OK
         code: 200
-        duration: 93.194166ms
+        duration: 686.402292ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -2749,8 +2749,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/74eabe50-405f-4517-9bd6-2540dafd4f89/private-networks?order_by=created_at_asc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/d774a252-83bc-4ff8-93d0-770d444a0574
         method: GET
       response:
         proto: HTTP/2.0
@@ -2758,20 +2758,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1208
+        content_length: 1118
         uncompressed: false
-        body: '{"private_network":[{"created_at":"2025-01-24T14:16:03.474743Z","dhcp_config":{"ip_id":"ca6d2b0a-935a-42f4-83d2-1d35e4e2c57a"},"ipam_ids":["ca6d2b0a-935a-42f4-83d2-1d35e4e2c57a"],"lb":{"backend_count":0,"created_at":"2025-01-24T14:15:32.867435Z","description":"","frontend_count":0,"id":"74eabe50-405f-4517-9bd6-2540dafd4f89","instances":[],"ip":[{"id":"df74cb2c-3245-49d9-b592-e67c753e77ac","ip_address":"51.159.25.55","lb_id":"74eabe50-405f-4517-9bd6-2540dafd4f89","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-25-55.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2025-01-24T14:15:36.612864Z","zone":"fr-par-1"},"private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","status":"ready","updated_at":"2025-01-24T14:16:09.657372Z"}],"total_count":1}'
+        body: '{"backend_count":0,"created_at":"2025-02-12T16:10:45.871197Z","description":"","frontend_count":0,"id":"d774a252-83bc-4ff8-93d0-770d444a0574","instances":[{"created_at":"2025-02-12T16:06:55.264058Z","id":"e43221b3-c700-4951-b53d-cf6ad775b8c0","ip_address":"","region":"fr-par","status":"ready","updated_at":"2025-02-12T16:11:18.860674Z","zone":"fr-par-1"}],"ip":[{"id":"d44cc37b-f392-46c9-a576-e42711323050","ip_address":"51.159.9.241","lb_id":"d774a252-83bc-4ff8-93d0-770d444a0574","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-9-241.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2025-02-12T16:10:49.157407Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1208"
+                - "1118"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:33 GMT
+                - Wed, 12 Feb 2025 16:11:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2779,10 +2779,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f9769d2a-e3e5-497d-b93e-f90d78866142
+                - 1e366fc2-56d4-4573-9349-3cc03203a25b
         status: 200 OK
         code: 200
-        duration: 106.426625ms
+        duration: 114.247958ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2798,8 +2798,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/74eabe50-405f-4517-9bd6-2540dafd4f89
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/d774a252-83bc-4ff8-93d0-770d444a0574
         method: GET
       response:
         proto: HTTP/2.0
@@ -2807,20 +2807,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1085
+        content_length: 1118
         uncompressed: false
-        body: '{"backend_count":0,"created_at":"2025-01-24T14:15:32.867435Z","description":"","frontend_count":0,"id":"74eabe50-405f-4517-9bd6-2540dafd4f89","instances":[{"created_at":"2025-01-24T14:11:38.800501Z","id":"db97ec97-2d4e-4ffe-9447-7fa34e014506","ip_address":"","region":"fr-par","status":"ready","updated_at":"2025-01-24T14:16:08.493285Z","zone":"fr-par-1"}],"ip":[{"id":"df74cb2c-3245-49d9-b592-e67c753e77ac","ip_address":"51.159.25.55","lb_id":"74eabe50-405f-4517-9bd6-2540dafd4f89","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-25-55.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2025-01-24T14:15:36.612864Z","zone":"fr-par-1"}'
+        body: '{"backend_count":0,"created_at":"2025-02-12T16:10:45.871197Z","description":"","frontend_count":0,"id":"d774a252-83bc-4ff8-93d0-770d444a0574","instances":[{"created_at":"2025-02-12T16:06:55.264058Z","id":"e43221b3-c700-4951-b53d-cf6ad775b8c0","ip_address":"","region":"fr-par","status":"ready","updated_at":"2025-02-12T16:11:18.860674Z","zone":"fr-par-1"}],"ip":[{"id":"d44cc37b-f392-46c9-a576-e42711323050","ip_address":"51.159.9.241","lb_id":"d774a252-83bc-4ff8-93d0-770d444a0574","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-9-241.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2025-02-12T16:10:49.157407Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1085"
+                - "1118"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:33 GMT
+                - Wed, 12 Feb 2025 16:11:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2828,10 +2828,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 079d7619-50da-4c3e-8224-0ae9e6623915
+                - 60479f6d-7dac-4893-8dfc-afe3de44e646
         status: 200 OK
         code: 200
-        duration: 102.90125ms
+        duration: 115.015583ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2847,8 +2847,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/74eabe50-405f-4517-9bd6-2540dafd4f89
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/d774a252-83bc-4ff8-93d0-770d444a0574/private-networks?order_by=created_at_asc
         method: GET
       response:
         proto: HTTP/2.0
@@ -2856,20 +2856,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1085
+        content_length: 1242
         uncompressed: false
-        body: '{"backend_count":0,"created_at":"2025-01-24T14:15:32.867435Z","description":"","frontend_count":0,"id":"74eabe50-405f-4517-9bd6-2540dafd4f89","instances":[{"created_at":"2025-01-24T14:11:38.800501Z","id":"db97ec97-2d4e-4ffe-9447-7fa34e014506","ip_address":"","region":"fr-par","status":"ready","updated_at":"2025-01-24T14:16:08.493285Z","zone":"fr-par-1"}],"ip":[{"id":"df74cb2c-3245-49d9-b592-e67c753e77ac","ip_address":"51.159.25.55","lb_id":"74eabe50-405f-4517-9bd6-2540dafd4f89","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-25-55.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2025-01-24T14:15:36.612864Z","zone":"fr-par-1"}'
+        body: '{"private_network":[{"created_at":"2025-02-12T16:11:16.557208Z","dhcp_config":{"ip_id":"ce282ae5-f717-4ba1-a026-40754d835ca6"},"ipam_ids":["ce282ae5-f717-4ba1-a026-40754d835ca6"],"lb":{"backend_count":0,"created_at":"2025-02-12T16:10:45.871197Z","description":"","frontend_count":0,"id":"d774a252-83bc-4ff8-93d0-770d444a0574","instances":[],"ip":[{"id":"d44cc37b-f392-46c9-a576-e42711323050","ip_address":"51.159.9.241","lb_id":"d774a252-83bc-4ff8-93d0-770d444a0574","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-9-241.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2025-02-12T16:10:49.157407Z","zone":"fr-par-1"},"private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","status":"ready","updated_at":"2025-02-12T16:11:19.154906Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "1085"
+                - "1242"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:34 GMT
+                - Wed, 12 Feb 2025 16:11:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2877,10 +2877,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d027bb41-f567-49f9-a8a6-5a8b9f9dd206
+                - 99fdf7fb-0224-4c71-bef0-1afd4d3b8563
         status: 200 OK
         code: 200
-        duration: 86.634541ms
+        duration: 223.02575ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -2896,8 +2896,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/74eabe50-405f-4517-9bd6-2540dafd4f89/private-networks?order_by=created_at_asc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/d774a252-83bc-4ff8-93d0-770d444a0574
         method: GET
       response:
         proto: HTTP/2.0
@@ -2905,20 +2905,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1208
+        content_length: 1118
         uncompressed: false
-        body: '{"private_network":[{"created_at":"2025-01-24T14:16:03.474743Z","dhcp_config":{"ip_id":"ca6d2b0a-935a-42f4-83d2-1d35e4e2c57a"},"ipam_ids":["ca6d2b0a-935a-42f4-83d2-1d35e4e2c57a"],"lb":{"backend_count":0,"created_at":"2025-01-24T14:15:32.867435Z","description":"","frontend_count":0,"id":"74eabe50-405f-4517-9bd6-2540dafd4f89","instances":[],"ip":[{"id":"df74cb2c-3245-49d9-b592-e67c753e77ac","ip_address":"51.159.25.55","lb_id":"74eabe50-405f-4517-9bd6-2540dafd4f89","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-25-55.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2025-01-24T14:15:36.612864Z","zone":"fr-par-1"},"private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","status":"ready","updated_at":"2025-01-24T14:16:09.657372Z"}],"total_count":1}'
+        body: '{"backend_count":0,"created_at":"2025-02-12T16:10:45.871197Z","description":"","frontend_count":0,"id":"d774a252-83bc-4ff8-93d0-770d444a0574","instances":[{"created_at":"2025-02-12T16:06:55.264058Z","id":"e43221b3-c700-4951-b53d-cf6ad775b8c0","ip_address":"","region":"fr-par","status":"ready","updated_at":"2025-02-12T16:11:18.860674Z","zone":"fr-par-1"}],"ip":[{"id":"d44cc37b-f392-46c9-a576-e42711323050","ip_address":"51.159.9.241","lb_id":"d774a252-83bc-4ff8-93d0-770d444a0574","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-9-241.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2025-02-12T16:10:49.157407Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1208"
+                - "1118"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:34 GMT
+                - Wed, 12 Feb 2025 16:11:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2926,10 +2926,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f9539aae-7ea8-4f49-bc13-a48fabc8a02a
+                - d633125f-5fe0-414e-9d8e-b0832e2111c3
         status: 200 OK
         code: 200
-        duration: 90.41025ms
+        duration: 115.576584ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -2945,8 +2945,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/74eabe50-405f-4517-9bd6-2540dafd4f89
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/d44cc37b-f392-46c9-a576-e42711323050
         method: GET
       response:
         proto: HTTP/2.0
@@ -2954,20 +2954,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1085
+        content_length: 328
         uncompressed: false
-        body: '{"backend_count":0,"created_at":"2025-01-24T14:15:32.867435Z","description":"","frontend_count":0,"id":"74eabe50-405f-4517-9bd6-2540dafd4f89","instances":[{"created_at":"2025-01-24T14:11:38.800501Z","id":"db97ec97-2d4e-4ffe-9447-7fa34e014506","ip_address":"","region":"fr-par","status":"ready","updated_at":"2025-01-24T14:16:08.493285Z","zone":"fr-par-1"}],"ip":[{"id":"df74cb2c-3245-49d9-b592-e67c753e77ac","ip_address":"51.159.25.55","lb_id":"74eabe50-405f-4517-9bd6-2540dafd4f89","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-25-55.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2025-01-24T14:15:36.612864Z","zone":"fr-par-1"}'
+        body: '{"id":"d44cc37b-f392-46c9-a576-e42711323050","ip_address":"51.159.9.241","lb_id":"d774a252-83bc-4ff8-93d0-770d444a0574","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-9-241.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1085"
+                - "328"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:34 GMT
+                - Wed, 12 Feb 2025 16:11:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2975,10 +2975,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5c776f3f-2b15-498d-9dc3-af88b5668092
+                - d8dd561e-a08e-4470-af94-3b6a27f7291a
         status: 200 OK
         code: 200
-        duration: 86.04575ms
+        duration: 75.999042ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -2994,8 +2994,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/df74cb2c-3245-49d9-b592-e67c753e77ac
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/1248e521-f708-4f4a-80ee-9d3084b0616f
         method: GET
       response:
         proto: HTTP/2.0
@@ -3003,20 +3003,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 320
+        content_length: 574
         uncompressed: false
-        body: '{"id":"df74cb2c-3245-49d9-b592-e67c753e77ac","ip_address":"51.159.25.55","lb_id":"74eabe50-405f-4517-9bd6-2540dafd4f89","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-25-55.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}'
+        body: '{"address":"10.0.0.1","created_at":"2025-02-12T16:10:33.561435Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1248e521-f708-4f4a-80ee-9d3084b0616f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:10:33.561435Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "320"
+                - "574"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:34 GMT
+                - Wed, 12 Feb 2025 16:11:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3024,10 +3024,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c251056c-0b77-4fba-93c3-c103429b92d2
+                - 59846154-c78d-4132-906b-291306e1c3a0
         status: 200 OK
         code: 200
-        duration: 70.370334ms
+        duration: 51.589792ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -3043,8 +3043,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/5e32e435-6bf9-4406-8f72-8f76be892a2f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/d217409e-10e1-4bbc-97d6-1daedb998b38
         method: GET
       response:
         proto: HTTP/2.0
@@ -3052,20 +3052,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 394
+        content_length: 405
         uncompressed: false
-        body: '{"address":"51.158.121.168","created_at":"2025-01-24T14:15:22.212402Z","gateway_id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","id":"5e32e435-6bf9-4406-8f72-8f76be892a2f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"168-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-24T14:15:22.212402Z","zone":"fr-par-1"}'
+        body: '{"address":"163.172.162.186","created_at":"2025-02-12T16:10:34.957253Z","gateway_id":"8ebafec9-15fb-496d-b212-1719a0311c3b","id":"d217409e-10e1-4bbc-97d6-1daedb998b38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:10:34.957253Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "394"
+                - "405"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:35 GMT
+                - Wed, 12 Feb 2025 16:11:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3073,10 +3073,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 198965c6-126c-423d-a017-7ae8fa606c15
+                - c80a621f-44eb-415a-bc24-25c1e8960e1b
         status: 200 OK
         code: 200
-        duration: 27.601209ms
+        duration: 92.230292ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -3092,8 +3092,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/48b28823-2ed8-4a73-82a5-752bc9447518
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7abd3366-919a-46e1-88ad-af224037959a
         method: GET
       response:
         proto: HTTP/2.0
@@ -3101,20 +3101,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 556
+        content_length: 1057
         uncompressed: false
-        body: '{"address":"10.0.0.1","created_at":"2025-01-24T14:15:20.581273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"48b28823-2ed8-4a73-82a5-752bc9447518","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-24T14:15:20.581273Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:10:33.577102Z","dhcp_enabled":true,"id":"7abd3366-919a-46e1-88ad-af224037959a","name":"private network with a DHCP config","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:10:33.577102Z","id":"eca4e6e3-9dfa-4837-a839-b6506b1f69e7","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:10:46.155109Z","vpc_id":"1af3d1be-b9c7-41fd-b4e8-a8023bcb3772"},{"created_at":"2025-02-12T16:10:33.577102Z","id":"afcdeb34-4c8b-495d-98ca-5c35531d6fed","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:4ef::/64","updated_at":"2025-02-12T16:10:46.158974Z","vpc_id":"1af3d1be-b9c7-41fd-b4e8-a8023bcb3772"}],"tags":[],"updated_at":"2025-02-12T16:10:55.238221Z","vpc_id":"1af3d1be-b9c7-41fd-b4e8-a8023bcb3772"}'
         headers:
             Content-Length:
-                - "556"
+                - "1057"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:35 GMT
+                - Wed, 12 Feb 2025 16:11:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3122,10 +3122,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 45104328-3685-4896-8869-cbba587080bb
+                - 28b00591-6156-4c04-9472-d72179e9dd57
         status: 200 OK
         code: 200
-        duration: 25.944125ms
+        duration: 96.45575ms
     - id: 63
       request:
         proto: HTTP/1.1
@@ -3141,8 +3141,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/57acd471-d6d6-471a-be4f-6464a3976f5b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/d44cc37b-f392-46c9-a576-e42711323050
         method: GET
       response:
         proto: HTTP/2.0
@@ -3150,20 +3150,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1035
+        content_length: 328
         uncompressed: false
-        body: '{"created_at":"2025-01-24T14:15:20.580798Z","dhcp_enabled":true,"id":"57acd471-d6d6-471a-be4f-6464a3976f5b","name":"private network with a DHCP config","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-24T14:15:20.580798Z","id":"f6142587-74eb-45b3-a361-72fa990fcec1","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"10.0.0.0/24","updated_at":"2025-01-24T14:15:33.062704Z","vpc_id":"bf83c6f6-2f6d-48ef-b59c-ae8086b2bb1c"},{"created_at":"2025-01-24T14:15:20.580798Z","id":"ed64f437-e22a-454d-8f4c-34b7c0a996d3","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:cece::/64","updated_at":"2025-01-24T14:15:33.065902Z","vpc_id":"bf83c6f6-2f6d-48ef-b59c-ae8086b2bb1c"}],"tags":[],"updated_at":"2025-01-24T14:15:41.703440Z","vpc_id":"bf83c6f6-2f6d-48ef-b59c-ae8086b2bb1c"}'
+        body: '{"id":"d44cc37b-f392-46c9-a576-e42711323050","ip_address":"51.159.9.241","lb_id":"d774a252-83bc-4ff8-93d0-770d444a0574","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-9-241.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1035"
+                - "328"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:35 GMT
+                - Wed, 12 Feb 2025 16:11:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3171,10 +3171,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 45e4dea9-6497-4874-9a06-22c4418b5371
+                - d9daa8f7-2bcf-4c66-9028-d95e316cbb99
         status: 200 OK
         code: 200
-        duration: 27.160375ms
+        duration: 96.92575ms
     - id: 64
       request:
         proto: HTTP/1.1
@@ -3190,8 +3190,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/df74cb2c-3245-49d9-b592-e67c753e77ac
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/8ebafec9-15fb-496d-b212-1719a0311c3b
         method: GET
       response:
         proto: HTTP/2.0
@@ -3199,20 +3199,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 320
+        content_length: 1995
         uncompressed: false
-        body: '{"id":"df74cb2c-3245-49d9-b592-e67c753e77ac","ip_address":"51.159.25.55","lb_id":"74eabe50-405f-4517-9bd6-2540dafd4f89","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-25-55.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:10:35.342174Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:10:48.362447Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:10:33.561435Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1248e521-f708-4f4a-80ee-9d3084b0616f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:10:33.561435Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8ebafec9-15fb-496d-b212-1719a0311c3b","id":"fa8d0cb8-6e84-4edf-beba-cfefaa1bd81c","ipam_config":null,"mac_address":"02:00:00:18:61:C7","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","status":"ready","updated_at":"2025-02-12T16:10:59.506156Z","zone":"fr-par-1"}],"id":"8ebafec9-15fb-496d-b212-1719a0311c3b","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:10:34.957253Z","gateway_id":"8ebafec9-15fb-496d-b212-1719a0311c3b","id":"d217409e-10e1-4bbc-97d6-1daedb998b38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:10:34.957253Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:10:59.705659Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "320"
+                - "1995"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:35 GMT
+                - Wed, 12 Feb 2025 16:11:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3220,10 +3220,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 247b6340-8206-4465-8726-2f32b5c94b94
+                - d429fa76-8079-4259-85f1-9e3a79e7ac83
         status: 200 OK
         code: 200
-        duration: 68.514834ms
+        duration: 50.739959ms
     - id: 65
       request:
         proto: HTTP/1.1
@@ -3239,8 +3239,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0cdaf520-f0e0-46ed-b197-36c28975d51c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/fa8d0cb8-6e84-4edf-beba-cfefaa1bd81c
         method: GET
       response:
         proto: HTTP/2.0
@@ -3248,20 +3248,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1933
+        content_length: 984
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-24T14:15:22.458029Z","gateway_networks":[{"address":null,"created_at":"2025-01-24T14:15:34.959930Z","dhcp":{"address":"10.0.0.1","created_at":"2025-01-24T14:15:20.581273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"48b28823-2ed8-4a73-82a5-752bc9447518","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-24T14:15:20.581273Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","id":"92b71032-5580-4650-bd52-b63253bcc3b5","ipam_config":null,"mac_address":"02:00:00:17:E0:4B","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","status":"ready","updated_at":"2025-01-24T14:15:43.507917Z","zone":"fr-par-1"}],"id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","ip":{"address":"51.158.121.168","created_at":"2025-01-24T14:15:22.212402Z","gateway_id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","id":"5e32e435-6bf9-4406-8f72-8f76be892a2f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"168-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-24T14:15:22.212402Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-24T14:15:43.659223Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:10:48.362447Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:10:33.561435Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1248e521-f708-4f4a-80ee-9d3084b0616f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:10:33.561435Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8ebafec9-15fb-496d-b212-1719a0311c3b","id":"fa8d0cb8-6e84-4edf-beba-cfefaa1bd81c","ipam_config":null,"mac_address":"02:00:00:18:61:C7","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","status":"ready","updated_at":"2025-02-12T16:10:59.506156Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1933"
+                - "984"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:35 GMT
+                - Wed, 12 Feb 2025 16:11:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3269,10 +3269,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f8365f95-ed91-45e4-9118-5d316d470bc2
+                - e6fc67db-a1f0-4e78-82b8-86173c1f75ba
         status: 200 OK
         code: 200
-        duration: 31.16325ms
+        duration: 75.5605ms
     - id: 66
       request:
         proto: HTTP/1.1
@@ -3288,8 +3288,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/92b71032-5580-4650-bd52-b63253bcc3b5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/d774a252-83bc-4ff8-93d0-770d444a0574
         method: GET
       response:
         proto: HTTP/2.0
@@ -3297,20 +3297,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 954
+        content_length: 1118
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-24T14:15:34.959930Z","dhcp":{"address":"10.0.0.1","created_at":"2025-01-24T14:15:20.581273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"48b28823-2ed8-4a73-82a5-752bc9447518","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-24T14:15:20.581273Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","id":"92b71032-5580-4650-bd52-b63253bcc3b5","ipam_config":null,"mac_address":"02:00:00:17:E0:4B","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","status":"ready","updated_at":"2025-01-24T14:15:43.507917Z","zone":"fr-par-1"}'
+        body: '{"backend_count":0,"created_at":"2025-02-12T16:10:45.871197Z","description":"","frontend_count":0,"id":"d774a252-83bc-4ff8-93d0-770d444a0574","instances":[{"created_at":"2025-02-12T16:06:55.264058Z","id":"e43221b3-c700-4951-b53d-cf6ad775b8c0","ip_address":"","region":"fr-par","status":"ready","updated_at":"2025-02-12T16:11:18.860674Z","zone":"fr-par-1"}],"ip":[{"id":"d44cc37b-f392-46c9-a576-e42711323050","ip_address":"51.159.9.241","lb_id":"d774a252-83bc-4ff8-93d0-770d444a0574","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-9-241.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2025-02-12T16:10:49.157407Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "954"
+                - "1118"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:35 GMT
+                - Wed, 12 Feb 2025 16:11:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3318,10 +3318,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7e0198a5-d1fd-4037-8203-1fc143b46948
+                - 5476f6ad-c47d-42d2-b0cf-8c1f7dbf1e74
         status: 200 OK
         code: 200
-        duration: 58.871667ms
+        duration: 141.827833ms
     - id: 67
       request:
         proto: HTTP/1.1
@@ -3337,8 +3337,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/74eabe50-405f-4517-9bd6-2540dafd4f89
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/8ebafec9-15fb-496d-b212-1719a0311c3b
         method: GET
       response:
         proto: HTTP/2.0
@@ -3346,20 +3346,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1085
+        content_length: 1995
         uncompressed: false
-        body: '{"backend_count":0,"created_at":"2025-01-24T14:15:32.867435Z","description":"","frontend_count":0,"id":"74eabe50-405f-4517-9bd6-2540dafd4f89","instances":[{"created_at":"2025-01-24T14:11:38.800501Z","id":"db97ec97-2d4e-4ffe-9447-7fa34e014506","ip_address":"","region":"fr-par","status":"ready","updated_at":"2025-01-24T14:16:08.493285Z","zone":"fr-par-1"}],"ip":[{"id":"df74cb2c-3245-49d9-b592-e67c753e77ac","ip_address":"51.159.25.55","lb_id":"74eabe50-405f-4517-9bd6-2540dafd4f89","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-25-55.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2025-01-24T14:15:36.612864Z","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:10:35.342174Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:10:48.362447Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:10:33.561435Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1248e521-f708-4f4a-80ee-9d3084b0616f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:10:33.561435Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8ebafec9-15fb-496d-b212-1719a0311c3b","id":"fa8d0cb8-6e84-4edf-beba-cfefaa1bd81c","ipam_config":null,"mac_address":"02:00:00:18:61:C7","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","status":"ready","updated_at":"2025-02-12T16:10:59.506156Z","zone":"fr-par-1"}],"id":"8ebafec9-15fb-496d-b212-1719a0311c3b","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:10:34.957253Z","gateway_id":"8ebafec9-15fb-496d-b212-1719a0311c3b","id":"d217409e-10e1-4bbc-97d6-1daedb998b38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:10:34.957253Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:10:59.705659Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1085"
+                - "1995"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:35 GMT
+                - Wed, 12 Feb 2025 16:11:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3367,10 +3367,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a68f4aa2-7583-4d21-bdd6-8811ea9ded8c
+                - eb7b0f31-9996-4e08-9ec7-82494658b7d9
         status: 200 OK
         code: 200
-        duration: 87.821833ms
+        duration: 53.605667ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -3386,8 +3386,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0cdaf520-f0e0-46ed-b197-36c28975d51c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/fa8d0cb8-6e84-4edf-beba-cfefaa1bd81c
         method: GET
       response:
         proto: HTTP/2.0
@@ -3395,20 +3395,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1933
+        content_length: 984
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-24T14:15:22.458029Z","gateway_networks":[{"address":null,"created_at":"2025-01-24T14:15:34.959930Z","dhcp":{"address":"10.0.0.1","created_at":"2025-01-24T14:15:20.581273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"48b28823-2ed8-4a73-82a5-752bc9447518","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-24T14:15:20.581273Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","id":"92b71032-5580-4650-bd52-b63253bcc3b5","ipam_config":null,"mac_address":"02:00:00:17:E0:4B","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","status":"ready","updated_at":"2025-01-24T14:15:43.507917Z","zone":"fr-par-1"}],"id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","ip":{"address":"51.158.121.168","created_at":"2025-01-24T14:15:22.212402Z","gateway_id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","id":"5e32e435-6bf9-4406-8f72-8f76be892a2f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"168-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-24T14:15:22.212402Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-24T14:15:43.659223Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:10:48.362447Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:10:33.561435Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1248e521-f708-4f4a-80ee-9d3084b0616f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:10:33.561435Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8ebafec9-15fb-496d-b212-1719a0311c3b","id":"fa8d0cb8-6e84-4edf-beba-cfefaa1bd81c","ipam_config":null,"mac_address":"02:00:00:18:61:C7","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","status":"ready","updated_at":"2025-02-12T16:10:59.506156Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1933"
+                - "984"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:35 GMT
+                - Wed, 12 Feb 2025 16:11:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3416,10 +3416,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7f2377ad-245a-451e-9780-4e3e6db1b758
+                - 06edcfc0-54b5-448b-818b-e5d0610c5a86
         status: 200 OK
         code: 200
-        duration: 28.533667ms
+        duration: 75.1505ms
     - id: 69
       request:
         proto: HTTP/1.1
@@ -3435,8 +3435,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/92b71032-5580-4650-bd52-b63253bcc3b5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/d774a252-83bc-4ff8-93d0-770d444a0574
         method: GET
       response:
         proto: HTTP/2.0
@@ -3444,20 +3444,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 954
+        content_length: 1118
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-24T14:15:34.959930Z","dhcp":{"address":"10.0.0.1","created_at":"2025-01-24T14:15:20.581273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"48b28823-2ed8-4a73-82a5-752bc9447518","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-24T14:15:20.581273Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","id":"92b71032-5580-4650-bd52-b63253bcc3b5","ipam_config":null,"mac_address":"02:00:00:17:E0:4B","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","status":"ready","updated_at":"2025-01-24T14:15:43.507917Z","zone":"fr-par-1"}'
+        body: '{"backend_count":0,"created_at":"2025-02-12T16:10:45.871197Z","description":"","frontend_count":0,"id":"d774a252-83bc-4ff8-93d0-770d444a0574","instances":[{"created_at":"2025-02-12T16:06:55.264058Z","id":"e43221b3-c700-4951-b53d-cf6ad775b8c0","ip_address":"","region":"fr-par","status":"ready","updated_at":"2025-02-12T16:11:18.860674Z","zone":"fr-par-1"}],"ip":[{"id":"d44cc37b-f392-46c9-a576-e42711323050","ip_address":"51.159.9.241","lb_id":"d774a252-83bc-4ff8-93d0-770d444a0574","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-9-241.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2025-02-12T16:10:49.157407Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "954"
+                - "1118"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:35 GMT
+                - Wed, 12 Feb 2025 16:11:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3465,10 +3465,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d1b77498-c4a2-42e9-bb3e-324a69dda6d6
+                - e7058084-8ccb-44b2-83f9-f04ea253f6cf
         status: 200 OK
         code: 200
-        duration: 45.074583ms
+        duration: 113.783291ms
     - id: 70
       request:
         proto: HTTP/1.1
@@ -3484,8 +3484,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -3493,20 +3493,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2721
+        content_length: 2289
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-24T14:15:22.371679+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"8b61785d-9e59-462c-8c73-602613da26ec","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1802","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:83:d3","maintenances":[],"modification_date":"2025-01-24T14:15:39.592074+00:00","name":"Scaleway Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-24T14:15:44.689986+00:00","id":"9046d524-d6a4-49ac-93cc-7dc56744d7ee","ipam_ip_ids":["2434ba0e-6dd2-4176-adca-a051205c78e8","bbadcc9e-16cd-475d-9167-9728c06de445"],"mac_address":"02:00:00:10:c8:b7","modification_date":"2025-01-24T14:16:16.703652+00:00","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","server_id":"8b61785d-9e59-462c-8c73-602613da26ec","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-24T14:15:22.371679+00:00","export_uri":null,"id":"bdaabaac-1ef9-4b2b-9f03-f8a6e88a1135","modification_date":"2025-01-24T14:15:22.371679+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"8b61785d-9e59-462c-8c73-602613da26ec","name":"Scaleway Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:10:34.904348+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"701","node_id":"23","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:9d","maintenances":[],"modification_date":"2025-02-12T16:10:41.323660+00:00","name":"Scaleway Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:10:42.196064+00:00","id":"cd2ffe8a-cda4-4325-8df1-e348145dcbf5","ipam_ip_ids":["8f0f24a6-2948-4029-94cf-8f7783d650d0","481a5ee7-ae89-4dc2-b0d2-95e88d40bb84"],"mac_address":"02:00:00:16:45:44","modification_date":"2025-02-12T16:11:14.306581+00:00","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","server_id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"6b9656e5-88c1-4a8f-af6a-01ecf39a238a","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2721"
+                - "2289"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:35 GMT
+                - Wed, 12 Feb 2025 16:11:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3514,10 +3514,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 914286f1-423d-43ea-a20f-136599ad0f04
+                - fd795f27-0aae-4d01-8eb7-166893a20364
         status: 200 OK
         code: 200
-        duration: 177.797542ms
+        duration: 309.036208ms
     - id: 71
       request:
         proto: HTTP/1.1
@@ -3533,8 +3533,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/74eabe50-405f-4517-9bd6-2540dafd4f89
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/6b9656e5-88c1-4a8f-af6a-01ecf39a238a
         method: GET
       response:
         proto: HTTP/2.0
@@ -3542,20 +3542,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1085
+        content_length: 143
         uncompressed: false
-        body: '{"backend_count":0,"created_at":"2025-01-24T14:15:32.867435Z","description":"","frontend_count":0,"id":"74eabe50-405f-4517-9bd6-2540dafd4f89","instances":[{"created_at":"2025-01-24T14:11:38.800501Z","id":"db97ec97-2d4e-4ffe-9447-7fa34e014506","ip_address":"","region":"fr-par","status":"ready","updated_at":"2025-01-24T14:16:08.493285Z","zone":"fr-par-1"}],"ip":[{"id":"df74cb2c-3245-49d9-b592-e67c753e77ac","ip_address":"51.159.25.55","lb_id":"74eabe50-405f-4517-9bd6-2540dafd4f89","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-25-55.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2025-01-24T14:15:36.612864Z","zone":"fr-par-1"}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"6b9656e5-88c1-4a8f-af6a-01ecf39a238a","type":"not_found"}'
         headers:
             Content-Length:
-                - "1085"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:35 GMT
+                - Wed, 12 Feb 2025 16:11:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3563,10 +3563,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 71d5f869-61c7-4d1f-bd5b-dcb8d65845aa
-        status: 200 OK
-        code: 200
-        duration: 95.963709ms
+                - e0479552-04fb-4f26-bd18-0e7c38b70b86
+        status: 404 Not Found
+        code: 404
+        duration: 63.245416ms
     - id: 72
       request:
         proto: HTTP/1.1
@@ -3582,8 +3582,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/bdaabaac-1ef9-4b2b-9f03-f8a6e88a1135
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/d774a252-83bc-4ff8-93d0-770d444a0574/private-networks?order_by=created_at_asc
         method: GET
       response:
         proto: HTTP/2.0
@@ -3591,20 +3591,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 518
+        content_length: 1242
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-24T14:15:22.371679+00:00","export_uri":null,"id":"bdaabaac-1ef9-4b2b-9f03-f8a6e88a1135","modification_date":"2025-01-24T14:15:22.371679+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"8b61785d-9e59-462c-8c73-602613da26ec","name":"Scaleway Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"private_network":[{"created_at":"2025-02-12T16:11:16.557208Z","dhcp_config":{"ip_id":"ce282ae5-f717-4ba1-a026-40754d835ca6"},"ipam_ids":["ce282ae5-f717-4ba1-a026-40754d835ca6"],"lb":{"backend_count":0,"created_at":"2025-02-12T16:10:45.871197Z","description":"","frontend_count":0,"id":"d774a252-83bc-4ff8-93d0-770d444a0574","instances":[],"ip":[{"id":"d44cc37b-f392-46c9-a576-e42711323050","ip_address":"51.159.9.241","lb_id":"d774a252-83bc-4ff8-93d0-770d444a0574","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-9-241.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2025-02-12T16:10:49.157407Z","zone":"fr-par-1"},"private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","status":"ready","updated_at":"2025-02-12T16:11:19.154906Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "518"
+                - "1242"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:35 GMT
+                - Wed, 12 Feb 2025 16:11:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3612,10 +3612,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c8cf5740-43e2-4a16-8975-ab45d9619ff2
+                - c313ca8a-9c1e-42bf-891c-9418f583179c
         status: 200 OK
         code: 200
-        duration: 89.573625ms
+        duration: 188.02375ms
     - id: 73
       request:
         proto: HTTP/1.1
@@ -3631,8 +3631,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/74eabe50-405f-4517-9bd6-2540dafd4f89/private-networks?order_by=created_at_asc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/6b9656e5-88c1-4a8f-af6a-01ecf39a238a
         method: GET
       response:
         proto: HTTP/2.0
@@ -3640,20 +3640,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1208
+        content_length: 692
         uncompressed: false
-        body: '{"private_network":[{"created_at":"2025-01-24T14:16:03.474743Z","dhcp_config":{"ip_id":"ca6d2b0a-935a-42f4-83d2-1d35e4e2c57a"},"ipam_ids":["ca6d2b0a-935a-42f4-83d2-1d35e4e2c57a"],"lb":{"backend_count":0,"created_at":"2025-01-24T14:15:32.867435Z","description":"","frontend_count":0,"id":"74eabe50-405f-4517-9bd6-2540dafd4f89","instances":[],"ip":[{"id":"df74cb2c-3245-49d9-b592-e67c753e77ac","ip_address":"51.159.25.55","lb_id":"74eabe50-405f-4517-9bd6-2540dafd4f89","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-25-55.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2025-01-24T14:15:36.612864Z","zone":"fr-par-1"},"private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","status":"ready","updated_at":"2025-01-24T14:16:09.657372Z"}],"total_count":1}'
+        body: '{"created_at":"2025-02-12T16:10:35.127132Z","id":"6b9656e5-88c1-4a8f-af6a-01ecf39a238a","last_detached_at":null,"name":"Debian Bullseye_sbs_volume_0","parent_snapshot_id":"a50e6921-21b9-4a69-83cc-191359208d4c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:10:35.127132Z","id":"8bc47366-83a8-4780-a8b2-b589142d9451","product_resource_id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:10:35.127132Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1208"
+                - "692"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:35 GMT
+                - Wed, 12 Feb 2025 16:11:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3661,10 +3661,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 28faaad9-0f52-4d59-a9af-e80ad16e51af
+                - 5de50841-bc47-40a8-94f9-aa093ece5c01
         status: 200 OK
         code: 200
-        duration: 87.773708ms
+        duration: 79.021542ms
     - id: 74
       request:
         proto: HTTP/1.1
@@ -3680,8 +3680,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -3700,9 +3700,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:35 GMT
+                - Wed, 12 Feb 2025 16:11:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3710,10 +3710,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4305bf4a-f174-438f-9c8c-d29c02bb7ba0
+                - 167ff92b-a604-432c-8caf-cf6f7057fdd7
         status: 200 OK
         code: 200
-        duration: 73.807458ms
+        duration: 279.178833ms
     - id: 75
       request:
         proto: HTTP/1.1
@@ -3729,8 +3729,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -3740,7 +3740,7 @@ interactions:
         trailer: {}
         content_length: 478
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-24T14:15:44.689986+00:00","id":"9046d524-d6a4-49ac-93cc-7dc56744d7ee","ipam_ip_ids":["2434ba0e-6dd2-4176-adca-a051205c78e8","bbadcc9e-16cd-475d-9167-9728c06de445"],"mac_address":"02:00:00:10:c8:b7","modification_date":"2025-01-24T14:16:16.703652+00:00","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","server_id":"8b61785d-9e59-462c-8c73-602613da26ec","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:10:42.196064+00:00","id":"cd2ffe8a-cda4-4325-8df1-e348145dcbf5","ipam_ip_ids":["8f0f24a6-2948-4029-94cf-8f7783d650d0","481a5ee7-ae89-4dc2-b0d2-95e88d40bb84"],"mac_address":"02:00:00:16:45:44","modification_date":"2025-02-12T16:11:14.306581+00:00","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","server_id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
                 - "478"
@@ -3749,11 +3749,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:35 GMT
+                - Wed, 12 Feb 2025 16:11:49 GMT
             Link:
-                - </servers/8b61785d-9e59-462c-8c73-602613da26ec/private_nics?page=1&per_page=50&>; rel="last"
+                - </servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f/private_nics?page=1&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3761,12 +3761,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a9388e04-ca76-435a-8da9-dab2f3e0f868
+                - 2ba0ee1c-b79c-48ce-9b0c-64cf54ebfe25
             X-Total-Count:
                 - "1"
         status: 200 OK
         code: 200
-        duration: 82.138333ms
+        duration: 142.151459ms
     - id: 76
       request:
         proto: HTTP/1.1
@@ -3782,8 +3782,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/92b71032-5580-4650-bd52-b63253bcc3b5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/fa8d0cb8-6e84-4edf-beba-cfefaa1bd81c
         method: GET
       response:
         proto: HTTP/2.0
@@ -3791,20 +3791,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 954
+        content_length: 984
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-24T14:15:34.959930Z","dhcp":{"address":"10.0.0.1","created_at":"2025-01-24T14:15:20.581273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"48b28823-2ed8-4a73-82a5-752bc9447518","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-24T14:15:20.581273Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","id":"92b71032-5580-4650-bd52-b63253bcc3b5","ipam_config":null,"mac_address":"02:00:00:17:E0:4B","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","status":"ready","updated_at":"2025-01-24T14:15:43.507917Z","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:10:48.362447Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:10:33.561435Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1248e521-f708-4f4a-80ee-9d3084b0616f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:10:33.561435Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8ebafec9-15fb-496d-b212-1719a0311c3b","id":"fa8d0cb8-6e84-4edf-beba-cfefaa1bd81c","ipam_config":null,"mac_address":"02:00:00:18:61:C7","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","status":"ready","updated_at":"2025-02-12T16:10:59.506156Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "954"
+                - "984"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:36 GMT
+                - Wed, 12 Feb 2025 16:11:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3812,10 +3812,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 074582d5-ee8a-4d1d-845b-79d282fee20e
+                - 1d471b93-41a7-4b75-9ee7-8577c3b4abf7
         status: 200 OK
         code: 200
-        duration: 40.001542ms
+        duration: 81.015958ms
     - id: 77
       request:
         proto: HTTP/1.1
@@ -3831,8 +3831,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/74eabe50-405f-4517-9bd6-2540dafd4f89
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/d774a252-83bc-4ff8-93d0-770d444a0574
         method: GET
       response:
         proto: HTTP/2.0
@@ -3840,20 +3840,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1085
+        content_length: 1118
         uncompressed: false
-        body: '{"backend_count":0,"created_at":"2025-01-24T14:15:32.867435Z","description":"","frontend_count":0,"id":"74eabe50-405f-4517-9bd6-2540dafd4f89","instances":[{"created_at":"2025-01-24T14:11:38.800501Z","id":"db97ec97-2d4e-4ffe-9447-7fa34e014506","ip_address":"","region":"fr-par","status":"ready","updated_at":"2025-01-24T14:16:08.493285Z","zone":"fr-par-1"}],"ip":[{"id":"df74cb2c-3245-49d9-b592-e67c753e77ac","ip_address":"51.159.25.55","lb_id":"74eabe50-405f-4517-9bd6-2540dafd4f89","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-25-55.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2025-01-24T14:15:36.612864Z","zone":"fr-par-1"}'
+        body: '{"backend_count":0,"created_at":"2025-02-12T16:10:45.871197Z","description":"","frontend_count":0,"id":"d774a252-83bc-4ff8-93d0-770d444a0574","instances":[{"created_at":"2025-02-12T16:06:55.264058Z","id":"e43221b3-c700-4951-b53d-cf6ad775b8c0","ip_address":"","region":"fr-par","status":"ready","updated_at":"2025-02-12T16:11:18.860674Z","zone":"fr-par-1"}],"ip":[{"id":"d44cc37b-f392-46c9-a576-e42711323050","ip_address":"51.159.9.241","lb_id":"d774a252-83bc-4ff8-93d0-770d444a0574","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-9-241.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2025-02-12T16:10:49.157407Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1085"
+                - "1118"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:36 GMT
+                - Wed, 12 Feb 2025 16:11:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3861,10 +3861,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0ec9d7f6-110b-4d6d-a78a-96389ef4f22b
+                - d9fca286-c652-45a2-a244-a916c9bad689
         status: 200 OK
         code: 200
-        duration: 101.042625ms
+        duration: 99.344708ms
     - id: 78
       request:
         proto: HTTP/1.1
@@ -3880,8 +3880,57 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/92b71032-5580-4650-bd52-b63253bcc3b5?cleanup_dhcp=true
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2289
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:10:34.904348+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"701","node_id":"23","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:9d","maintenances":[],"modification_date":"2025-02-12T16:10:41.323660+00:00","name":"Scaleway Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:10:42.196064+00:00","id":"cd2ffe8a-cda4-4325-8df1-e348145dcbf5","ipam_ip_ids":["8f0f24a6-2948-4029-94cf-8f7783d650d0","481a5ee7-ae89-4dc2-b0d2-95e88d40bb84"],"mac_address":"02:00:00:16:45:44","modification_date":"2025-02-12T16:11:14.306581+00:00","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","server_id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"6b9656e5-88c1-4a8f-af6a-01ecf39a238a","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2289"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:11:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9f39a52a-58d0-4441-ab67-f4edb7c12df2
+        status: 200 OK
+        code: 200
+        duration: 220.657625ms
+    - id: 79
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/fa8d0cb8-6e84-4edf-beba-cfefaa1bd81c?cleanup_dhcp=true
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3898,9 +3947,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:36 GMT
+                - Wed, 12 Feb 2025 16:11:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3908,59 +3957,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8d311159-6cea-4158-8fa8-405b66f66b24
+                - 933c20c0-ac09-4fa5-b26c-05e901712fa1
         status: 204 No Content
         code: 204
-        duration: 66.118667ms
-    - id: 79
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/92b71032-5580-4650-bd52-b63253bcc3b5
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 958
-        uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-24T14:15:34.959930Z","dhcp":{"address":"10.0.0.1","created_at":"2025-01-24T14:15:20.581273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"48b28823-2ed8-4a73-82a5-752bc9447518","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-24T14:15:20.581273Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","id":"92b71032-5580-4650-bd52-b63253bcc3b5","ipam_config":null,"mac_address":"02:00:00:17:E0:4B","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","status":"detaching","updated_at":"2025-01-24T14:16:36.590763Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "958"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 14:16:36 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - b716ae36-f594-416f-a827-192716d7c556
-        status: 200 OK
-        code: 200
-        duration: 46.856792ms
+        duration: 171.837834ms
     - id: 80
       request:
         proto: HTTP/1.1
@@ -3976,8 +3976,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/74eabe50-405f-4517-9bd6-2540dafd4f89/private-networks?order_by=created_at_asc
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/d774a252-83bc-4ff8-93d0-770d444a0574/private-networks?order_by=created_at_asc
         method: GET
       response:
         proto: HTTP/2.0
@@ -3985,20 +3985,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1208
+        content_length: 1242
         uncompressed: false
-        body: '{"private_network":[{"created_at":"2025-01-24T14:16:03.474743Z","dhcp_config":{"ip_id":"ca6d2b0a-935a-42f4-83d2-1d35e4e2c57a"},"ipam_ids":["ca6d2b0a-935a-42f4-83d2-1d35e4e2c57a"],"lb":{"backend_count":0,"created_at":"2025-01-24T14:15:32.867435Z","description":"","frontend_count":0,"id":"74eabe50-405f-4517-9bd6-2540dafd4f89","instances":[],"ip":[{"id":"df74cb2c-3245-49d9-b592-e67c753e77ac","ip_address":"51.159.25.55","lb_id":"74eabe50-405f-4517-9bd6-2540dafd4f89","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-25-55.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2025-01-24T14:15:36.612864Z","zone":"fr-par-1"},"private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","status":"ready","updated_at":"2025-01-24T14:16:09.657372Z"}],"total_count":1}'
+        body: '{"private_network":[{"created_at":"2025-02-12T16:11:16.557208Z","dhcp_config":{"ip_id":"ce282ae5-f717-4ba1-a026-40754d835ca6"},"ipam_ids":["ce282ae5-f717-4ba1-a026-40754d835ca6"],"lb":{"backend_count":0,"created_at":"2025-02-12T16:10:45.871197Z","description":"","frontend_count":0,"id":"d774a252-83bc-4ff8-93d0-770d444a0574","instances":[],"ip":[{"id":"d44cc37b-f392-46c9-a576-e42711323050","ip_address":"51.159.9.241","lb_id":"d774a252-83bc-4ff8-93d0-770d444a0574","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-9-241.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2025-02-12T16:10:49.157407Z","zone":"fr-par-1"},"private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","status":"ready","updated_at":"2025-02-12T16:11:19.154906Z"}],"total_count":1}'
         headers:
             Content-Length:
-                - "1208"
+                - "1242"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:36 GMT
+                - Wed, 12 Feb 2025 16:11:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4006,10 +4006,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 622bd8dc-eb05-45ae-b0c8-90083ee56955
+                - d991e6f3-b9bc-4246-8e34-def4b2ec2a0d
         status: 200 OK
         code: 200
-        duration: 100.899333ms
+        duration: 185.536125ms
     - id: 81
       request:
         proto: HTTP/1.1
@@ -4025,8 +4025,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/6b9656e5-88c1-4a8f-af6a-01ecf39a238a
         method: GET
       response:
         proto: HTTP/2.0
@@ -4034,20 +4034,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2721
+        content_length: 692
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-24T14:15:22.371679+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"8b61785d-9e59-462c-8c73-602613da26ec","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1802","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:83:d3","maintenances":[],"modification_date":"2025-01-24T14:15:39.592074+00:00","name":"Scaleway Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-24T14:15:44.689986+00:00","id":"9046d524-d6a4-49ac-93cc-7dc56744d7ee","ipam_ip_ids":["2434ba0e-6dd2-4176-adca-a051205c78e8","bbadcc9e-16cd-475d-9167-9728c06de445"],"mac_address":"02:00:00:10:c8:b7","modification_date":"2025-01-24T14:16:16.703652+00:00","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","server_id":"8b61785d-9e59-462c-8c73-602613da26ec","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-24T14:15:22.371679+00:00","export_uri":null,"id":"bdaabaac-1ef9-4b2b-9f03-f8a6e88a1135","modification_date":"2025-01-24T14:15:22.371679+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"8b61785d-9e59-462c-8c73-602613da26ec","name":"Scaleway Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-12T16:10:35.127132Z","id":"6b9656e5-88c1-4a8f-af6a-01ecf39a238a","last_detached_at":null,"name":"Debian Bullseye_sbs_volume_0","parent_snapshot_id":"a50e6921-21b9-4a69-83cc-191359208d4c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:10:35.127132Z","id":"8bc47366-83a8-4780-a8b2-b589142d9451","product_resource_id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:10:35.127132Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2721"
+                - "692"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:36 GMT
+                - Wed, 12 Feb 2025 16:11:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4055,48 +4055,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1adaa2a9-e78c-49ae-93e7-c3e9653e9739
+                - c35495c9-9590-470a-9d0d-773ea8be81e1
         status: 200 OK
         code: 200
-        duration: 244.203917ms
+        duration: 88.79325ms
     - id: 82
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 2
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/74eabe50-405f-4517-9bd6-2540dafd4f89/private-networks/57acd471-d6d6-471a-be4f-6464a3976f5b/detach
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/fa8d0cb8-6e84-4edf-beba-cfefaa1bd81c
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 988
         uncompressed: false
-        body: ""
+        body: '{"address":null,"created_at":"2025-02-12T16:10:48.362447Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:10:33.561435Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1248e521-f708-4f4a-80ee-9d3084b0616f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:10:33.561435Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8ebafec9-15fb-496d-b212-1719a0311c3b","id":"fa8d0cb8-6e84-4edf-beba-cfefaa1bd81c","ipam_config":null,"mac_address":"02:00:00:18:61:C7","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","status":"detaching","updated_at":"2025-02-12T16:11:50.132046Z","zone":"fr-par-1"}'
         headers:
+            Content-Length:
+                - "988"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:36 GMT
+                - Wed, 12 Feb 2025 16:11:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4104,10 +4104,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 46d0ddec-4fbf-46d8-af0d-8f697c953f21
-        status: 204 No Content
-        code: 204
-        duration: 274.985375ms
+                - 496bcd72-eda2-4cfc-8ec8-c5017adce425
+        status: 200 OK
+        code: 200
+        duration: 67.551209ms
     - id: 83
       request:
         proto: HTTP/1.1
@@ -4125,8 +4125,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -4136,7 +4136,7 @@ interactions:
         trailer: {}
         content_length: 352
         uncompressed: false
-        body: '{"task":{"description":"server_poweroff","href_from":"/servers/8b61785d-9e59-462c-8c73-602613da26ec/action","href_result":"/servers/8b61785d-9e59-462c-8c73-602613da26ec","id":"1e6db5b4-571f-46ce-8815-05cd1658d800","progress":0,"started_at":"2025-01-24T14:16:36.975423+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_poweroff","href_from":"/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f/action","href_result":"/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f","id":"e6a3d79c-e83d-450e-923a-fb1448f243e1","progress":0,"started_at":"2025-02-12T16:11:50.471477+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "352"
@@ -4145,11 +4145,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:36 GMT
+                - Wed, 12 Feb 2025 16:11:50 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/1e6db5b4-571f-46ce-8815-05cd1658d800
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/e6a3d79c-e83d-450e-923a-fb1448f243e1
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4157,48 +4157,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0dd71622-e3c2-49ee-b84b-026b53cd463b
+                - 3383d3dd-fedd-40fc-9f88-48a459f74daa
         status: 202 Accepted
         code: 202
-        duration: 246.8755ms
+        duration: 363.841916ms
     - id: 84
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 2
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/74eabe50-405f-4517-9bd6-2540dafd4f89
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/d774a252-83bc-4ff8-93d0-770d444a0574/private-networks/7abd3366-919a-46e1-88ad-af224037959a/detach
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1085
+        content_length: 0
         uncompressed: false
-        body: '{"backend_count":0,"created_at":"2025-01-24T14:15:32.867435Z","description":"","frontend_count":0,"id":"74eabe50-405f-4517-9bd6-2540dafd4f89","instances":[{"created_at":"2025-01-24T14:11:38.800501Z","id":"db97ec97-2d4e-4ffe-9447-7fa34e014506","ip_address":"","region":"fr-par","status":"ready","updated_at":"2025-01-24T14:16:08.493285Z","zone":"fr-par-1"}],"ip":[{"id":"df74cb2c-3245-49d9-b592-e67c753e77ac","ip_address":"51.159.25.55","lb_id":"74eabe50-405f-4517-9bd6-2540dafd4f89","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-25-55.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2025-01-24T14:15:36.612864Z","zone":"fr-par-1"}'
+        body: ""
         headers:
-            Content-Length:
-                - "1085"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:37 GMT
+                - Wed, 12 Feb 2025 16:11:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4206,10 +4206,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ce908d5c-7ec6-4e35-bc10-2015a451be87
-        status: 200 OK
-        code: 200
-        duration: 86.752958ms
+                - 7d5560ee-6c58-45e6-ba06-ec11a0efd772
+        status: 204 No Content
+        code: 204
+        duration: 398.469875ms
     - id: 85
       request:
         proto: HTTP/1.1
@@ -4225,8 +4225,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/d774a252-83bc-4ff8-93d0-770d444a0574
         method: GET
       response:
         proto: HTTP/2.0
@@ -4234,20 +4234,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2681
+        content_length: 1118
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-24T14:15:22.371679+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"8b61785d-9e59-462c-8c73-602613da26ec","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1802","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:83:d3","maintenances":[],"modification_date":"2025-01-24T14:16:36.776366+00:00","name":"Scaleway Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-24T14:15:44.689986+00:00","id":"9046d524-d6a4-49ac-93cc-7dc56744d7ee","ipam_ip_ids":["2434ba0e-6dd2-4176-adca-a051205c78e8","bbadcc9e-16cd-475d-9167-9728c06de445"],"mac_address":"02:00:00:10:c8:b7","modification_date":"2025-01-24T14:16:16.703652+00:00","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","server_id":"8b61785d-9e59-462c-8c73-602613da26ec","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-24T14:15:22.371679+00:00","export_uri":null,"id":"bdaabaac-1ef9-4b2b-9f03-f8a6e88a1135","modification_date":"2025-01-24T14:15:22.371679+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"8b61785d-9e59-462c-8c73-602613da26ec","name":"Scaleway Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"backend_count":0,"created_at":"2025-02-12T16:10:45.871197Z","description":"","frontend_count":0,"id":"d774a252-83bc-4ff8-93d0-770d444a0574","instances":[{"created_at":"2025-02-12T16:06:55.264058Z","id":"e43221b3-c700-4951-b53d-cf6ad775b8c0","ip_address":"","region":"fr-par","status":"ready","updated_at":"2025-02-12T16:11:18.860674Z","zone":"fr-par-1"}],"ip":[{"id":"d44cc37b-f392-46c9-a576-e42711323050","ip_address":"51.159.9.241","lb_id":"d774a252-83bc-4ff8-93d0-770d444a0574","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-9-241.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2025-02-12T16:10:49.157407Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2681"
+                - "1118"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:37 GMT
+                - Wed, 12 Feb 2025 16:11:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4255,10 +4255,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 555adf60-bdde-42b3-989c-81768e74094e
+                - 22a276bb-efb3-45fc-bb0b-cd422dcfbbc3
         status: 200 OK
         code: 200
-        duration: 157.941875ms
+        duration: 121.386625ms
     - id: 86
       request:
         proto: HTTP/1.1
@@ -4274,27 +4274,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/74eabe50-405f-4517-9bd6-2540dafd4f89?release_ip=false
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 2249
         uncompressed: false
-        body: ""
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:10:34.904348+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"701","node_id":"23","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:9d","maintenances":[],"modification_date":"2025-02-12T16:11:50.272233+00:00","name":"Scaleway Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:10:42.196064+00:00","id":"cd2ffe8a-cda4-4325-8df1-e348145dcbf5","ipam_ip_ids":["8f0f24a6-2948-4029-94cf-8f7783d650d0","481a5ee7-ae89-4dc2-b0d2-95e88d40bb84"],"mac_address":"02:00:00:16:45:44","modification_date":"2025-02-12T16:11:14.306581+00:00","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","server_id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"6b9656e5-88c1-4a8f-af6a-01ecf39a238a","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
+            Content-Length:
+                - "2249"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:37 GMT
+                - Wed, 12 Feb 2025 16:11:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4302,10 +4304,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9a32e0ed-a149-453c-869d-17605ef62966
-        status: 204 No Content
-        code: 204
-        duration: 346.222875ms
+                - 9de97bc1-970e-4b52-8483-71952fc22f2d
+        status: 200 OK
+        code: 200
+        duration: 406.269583ms
     - id: 87
       request:
         proto: HTTP/1.1
@@ -4321,29 +4323,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/74eabe50-405f-4517-9bd6-2540dafd4f89
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/d774a252-83bc-4ff8-93d0-770d444a0574?release_ip=false
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1089
+        content_length: 0
         uncompressed: false
-        body: '{"backend_count":0,"created_at":"2025-01-24T14:15:32.867435Z","description":"","frontend_count":0,"id":"74eabe50-405f-4517-9bd6-2540dafd4f89","instances":[{"created_at":"2025-01-24T14:11:38.800501Z","id":"db97ec97-2d4e-4ffe-9447-7fa34e014506","ip_address":"","region":"fr-par","status":"ready","updated_at":"2025-01-24T14:16:08.493285Z","zone":"fr-par-1"}],"ip":[{"id":"df74cb2c-3245-49d9-b592-e67c753e77ac","ip_address":"51.159.25.55","lb_id":"74eabe50-405f-4517-9bd6-2540dafd4f89","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-25-55.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"to_delete","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2025-01-24T14:16:37.181065Z","zone":"fr-par-1"}'
+        body: ""
         headers:
-            Content-Length:
-                - "1089"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:37 GMT
+                - Wed, 12 Feb 2025 16:11:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4351,10 +4351,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 040296ae-3683-47a2-a302-e1f07fcc0da6
-        status: 200 OK
-        code: 200
-        duration: 85.241ms
+                - a7c62600-a42b-437d-a3c7-f11c0717e377
+        status: 204 No Content
+        code: 204
+        duration: 364.852ms
     - id: 88
       request:
         proto: HTTP/1.1
@@ -4370,8 +4370,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/92b71032-5580-4650-bd52-b63253bcc3b5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/d774a252-83bc-4ff8-93d0-770d444a0574
         method: GET
       response:
         proto: HTTP/2.0
@@ -4379,20 +4379,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 136
+        content_length: 1122
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"92b71032-5580-4650-bd52-b63253bcc3b5","type":"not_found"}'
+        body: '{"backend_count":0,"created_at":"2025-02-12T16:10:45.871197Z","description":"","frontend_count":0,"id":"d774a252-83bc-4ff8-93d0-770d444a0574","instances":[{"created_at":"2025-02-12T16:06:55.264058Z","id":"e43221b3-c700-4951-b53d-cf6ad775b8c0","ip_address":"","region":"fr-par","status":"ready","updated_at":"2025-02-12T16:11:18.860674Z","zone":"fr-par-1"}],"ip":[{"id":"d44cc37b-f392-46c9-a576-e42711323050","ip_address":"51.159.9.241","lb_id":"d774a252-83bc-4ff8-93d0-770d444a0574","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-9-241.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"to_delete","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2025-02-12T16:11:50.851225Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "136"
+                - "1122"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:41 GMT
+                - Wed, 12 Feb 2025 16:11:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4400,10 +4400,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 70a46bed-0069-4493-8472-8e01926d52de
-        status: 404 Not Found
-        code: 404
-        duration: 22.66375ms
+                - 78890cdf-1446-41ad-9570-41c1496c5b71
+        status: 200 OK
+        code: 200
+        duration: 138.819041ms
     - id: 89
       request:
         proto: HTTP/1.1
@@ -4419,8 +4419,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0cdaf520-f0e0-46ed-b197-36c28975d51c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/fa8d0cb8-6e84-4edf-beba-cfefaa1bd81c
         method: GET
       response:
         proto: HTTP/2.0
@@ -4428,20 +4428,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 979
+        content_length: 136
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-24T14:15:22.458029Z","gateway_networks":[],"id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","ip":{"address":"51.158.121.168","created_at":"2025-01-24T14:15:22.212402Z","gateway_id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","id":"5e32e435-6bf9-4406-8f72-8f76be892a2f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"168-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-24T14:15:22.212402Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-24T14:15:43.659223Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"fa8d0cb8-6e84-4edf-beba-cfefaa1bd81c","type":"not_found"}'
         headers:
             Content-Length:
-                - "979"
+                - "136"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:41 GMT
+                - Wed, 12 Feb 2025 16:11:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4449,10 +4449,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1e7393bb-3411-4a8e-bf4e-fe24534acb18
-        status: 200 OK
-        code: 200
-        duration: 28.275959ms
+                - abd2bdf0-7327-448f-a538-6542cff6ab76
+        status: 404 Not Found
+        code: 404
+        duration: 45.074167ms
     - id: 90
       request:
         proto: HTTP/1.1
@@ -4468,29 +4468,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/48b28823-2ed8-4a73-82a5-752bc9447518
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/8ebafec9-15fb-496d-b212-1719a0311c3b
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 125
+        content_length: 1011
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"dhcp","resource_id":"48b28823-2ed8-4a73-82a5-752bc9447518","type":"not_found"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:10:35.342174Z","gateway_networks":[],"id":"8ebafec9-15fb-496d-b212-1719a0311c3b","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:10:34.957253Z","gateway_id":"8ebafec9-15fb-496d-b212-1719a0311c3b","id":"d217409e-10e1-4bbc-97d6-1daedb998b38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:10:34.957253Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:10:59.705659Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "125"
+                - "1011"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:41 GMT
+                - Wed, 12 Feb 2025 16:11:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4498,10 +4498,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3fe5aaf6-e4d1-4d71-b612-337844d28f01
-        status: 404 Not Found
-        code: 404
-        duration: 26.516167ms
+                - b1f4eb08-2b82-4eb2-8b79-1fef06b55ed0
+        status: 200 OK
+        code: 200
+        duration: 53.209167ms
     - id: 91
       request:
         proto: HTTP/1.1
@@ -4517,29 +4517,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/1248e521-f708-4f4a-80ee-9d3084b0616f
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2681
+        content_length: 125
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-24T14:15:22.371679+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"8b61785d-9e59-462c-8c73-602613da26ec","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1802","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:83:d3","maintenances":[],"modification_date":"2025-01-24T14:16:36.776366+00:00","name":"Scaleway Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-24T14:15:44.689986+00:00","id":"9046d524-d6a4-49ac-93cc-7dc56744d7ee","ipam_ip_ids":["2434ba0e-6dd2-4176-adca-a051205c78e8","bbadcc9e-16cd-475d-9167-9728c06de445"],"mac_address":"02:00:00:10:c8:b7","modification_date":"2025-01-24T14:16:16.703652+00:00","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","server_id":"8b61785d-9e59-462c-8c73-602613da26ec","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-24T14:15:22.371679+00:00","export_uri":null,"id":"bdaabaac-1ef9-4b2b-9f03-f8a6e88a1135","modification_date":"2025-01-24T14:15:22.371679+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"8b61785d-9e59-462c-8c73-602613da26ec","name":"Scaleway Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"dhcp","resource_id":"1248e521-f708-4f4a-80ee-9d3084b0616f","type":"not_found"}'
         headers:
             Content-Length:
-                - "2681"
+                - "125"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:41 GMT
+                - Wed, 12 Feb 2025 16:11:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4547,10 +4547,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 35229699-0c79-49cc-888e-9a6fc69202e8
-        status: 200 OK
-        code: 200
-        duration: 144.946375ms
+                - 673eb803-1928-46b2-b248-a280fd650b84
+        status: 404 Not Found
+        code: 404
+        duration: 42.301583ms
     - id: 92
       request:
         proto: HTTP/1.1
@@ -4566,8 +4566,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -4575,20 +4575,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2681
+        content_length: 2249
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-24T14:15:22.371679+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"8b61785d-9e59-462c-8c73-602613da26ec","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1802","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:83:d3","maintenances":[],"modification_date":"2025-01-24T14:16:36.776366+00:00","name":"Scaleway Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-24T14:15:44.689986+00:00","id":"9046d524-d6a4-49ac-93cc-7dc56744d7ee","ipam_ip_ids":["2434ba0e-6dd2-4176-adca-a051205c78e8","bbadcc9e-16cd-475d-9167-9728c06de445"],"mac_address":"02:00:00:10:c8:b7","modification_date":"2025-01-24T14:16:16.703652+00:00","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","server_id":"8b61785d-9e59-462c-8c73-602613da26ec","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-24T14:15:22.371679+00:00","export_uri":null,"id":"bdaabaac-1ef9-4b2b-9f03-f8a6e88a1135","modification_date":"2025-01-24T14:15:22.371679+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"8b61785d-9e59-462c-8c73-602613da26ec","name":"Scaleway Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:10:34.904348+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"701","node_id":"23","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:9d","maintenances":[],"modification_date":"2025-02-12T16:11:50.272233+00:00","name":"Scaleway Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:10:42.196064+00:00","id":"cd2ffe8a-cda4-4325-8df1-e348145dcbf5","ipam_ip_ids":["8f0f24a6-2948-4029-94cf-8f7783d650d0","481a5ee7-ae89-4dc2-b0d2-95e88d40bb84"],"mac_address":"02:00:00:16:45:44","modification_date":"2025-02-12T16:11:14.306581+00:00","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","server_id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"6b9656e5-88c1-4a8f-af6a-01ecf39a238a","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2681"
+                - "2249"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:47 GMT
+                - Wed, 12 Feb 2025 16:11:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4596,10 +4596,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f939bb95-d4c7-4b2d-b328-f0e3be830c00
+                - 2a79f1a5-90cd-49a3-8020-81bb6e949785
         status: 200 OK
         code: 200
-        duration: 176.808834ms
+        duration: 222.87725ms
     - id: 93
       request:
         proto: HTTP/1.1
@@ -4615,8 +4615,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -4624,20 +4624,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2681
+        content_length: 2249
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-24T14:15:22.371679+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"8b61785d-9e59-462c-8c73-602613da26ec","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1802","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:83:d3","maintenances":[],"modification_date":"2025-01-24T14:16:36.776366+00:00","name":"Scaleway Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-24T14:15:44.689986+00:00","id":"9046d524-d6a4-49ac-93cc-7dc56744d7ee","ipam_ip_ids":["2434ba0e-6dd2-4176-adca-a051205c78e8","bbadcc9e-16cd-475d-9167-9728c06de445"],"mac_address":"02:00:00:10:c8:b7","modification_date":"2025-01-24T14:16:16.703652+00:00","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","server_id":"8b61785d-9e59-462c-8c73-602613da26ec","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-24T14:15:22.371679+00:00","export_uri":null,"id":"bdaabaac-1ef9-4b2b-9f03-f8a6e88a1135","modification_date":"2025-01-24T14:15:22.371679+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"8b61785d-9e59-462c-8c73-602613da26ec","name":"Scaleway Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:10:34.904348+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"35","hypervisor_id":"701","node_id":"23","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:9d","maintenances":[],"modification_date":"2025-02-12T16:11:50.272233+00:00","name":"Scaleway Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:10:42.196064+00:00","id":"cd2ffe8a-cda4-4325-8df1-e348145dcbf5","ipam_ip_ids":["8f0f24a6-2948-4029-94cf-8f7783d650d0","481a5ee7-ae89-4dc2-b0d2-95e88d40bb84"],"mac_address":"02:00:00:16:45:44","modification_date":"2025-02-12T16:11:14.306581+00:00","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","server_id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"6b9656e5-88c1-4a8f-af6a-01ecf39a238a","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2681"
+                - "2249"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:52 GMT
+                - Wed, 12 Feb 2025 16:12:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4645,10 +4645,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 29596eac-37f1-4a57-9b27-68280adafb6f
+                - 69d27a15-fa3f-4d04-8c79-676452441078
         status: 200 OK
         code: 200
-        duration: 152.212625ms
+        duration: 214.162375ms
     - id: 94
       request:
         proto: HTTP/1.1
@@ -4664,8 +4664,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -4673,20 +4673,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2681
+        content_length: 2133
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-24T14:15:22.371679+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"8b61785d-9e59-462c-8c73-602613da26ec","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1802","node_id":"11","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:83:d3","maintenances":[],"modification_date":"2025-01-24T14:16:36.776366+00:00","name":"Scaleway Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-24T14:15:44.689986+00:00","id":"9046d524-d6a4-49ac-93cc-7dc56744d7ee","ipam_ip_ids":["2434ba0e-6dd2-4176-adca-a051205c78e8","bbadcc9e-16cd-475d-9167-9728c06de445"],"mac_address":"02:00:00:10:c8:b7","modification_date":"2025-01-24T14:16:16.703652+00:00","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","server_id":"8b61785d-9e59-462c-8c73-602613da26ec","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-24T14:15:22.371679+00:00","export_uri":null,"id":"bdaabaac-1ef9-4b2b-9f03-f8a6e88a1135","modification_date":"2025-01-24T14:15:22.371679+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"8b61785d-9e59-462c-8c73-602613da26ec","name":"Scaleway Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:10:34.904348+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:9d","maintenances":[],"modification_date":"2025-02-12T16:12:03.981561+00:00","name":"Scaleway Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:10:42.196064+00:00","id":"cd2ffe8a-cda4-4325-8df1-e348145dcbf5","ipam_ip_ids":["8f0f24a6-2948-4029-94cf-8f7783d650d0","481a5ee7-ae89-4dc2-b0d2-95e88d40bb84"],"mac_address":"02:00:00:16:45:44","modification_date":"2025-02-12T16:11:14.306581+00:00","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","server_id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"6b9656e5-88c1-4a8f-af6a-01ecf39a238a","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2681"
+                - "2133"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:16:57 GMT
+                - Wed, 12 Feb 2025 16:12:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4694,10 +4694,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 55dcfaaf-cfb0-4b29-8f41-e632dee9ae79
+                - 2869d51a-59ac-4923-a7de-3736f11239c7
         status: 200 OK
         code: 200
-        duration: 152.92675ms
+        duration: 179.457875ms
     - id: 95
       request:
         proto: HTTP/1.1
@@ -4713,8 +4713,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -4722,20 +4722,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2564
+        content_length: 478
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-24T14:15:22.371679+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"8b61785d-9e59-462c-8c73-602613da26ec","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:83:d3","maintenances":[],"modification_date":"2025-01-24T14:16:58.971471+00:00","name":"Scaleway Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-24T14:15:44.689986+00:00","id":"9046d524-d6a4-49ac-93cc-7dc56744d7ee","ipam_ip_ids":["2434ba0e-6dd2-4176-adca-a051205c78e8","bbadcc9e-16cd-475d-9167-9728c06de445"],"mac_address":"02:00:00:10:c8:b7","modification_date":"2025-01-24T14:16:16.703652+00:00","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","server_id":"8b61785d-9e59-462c-8c73-602613da26ec","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-24T14:15:22.371679+00:00","export_uri":null,"id":"bdaabaac-1ef9-4b2b-9f03-f8a6e88a1135","modification_date":"2025-01-24T14:15:22.371679+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"8b61785d-9e59-462c-8c73-602613da26ec","name":"Scaleway Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:10:42.196064+00:00","id":"cd2ffe8a-cda4-4325-8df1-e348145dcbf5","ipam_ip_ids":["8f0f24a6-2948-4029-94cf-8f7783d650d0","481a5ee7-ae89-4dc2-b0d2-95e88d40bb84"],"mac_address":"02:00:00:16:45:44","modification_date":"2025-02-12T16:11:14.306581+00:00","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","server_id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "2564"
+                - "478"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:17:02 GMT
+                - Wed, 12 Feb 2025 16:12:06 GMT
+            Link:
+                - </servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f/private_nics?page=1&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4743,10 +4745,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 468f68c9-c498-4ed8-9a04-9dc8675725c4
+                - 7dbdfbac-ecc1-4298-90eb-de46548b7ef5
+            X-Total-Count:
+                - "1"
         status: 200 OK
         code: 200
-        duration: 130.021959ms
+        duration: 108.901458ms
     - id: 96
       request:
         proto: HTTP/1.1
@@ -4762,8 +4766,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f/private_nics/cd2ffe8a-cda4-4325-8df1-e348145dcbf5
         method: GET
       response:
         proto: HTTP/2.0
@@ -4771,22 +4775,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 478
+        content_length: 475
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-24T14:15:44.689986+00:00","id":"9046d524-d6a4-49ac-93cc-7dc56744d7ee","ipam_ip_ids":["2434ba0e-6dd2-4176-adca-a051205c78e8","bbadcc9e-16cd-475d-9167-9728c06de445"],"mac_address":"02:00:00:10:c8:b7","modification_date":"2025-01-24T14:16:16.703652+00:00","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","server_id":"8b61785d-9e59-462c-8c73-602613da26ec","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:10:42.196064+00:00","id":"cd2ffe8a-cda4-4325-8df1-e348145dcbf5","ipam_ip_ids":["8f0f24a6-2948-4029-94cf-8f7783d650d0","481a5ee7-ae89-4dc2-b0d2-95e88d40bb84"],"mac_address":"02:00:00:16:45:44","modification_date":"2025-02-12T16:11:14.306581+00:00","private_network_id":"7abd3366-919a-46e1-88ad-af224037959a","server_id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "478"
+                - "475"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:17:02 GMT
-            Link:
-                - </servers/8b61785d-9e59-462c-8c73-602613da26ec/private_nics?page=1&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 16:12:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4794,12 +4796,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - adc31bc4-8b68-464b-8870-cb3be98375f9
-            X-Total-Count:
-                - "1"
+                - 74c7d6f5-4925-4c29-a31b-20c5db37818f
         status: 200 OK
         code: 200
-        duration: 95.670708ms
+        duration: 98.617625ms
     - id: 97
       request:
         proto: HTTP/1.1
@@ -4815,29 +4815,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec/private_nics/9046d524-d6a4-49ac-93cc-7dc56744d7ee
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f/private_nics/cd2ffe8a-cda4-4325-8df1-e348145dcbf5
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 475
+        content_length: 0
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-24T14:15:44.689986+00:00","id":"9046d524-d6a4-49ac-93cc-7dc56744d7ee","ipam_ip_ids":["2434ba0e-6dd2-4176-adca-a051205c78e8","bbadcc9e-16cd-475d-9167-9728c06de445"],"mac_address":"02:00:00:10:c8:b7","modification_date":"2025-01-24T14:16:16.703652+00:00","private_network_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","server_id":"8b61785d-9e59-462c-8c73-602613da26ec","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: ""
         headers:
-            Content-Length:
-                - "475"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:17:03 GMT
+                - Wed, 12 Feb 2025 16:12:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4845,10 +4843,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0c7f876e-ca6b-475b-a5ca-675847d3a8b8
-        status: 200 OK
-        code: 200
-        duration: 72.789791ms
+                - 543d0f2b-745a-45e6-a847-55f1d595671f
+        status: 204 No Content
+        code: 204
+        duration: 452.893208ms
     - id: 98
       request:
         proto: HTTP/1.1
@@ -4864,27 +4862,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec/private_nics/9046d524-d6a4-49ac-93cc-7dc56744d7ee
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f/private_nics/cd2ffe8a-cda4-4325-8df1-e348145dcbf5
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 148
         uncompressed: false
-        body: ""
+        body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"cd2ffe8a-cda4-4325-8df1-e348145dcbf5","type":"not_found"}'
         headers:
+            Content-Length:
+                - "148"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:17:03 GMT
+                - Wed, 12 Feb 2025 16:12:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4892,10 +4892,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a298138c-e7de-4e04-989e-03dcd8a7e606
-        status: 204 No Content
-        code: 204
-        duration: 305.651417ms
+                - 4feff684-e921-4b2e-bf7e-491e595cf85d
+        status: 404 Not Found
+        code: 404
+        duration: 101.391167ms
     - id: 99
       request:
         proto: HTTP/1.1
@@ -4911,8 +4911,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec/private_nics/9046d524-d6a4-49ac-93cc-7dc56744d7ee
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f
         method: GET
       response:
         proto: HTTP/2.0
@@ -4920,20 +4920,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 148
+        content_length: 1675
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"9046d524-d6a4-49ac-93cc-7dc56744d7ee","type":"not_found"}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:10:34.904348+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:9d","maintenances":[],"modification_date":"2025-02-12T16:12:03.981561+00:00","name":"Scaleway Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"6b9656e5-88c1-4a8f-af6a-01ecf39a238a","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "148"
+                - "1675"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:17:03 GMT
+                - Wed, 12 Feb 2025 16:12:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4941,10 +4941,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7a51797a-2091-4985-b4eb-280be3ce78c7
-        status: 404 Not Found
-        code: 404
-        duration: 121.944041ms
+                - 5d72e4c3-0844-42a0-8d10-c97f6fec19d7
+        status: 200 OK
+        code: 200
+        duration: 204.419375ms
     - id: 100
       request:
         proto: HTTP/1.1
@@ -4960,29 +4960,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2106
+        content_length: 0
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-24T14:15:22.371679+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"8b61785d-9e59-462c-8c73-602613da26ec","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:83:d3","maintenances":[],"modification_date":"2025-01-24T14:16:58.971471+00:00","name":"Scaleway Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-24T14:15:22.371679+00:00","export_uri":null,"id":"bdaabaac-1ef9-4b2b-9f03-f8a6e88a1135","modification_date":"2025-01-24T14:15:22.371679+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"8b61785d-9e59-462c-8c73-602613da26ec","name":"Scaleway Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: ""
         headers:
-            Content-Length:
-                - "2106"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:17:03 GMT
+                - Wed, 12 Feb 2025 16:12:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4990,10 +4988,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 311bb1b7-e901-4634-b054-03d6332cdef3
-        status: 200 OK
-        code: 200
-        duration: 137.487084ms
+                - fea7b3f0-59f3-463c-a297-876306193317
+        status: 204 No Content
+        code: 204
+        duration: 407.542459ms
     - id: 101
       request:
         proto: HTTP/1.1
@@ -5009,27 +5007,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 143
         uncompressed: false
-        body: ""
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","type":"not_found"}'
         headers:
+            Content-Length:
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:17:03 GMT
+                - Wed, 12 Feb 2025 16:12:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5037,10 +5037,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6089ab32-d0e3-4fee-b1a4-80514b89245d
-        status: 204 No Content
-        code: 204
-        duration: 172.366666ms
+                - 7f764563-2a8f-4462-86b3-d28896539372
+        status: 404 Not Found
+        code: 404
+        duration: 115.183833ms
     - id: 102
       request:
         proto: HTTP/1.1
@@ -5056,8 +5056,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/6b9656e5-88c1-4a8f-af6a-01ecf39a238a
         method: GET
       response:
         proto: HTTP/2.0
@@ -5067,7 +5067,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"8b61785d-9e59-462c-8c73-602613da26ec","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"6b9656e5-88c1-4a8f-af6a-01ecf39a238a","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -5076,9 +5076,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:17:03 GMT
+                - Wed, 12 Feb 2025 16:12:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5086,10 +5086,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 47bb26ab-f98e-4272-a1ea-80edb18841f2
+                - 8e8926ca-a40e-479c-8e72-72cc389e0525
         status: 404 Not Found
         code: 404
-        duration: 79.44275ms
+        duration: 48.403375ms
     - id: 103
       request:
         proto: HTTP/1.1
@@ -5105,8 +5105,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/bdaabaac-1ef9-4b2b-9f03-f8a6e88a1135
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/6b9656e5-88c1-4a8f-af6a-01ecf39a238a
         method: GET
       response:
         proto: HTTP/2.0
@@ -5114,20 +5114,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 437
+        content_length: 485
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-24T14:15:22.371679+00:00","export_uri":null,"id":"bdaabaac-1ef9-4b2b-9f03-f8a6e88a1135","modification_date":"2025-01-24T14:17:03.689267+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-12T16:10:35.127132Z","id":"6b9656e5-88c1-4a8f-af6a-01ecf39a238a","last_detached_at":"2025-02-12T16:12:07.995068Z","name":"Debian Bullseye_sbs_volume_0","parent_snapshot_id":"a50e6921-21b9-4a69-83cc-191359208d4c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:12:07.995068Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "437"
+                - "485"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:17:03 GMT
+                - Wed, 12 Feb 2025 16:12:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5135,10 +5135,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 18918423-5fb4-49ca-8329-7254930bdb26
+                - 3addd967-8d19-40e0-a070-7d10fd92b0f0
         status: 200 OK
         code: 200
-        duration: 81.553792ms
+        duration: 91.19075ms
     - id: 104
       request:
         proto: HTTP/1.1
@@ -5154,8 +5154,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/bdaabaac-1ef9-4b2b-9f03-f8a6e88a1135
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/6b9656e5-88c1-4a8f-af6a-01ecf39a238a
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5172,9 +5172,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:17:04 GMT
+                - Wed, 12 Feb 2025 16:12:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5182,10 +5182,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 69cf9941-6384-4235-bd88-a7d67c2cce3a
+                - 5cf97ff3-61be-4e45-9685-ef3245aaeda5
         status: 204 No Content
         code: 204
-        duration: 231.2215ms
+        duration: 137.594084ms
     - id: 105
       request:
         proto: HTTP/1.1
@@ -5201,8 +5201,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/74eabe50-405f-4517-9bd6-2540dafd4f89
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/d774a252-83bc-4ff8-93d0-770d444a0574
         method: GET
       response:
         proto: HTTP/2.0
@@ -5221,9 +5221,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:17:07 GMT
+                - Wed, 12 Feb 2025 16:12:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5231,10 +5231,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 306aeea3-ba96-401d-99c5-514b8a7a509e
+                - 3b569d04-afab-4d72-82e5-010ab3993589
         status: 404 Not Found
         code: 404
-        duration: 26.955417ms
+        duration: 43.14825ms
     - id: 106
       request:
         proto: HTTP/1.1
@@ -5250,8 +5250,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/74eabe50-405f-4517-9bd6-2540dafd4f89
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/d774a252-83bc-4ff8-93d0-770d444a0574
         method: GET
       response:
         proto: HTTP/2.0
@@ -5270,9 +5270,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:17:07 GMT
+                - Wed, 12 Feb 2025 16:12:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5280,10 +5280,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0d78a654-73e8-448c-9b55-12dca902f64e
+                - b321df04-102a-41b3-b758-14301b2e5837
         status: 404 Not Found
         code: 404
-        duration: 19.663208ms
+        duration: 40.757ms
     - id: 107
       request:
         proto: HTTP/1.1
@@ -5299,8 +5299,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0cdaf520-f0e0-46ed-b197-36c28975d51c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/8ebafec9-15fb-496d-b212-1719a0311c3b
         method: GET
       response:
         proto: HTTP/2.0
@@ -5308,20 +5308,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 979
+        content_length: 1011
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-24T14:15:22.458029Z","gateway_networks":[],"id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","ip":{"address":"51.158.121.168","created_at":"2025-01-24T14:15:22.212402Z","gateway_id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","id":"5e32e435-6bf9-4406-8f72-8f76be892a2f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"168-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-24T14:15:22.212402Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-24T14:15:43.659223Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:10:35.342174Z","gateway_networks":[],"id":"8ebafec9-15fb-496d-b212-1719a0311c3b","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:10:34.957253Z","gateway_id":"8ebafec9-15fb-496d-b212-1719a0311c3b","id":"d217409e-10e1-4bbc-97d6-1daedb998b38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:10:34.957253Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:10:59.705659Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "979"
+                - "1011"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:17:07 GMT
+                - Wed, 12 Feb 2025 16:12:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5329,10 +5329,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3063a738-9c49-4832-9513-fb267c46071f
+                - 3bd33055-be7c-4d7b-8a2c-63deed45a03c
         status: 200 OK
         code: 200
-        duration: 28.229ms
+        duration: 48.384583ms
     - id: 108
       request:
         proto: HTTP/1.1
@@ -5348,8 +5348,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/df74cb2c-3245-49d9-b592-e67c753e77ac
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/d44cc37b-f392-46c9-a576-e42711323050
         method: GET
       response:
         proto: HTTP/2.0
@@ -5357,20 +5357,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 286
+        content_length: 294
         uncompressed: false
-        body: '{"id":"df74cb2c-3245-49d9-b592-e67c753e77ac","ip_address":"51.159.25.55","lb_id":null,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-25-55.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}'
+        body: '{"id":"d44cc37b-f392-46c9-a576-e42711323050","ip_address":"51.159.9.241","lb_id":null,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-9-241.lb.fr-par.scw.cloud","tags":[],"zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "286"
+                - "294"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:17:07 GMT
+                - Wed, 12 Feb 2025 16:12:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5378,10 +5378,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b2e601c2-9eae-4967-90f2-9090cf72c577
+                - 8494e474-c49a-4d58-88af-fa9c78bbf8cc
         status: 200 OK
         code: 200
-        duration: 61.861416ms
+        duration: 83.003083ms
     - id: 109
       request:
         proto: HTTP/1.1
@@ -5397,8 +5397,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0cdaf520-f0e0-46ed-b197-36c28975d51c?cleanup_dhcp=false
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/8ebafec9-15fb-496d-b212-1719a0311c3b?cleanup_dhcp=false
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5415,9 +5415,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:17:07 GMT
+                - Wed, 12 Feb 2025 16:12:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5425,10 +5425,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fc9c8907-623c-44bc-9d01-aff7925d704c
+                - 7a604112-ed8e-4e27-920f-1c5e51e545f4
         status: 204 No Content
         code: 204
-        duration: 75.707375ms
+        duration: 73.218084ms
     - id: 110
       request:
         proto: HTTP/1.1
@@ -5444,8 +5444,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0cdaf520-f0e0-46ed-b197-36c28975d51c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/8ebafec9-15fb-496d-b212-1719a0311c3b
         method: GET
       response:
         proto: HTTP/2.0
@@ -5453,20 +5453,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 980
+        content_length: 128
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-24T14:15:22.458029Z","gateway_networks":[],"id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","ip":{"address":"51.158.121.168","created_at":"2025-01-24T14:15:22.212402Z","gateway_id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","id":"5e32e435-6bf9-4406-8f72-8f76be892a2f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"168-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-24T14:15:22.212402Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"deleting","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-24T14:17:07.639524Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"message":"resource is not found","resource":"gateway","resource_id":"8ebafec9-15fb-496d-b212-1719a0311c3b","type":"not_found"}'
         headers:
             Content-Length:
-                - "980"
+                - "128"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:17:07 GMT
+                - Wed, 12 Feb 2025 16:12:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5474,10 +5474,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d1103d25-be88-4930-9e22-23512a7cc067
-        status: 200 OK
-        code: 200
-        duration: 26.682125ms
+                - 2bfe7e00-79f5-4653-869b-5e49208bae18
+        status: 404 Not Found
+        code: 404
+        duration: 47.437166ms
     - id: 111
       request:
         proto: HTTP/1.1
@@ -5493,8 +5493,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/df74cb2c-3245-49d9-b592-e67c753e77ac
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/d44cc37b-f392-46c9-a576-e42711323050
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5511,9 +5511,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:17:07 GMT
+                - Wed, 12 Feb 2025 16:12:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5521,10 +5521,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6e6912df-3fd8-4531-a465-8828e0eaf408
+                - 716df382-0b37-4b65-9516-0674a5d260e3
         status: 204 No Content
         code: 204
-        duration: 339.035083ms
+        duration: 414.081208ms
     - id: 112
       request:
         proto: HTTP/1.1
@@ -5540,8 +5540,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/57acd471-d6d6-471a-be4f-6464a3976f5b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7abd3366-919a-46e1-88ad-af224037959a
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5558,9 +5558,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:17:08 GMT
+                - Wed, 12 Feb 2025 16:12:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5568,10 +5568,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f0543a54-efa8-4c33-86cd-0d2bde624cb9
+                - d9ef4383-78bb-4451-8901-dce0e7b832b0
         status: 204 No Content
         code: 204
-        duration: 1.107311834s
+        duration: 1.31326525s
     - id: 113
       request:
         proto: HTTP/1.1
@@ -5587,57 +5587,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0cdaf520-f0e0-46ed-b197-36c28975d51c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 128
-        uncompressed: false
-        body: '{"message":"resource is not found","resource":"gateway","resource_id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","type":"not_found"}'
-        headers:
-            Content-Length:
-                - "128"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 14:17:12 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 075014ea-8f52-4917-89af-13b093a36486
-        status: 404 Not Found
-        code: 404
-        duration: 22.934667ms
-    - id: 114
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/5e32e435-6bf9-4406-8f72-8f76be892a2f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/d217409e-10e1-4bbc-97d6-1daedb998b38
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5654,9 +5605,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:17:13 GMT
+                - Wed, 12 Feb 2025 16:12:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5664,10 +5615,59 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 22f18edb-cf9b-4ef8-86b8-53036bc2bb8a
+                - 736f9721-7550-41d4-982d-ce1e9ec0f41e
         status: 204 No Content
         code: 204
-        duration: 651.152ms
+        duration: 1.129751917s
+    - id: 114
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e49e763b-cd39-4e02-9693-044a4b0e5f7f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"e49e763b-cd39-4e02-9693-044a4b0e5f7f","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:12:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 30c903b2-3334-48f8-bbb5-9e67bdb125ff
+        status: 404 Not Found
+        code: 404
+        duration: 114.354416ms
     - id: 115
       request:
         proto: HTTP/1.1
@@ -5683,8 +5683,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8b61785d-9e59-462c-8c73-602613da26ec
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/d774a252-83bc-4ff8-93d0-770d444a0574
         method: GET
       response:
         proto: HTTP/2.0
@@ -5692,20 +5692,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 143
+        content_length: 27
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"8b61785d-9e59-462c-8c73-602613da26ec","type":"not_found"}'
+        body: '{"message":"lbs not Found"}'
         headers:
             Content-Length:
-                - "143"
+                - "27"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:17:13 GMT
+                - Wed, 12 Feb 2025 16:12:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5713,10 +5713,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 46f5be6c-fb62-4562-880f-dac9484e2e49
+                - 93ae98b0-9a3e-4fc0-881e-ec2c4f6da4d9
         status: 404 Not Found
         code: 404
-        duration: 89.108292ms
+        duration: 46.114958ms
     - id: 116
       request:
         proto: HTTP/1.1
@@ -5732,8 +5732,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/74eabe50-405f-4517-9bd6-2540dafd4f89
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/d774a252-83bc-4ff8-93d0-770d444a0574
         method: GET
       response:
         proto: HTTP/2.0
@@ -5752,9 +5752,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:17:13 GMT
+                - Wed, 12 Feb 2025 16:12:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5762,10 +5762,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 012b145e-3ae8-488d-b836-fa64a94a907a
+                - d0d6d562-c3c8-4a25-bd06-67f58200cd7c
         status: 404 Not Found
         code: 404
-        duration: 24.627417ms
+        duration: 38.98275ms
     - id: 117
       request:
         proto: HTTP/1.1
@@ -5781,57 +5781,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/74eabe50-405f-4517-9bd6-2540dafd4f89
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 27
-        uncompressed: false
-        body: '{"message":"lbs not Found"}'
-        headers:
-            Content-Length:
-                - "27"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 14:17:13 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 1ea8733a-a7a7-4456-bd10-63ef97364e4c
-        status: 404 Not Found
-        code: 404
-        duration: 30.729959ms
-    - id: 118
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/df74cb2c-3245-49d9-b592-e67c753e77ac
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/d44cc37b-f392-46c9-a576-e42711323050
         method: GET
       response:
         proto: HTTP/2.0
@@ -5850,9 +5801,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:17:13 GMT
+                - Wed, 12 Feb 2025 16:12:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5860,10 +5811,59 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b4c20935-a333-4ff5-9f67-95b2d3808a90
+                - ce61895b-d74c-45d5-8c44-f8bfd8ea9856
         status: 404 Not Found
         code: 404
-        duration: 23.2725ms
+        duration: 40.954208ms
+    - id: 118
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/fa8d0cb8-6e84-4edf-beba-cfefaa1bd81c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 136
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"fa8d0cb8-6e84-4edf-beba-cfefaa1bd81c","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "136"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:12:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fc56ec94-d2ce-4739-bbef-4c37fbff2adc
+        status: 404 Not Found
+        code: 404
+        duration: 42.656958ms
     - id: 119
       request:
         proto: HTTP/1.1
@@ -5879,8 +5879,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/92b71032-5580-4650-bd52-b63253bcc3b5
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7abd3366-919a-46e1-88ad-af224037959a
         method: GET
       response:
         proto: HTTP/2.0
@@ -5890,7 +5890,7 @@ interactions:
         trailer: {}
         content_length: 136
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"92b71032-5580-4650-bd52-b63253bcc3b5","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"private_network","resource_id":"7abd3366-919a-46e1-88ad-af224037959a","type":"not_found"}'
         headers:
             Content-Length:
                 - "136"
@@ -5899,9 +5899,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:17:13 GMT
+                - Wed, 12 Feb 2025 16:12:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5909,10 +5909,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 83d77368-d1e1-4fc5-9d37-396b5abd50cb
+                - 7457c415-48d1-4d7d-89ee-75b5bea7df5e
         status: 404 Not Found
         code: 404
-        duration: 24.156792ms
+        duration: 44.708542ms
     - id: 120
       request:
         proto: HTTP/1.1
@@ -5928,8 +5928,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/57acd471-d6d6-471a-be4f-6464a3976f5b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/1248e521-f708-4f4a-80ee-9d3084b0616f
         method: GET
       response:
         proto: HTTP/2.0
@@ -5937,20 +5937,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 136
+        content_length: 125
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"private_network","resource_id":"57acd471-d6d6-471a-be4f-6464a3976f5b","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"dhcp","resource_id":"1248e521-f708-4f4a-80ee-9d3084b0616f","type":"not_found"}'
         headers:
             Content-Length:
-                - "136"
+                - "125"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:17:13 GMT
+                - Wed, 12 Feb 2025 16:12:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5958,10 +5958,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c70832cb-6e96-4ecf-bf32-fbd196d67816
+                - 6499797b-1df5-4870-b7f3-c385974eefec
         status: 404 Not Found
         code: 404
-        duration: 23.162667ms
+        duration: 44.768292ms
     - id: 121
       request:
         proto: HTTP/1.1
@@ -5977,8 +5977,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/48b28823-2ed8-4a73-82a5-752bc9447518
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/8ebafec9-15fb-496d-b212-1719a0311c3b
         method: GET
       response:
         proto: HTTP/2.0
@@ -5986,20 +5986,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 125
+        content_length: 128
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"dhcp","resource_id":"48b28823-2ed8-4a73-82a5-752bc9447518","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"gateway","resource_id":"8ebafec9-15fb-496d-b212-1719a0311c3b","type":"not_found"}'
         headers:
             Content-Length:
-                - "125"
+                - "128"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:17:13 GMT
+                - Wed, 12 Feb 2025 16:12:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6007,10 +6007,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bfd738f5-67e3-49fd-a34c-ee540d4c2d6f
+                - 8249fb1b-e23d-4d74-8bfe-6a39b0d2983f
         status: 404 Not Found
         code: 404
-        duration: 20.511916ms
+        duration: 41.87475ms
     - id: 122
       request:
         proto: HTTP/1.1
@@ -6026,57 +6026,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0cdaf520-f0e0-46ed-b197-36c28975d51c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 128
-        uncompressed: false
-        body: '{"message":"resource is not found","resource":"gateway","resource_id":"0cdaf520-f0e0-46ed-b197-36c28975d51c","type":"not_found"}'
-        headers:
-            Content-Length:
-                - "128"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 24 Jan 2025 14:17:13 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - ffda0c36-1c6f-4169-a1dd-0284f99f3117
-        status: 404 Not Found
-        code: 404
-        duration: 22.561666ms
-    - id: 123
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/5e32e435-6bf9-4406-8f72-8f76be892a2f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/d217409e-10e1-4bbc-97d6-1daedb998b38
         method: GET
       response:
         proto: HTTP/2.0
@@ -6086,7 +6037,7 @@ interactions:
         trailer: {}
         content_length: 123
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"ip","resource_id":"5e32e435-6bf9-4406-8f72-8f76be892a2f","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"ip","resource_id":"d217409e-10e1-4bbc-97d6-1daedb998b38","type":"not_found"}'
         headers:
             Content-Length:
                 - "123"
@@ -6095,9 +6046,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 24 Jan 2025 14:17:13 GMT
+                - Wed, 12 Feb 2025 16:12:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6105,7 +6056,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0060e91e-77ea-4930-9315-84021ae69fdb
+                - 738bf948-bef2-4481-8326-72133e096798
         status: 404 Not Found
         code: 404
-        duration: 22.228916ms
+        duration: 39.528667ms

--- a/internal/services/vpcgw/testdata/data-source-vpc-public-gateway-dhcp-reservation-basic.cassette.yaml
+++ b/internal/services/vpcgw/testdata/data-source-vpc-public-gateway-dhcp-reservation-basic.cassette.yaml
@@ -29,7 +29,7 @@ interactions:
         trailer: {}
         content_length: 586
         uncompressed: false
-        body: '{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+        body: '{"address":"192.168.1.1","created_at":"2025-02-12T16:24:15.720530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"7ece1fd0-856b-4d14-81d8-d604bbe0be27","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:24:15.720530Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "586"
@@ -38,9 +38,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:14:55 GMT
+                - Wed, 12 Feb 2025 16:24:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bb088a75-f6a0-477a-a3a5-04243603dee9
+                - 24a8930d-a59a-4043-a062-43dc45e9fe61
         status: 200 OK
         code: 200
-        duration: 278.301541ms
+        duration: 258.252667ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -68,7 +68,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/2572e954-7dde-486b-821f-38300c6d0173
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/7ece1fd0-856b-4d14-81d8-d604bbe0be27
         method: GET
       response:
         proto: HTTP/2.0
@@ -78,7 +78,7 @@ interactions:
         trailer: {}
         content_length: 586
         uncompressed: false
-        body: '{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+        body: '{"address":"192.168.1.1","created_at":"2025-02-12T16:24:15.720530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"7ece1fd0-856b-4d14-81d8-d604bbe0be27","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:24:15.720530Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "586"
@@ -87,9 +87,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:14:55 GMT
+                - Wed, 12 Feb 2025 16:24:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9d56d66e-84aa-48bb-bb4a-0d9aa63f257c
+                - cc2157f4-7f9d-435e-98e5-0f89151997d2
         status: 200 OK
         code: 200
-        duration: 41.790833ms
+        duration: 39.92925ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -127,20 +127,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1088
+        content_length: 1089
         uncompressed: false
-        body: '{"created_at":"2025-02-12T16:14:56.161859Z","dhcp_enabled":true,"id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:14:56.161859Z","id":"1d110e71-77c2-4e0d-8b2a-44e5e61a0211","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.8.0/22","updated_at":"2025-02-12T16:14:56.161859Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-12T16:14:56.161859Z","id":"ad46a815-2df6-4e07-ad92-d99d79d18c7d","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:b62b::/64","updated_at":"2025-02-12T16:14:56.161859Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-12T16:14:56.161859Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"created_at":"2025-02-12T16:24:15.823279Z","dhcp_enabled":true,"id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:24:15.823279Z","id":"00415797-fa4c-46d3-ad73-f49acbd8298d","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.20.0/22","updated_at":"2025-02-12T16:24:15.823279Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-12T16:24:15.823279Z","id":"d6e4aef9-10a5-465b-9429-8e4662375a71","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:53ae::/64","updated_at":"2025-02-12T16:24:15.823279Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-12T16:24:15.823279Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "1088"
+                - "1089"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:14:56 GMT
+                - Wed, 12 Feb 2025 16:24:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -148,10 +148,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c5a6bcbe-a8b6-4f7a-b639-6ce31beb2360
+                - 66e976c9-6fdd-41f0-bc0f-caeecc06858b
         status: 200 OK
         code: 200
-        duration: 962.028667ms
+        duration: 923.813042ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -168,7 +168,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b3a3ea6c-4758-41c7-b9ad-22f9a410c192
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7b3fa7ac-78de-4097-b7b8-a141ed2c0b82
         method: GET
       response:
         proto: HTTP/2.0
@@ -176,20 +176,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1088
+        content_length: 1089
         uncompressed: false
-        body: '{"created_at":"2025-02-12T16:14:56.161859Z","dhcp_enabled":true,"id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:14:56.161859Z","id":"1d110e71-77c2-4e0d-8b2a-44e5e61a0211","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.8.0/22","updated_at":"2025-02-12T16:14:56.161859Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-12T16:14:56.161859Z","id":"ad46a815-2df6-4e07-ad92-d99d79d18c7d","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:b62b::/64","updated_at":"2025-02-12T16:14:56.161859Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-12T16:14:56.161859Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"created_at":"2025-02-12T16:24:15.823279Z","dhcp_enabled":true,"id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:24:15.823279Z","id":"00415797-fa4c-46d3-ad73-f49acbd8298d","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.20.0/22","updated_at":"2025-02-12T16:24:15.823279Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-12T16:24:15.823279Z","id":"d6e4aef9-10a5-465b-9429-8e4662375a71","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:53ae::/64","updated_at":"2025-02-12T16:24:15.823279Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-12T16:24:15.823279Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "1088"
+                - "1089"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:14:56 GMT
+                - Wed, 12 Feb 2025 16:24:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -197,11 +197,111 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 524cb59f-e71e-490a-a512-94183cfb71f9
+                - eaabbdf6-9869-446d-8cf6-f0ae8a624ccc
         status: 200 OK
         code: 200
-        duration: 45.06375ms
+        duration: 44.368583ms
     - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 63
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[]}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 371
+        uncompressed: false
+        body: '{"address":"163.172.159.229","created_at":"2025-02-12T16:24:16.448125Z","gateway_id":null,"id":"0650ad59-a7c2-4c38-b4c2-eff6527ca016","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.448125Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "371"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:24:16 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 93da327f-cafc-445c-ab57-2c2e3ec0c2ac
+        status: 200 OK
+        code: 200
+        duration: 991.008584ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/0650ad59-a7c2-4c38-b4c2-eff6527ca016
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 371
+        uncompressed: false
+        body: '{"address":"163.172.159.229","created_at":"2025-02-12T16:24:16.448125Z","gateway_id":null,"id":"0650ad59-a7c2-4c38-b4c2-eff6527ca016","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.448125Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "371"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:24:16 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4f0b3375-0b5e-4e23-8f6b-a14645401967
+        status: 200 OK
+        code: 200
+        duration: 47.574916ms
+    - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -236,11 +336,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:14:56 GMT
+                - Wed, 12 Feb 2025 16:24:16 GMT
             Link:
                 - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -248,13 +348,64 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 32895120-168a-4b6d-82ce-a57629b369a7
+                - 67f8738d-1d16-4abd-b45f-1d698e55cb7f
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 58.819834ms
-    - id: 5
+        duration: 116.00675ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 213
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"foobar","tags":[],"type":"VPC-GW-S","upstream_dns_servers":[],"ip_id":"0650ad59-a7c2-4c38-b4c2-eff6527ca016","enable_smtp":false,"enable_bastion":false}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1002
+        uncompressed: false
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:24:16.595820Z","gateway_networks":[],"id":"278eadb1-7bcf-4f53-87f9-e9325a950998","ip":{"address":"163.172.159.229","created_at":"2025-02-12T16:24:16.448125Z","gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"0650ad59-a7c2-4c38-b4c2-eff6527ca016","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.448125Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:24:16.595820Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "1002"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:24:16 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 063217c5-4aa6-4616-97ac-d3715160e74b
+        status: 200 OK
+        code: 200
+        duration: 97.095083ms
+    - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -289,11 +440,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:14:56 GMT
+                - Wed, 12 Feb 2025 16:24:16 GMT
             Link:
                 - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -301,13 +452,62 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c359c11f-d5e9-4382-8054-663d7897bd8d
+                - 34b5a2ed-7316-4c6e-9c52-05ce99235328
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 63.983041ms
-    - id: 6
+        duration: 68.904958ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/278eadb1-7bcf-4f53-87f9-e9325a950998
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1004
+        uncompressed: false
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:24:16.595820Z","gateway_networks":[],"id":"278eadb1-7bcf-4f53-87f9-e9325a950998","ip":{"address":"163.172.159.229","created_at":"2025-02-12T16:24:16.448125Z","gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"0650ad59-a7c2-4c38-b4c2-eff6527ca016","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.448125Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:24:16.642096Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "1004"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:24:16 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 51721b7a-981c-4ce2-ad6b-6e508097530f
+        status: 200 OK
+        code: 200
+        duration: 47.599ms
+    - id: 10
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -342,9 +542,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:14:56 GMT
+                - Wed, 12 Feb 2025 16:24:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -352,222 +552,22 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ea92a29e-95cd-4141-99d6-11eade8468c3
+                - 97714023-02a4-4b06-bc0e-36558fa38835
         status: 200 OK
         code: 200
-        duration: 93.43575ms
-    - id: 7
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 63
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[]}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 371
-        uncompressed: false
-        body: '{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":null,"id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "371"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 16:14:57 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - aa656ee6-31b4-4a72-964a-4d4a17a5eefe
-        status: 200 OK
-        code: 200
-        duration: 1.408300417s
-    - id: 8
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/da389c61-9c8f-475e-b2c5-b60333283fa5
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 371
-        uncompressed: false
-        body: '{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":null,"id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "371"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 16:14:57 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 063a987b-7ffa-47d5-9825-ba987130f41b
-        status: 200 OK
-        code: 200
-        duration: 46.512875ms
-    - id: 9
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 213
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"foobar","tags":[],"type":"VPC-GW-S","upstream_dns_servers":[],"ip_id":"da389c61-9c8f-475e-b2c5-b60333283fa5","enable_smtp":false,"enable_bastion":false}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1002
-        uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:57.205022Z","gateway_networks":[],"id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","ip":{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:14:57.205022Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "1002"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 16:14:57 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - ca942828-7ea4-4b73-8e7f-6c534a4f8c47
-        status: 200 OK
-        code: 200
-        duration: 121.448875ms
-    - id: 10
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1004
-        uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:57.205022Z","gateway_networks":[],"id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","ip":{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:14:57.251496Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "1004"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 16:14:57 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 6a884fab-50ab-4a81-995d-55ae6e364fe1
-        status: 200 OK
-        code: 200
-        duration: 60.557834ms
+        duration: 102.276125ms
     - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 236
+        content_length: 233
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-srv-vigilant-greider","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"57509e82-ac3b-49b7-9970-97b60f40ff72","volumes":{"0":{"boot":false}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+        body: '{"name":"tf-srv-sharp-bardeen","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"57509e82-ac3b-49b7-9970-97b60f40ff72","volumes":{"0":{"boot":false}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
         form: {}
         headers:
             Content-Type:
@@ -582,22 +582,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1676
+        content_length: 1670
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.380750+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-greider","id":"ee6b8302-d285-4412-9af2-b94bfecca21c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:d5","maintenances":[],"modification_date":"2025-02-12T16:14:57.380750+00:00","name":"tf-srv-vigilant-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:24:17.041400+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sharp-bardeen","id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c8:6b","maintenances":[],"modification_date":"2025-02-12T16:24:17.041400+00:00","name":"tf-srv-sharp-bardeen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"3d19ea3d-4d7f-4800-8a16-76324b03ba16","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1676"
+                - "1670"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:14:57 GMT
+                - Wed, 12 Feb 2025 16:24:17 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -605,10 +605,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d1965402-64ad-497d-8e69-27a8109192cf
+                - fee82aba-7a11-4fb3-993f-66136f77fa5c
         status: 201 Created
         code: 201
-        duration: 1.059627958s
+        duration: 957.383833ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -625,7 +625,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e
         method: GET
       response:
         proto: HTTP/2.0
@@ -633,20 +633,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1676
+        content_length: 1670
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.380750+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-greider","id":"ee6b8302-d285-4412-9af2-b94bfecca21c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:d5","maintenances":[],"modification_date":"2025-02-12T16:14:57.380750+00:00","name":"tf-srv-vigilant-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:24:17.041400+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sharp-bardeen","id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c8:6b","maintenances":[],"modification_date":"2025-02-12T16:24:17.041400+00:00","name":"tf-srv-sharp-bardeen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"3d19ea3d-4d7f-4800-8a16-76324b03ba16","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1676"
+                - "1670"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:14:58 GMT
+                - Wed, 12 Feb 2025 16:24:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -654,10 +654,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 760a8815-97dc-4424-90ea-5c4acda64482
+                - 85eb59f4-c6a5-4a55-9d72-44ae1514bac5
         status: 200 OK
         code: 200
-        duration: 139.462ms
+        duration: 305.066333ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -674,7 +674,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e
         method: GET
       response:
         proto: HTTP/2.0
@@ -682,20 +682,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1676
+        content_length: 1670
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.380750+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-greider","id":"ee6b8302-d285-4412-9af2-b94bfecca21c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:d5","maintenances":[],"modification_date":"2025-02-12T16:14:57.380750+00:00","name":"tf-srv-vigilant-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:24:17.041400+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sharp-bardeen","id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c8:6b","maintenances":[],"modification_date":"2025-02-12T16:24:17.041400+00:00","name":"tf-srv-sharp-bardeen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"3d19ea3d-4d7f-4800-8a16-76324b03ba16","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1676"
+                - "1670"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:14:58 GMT
+                - Wed, 12 Feb 2025 16:24:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -703,10 +703,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cd9b6e9e-514e-4e2a-a882-860a64eb21db
+                - 02fa0630-7041-4c00-9b2c-ab726ea3098e
         status: 200 OK
         code: 200
-        duration: 545.716125ms
+        duration: 159.008625ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -723,7 +723,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/a5c02cb7-8020-4442-8634-e5ee2eff2c2c
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/3d19ea3d-4d7f-4800-8a16-76324b03ba16
         method: GET
       response:
         proto: HTTP/2.0
@@ -733,7 +733,7 @@ interactions:
         trailer: {}
         content_length: 701
         uncompressed: false
-        body: '{"created_at":"2025-02-12T16:14:57.589514Z","id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:14:57.589514Z","id":"158fda61-e559-4737-996d-b3b846db132e","product_resource_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:14:57.589514Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:24:17.252844Z","id":"3d19ea3d-4d7f-4800-8a16-76324b03ba16","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:24:17.252844Z","id":"dbff681f-9b1f-49aa-a9eb-0e714f9d8792","product_resource_id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:24:17.252844Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "701"
@@ -742,9 +742,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:14:58 GMT
+                - Wed, 12 Feb 2025 16:24:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -752,10 +752,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fc2efefa-a43d-4bf7-a7fa-5c890be65dda
+                - 67a0ec57-3268-4357-a4d2-37f08bb2c816
         status: 200 OK
         code: 200
-        duration: 95.935666ms
+        duration: 91.593125ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -774,7 +774,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/action
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -784,7 +784,7 @@ interactions:
         trailer: {}
         content_length: 357
         uncompressed: false
-        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/action","href_result":"/servers/ee6b8302-d285-4412-9af2-b94bfecca21c","id":"165f5ce1-3137-4074-b6c0-2b9e0c58f999","progress":0,"started_at":"2025-02-12T16:14:59.023368+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e/action","href_result":"/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e","id":"10664c1b-7993-4315-ab3f-c8c1a8bf81ca","progress":0,"started_at":"2025-02-12T16:24:18.525697+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -793,11 +793,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:14:58 GMT
+                - Wed, 12 Feb 2025 16:24:18 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/165f5ce1-3137-4074-b6c0-2b9e0c58f999
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/10664c1b-7993-4315-ab3f-c8c1a8bf81ca
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -805,10 +805,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e620c0ca-76fa-4a3d-be2f-7849a4bf37f2
+                - 1269d678-8a34-4e8d-9090-41ccc1eb36c5
         status: 202 Accepted
         code: 202
-        duration: 299.936584ms
+        duration: 361.447ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -825,7 +825,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e
         method: GET
       response:
         proto: HTTP/2.0
@@ -833,20 +833,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1698
+        content_length: 1692
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.380750+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-greider","id":"ee6b8302-d285-4412-9af2-b94bfecca21c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:d5","maintenances":[],"modification_date":"2025-02-12T16:14:58.797053+00:00","name":"tf-srv-vigilant-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:24:17.041400+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sharp-bardeen","id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c8:6b","maintenances":[],"modification_date":"2025-02-12T16:24:18.315073+00:00","name":"tf-srv-sharp-bardeen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"id":"3d19ea3d-4d7f-4800-8a16-76324b03ba16","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1698"
+                - "1692"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:14:58 GMT
+                - Wed, 12 Feb 2025 16:24:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -854,10 +854,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d3a6ef56-f187-4551-af42-b465737c1a36
+                - f85783aa-3740-435d-906d-6e2f87ff5792
         status: 200 OK
         code: 200
-        duration: 203.421459ms
+        duration: 308.538708ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -874,7 +874,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/278eadb1-7bcf-4f53-87f9-e9325a950998
         method: GET
       response:
         proto: HTTP/2.0
@@ -884,7 +884,7 @@ interactions:
         trailer: {}
         content_length: 1001
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:57.205022Z","gateway_networks":[],"id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","ip":{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:02.135707Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:24:16.595820Z","gateway_networks":[],"id":"278eadb1-7bcf-4f53-87f9-e9325a950998","ip":{"address":"163.172.159.229","created_at":"2025-02-12T16:24:16.448125Z","gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"0650ad59-a7c2-4c38-b4c2-eff6527ca016","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.448125Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:24:21.580276Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "1001"
@@ -893,9 +893,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:02 GMT
+                - Wed, 12 Feb 2025 16:24:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -903,10 +903,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 91a6c97f-ce6f-454d-875e-cfa36081974a
+                - 17dd219d-9842-4d33-8e86-d1a84154eb53
         status: 200 OK
         code: 200
-        duration: 47.928334ms
+        duration: 52.689834ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -923,7 +923,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/278eadb1-7bcf-4f53-87f9-e9325a950998
         method: GET
       response:
         proto: HTTP/2.0
@@ -933,7 +933,7 @@ interactions:
         trailer: {}
         content_length: 1001
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:57.205022Z","gateway_networks":[],"id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","ip":{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:02.135707Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:24:16.595820Z","gateway_networks":[],"id":"278eadb1-7bcf-4f53-87f9-e9325a950998","ip":{"address":"163.172.159.229","created_at":"2025-02-12T16:24:16.448125Z","gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"0650ad59-a7c2-4c38-b4c2-eff6527ca016","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.448125Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:24:21.580276Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "1001"
@@ -942,9 +942,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:02 GMT
+                - Wed, 12 Feb 2025 16:24:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -952,10 +952,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e76aa58d-a571-45af-82dd-0b7b3942a419
+                - d534fdc8-c36e-4c00-9d65-3cdf9c98fdaf
         status: 200 OK
         code: 200
-        duration: 50.559875ms
+        duration: 48.018292ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -972,7 +972,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/278eadb1-7bcf-4f53-87f9-e9325a950998
         method: GET
       response:
         proto: HTTP/2.0
@@ -982,7 +982,7 @@ interactions:
         trailer: {}
         content_length: 1001
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:57.205022Z","gateway_networks":[],"id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","ip":{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:02.135707Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:24:16.595820Z","gateway_networks":[],"id":"278eadb1-7bcf-4f53-87f9-e9325a950998","ip":{"address":"163.172.159.229","created_at":"2025-02-12T16:24:16.448125Z","gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"0650ad59-a7c2-4c38-b4c2-eff6527ca016","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.448125Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:24:21.580276Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "1001"
@@ -991,9 +991,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:02 GMT
+                - Wed, 12 Feb 2025 16:24:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1001,10 +1001,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9a8abfa1-5c27-490e-8693-0be17eaf165b
+                - b6934713-724d-41b4-a716-8ae97c8936a2
         status: 200 OK
         code: 200
-        duration: 50.008958ms
+        duration: 46.608125ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1021,7 +1021,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1029,20 +1029,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1831
+        content_length: 1795
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.380750+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-greider","id":"ee6b8302-d285-4412-9af2-b94bfecca21c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"304","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d5","maintenances":[],"modification_date":"2025-02-12T16:15:03.386466+00:00","name":"tf-srv-vigilant-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:24:17.041400+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sharp-bardeen","id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"2002","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c8:6b","maintenances":[],"modification_date":"2025-02-12T16:24:18.315073+00:00","name":"tf-srv-sharp-bardeen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"id":"3d19ea3d-4d7f-4800-8a16-76324b03ba16","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1831"
+                - "1795"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:04 GMT
+                - Wed, 12 Feb 2025 16:24:23 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1050,520 +1050,22 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8cd6657c-eacb-4002-9cb4-a8bc5659d99c
+                - 94d11c4d-ca36-4c78-9171-4cf22f52b82d
         status: 200 OK
         code: 200
-        duration: 164.590834ms
+        duration: 164.332542ms
     - id: 21
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b3a3ea6c-4758-41c7-b9ad-22f9a410c192
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1088
-        uncompressed: false
-        body: '{"created_at":"2025-02-12T16:14:56.161859Z","dhcp_enabled":true,"id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:14:56.161859Z","id":"1d110e71-77c2-4e0d-8b2a-44e5e61a0211","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.8.0/22","updated_at":"2025-02-12T16:14:56.161859Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-12T16:14:56.161859Z","id":"ad46a815-2df6-4e07-ad92-d99d79d18c7d","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:b62b::/64","updated_at":"2025-02-12T16:14:56.161859Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-12T16:14:56.161859Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
-        headers:
-            Content-Length:
-                - "1088"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 16:15:04 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 847237e9-6a74-4cf4-9ba2-b4870ebe2e0b
-        status: 200 OK
-        code: 200
-        duration: 58.90775ms
-    - id: 22
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1831
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.380750+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-greider","id":"ee6b8302-d285-4412-9af2-b94bfecca21c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"304","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d5","maintenances":[],"modification_date":"2025-02-12T16:15:03.386466+00:00","name":"tf-srv-vigilant-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "1831"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 16:15:04 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - e8e0e488-05c5-4329-98cd-9b514b31c7c6
-        status: 200 OK
-        code: 200
-        duration: 279.981375ms
-    - id: 23
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
         content_length: 206
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"2572e954-7dde-486b-821f-38300c6d0173"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 28
-        uncompressed: false
-        body: '{"message":"internal error"}'
-        headers:
-            Content-Length:
-                - "28"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 16:15:06 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - d299e554-04b3-4292-9087-a50f900e978c
-        status: 500 Internal Server Error
-        code: 500
-        duration: 4.316993708s
-    - id: 24
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 61
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 473
-        uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:04.992700+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "473"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 16:15:06 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 21de8669-b5cd-4be6-ad17-72bb2e6b34e0
-        status: 201 Created
-        code: 201
-        duration: 2.053207791s
-    - id: 25
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics/ba175159-76a5-4f16-b338-f91217d775e7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 473
-        uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:04.992700+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "473"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 16:15:06 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 05ac048f-9d3d-49cc-a996-06e858a900f1
-        status: 200 OK
-        code: 200
-        duration: 93.644833ms
-    - id: 26
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 206
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"2572e954-7dde-486b-821f-38300c6d0173"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 28
-        uncompressed: false
-        body: '{"message":"internal error"}'
-        headers:
-            Content-Length:
-                - "28"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 16:15:09 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - bca8d7d6-50f9-4044-8053-a5ec73d117fe
-        status: 500 Internal Server Error
-        code: 500
-        duration: 354.386583ms
-    - id: 27
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics/ba175159-76a5-4f16-b338-f91217d775e7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 473
-        uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:04.992700+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "473"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 16:15:11 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 03e1d447-6786-48a2-8098-b617c616adb6
-        status: 200 OK
-        code: 200
-        duration: 118.538875ms
-    - id: 28
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 206
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"2572e954-7dde-486b-821f-38300c6d0173"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 28
-        uncompressed: false
-        body: '{"message":"internal error"}'
-        headers:
-            Content-Length:
-                - "28"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 16:15:13 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 6b33be06-ecc8-4978-a958-1cdfbbe412a2
-        status: 500 Internal Server Error
-        code: 500
-        duration: 296.291542ms
-    - id: 29
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics/ba175159-76a5-4f16-b338-f91217d775e7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 473
-        uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:04.992700+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "473"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 16:15:16 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 7e374eb3-f85d-4cf2-b8ee-6742ae6e8f84
-        status: 200 OK
-        code: 200
-        duration: 115.202917ms
-    - id: 30
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics/ba175159-76a5-4f16-b338-f91217d775e7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 473
-        uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:04.992700+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "473"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 16:15:21 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 0ea365cc-3d93-4224-a31a-738030e64cda
-        status: 200 OK
-        code: 200
-        duration: 412.169667ms
-    - id: 31
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 206
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"2572e954-7dde-486b-821f-38300c6d0173"}'
+        body: '{"gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"7ece1fd0-856b-4d14-81d8-d604bbe0be27"}'
         form: {}
         headers:
             Content-Type:
@@ -1580,7 +1082,7 @@ interactions:
         trailer: {}
         content_length: 983
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":null,"private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"created","updated_at":"2025-02-12T16:15:23.555839Z","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:24:25.196682Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:24:15.720530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"7ece1fd0-856b-4d14-81d8-d604bbe0be27","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:24:15.720530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"d283d880-a865-4b90-8403-ea6dfd3a239e","ipam_config":null,"mac_address":null,"private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","status":"created","updated_at":"2025-02-12T16:24:25.196682Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "983"
@@ -1589,9 +1091,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:23 GMT
+                - Wed, 12 Feb 2025 16:24:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1599,10 +1101,502 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 44512760-987e-44e9-96fa-126794b4f0f5
+                - f9f4b9e8-641f-4d28-9d0f-c1ce7c111718
         status: 200 OK
         code: 200
-        duration: 2.342331333s
+        duration: 3.543488333s
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/278eadb1-7bcf-4f53-87f9-e9325a950998
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1987
+        uncompressed: false
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:24:16.595820Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:24:25.196682Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:24:15.720530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"7ece1fd0-856b-4d14-81d8-d604bbe0be27","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:24:15.720530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"d283d880-a865-4b90-8403-ea6dfd3a239e","ipam_config":null,"mac_address":null,"private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","status":"created","updated_at":"2025-02-12T16:24:25.196682Z","zone":"fr-par-1"}],"id":"278eadb1-7bcf-4f53-87f9-e9325a950998","ip":{"address":"163.172.159.229","created_at":"2025-02-12T16:24:16.448125Z","gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"0650ad59-a7c2-4c38-b4c2-eff6527ca016","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.448125Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:24:25.331859Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "1987"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:24:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 81b4425c-e817-4e95-9720-4dd6dfa037c7
+        status: 200 OK
+        code: 200
+        duration: 49.784709ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1826
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:24:17.041400+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sharp-bardeen","id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"2002","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c8:6b","maintenances":[],"modification_date":"2025-02-12T16:24:24.867408+00:00","name":"tf-srv-sharp-bardeen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"3d19ea3d-4d7f-4800-8a16-76324b03ba16","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1826"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:24:29 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a1654ad5-2828-4001-9044-dd100f704f29
+        status: 200 OK
+        code: 200
+        duration: 166.46675ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7b3fa7ac-78de-4097-b7b8-a141ed2c0b82
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1089
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:24:15.823279Z","dhcp_enabled":true,"id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:24:15.823279Z","id":"00415797-fa4c-46d3-ad73-f49acbd8298d","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:24:22.247568Z","vpc_id":"64dfae5d-85fa-4558-9c3e-18fe130ee80d"},{"created_at":"2025-02-12T16:24:15.823279Z","id":"d6e4aef9-10a5-465b-9429-8e4662375a71","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:53ae::/64","updated_at":"2025-02-12T16:24:22.251290Z","vpc_id":"64dfae5d-85fa-4558-9c3e-18fe130ee80d"}],"tags":[],"updated_at":"2025-02-12T16:24:22.244561Z","vpc_id":"64dfae5d-85fa-4558-9c3e-18fe130ee80d"}'
+        headers:
+            Content-Length:
+                - "1089"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:24:29 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - eff7d218-9ab3-4801-b3e3-52c4237f58cf
+        status: 200 OK
+        code: 200
+        duration: 55.337417ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1826
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:24:17.041400+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sharp-bardeen","id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"2002","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c8:6b","maintenances":[],"modification_date":"2025-02-12T16:24:24.867408+00:00","name":"tf-srv-sharp-bardeen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"3d19ea3d-4d7f-4800-8a16-76324b03ba16","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1826"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:24:29 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4fb436b2-f5ff-40f4-801b-89a0b056d89f
+        status: 200 OK
+        code: 200
+        duration: 218.680625ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/278eadb1-7bcf-4f53-87f9-e9325a950998
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1987
+        uncompressed: false
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:24:16.595820Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:24:25.196682Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:24:15.720530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"7ece1fd0-856b-4d14-81d8-d604bbe0be27","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:24:15.720530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"d283d880-a865-4b90-8403-ea6dfd3a239e","ipam_config":null,"mac_address":null,"private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","status":"created","updated_at":"2025-02-12T16:24:25.196682Z","zone":"fr-par-1"}],"id":"278eadb1-7bcf-4f53-87f9-e9325a950998","ip":{"address":"163.172.159.229","created_at":"2025-02-12T16:24:16.448125Z","gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"0650ad59-a7c2-4c38-b4c2-eff6527ca016","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.448125Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:24:25.331859Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "1987"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:24:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f6103c94-8dc0-47de-93d0-9f817b16e971
+        status: 200 OK
+        code: 200
+        duration: 54.499875ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 61
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e/private_nics
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 473
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:24:29.642246+00:00","id":"af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab","ipam_ip_ids":["3d868c45-94ac-419f-84f2-8d5bd75bc78d","399674a2-9f70-400b-a35b-dff5e1319b67"],"mac_address":"02:00:00:1c:eb:bc","modification_date":"2025-02-12T16:24:29.859091+00:00","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","server_id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "473"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:24:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 276b289e-a44c-4d6c-92b0-c7387278771c
+        status: 201 Created
+        code: 201
+        duration: 1.122227167s
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e/private_nics/af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 473
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:24:29.642246+00:00","id":"af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab","ipam_ip_ids":["3d868c45-94ac-419f-84f2-8d5bd75bc78d","399674a2-9f70-400b-a35b-dff5e1319b67"],"mac_address":"02:00:00:1c:eb:bc","modification_date":"2025-02-12T16:24:29.859091+00:00","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","server_id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "473"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:24:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 48964e88-0107-4aae-b9fc-f771cd902afb
+        status: 200 OK
+        code: 200
+        duration: 115.958583ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/278eadb1-7bcf-4f53-87f9-e9325a950998
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2006
+        uncompressed: false
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:24:16.595820Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:24:25.196682Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:24:15.720530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"7ece1fd0-856b-4d14-81d8-d604bbe0be27","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:24:15.720530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"d283d880-a865-4b90-8403-ea6dfd3a239e","ipam_config":null,"mac_address":"02:00:00:12:45:AE","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","status":"configuring","updated_at":"2025-02-12T16:24:31.055863Z","zone":"fr-par-1"}],"id":"278eadb1-7bcf-4f53-87f9-e9325a950998","ip":{"address":"163.172.159.229","created_at":"2025-02-12T16:24:16.448125Z","gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"0650ad59-a7c2-4c38-b4c2-eff6527ca016","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.448125Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:24:25.331859Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "2006"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:24:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1b116a5f-267a-4d2a-be19-cd316ccd47dd
+        status: 200 OK
+        code: 200
+        duration: 54.635417ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e/private_nics/af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 473
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:24:29.642246+00:00","id":"af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab","ipam_ip_ids":["3d868c45-94ac-419f-84f2-8d5bd75bc78d","399674a2-9f70-400b-a35b-dff5e1319b67"],"mac_address":"02:00:00:1c:eb:bc","modification_date":"2025-02-12T16:24:29.859091+00:00","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","server_id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "473"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:24:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 04982aa1-2224-493b-8aab-eede46318a34
+        status: 200 OK
+        code: 200
+        duration: 115.193583ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/278eadb1-7bcf-4f53-87f9-e9325a950998
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1996
+        uncompressed: false
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:24:16.595820Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:24:25.196682Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:24:15.720530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"7ece1fd0-856b-4d14-81d8-d604bbe0be27","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:24:15.720530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"d283d880-a865-4b90-8403-ea6dfd3a239e","ipam_config":null,"mac_address":"02:00:00:12:45:AE","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","status":"ready","updated_at":"2025-02-12T16:24:35.671554Z","zone":"fr-par-1"}],"id":"278eadb1-7bcf-4f53-87f9-e9325a950998","ip":{"address":"163.172.159.229","created_at":"2025-02-12T16:24:16.448125Z","gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"0650ad59-a7c2-4c38-b4c2-eff6527ca016","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.448125Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:24:35.855992Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "1996"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:24:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8043363e-9a84-4edd-b685-9e25d2cb2b13
+        status: 200 OK
+        code: 200
+        duration: 52.957375ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1619,7 +1613,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/d283d880-a865-4b90-8403-ea6dfd3a239e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1627,20 +1621,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1987
+        content_length: 996
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:57.205022Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":null,"private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"created","updated_at":"2025-02-12T16:15:23.555839Z","zone":"fr-par-1"}],"id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","ip":{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:23.710859Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:24:25.196682Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:24:15.720530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"7ece1fd0-856b-4d14-81d8-d604bbe0be27","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:24:15.720530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"d283d880-a865-4b90-8403-ea6dfd3a239e","ipam_config":null,"mac_address":"02:00:00:12:45:AE","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","status":"ready","updated_at":"2025-02-12T16:24:35.671554Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1987"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:23 GMT
+                - Wed, 12 Feb 2025 16:24:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1648,10 +1642,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a48fd194-7403-419c-8c10-1247f7de08cb
+                - 8489fced-f716-4a30-9c68-9437429b6ca0
         status: 200 OK
         code: 200
-        duration: 53.532542ms
+        duration: 72.142042ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1668,7 +1662,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics/ba175159-76a5-4f16-b338-f91217d775e7
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/d283d880-a865-4b90-8403-ea6dfd3a239e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1676,20 +1670,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 473
+        content_length: 996
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:04.992700+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"address":null,"created_at":"2025-02-12T16:24:25.196682Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:24:15.720530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"7ece1fd0-856b-4d14-81d8-d604bbe0be27","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:24:15.720530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"d283d880-a865-4b90-8403-ea6dfd3a239e","ipam_config":null,"mac_address":"02:00:00:12:45:AE","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","status":"ready","updated_at":"2025-02-12T16:24:35.671554Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "473"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:27 GMT
+                - Wed, 12 Feb 2025 16:24:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1697,10 +1691,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 76efc89b-5f7e-433a-bed1-1b06686577b9
+                - b69b118f-6c0e-4ebf-b847-75fc3ba13cf6
         status: 200 OK
         code: 200
-        duration: 117.063041ms
+        duration: 92.8305ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1717,7 +1711,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/278eadb1-7bcf-4f53-87f9-e9325a950998
         method: GET
       response:
         proto: HTTP/2.0
@@ -1725,20 +1719,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1987
+        content_length: 1996
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:57.205022Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":null,"private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"created","updated_at":"2025-02-12T16:15:23.555839Z","zone":"fr-par-1"}],"id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","ip":{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:23.710859Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:24:16.595820Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:24:25.196682Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:24:15.720530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"7ece1fd0-856b-4d14-81d8-d604bbe0be27","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:24:15.720530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"d283d880-a865-4b90-8403-ea6dfd3a239e","ipam_config":null,"mac_address":"02:00:00:12:45:AE","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","status":"ready","updated_at":"2025-02-12T16:24:35.671554Z","zone":"fr-par-1"}],"id":"278eadb1-7bcf-4f53-87f9-e9325a950998","ip":{"address":"163.172.159.229","created_at":"2025-02-12T16:24:16.448125Z","gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"0650ad59-a7c2-4c38-b4c2-eff6527ca016","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.448125Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:24:35.855992Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1987"
+                - "1996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:28 GMT
+                - Wed, 12 Feb 2025 16:24:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1746,10 +1740,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 31350ebf-34c3-466e-b5be-2021fcc2e206
+                - b36251df-8f63-46bd-8531-f29507581165
         status: 200 OK
         code: 200
-        duration: 55.217041ms
+        duration: 50.67825ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1766,7 +1760,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics/ba175159-76a5-4f16-b338-f91217d775e7
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/d283d880-a865-4b90-8403-ea6dfd3a239e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1774,20 +1768,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 473
+        content_length: 996
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:04.992700+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"address":null,"created_at":"2025-02-12T16:24:25.196682Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:24:15.720530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"7ece1fd0-856b-4d14-81d8-d604bbe0be27","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:24:15.720530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"d283d880-a865-4b90-8403-ea6dfd3a239e","ipam_config":null,"mac_address":"02:00:00:12:45:AE","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","status":"ready","updated_at":"2025-02-12T16:24:35.671554Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "473"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:32 GMT
+                - Wed, 12 Feb 2025 16:24:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1795,10 +1789,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d8285bf8-45f3-4bba-b306-aeee343bd033
+                - 2eb7e898-2cae-44f6-b6e7-8410975822c0
         status: 200 OK
         code: 200
-        duration: 99.913625ms
+        duration: 65.451417ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1815,7 +1809,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e/private_nics/af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab
         method: GET
       response:
         proto: HTTP/2.0
@@ -1823,20 +1817,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2006
+        content_length: 473
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:57.205022Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"configuring","updated_at":"2025-02-12T16:15:29.357361Z","zone":"fr-par-1"}],"id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","ip":{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:23.710859Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:24:29.642246+00:00","id":"af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab","ipam_ip_ids":["3d868c45-94ac-419f-84f2-8d5bd75bc78d","399674a2-9f70-400b-a35b-dff5e1319b67"],"mac_address":"02:00:00:1c:eb:bc","modification_date":"2025-02-12T16:24:29.859091+00:00","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","server_id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2006"
+                - "473"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:33 GMT
+                - Wed, 12 Feb 2025 16:24:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1844,10 +1838,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 19a18bb8-429b-4780-bb0b-ab6e544e846e
+                - bab8eaef-7aae-408c-8ff6-a33a0daf4a8d
         status: 200 OK
         code: 200
-        duration: 65.742584ms
+        duration: 107.848542ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1864,7 +1858,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics/ba175159-76a5-4f16-b338-f91217d775e7
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e/private_nics/af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab
         method: GET
       response:
         proto: HTTP/2.0
@@ -1872,20 +1866,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 475
+        content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:24:29.642246+00:00","id":"af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab","ipam_ip_ids":["3d868c45-94ac-419f-84f2-8d5bd75bc78d","399674a2-9f70-400b-a35b-dff5e1319b67"],"mac_address":"02:00:00:1c:eb:bc","modification_date":"2025-02-12T16:24:29.859091+00:00","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","server_id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "475"
+                - "473"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:37 GMT
+                - Wed, 12 Feb 2025 16:24:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1893,10 +1887,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0ea817b2-2a27-4b8e-8ed2-248212a6c203
+                - d5be1d23-4623-40d8-8583-399191a10d8e
         status: 200 OK
         code: 200
-        duration: 582.557792ms
+        duration: 109.112125ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1913,7 +1907,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics/ba175159-76a5-4f16-b338-f91217d775e7
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e/private_nics/af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab
         method: GET
       response:
         proto: HTTP/2.0
@@ -1921,20 +1915,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 475
+        content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:24:29.642246+00:00","id":"af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab","ipam_ip_ids":["3d868c45-94ac-419f-84f2-8d5bd75bc78d","399674a2-9f70-400b-a35b-dff5e1319b67"],"mac_address":"02:00:00:1c:eb:bc","modification_date":"2025-02-12T16:24:29.859091+00:00","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","server_id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "475"
+                - "473"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:38 GMT
+                - Wed, 12 Feb 2025 16:24:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1942,10 +1936,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d03de657-3fed-4d17-9790-df5fb10139a3
+                - d30edc65-4e37-41f2-8653-138316330538
         status: 200 OK
         code: 200
-        duration: 100.719584ms
+        duration: 97.581334ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1962,7 +1956,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e/private_nics/af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab
         method: GET
       response:
         proto: HTTP/2.0
@@ -1970,20 +1964,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2289
+        content_length: 473
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.380750+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-greider","id":"ee6b8302-d285-4412-9af2-b94bfecca21c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"304","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d5","maintenances":[],"modification_date":"2025-02-12T16:15:03.386466+00:00","name":"tf-srv-vigilant-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:24:29.642246+00:00","id":"af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab","ipam_ip_ids":["3d868c45-94ac-419f-84f2-8d5bd75bc78d","399674a2-9f70-400b-a35b-dff5e1319b67"],"mac_address":"02:00:00:1c:eb:bc","modification_date":"2025-02-12T16:24:29.859091+00:00","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","server_id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2289"
+                - "473"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:38 GMT
+                - Wed, 12 Feb 2025 16:24:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1991,10 +1985,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 031205d2-bf6d-4f12-8b4f-ca984ef98f8a
+                - 22eb2afd-6498-468d-bfdf-7ad1b9cd892a
         status: 200 OK
         code: 200
-        duration: 194.335625ms
+        duration: 113.289625ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2011,7 +2005,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/a5c02cb7-8020-4442-8634-e5ee2eff2c2c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e/private_nics/af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab
         method: GET
       response:
         proto: HTTP/2.0
@@ -2019,20 +2013,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 143
+        content_length: 473
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","type":"not_found"}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:24:29.642246+00:00","id":"af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab","ipam_ip_ids":["3d868c45-94ac-419f-84f2-8d5bd75bc78d","399674a2-9f70-400b-a35b-dff5e1319b67"],"mac_address":"02:00:00:1c:eb:bc","modification_date":"2025-02-12T16:24:29.859091+00:00","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","server_id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "143"
+                - "473"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:38 GMT
+                - Wed, 12 Feb 2025 16:25:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2040,10 +2034,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 469e213f-f69b-4362-ac5c-8faf55d60426
-        status: 404 Not Found
-        code: 404
-        duration: 58.354584ms
+                - 80672104-aca7-4e9d-a051-76aa3ede8bb8
+        status: 200 OK
+        code: 200
+        duration: 121.96525ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2060,7 +2054,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/a5c02cb7-8020-4442-8634-e5ee2eff2c2c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e/private_nics/af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab
         method: GET
       response:
         proto: HTTP/2.0
@@ -2068,20 +2062,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 701
+        content_length: 475
         uncompressed: false
-        body: '{"created_at":"2025-02-12T16:14:57.589514Z","id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:14:57.589514Z","id":"158fda61-e559-4737-996d-b3b846db132e","product_resource_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:14:57.589514Z","zone":"fr-par-1"}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:24:29.642246+00:00","id":"af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab","ipam_ip_ids":["3d868c45-94ac-419f-84f2-8d5bd75bc78d","399674a2-9f70-400b-a35b-dff5e1319b67"],"mac_address":"02:00:00:1c:eb:bc","modification_date":"2025-02-12T16:25:01.635033+00:00","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","server_id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "701"
+                - "475"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:38 GMT
+                - Wed, 12 Feb 2025 16:25:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2089,10 +2083,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9de9d54f-2376-429e-991c-c91b0378450a
+                - db081713-7d91-4248-8d71-d60c99da8641
         status: 200 OK
         code: 200
-        duration: 84.813875ms
+        duration: 113.933042ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2109,7 +2103,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/user_data
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e/private_nics/af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab
         method: GET
       response:
         proto: HTTP/2.0
@@ -2117,20 +2111,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 475
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:24:29.642246+00:00","id":"af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab","ipam_ip_ids":["3d868c45-94ac-419f-84f2-8d5bd75bc78d","399674a2-9f70-400b-a35b-dff5e1319b67"],"mac_address":"02:00:00:1c:eb:bc","modification_date":"2025-02-12T16:25:01.635033+00:00","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","server_id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "17"
+                - "475"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:38 GMT
+                - Wed, 12 Feb 2025 16:25:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2138,10 +2132,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 08920b58-508b-46e8-aab3-96a8a7e6b9ec
+                - 355e722c-fabe-48e0-9801-146a26a6283a
         status: 200 OK
         code: 200
-        duration: 105.808625ms
+        duration: 94.040833ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2158,7 +2152,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e
         method: GET
       response:
         proto: HTTP/2.0
@@ -2166,20 +2160,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1996
+        content_length: 2284
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:57.205022Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"ready","updated_at":"2025-02-12T16:15:34.005146Z","zone":"fr-par-1"}],"id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","ip":{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:34.260759Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:24:17.041400+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sharp-bardeen","id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"2002","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c8:6b","maintenances":[],"modification_date":"2025-02-12T16:24:24.867408+00:00","name":"tf-srv-sharp-bardeen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:24:29.642246+00:00","id":"af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab","ipam_ip_ids":["3d868c45-94ac-419f-84f2-8d5bd75bc78d","399674a2-9f70-400b-a35b-dff5e1319b67"],"mac_address":"02:00:00:1c:eb:bc","modification_date":"2025-02-12T16:25:01.635033+00:00","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","server_id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"3d19ea3d-4d7f-4800-8a16-76324b03ba16","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1996"
+                - "2284"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:39 GMT
+                - Wed, 12 Feb 2025 16:25:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2187,10 +2181,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c49827e8-beca-4c7c-a010-5702aef9ed87
+                - b2683ef4-2174-4635-aa51-f78dd952d778
         status: 200 OK
         code: 200
-        duration: 58.169542ms
+        duration: 237.16275ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2207,7 +2201,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3bbc5634-ce11-4bce-adc4-39e0fac0db51
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/3d19ea3d-4d7f-4800-8a16-76324b03ba16
         method: GET
       response:
         proto: HTTP/2.0
@@ -2215,20 +2209,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 996
+        content_length: 143
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"ready","updated_at":"2025-02-12T16:15:34.005146Z","zone":"fr-par-1"}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"3d19ea3d-4d7f-4800-8a16-76324b03ba16","type":"not_found"}'
         headers:
             Content-Length:
-                - "996"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:39 GMT
+                - Wed, 12 Feb 2025 16:25:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2236,10 +2230,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 45abfd67-b4c2-4641-87d2-d21620ad6c3b
-        status: 200 OK
-        code: 200
-        duration: 65.058083ms
+                - aad03295-d042-4715-b84f-055eccf53ba8
+        status: 404 Not Found
+        code: 404
+        duration: 52.311959ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2256,7 +2250,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/3d19ea3d-4d7f-4800-8a16-76324b03ba16
         method: GET
       response:
         proto: HTTP/2.0
@@ -2264,22 +2258,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 478
+        content_length: 701
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"created_at":"2025-02-12T16:24:17.252844Z","id":"3d19ea3d-4d7f-4800-8a16-76324b03ba16","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:24:17.252844Z","id":"dbff681f-9b1f-49aa-a9eb-0e714f9d8792","product_resource_id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:24:17.252844Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "478"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:38 GMT
-            Link:
-                - </servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics?page=1&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 16:25:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2287,12 +2279,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f1f9db21-9d6e-4eb3-b657-41723678d872
-            X-Total-Count:
-                - "1"
+                - 6ac53ce0-b106-4c19-bfe7-1f7a6896d650
         status: 200 OK
         code: 200
-        duration: 249.08125ms
+        duration: 84.394458ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2309,7 +2299,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3bbc5634-ce11-4bce-adc4-39e0fac0db51
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -2317,20 +2307,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 996
+        content_length: 17
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"ready","updated_at":"2025-02-12T16:15:34.005146Z","zone":"fr-par-1"}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "996"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:39 GMT
+                - Wed, 12 Feb 2025 16:25:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2338,10 +2328,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 48e0b9e1-39ae-4a98-8b7c-593a902fb9a1
+                - a55e9f16-0b7c-4ba6-8e4d-34b8bf601367
         status: 200 OK
         code: 200
-        duration: 68.248709ms
+        duration: 101.223625ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2358,7 +2348,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -2366,20 +2356,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1996
+        content_length: 478
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:57.205022Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"ready","updated_at":"2025-02-12T16:15:34.005146Z","zone":"fr-par-1"}],"id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","ip":{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:34.260759Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:24:29.642246+00:00","id":"af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab","ipam_ip_ids":["3d868c45-94ac-419f-84f2-8d5bd75bc78d","399674a2-9f70-400b-a35b-dff5e1319b67"],"mac_address":"02:00:00:1c:eb:bc","modification_date":"2025-02-12T16:25:01.635033+00:00","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","server_id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "1996"
+                - "478"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:39 GMT
+                - Wed, 12 Feb 2025 16:25:06 GMT
+            Link:
+                - </servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e/private_nics?page=1&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2387,10 +2379,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8af6daab-37e3-4c6e-a267-2e1c887abc66
+                - baeba2b0-d957-406c-88ce-af4f9d61c3b4
+            X-Total-Count:
+                - "1"
         status: 200 OK
         code: 200
-        duration: 54.068583ms
+        duration: 119.724791ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2407,7 +2401,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3bbc5634-ce11-4bce-adc4-39e0fac0db51
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/0650ad59-a7c2-4c38-b4c2-eff6527ca016
         method: GET
       response:
         proto: HTTP/2.0
@@ -2415,20 +2409,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 996
+        content_length: 405
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"ready","updated_at":"2025-02-12T16:15:34.005146Z","zone":"fr-par-1"}'
+        body: '{"address":"163.172.159.229","created_at":"2025-02-12T16:24:16.448125Z","gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"0650ad59-a7c2-4c38-b4c2-eff6527ca016","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.448125Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "996"
+                - "405"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:39 GMT
+                - Wed, 12 Feb 2025 16:25:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2436,10 +2430,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0d34de6b-9a3e-445e-8d9b-7d56eb02688c
+                - 9f416d50-6a20-43de-ae6c-e0c913d72e06
         status: 200 OK
         code: 200
-        duration: 65.994458ms
+        duration: 41.926625ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2456,7 +2450,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/2572e954-7dde-486b-821f-38300c6d0173
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7b3fa7ac-78de-4097-b7b8-a141ed2c0b82
         method: GET
       response:
         proto: HTTP/2.0
@@ -2464,20 +2458,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 586
+        content_length: 1089
         uncompressed: false
-        body: '{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:24:15.823279Z","dhcp_enabled":true,"id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:24:15.823279Z","id":"00415797-fa4c-46d3-ad73-f49acbd8298d","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:24:22.247568Z","vpc_id":"64dfae5d-85fa-4558-9c3e-18fe130ee80d"},{"created_at":"2025-02-12T16:24:15.823279Z","id":"d6e4aef9-10a5-465b-9429-8e4662375a71","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:53ae::/64","updated_at":"2025-02-12T16:24:22.251290Z","vpc_id":"64dfae5d-85fa-4558-9c3e-18fe130ee80d"}],"tags":[],"updated_at":"2025-02-12T16:24:31.909715Z","vpc_id":"64dfae5d-85fa-4558-9c3e-18fe130ee80d"}'
         headers:
             Content-Length:
-                - "586"
+                - "1089"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:39 GMT
+                - Wed, 12 Feb 2025 16:25:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2485,10 +2479,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0728c60a-3ba5-49f9-81d7-d767b5d8f189
+                - 6a4ed15c-8398-44ad-8ca0-749b91ca5210
         status: 200 OK
         code: 200
-        duration: 44.9625ms
+        duration: 45.001958ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -2505,7 +2499,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/da389c61-9c8f-475e-b2c5-b60333283fa5
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/7ece1fd0-856b-4d14-81d8-d604bbe0be27
         method: GET
       response:
         proto: HTTP/2.0
@@ -2513,20 +2507,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 405
+        content_length: 586
         uncompressed: false
-        body: '{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"}'
+        body: '{"address":"192.168.1.1","created_at":"2025-02-12T16:24:15.720530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"7ece1fd0-856b-4d14-81d8-d604bbe0be27","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:24:15.720530Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "405"
+                - "586"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:39 GMT
+                - Wed, 12 Feb 2025 16:25:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2534,10 +2528,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f366e9a0-194d-4787-9744-24e1742637ef
+                - 4ac86a85-def6-4ddb-9a8b-c202cb58c028
         status: 200 OK
         code: 200
-        duration: 47.36475ms
+        duration: 45.166084ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2554,7 +2548,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b3a3ea6c-4758-41c7-b9ad-22f9a410c192
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/278eadb1-7bcf-4f53-87f9-e9325a950998
         method: GET
       response:
         proto: HTTP/2.0
@@ -2562,20 +2556,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1089
+        content_length: 1996
         uncompressed: false
-        body: '{"created_at":"2025-02-12T16:14:56.161859Z","dhcp_enabled":true,"id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:14:56.161859Z","id":"1d110e71-77c2-4e0d-8b2a-44e5e61a0211","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:15:21.807710Z","vpc_id":"b388d228-a931-443f-87b2-379c9af5934b"},{"created_at":"2025-02-12T16:14:56.161859Z","id":"ad46a815-2df6-4e07-ad92-d99d79d18c7d","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:b62b::/64","updated_at":"2025-02-12T16:15:21.811374Z","vpc_id":"b388d228-a931-443f-87b2-379c9af5934b"}],"tags":[],"updated_at":"2025-02-12T16:15:30.215218Z","vpc_id":"b388d228-a931-443f-87b2-379c9af5934b"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:24:16.595820Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:24:25.196682Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:24:15.720530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"7ece1fd0-856b-4d14-81d8-d604bbe0be27","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:24:15.720530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"d283d880-a865-4b90-8403-ea6dfd3a239e","ipam_config":null,"mac_address":"02:00:00:12:45:AE","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","status":"ready","updated_at":"2025-02-12T16:24:35.671554Z","zone":"fr-par-1"}],"id":"278eadb1-7bcf-4f53-87f9-e9325a950998","ip":{"address":"163.172.159.229","created_at":"2025-02-12T16:24:16.448125Z","gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"0650ad59-a7c2-4c38-b4c2-eff6527ca016","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.448125Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:24:35.855992Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1089"
+                - "1996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:39 GMT
+                - Wed, 12 Feb 2025 16:25:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2583,10 +2577,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 638be8d4-7e8d-4712-9718-23cfb5b67a41
+                - 12d0ef7d-1560-48d1-bc27-146ce7d27bae
         status: 200 OK
         code: 200
-        duration: 90.367125ms
+        duration: 48.5165ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -2603,7 +2597,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/d283d880-a865-4b90-8403-ea6dfd3a239e
         method: GET
       response:
         proto: HTTP/2.0
@@ -2611,20 +2605,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1996
+        content_length: 996
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:57.205022Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"ready","updated_at":"2025-02-12T16:15:34.005146Z","zone":"fr-par-1"}],"id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","ip":{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:34.260759Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:24:25.196682Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:24:15.720530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"7ece1fd0-856b-4d14-81d8-d604bbe0be27","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:24:15.720530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"d283d880-a865-4b90-8403-ea6dfd3a239e","ipam_config":null,"mac_address":"02:00:00:12:45:AE","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","status":"ready","updated_at":"2025-02-12T16:24:35.671554Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1996"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:39 GMT
+                - Wed, 12 Feb 2025 16:25:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2632,10 +2626,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dac31f8a-ca3e-4718-858c-2c1c5b739888
+                - 9fbfc47a-536e-4778-85d9-cd203c234f90
         status: 200 OK
         code: 200
-        duration: 48.073834ms
+        duration: 61.540125ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -2652,7 +2646,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3bbc5634-ce11-4bce-adc4-39e0fac0db51
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/278eadb1-7bcf-4f53-87f9-e9325a950998
         method: GET
       response:
         proto: HTTP/2.0
@@ -2660,20 +2654,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 996
+        content_length: 1996
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"ready","updated_at":"2025-02-12T16:15:34.005146Z","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:24:16.595820Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:24:25.196682Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:24:15.720530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"7ece1fd0-856b-4d14-81d8-d604bbe0be27","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:24:15.720530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"d283d880-a865-4b90-8403-ea6dfd3a239e","ipam_config":null,"mac_address":"02:00:00:12:45:AE","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","status":"ready","updated_at":"2025-02-12T16:24:35.671554Z","zone":"fr-par-1"}],"id":"278eadb1-7bcf-4f53-87f9-e9325a950998","ip":{"address":"163.172.159.229","created_at":"2025-02-12T16:24:16.448125Z","gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"0650ad59-a7c2-4c38-b4c2-eff6527ca016","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.448125Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:24:35.855992Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "996"
+                - "1996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:39 GMT
+                - Wed, 12 Feb 2025 16:25:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2681,10 +2675,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fd7205f3-3873-46f7-9ab2-22ea56338b0c
+                - 369581c5-59cb-43e5-aa40-0b1af3d4ef8a
         status: 200 OK
         code: 200
-        duration: 61.978334ms
+        duration: 49.411916ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -2701,7 +2695,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e
         method: GET
       response:
         proto: HTTP/2.0
@@ -2709,20 +2703,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1996
+        content_length: 2284
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:57.205022Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"ready","updated_at":"2025-02-12T16:15:34.005146Z","zone":"fr-par-1"}],"id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","ip":{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:34.260759Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:24:17.041400+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sharp-bardeen","id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"2002","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c8:6b","maintenances":[],"modification_date":"2025-02-12T16:24:24.867408+00:00","name":"tf-srv-sharp-bardeen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:24:29.642246+00:00","id":"af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab","ipam_ip_ids":["3d868c45-94ac-419f-84f2-8d5bd75bc78d","399674a2-9f70-400b-a35b-dff5e1319b67"],"mac_address":"02:00:00:1c:eb:bc","modification_date":"2025-02-12T16:25:01.635033+00:00","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","server_id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"3d19ea3d-4d7f-4800-8a16-76324b03ba16","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1996"
+                - "2284"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:39 GMT
+                - Wed, 12 Feb 2025 16:25:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2730,10 +2724,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 254e11b7-2f9e-4579-92ef-fd415a539f7d
+                - a7307801-f18c-4a8e-84cc-8cef0667df83
         status: 200 OK
         code: 200
-        duration: 48.595292ms
+        duration: 186.065125ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -2750,7 +2744,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/d283d880-a865-4b90-8403-ea6dfd3a239e
         method: GET
       response:
         proto: HTTP/2.0
@@ -2758,20 +2752,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2289
+        content_length: 996
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.380750+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-greider","id":"ee6b8302-d285-4412-9af2-b94bfecca21c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"304","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d5","maintenances":[],"modification_date":"2025-02-12T16:15:03.386466+00:00","name":"tf-srv-vigilant-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"address":null,"created_at":"2025-02-12T16:24:25.196682Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:24:15.720530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"7ece1fd0-856b-4d14-81d8-d604bbe0be27","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:24:15.720530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"d283d880-a865-4b90-8403-ea6dfd3a239e","ipam_config":null,"mac_address":"02:00:00:12:45:AE","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","status":"ready","updated_at":"2025-02-12T16:24:35.671554Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2289"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:39 GMT
+                - Wed, 12 Feb 2025 16:25:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2779,10 +2773,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6f17b1fa-29ee-418a-bec6-b758ea0e7e24
+                - cdb0538e-ae61-4d17-aed5-2e5fdbfd2123
         status: 200 OK
         code: 200
-        duration: 185.404083ms
+        duration: 62.023667ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2799,7 +2793,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3bbc5634-ce11-4bce-adc4-39e0fac0db51
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/3d19ea3d-4d7f-4800-8a16-76324b03ba16
         method: GET
       response:
         proto: HTTP/2.0
@@ -2807,20 +2801,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 996
+        content_length: 143
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"ready","updated_at":"2025-02-12T16:15:34.005146Z","zone":"fr-par-1"}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"3d19ea3d-4d7f-4800-8a16-76324b03ba16","type":"not_found"}'
         headers:
             Content-Length:
-                - "996"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:39 GMT
+                - Wed, 12 Feb 2025 16:25:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2828,10 +2822,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cbd9f51e-e0bb-44c0-8741-d7434e5c1b51
-        status: 200 OK
-        code: 200
-        duration: 67.928875ms
+                - 7c2f840d-60f4-4072-a141-966c037132ba
+        status: 404 Not Found
+        code: 404
+        duration: 53.973917ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2848,7 +2842,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/a5c02cb7-8020-4442-8634-e5ee2eff2c2c
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/3d19ea3d-4d7f-4800-8a16-76324b03ba16
         method: GET
       response:
         proto: HTTP/2.0
@@ -2856,20 +2850,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 143
+        content_length: 701
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","type":"not_found"}'
+        body: '{"created_at":"2025-02-12T16:24:17.252844Z","id":"3d19ea3d-4d7f-4800-8a16-76324b03ba16","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:24:17.252844Z","id":"dbff681f-9b1f-49aa-a9eb-0e714f9d8792","product_resource_id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:24:17.252844Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "143"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:39 GMT
+                - Wed, 12 Feb 2025 16:25:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2877,10 +2871,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c5091cec-fe42-437d-9c69-6285c2635aff
-        status: 404 Not Found
-        code: 404
-        duration: 65.210125ms
+                - 8156f8bb-0ab4-4e18-b9f4-dbff09b06b98
+        status: 200 OK
+        code: 200
+        duration: 102.85175ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -2897,7 +2891,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/a5c02cb7-8020-4442-8634-e5ee2eff2c2c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -2905,20 +2899,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 701
+        content_length: 17
         uncompressed: false
-        body: '{"created_at":"2025-02-12T16:14:57.589514Z","id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:14:57.589514Z","id":"158fda61-e559-4737-996d-b3b846db132e","product_resource_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:14:57.589514Z","zone":"fr-par-1"}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "701"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:40 GMT
+                - Wed, 12 Feb 2025 16:25:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2926,10 +2920,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0b65d959-fdd9-4182-a10d-609529fc4cc1
+                - b2e17a5e-2df9-4a40-a71a-8cbf78ed23eb
         status: 200 OK
         code: 200
-        duration: 85.381292ms
+        duration: 110.914542ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -2946,7 +2940,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/user_data
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -2954,20 +2948,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 478
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:24:29.642246+00:00","id":"af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab","ipam_ip_ids":["3d868c45-94ac-419f-84f2-8d5bd75bc78d","399674a2-9f70-400b-a35b-dff5e1319b67"],"mac_address":"02:00:00:1c:eb:bc","modification_date":"2025-02-12T16:25:01.635033+00:00","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","server_id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "17"
+                - "478"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:39 GMT
+                - Wed, 12 Feb 2025 16:25:08 GMT
+            Link:
+                - </servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e/private_nics?page=1&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2975,10 +2971,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9a24aae5-61de-4243-9721-836a120f75b6
+                - c95e3218-8653-483b-ac3d-c5f26569d252
+            X-Total-Count:
+                - "1"
         status: 200 OK
         code: 200
-        duration: 101.813042ms
+        duration: 111.670958ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -2995,7 +2993,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/0650ad59-a7c2-4c38-b4c2-eff6527ca016
         method: GET
       response:
         proto: HTTP/2.0
@@ -3003,22 +3001,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 478
+        content_length: 405
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"address":"163.172.159.229","created_at":"2025-02-12T16:24:16.448125Z","gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"0650ad59-a7c2-4c38-b4c2-eff6527ca016","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.448125Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "478"
+                - "405"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:40 GMT
-            Link:
-                - </servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics?page=1&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 16:25:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3026,12 +3022,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1e853c8c-b8d4-4500-a31d-55feafd3f7a4
-            X-Total-Count:
-                - "1"
+                - a305eba1-f5bd-42aa-a790-f33985cfd67f
         status: 200 OK
         code: 200
-        duration: 113.95425ms
+        duration: 42.0785ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -3048,7 +3042,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/2572e954-7dde-486b-821f-38300c6d0173
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/7ece1fd0-856b-4d14-81d8-d604bbe0be27
         method: GET
       response:
         proto: HTTP/2.0
@@ -3058,7 +3052,7 @@ interactions:
         trailer: {}
         content_length: 586
         uncompressed: false
-        body: '{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+        body: '{"address":"192.168.1.1","created_at":"2025-02-12T16:24:15.720530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"7ece1fd0-856b-4d14-81d8-d604bbe0be27","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:24:15.720530Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "586"
@@ -3067,9 +3061,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:40 GMT
+                - Wed, 12 Feb 2025 16:25:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3077,10 +3071,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b3dbb0f1-06f9-40af-bcb6-45eebdb441b4
+                - 0c785946-c4c7-4371-937b-9452cb79ca4c
         status: 200 OK
         code: 200
-        duration: 42.986666ms
+        duration: 43.985542ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -3097,7 +3091,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/da389c61-9c8f-475e-b2c5-b60333283fa5
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7b3fa7ac-78de-4097-b7b8-a141ed2c0b82
         method: GET
       response:
         proto: HTTP/2.0
@@ -3105,20 +3099,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 405
+        content_length: 1089
         uncompressed: false
-        body: '{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:24:15.823279Z","dhcp_enabled":true,"id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:24:15.823279Z","id":"00415797-fa4c-46d3-ad73-f49acbd8298d","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:24:22.247568Z","vpc_id":"64dfae5d-85fa-4558-9c3e-18fe130ee80d"},{"created_at":"2025-02-12T16:24:15.823279Z","id":"d6e4aef9-10a5-465b-9429-8e4662375a71","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:53ae::/64","updated_at":"2025-02-12T16:24:22.251290Z","vpc_id":"64dfae5d-85fa-4558-9c3e-18fe130ee80d"}],"tags":[],"updated_at":"2025-02-12T16:24:31.909715Z","vpc_id":"64dfae5d-85fa-4558-9c3e-18fe130ee80d"}'
         headers:
             Content-Length:
-                - "405"
+                - "1089"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:40 GMT
+                - Wed, 12 Feb 2025 16:25:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3126,10 +3120,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 50264912-b9e3-4431-bb76-ed3ca90537e6
+                - dcf09adc-7c18-4c01-a9df-10687d566674
         status: 200 OK
         code: 200
-        duration: 43.362333ms
+        duration: 48.549584ms
     - id: 63
       request:
         proto: HTTP/1.1
@@ -3146,7 +3140,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b3a3ea6c-4758-41c7-b9ad-22f9a410c192
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/278eadb1-7bcf-4f53-87f9-e9325a950998
         method: GET
       response:
         proto: HTTP/2.0
@@ -3154,20 +3148,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1089
+        content_length: 1996
         uncompressed: false
-        body: '{"created_at":"2025-02-12T16:14:56.161859Z","dhcp_enabled":true,"id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:14:56.161859Z","id":"1d110e71-77c2-4e0d-8b2a-44e5e61a0211","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:15:21.807710Z","vpc_id":"b388d228-a931-443f-87b2-379c9af5934b"},{"created_at":"2025-02-12T16:14:56.161859Z","id":"ad46a815-2df6-4e07-ad92-d99d79d18c7d","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:b62b::/64","updated_at":"2025-02-12T16:15:21.811374Z","vpc_id":"b388d228-a931-443f-87b2-379c9af5934b"}],"tags":[],"updated_at":"2025-02-12T16:15:30.215218Z","vpc_id":"b388d228-a931-443f-87b2-379c9af5934b"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:24:16.595820Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:24:25.196682Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:24:15.720530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"7ece1fd0-856b-4d14-81d8-d604bbe0be27","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:24:15.720530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"d283d880-a865-4b90-8403-ea6dfd3a239e","ipam_config":null,"mac_address":"02:00:00:12:45:AE","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","status":"ready","updated_at":"2025-02-12T16:24:35.671554Z","zone":"fr-par-1"}],"id":"278eadb1-7bcf-4f53-87f9-e9325a950998","ip":{"address":"163.172.159.229","created_at":"2025-02-12T16:24:16.448125Z","gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"0650ad59-a7c2-4c38-b4c2-eff6527ca016","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.448125Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:24:35.855992Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1089"
+                - "1996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:40 GMT
+                - Wed, 12 Feb 2025 16:25:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3175,10 +3169,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7f5a029f-5cda-4707-b174-af070a6d08af
+                - e98642d7-1388-4859-98a0-675196cf4510
         status: 200 OK
         code: 200
-        duration: 49.480834ms
+        duration: 43.940125ms
     - id: 64
       request:
         proto: HTTP/1.1
@@ -3195,7 +3189,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/d283d880-a865-4b90-8403-ea6dfd3a239e
         method: GET
       response:
         proto: HTTP/2.0
@@ -3203,20 +3197,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1996
+        content_length: 996
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:57.205022Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"ready","updated_at":"2025-02-12T16:15:34.005146Z","zone":"fr-par-1"}],"id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","ip":{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:34.260759Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:24:25.196682Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:24:15.720530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"7ece1fd0-856b-4d14-81d8-d604bbe0be27","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:24:15.720530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"d283d880-a865-4b90-8403-ea6dfd3a239e","ipam_config":null,"mac_address":"02:00:00:12:45:AE","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","status":"ready","updated_at":"2025-02-12T16:24:35.671554Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1996"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:40 GMT
+                - Wed, 12 Feb 2025 16:25:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3224,10 +3218,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cb115cf3-7688-46f9-9808-a222b96ef4c1
+                - a13e77a6-fb9f-4a0e-b24f-60c3c8fb3ae3
         status: 200 OK
         code: 200
-        duration: 48.026208ms
+        duration: 71.453917ms
     - id: 65
       request:
         proto: HTTP/1.1
@@ -3244,7 +3238,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3bbc5634-ce11-4bce-adc4-39e0fac0db51
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/278eadb1-7bcf-4f53-87f9-e9325a950998
         method: GET
       response:
         proto: HTTP/2.0
@@ -3252,20 +3246,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 996
+        content_length: 1996
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"ready","updated_at":"2025-02-12T16:15:34.005146Z","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:24:16.595820Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:24:25.196682Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:24:15.720530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"7ece1fd0-856b-4d14-81d8-d604bbe0be27","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:24:15.720530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"d283d880-a865-4b90-8403-ea6dfd3a239e","ipam_config":null,"mac_address":"02:00:00:12:45:AE","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","status":"ready","updated_at":"2025-02-12T16:24:35.671554Z","zone":"fr-par-1"}],"id":"278eadb1-7bcf-4f53-87f9-e9325a950998","ip":{"address":"163.172.159.229","created_at":"2025-02-12T16:24:16.448125Z","gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"0650ad59-a7c2-4c38-b4c2-eff6527ca016","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.448125Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:24:35.855992Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "996"
+                - "1996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:40 GMT
+                - Wed, 12 Feb 2025 16:25:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3273,10 +3267,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 08e8c2bd-ec30-4501-a30e-1196feaf022b
+                - 7a6f4087-57f2-475c-8044-0418ed586dfa
         status: 200 OK
         code: 200
-        duration: 67.089292ms
+        duration: 42.798375ms
     - id: 66
       request:
         proto: HTTP/1.1
@@ -3293,7 +3287,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e
         method: GET
       response:
         proto: HTTP/2.0
@@ -3301,20 +3295,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1996
+        content_length: 2284
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:57.205022Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"ready","updated_at":"2025-02-12T16:15:34.005146Z","zone":"fr-par-1"}],"id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","ip":{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:34.260759Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:24:17.041400+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sharp-bardeen","id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"2002","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c8:6b","maintenances":[],"modification_date":"2025-02-12T16:24:24.867408+00:00","name":"tf-srv-sharp-bardeen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:24:29.642246+00:00","id":"af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab","ipam_ip_ids":["3d868c45-94ac-419f-84f2-8d5bd75bc78d","399674a2-9f70-400b-a35b-dff5e1319b67"],"mac_address":"02:00:00:1c:eb:bc","modification_date":"2025-02-12T16:25:01.635033+00:00","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","server_id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"3d19ea3d-4d7f-4800-8a16-76324b03ba16","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1996"
+                - "2284"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:40 GMT
+                - Wed, 12 Feb 2025 16:25:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3322,10 +3316,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 885747b0-d442-486f-9be9-192b45646325
+                - 1db4b3a9-dc5a-4265-81c3-950162082e12
         status: 200 OK
         code: 200
-        duration: 46.152125ms
+        duration: 214.0325ms
     - id: 67
       request:
         proto: HTTP/1.1
@@ -3342,7 +3336,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3bbc5634-ce11-4bce-adc4-39e0fac0db51
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/d283d880-a865-4b90-8403-ea6dfd3a239e
         method: GET
       response:
         proto: HTTP/2.0
@@ -3352,7 +3346,7 @@ interactions:
         trailer: {}
         content_length: 996
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"ready","updated_at":"2025-02-12T16:15:34.005146Z","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:24:25.196682Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:24:15.720530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"7ece1fd0-856b-4d14-81d8-d604bbe0be27","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:24:15.720530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"d283d880-a865-4b90-8403-ea6dfd3a239e","ipam_config":null,"mac_address":"02:00:00:12:45:AE","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","status":"ready","updated_at":"2025-02-12T16:24:35.671554Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "996"
@@ -3361,9 +3355,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:40 GMT
+                - Wed, 12 Feb 2025 16:25:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3371,10 +3365,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b0fdb8fe-b183-4709-8954-b94957576b5e
+                - 590b02cb-da22-4b76-a65b-0e3241572941
         status: 200 OK
         code: 200
-        duration: 71.531333ms
+        duration: 64.463959ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -3391,7 +3385,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/3d19ea3d-4d7f-4800-8a16-76324b03ba16
         method: GET
       response:
         proto: HTTP/2.0
@@ -3399,20 +3393,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2289
+        content_length: 143
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.380750+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-greider","id":"ee6b8302-d285-4412-9af2-b94bfecca21c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"304","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d5","maintenances":[],"modification_date":"2025-02-12T16:15:03.386466+00:00","name":"tf-srv-vigilant-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"3d19ea3d-4d7f-4800-8a16-76324b03ba16","type":"not_found"}'
         headers:
             Content-Length:
-                - "2289"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:40 GMT
+                - Wed, 12 Feb 2025 16:25:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3420,10 +3414,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0911211c-98b4-4b8f-9980-3123c656175d
-        status: 200 OK
-        code: 200
-        duration: 254.308083ms
+                - 92dda266-c806-420c-a1bd-b41a90eeceb2
+        status: 404 Not Found
+        code: 404
+        duration: 56.233083ms
     - id: 69
       request:
         proto: HTTP/1.1
@@ -3440,7 +3434,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/a5c02cb7-8020-4442-8634-e5ee2eff2c2c
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/3d19ea3d-4d7f-4800-8a16-76324b03ba16
         method: GET
       response:
         proto: HTTP/2.0
@@ -3448,20 +3442,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 143
+        content_length: 701
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","type":"not_found"}'
+        body: '{"created_at":"2025-02-12T16:24:17.252844Z","id":"3d19ea3d-4d7f-4800-8a16-76324b03ba16","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:24:17.252844Z","id":"dbff681f-9b1f-49aa-a9eb-0e714f9d8792","product_resource_id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:24:17.252844Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "143"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:40 GMT
+                - Wed, 12 Feb 2025 16:25:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3469,10 +3463,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 98372324-f4f9-4305-95dd-598e0b1bfd66
-        status: 404 Not Found
-        code: 404
-        duration: 68.79275ms
+                - 3bd8d4dd-5778-4838-9eac-d05828a342c7
+        status: 200 OK
+        code: 200
+        duration: 108.072792ms
     - id: 70
       request:
         proto: HTTP/1.1
@@ -3489,7 +3483,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/a5c02cb7-8020-4442-8634-e5ee2eff2c2c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -3497,20 +3491,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 701
+        content_length: 17
         uncompressed: false
-        body: '{"created_at":"2025-02-12T16:14:57.589514Z","id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:14:57.589514Z","id":"158fda61-e559-4737-996d-b3b846db132e","product_resource_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:14:57.589514Z","zone":"fr-par-1"}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "701"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:40 GMT
+                - Wed, 12 Feb 2025 16:25:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3518,10 +3512,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 42bc6e08-7f5e-4f88-b9cb-95729c6425da
+                - 699b6c94-c2b8-4b23-a0fe-d58787c5f6ba
         status: 200 OK
         code: 200
-        duration: 93.464792ms
+        duration: 114.140708ms
     - id: 71
       request:
         proto: HTTP/1.1
@@ -3538,7 +3532,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/user_data
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -3546,20 +3540,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 478
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:24:29.642246+00:00","id":"af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab","ipam_ip_ids":["3d868c45-94ac-419f-84f2-8d5bd75bc78d","399674a2-9f70-400b-a35b-dff5e1319b67"],"mac_address":"02:00:00:1c:eb:bc","modification_date":"2025-02-12T16:25:01.635033+00:00","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","server_id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "17"
+                - "478"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:40 GMT
+                - Wed, 12 Feb 2025 16:25:08 GMT
+            Link:
+                - </servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e/private_nics?page=1&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3567,10 +3563,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5a15f0b7-3dec-409b-b53f-f08a316de0e9
+                - b9a51258-d2d0-419a-aeb2-d5559b84e3ce
+            X-Total-Count:
+                - "1"
         status: 200 OK
         code: 200
-        duration: 101.676917ms
+        duration: 167.261667ms
     - id: 72
       request:
         proto: HTTP/1.1
@@ -3587,7 +3585,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=d283d880-a865-4b90-8403-ea6dfd3a239e&mac_address=02%3A00%3A00%3A1c%3Aeb%3Abc&order_by=created_at_asc&type=unknown
         method: GET
       response:
         proto: HTTP/2.0
@@ -3595,22 +3593,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 478
+        content_length: 369
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"dhcp_entries":[{"created_at":"2025-02-12T16:24:30.082956Z","gateway_network_id":"d283d880-a865-4b90-8403-ea6dfd3a239e","hostname":"tf-srv-sharp-bardeen","id":"3d868c45-94ac-419f-84f2-8d5bd75bc78d","ip_address":"192.168.1.2","mac_address":"02:00:00:1c:eb:bc","type":"reservation","updated_at":"2025-02-12T16:24:30.082956Z","zone":"fr-par-1"}],"total_count":1}'
         headers:
             Content-Length:
-                - "478"
+                - "369"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:41 GMT
-            Link:
-                - </servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics?page=1&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 16:25:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3618,12 +3614,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8ae042a8-81e5-4e3f-9a81-7a21b152bca5
-            X-Total-Count:
-                - "1"
+                - d3900481-3fe0-4251-ab25-3d19ca59c149
         status: 200 OK
         code: 200
-        duration: 99.224791ms
+        duration: 78.256959ms
     - id: 73
       request:
         proto: HTTP/1.1
@@ -3640,7 +3634,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=3bbc5634-ce11-4bce-adc4-39e0fac0db51&mac_address=02%3A00%3A00%3A1a%3Ab9%3A0f&order_by=created_at_asc&type=unknown
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/3d868c45-94ac-419f-84f2-8d5bd75bc78d
         method: GET
       response:
         proto: HTTP/2.0
@@ -3648,20 +3642,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 371
+        content_length: 333
         uncompressed: false
-        body: '{"dhcp_entries":[{"created_at":"2025-02-12T16:15:06.192027Z","gateway_network_id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","hostname":"tf-srv-vigilant-greider","id":"a0e6c4af-1b58-48dc-8357-7f7e2795ad61","ip_address":"172.16.8.2","mac_address":"02:00:00:1a:b9:0f","type":"reservation","updated_at":"2025-02-12T16:15:06.192027Z","zone":"fr-par-1"}],"total_count":1}'
+        body: '{"created_at":"2025-02-12T16:24:30.082956Z","gateway_network_id":"d283d880-a865-4b90-8403-ea6dfd3a239e","hostname":"tf-srv-sharp-bardeen","id":"3d868c45-94ac-419f-84f2-8d5bd75bc78d","ip_address":"192.168.1.2","mac_address":"02:00:00:1c:eb:bc","type":"reservation","updated_at":"2025-02-12T16:24:30.082956Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "371"
+                - "333"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:41 GMT
+                - Wed, 12 Feb 2025 16:25:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3669,10 +3663,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3e2d3e33-1dc8-4b5b-b837-b0293486a826
+                - 2efd4e58-c555-4a96-929d-126c62a5e122
         status: 200 OK
         code: 200
-        duration: 87.979958ms
+        duration: 93.700875ms
     - id: 74
       request:
         proto: HTTP/1.1
@@ -3689,7 +3683,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/a0e6c4af-1b58-48dc-8357-7f7e2795ad61
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=d283d880-a865-4b90-8403-ea6dfd3a239e&mac_address=02%3A00%3A00%3A1c%3Aeb%3Abc&order_by=created_at_asc&type=unknown
         method: GET
       response:
         proto: HTTP/2.0
@@ -3697,20 +3691,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 335
+        content_length: 369
         uncompressed: false
-        body: '{"created_at":"2025-02-12T16:15:06.192027Z","gateway_network_id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","hostname":"tf-srv-vigilant-greider","id":"a0e6c4af-1b58-48dc-8357-7f7e2795ad61","ip_address":"172.16.8.2","mac_address":"02:00:00:1a:b9:0f","type":"reservation","updated_at":"2025-02-12T16:15:06.192027Z","zone":"fr-par-1"}'
+        body: '{"dhcp_entries":[{"created_at":"2025-02-12T16:24:30.082956Z","gateway_network_id":"d283d880-a865-4b90-8403-ea6dfd3a239e","hostname":"tf-srv-sharp-bardeen","id":"3d868c45-94ac-419f-84f2-8d5bd75bc78d","ip_address":"192.168.1.2","mac_address":"02:00:00:1c:eb:bc","type":"reservation","updated_at":"2025-02-12T16:24:30.082956Z","zone":"fr-par-1"}],"total_count":1}'
         headers:
             Content-Length:
-                - "335"
+                - "369"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:41 GMT
+                - Wed, 12 Feb 2025 16:25:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3718,10 +3712,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e1c22caf-ff51-41d2-bc82-4e2620990a59
+                - 6badd3df-ae3a-4509-9431-b29c3ece17ef
         status: 200 OK
         code: 200
-        duration: 112.733209ms
+        duration: 92.13175ms
     - id: 75
       request:
         proto: HTTP/1.1
@@ -3738,7 +3732,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=3bbc5634-ce11-4bce-adc4-39e0fac0db51&mac_address=02%3A00%3A00%3A1a%3Ab9%3A0f&order_by=created_at_asc&type=unknown
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/3d868c45-94ac-419f-84f2-8d5bd75bc78d
         method: GET
       response:
         proto: HTTP/2.0
@@ -3746,20 +3740,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 371
+        content_length: 333
         uncompressed: false
-        body: '{"dhcp_entries":[{"created_at":"2025-02-12T16:15:06.192027Z","gateway_network_id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","hostname":"tf-srv-vigilant-greider","id":"a0e6c4af-1b58-48dc-8357-7f7e2795ad61","ip_address":"172.16.8.2","mac_address":"02:00:00:1a:b9:0f","type":"reservation","updated_at":"2025-02-12T16:15:06.192027Z","zone":"fr-par-1"}],"total_count":1}'
+        body: '{"created_at":"2025-02-12T16:24:30.082956Z","gateway_network_id":"d283d880-a865-4b90-8403-ea6dfd3a239e","hostname":"tf-srv-sharp-bardeen","id":"3d868c45-94ac-419f-84f2-8d5bd75bc78d","ip_address":"192.168.1.2","mac_address":"02:00:00:1c:eb:bc","type":"reservation","updated_at":"2025-02-12T16:24:30.082956Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "371"
+                - "333"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:41 GMT
+                - Wed, 12 Feb 2025 16:25:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3767,10 +3761,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 54cb9a04-7577-4b15-9fd3-0b4c3ffa3da4
+                - 52d31da2-1182-4574-914c-a78ac024c221
         status: 200 OK
         code: 200
-        duration: 96.77925ms
+        duration: 96.65875ms
     - id: 76
       request:
         proto: HTTP/1.1
@@ -3787,7 +3781,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/a0e6c4af-1b58-48dc-8357-7f7e2795ad61
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=d283d880-a865-4b90-8403-ea6dfd3a239e&mac_address=02%3A00%3A00%3A1c%3Aeb%3Abc&order_by=created_at_asc&type=unknown
         method: GET
       response:
         proto: HTTP/2.0
@@ -3795,20 +3789,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 335
+        content_length: 369
         uncompressed: false
-        body: '{"created_at":"2025-02-12T16:15:06.192027Z","gateway_network_id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","hostname":"tf-srv-vigilant-greider","id":"a0e6c4af-1b58-48dc-8357-7f7e2795ad61","ip_address":"172.16.8.2","mac_address":"02:00:00:1a:b9:0f","type":"reservation","updated_at":"2025-02-12T16:15:06.192027Z","zone":"fr-par-1"}'
+        body: '{"dhcp_entries":[{"created_at":"2025-02-12T16:24:30.082956Z","gateway_network_id":"d283d880-a865-4b90-8403-ea6dfd3a239e","hostname":"tf-srv-sharp-bardeen","id":"3d868c45-94ac-419f-84f2-8d5bd75bc78d","ip_address":"192.168.1.2","mac_address":"02:00:00:1c:eb:bc","type":"reservation","updated_at":"2025-02-12T16:24:30.082956Z","zone":"fr-par-1"}],"total_count":1}'
         headers:
             Content-Length:
-                - "335"
+                - "369"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:41 GMT
+                - Wed, 12 Feb 2025 16:25:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3816,10 +3810,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9b17a850-fde7-4161-927c-f53559c2781f
+                - ae365f94-19f2-4cb7-a216-73796a48e2c7
         status: 200 OK
         code: 200
-        duration: 112.009375ms
+        duration: 80.283833ms
     - id: 77
       request:
         proto: HTTP/1.1
@@ -3836,7 +3830,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=3bbc5634-ce11-4bce-adc4-39e0fac0db51&mac_address=02%3A00%3A00%3A1a%3Ab9%3A0f&order_by=created_at_asc&type=unknown
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/3d868c45-94ac-419f-84f2-8d5bd75bc78d
         method: GET
       response:
         proto: HTTP/2.0
@@ -3844,20 +3838,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 371
+        content_length: 333
         uncompressed: false
-        body: '{"dhcp_entries":[{"created_at":"2025-02-12T16:15:06.192027Z","gateway_network_id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","hostname":"tf-srv-vigilant-greider","id":"a0e6c4af-1b58-48dc-8357-7f7e2795ad61","ip_address":"172.16.8.2","mac_address":"02:00:00:1a:b9:0f","type":"reservation","updated_at":"2025-02-12T16:15:06.192027Z","zone":"fr-par-1"}],"total_count":1}'
+        body: '{"created_at":"2025-02-12T16:24:30.082956Z","gateway_network_id":"d283d880-a865-4b90-8403-ea6dfd3a239e","hostname":"tf-srv-sharp-bardeen","id":"3d868c45-94ac-419f-84f2-8d5bd75bc78d","ip_address":"192.168.1.2","mac_address":"02:00:00:1c:eb:bc","type":"reservation","updated_at":"2025-02-12T16:24:30.082956Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "371"
+                - "333"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:42 GMT
+                - Wed, 12 Feb 2025 16:25:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3865,10 +3859,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c9f165a7-816e-4d8b-b4ad-f22661a0da74
+                - 2a456f34-c8ed-4c84-a1e5-931d900727a8
         status: 200 OK
         code: 200
-        duration: 95.373875ms
+        duration: 84.183917ms
     - id: 78
       request:
         proto: HTTP/1.1
@@ -3885,7 +3879,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/a0e6c4af-1b58-48dc-8357-7f7e2795ad61
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/7ece1fd0-856b-4d14-81d8-d604bbe0be27
         method: GET
       response:
         proto: HTTP/2.0
@@ -3893,20 +3887,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 335
+        content_length: 586
         uncompressed: false
-        body: '{"created_at":"2025-02-12T16:15:06.192027Z","gateway_network_id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","hostname":"tf-srv-vigilant-greider","id":"a0e6c4af-1b58-48dc-8357-7f7e2795ad61","ip_address":"172.16.8.2","mac_address":"02:00:00:1a:b9:0f","type":"reservation","updated_at":"2025-02-12T16:15:06.192027Z","zone":"fr-par-1"}'
+        body: '{"address":"192.168.1.1","created_at":"2025-02-12T16:24:15.720530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"7ece1fd0-856b-4d14-81d8-d604bbe0be27","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:24:15.720530Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "335"
+                - "586"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:42 GMT
+                - Wed, 12 Feb 2025 16:25:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3914,10 +3908,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b6bdd128-46e5-4928-968b-e4d0a89b35f0
+                - d4a5b0fe-45df-4617-a60f-8668e835d20a
         status: 200 OK
         code: 200
-        duration: 99.869792ms
+        duration: 43.208959ms
     - id: 79
       request:
         proto: HTTP/1.1
@@ -3934,7 +3928,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/da389c61-9c8f-475e-b2c5-b60333283fa5
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/0650ad59-a7c2-4c38-b4c2-eff6527ca016
         method: GET
       response:
         proto: HTTP/2.0
@@ -3944,7 +3938,7 @@ interactions:
         trailer: {}
         content_length: 405
         uncompressed: false
-        body: '{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"}'
+        body: '{"address":"163.172.159.229","created_at":"2025-02-12T16:24:16.448125Z","gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"0650ad59-a7c2-4c38-b4c2-eff6527ca016","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.448125Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "405"
@@ -3953,9 +3947,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:42 GMT
+                - Wed, 12 Feb 2025 16:25:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3963,10 +3957,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 88ffec3b-7cbc-4915-ba11-a72d6867837f
+                - c777da89-1a79-4b94-abec-eafa35c17c39
         status: 200 OK
         code: 200
-        duration: 41.328542ms
+        duration: 43.632917ms
     - id: 80
       request:
         proto: HTTP/1.1
@@ -3983,7 +3977,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/2572e954-7dde-486b-821f-38300c6d0173
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7b3fa7ac-78de-4097-b7b8-a141ed2c0b82
         method: GET
       response:
         proto: HTTP/2.0
@@ -3991,20 +3985,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 586
+        content_length: 1089
         uncompressed: false
-        body: '{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:24:15.823279Z","dhcp_enabled":true,"id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:24:15.823279Z","id":"00415797-fa4c-46d3-ad73-f49acbd8298d","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:24:22.247568Z","vpc_id":"64dfae5d-85fa-4558-9c3e-18fe130ee80d"},{"created_at":"2025-02-12T16:24:15.823279Z","id":"d6e4aef9-10a5-465b-9429-8e4662375a71","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:53ae::/64","updated_at":"2025-02-12T16:24:22.251290Z","vpc_id":"64dfae5d-85fa-4558-9c3e-18fe130ee80d"}],"tags":[],"updated_at":"2025-02-12T16:24:31.909715Z","vpc_id":"64dfae5d-85fa-4558-9c3e-18fe130ee80d"}'
         headers:
             Content-Length:
-                - "586"
+                - "1089"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:42 GMT
+                - Wed, 12 Feb 2025 16:25:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4012,10 +4006,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5065c594-6090-4a2b-a841-c1fbbb5ff116
+                - ff915b43-e673-4d9b-a720-d9e4524741a8
         status: 200 OK
         code: 200
-        duration: 45.846167ms
+        duration: 48.455083ms
     - id: 81
       request:
         proto: HTTP/1.1
@@ -4032,7 +4026,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b3a3ea6c-4758-41c7-b9ad-22f9a410c192
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/278eadb1-7bcf-4f53-87f9-e9325a950998
         method: GET
       response:
         proto: HTTP/2.0
@@ -4040,20 +4034,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1089
+        content_length: 1996
         uncompressed: false
-        body: '{"created_at":"2025-02-12T16:14:56.161859Z","dhcp_enabled":true,"id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:14:56.161859Z","id":"1d110e71-77c2-4e0d-8b2a-44e5e61a0211","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:15:21.807710Z","vpc_id":"b388d228-a931-443f-87b2-379c9af5934b"},{"created_at":"2025-02-12T16:14:56.161859Z","id":"ad46a815-2df6-4e07-ad92-d99d79d18c7d","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:b62b::/64","updated_at":"2025-02-12T16:15:21.811374Z","vpc_id":"b388d228-a931-443f-87b2-379c9af5934b"}],"tags":[],"updated_at":"2025-02-12T16:15:30.215218Z","vpc_id":"b388d228-a931-443f-87b2-379c9af5934b"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:24:16.595820Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:24:25.196682Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:24:15.720530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"7ece1fd0-856b-4d14-81d8-d604bbe0be27","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:24:15.720530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"d283d880-a865-4b90-8403-ea6dfd3a239e","ipam_config":null,"mac_address":"02:00:00:12:45:AE","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","status":"ready","updated_at":"2025-02-12T16:24:35.671554Z","zone":"fr-par-1"}],"id":"278eadb1-7bcf-4f53-87f9-e9325a950998","ip":{"address":"163.172.159.229","created_at":"2025-02-12T16:24:16.448125Z","gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"0650ad59-a7c2-4c38-b4c2-eff6527ca016","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.448125Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:24:35.855992Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1089"
+                - "1996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:42 GMT
+                - Wed, 12 Feb 2025 16:25:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4061,10 +4055,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 59e7236e-bae6-4a23-b225-1c2f3f0319be
+                - 0486f2ac-dafb-4381-8be6-642423f339f3
         status: 200 OK
         code: 200
-        duration: 50.109625ms
+        duration: 42.873083ms
     - id: 82
       request:
         proto: HTTP/1.1
@@ -4081,7 +4075,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/d283d880-a865-4b90-8403-ea6dfd3a239e
         method: GET
       response:
         proto: HTTP/2.0
@@ -4089,20 +4083,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1996
+        content_length: 996
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:57.205022Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"ready","updated_at":"2025-02-12T16:15:34.005146Z","zone":"fr-par-1"}],"id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","ip":{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:34.260759Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:24:25.196682Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:24:15.720530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"7ece1fd0-856b-4d14-81d8-d604bbe0be27","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:24:15.720530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"d283d880-a865-4b90-8403-ea6dfd3a239e","ipam_config":null,"mac_address":"02:00:00:12:45:AE","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","status":"ready","updated_at":"2025-02-12T16:24:35.671554Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1996"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:42 GMT
+                - Wed, 12 Feb 2025 16:25:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4110,10 +4104,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b90fc793-3427-405d-9412-69cc3cc63d6c
+                - 96ce0d14-c06d-4367-8029-1ed91e2b60f7
         status: 200 OK
         code: 200
-        duration: 43.784958ms
+        duration: 63.858041ms
     - id: 83
       request:
         proto: HTTP/1.1
@@ -4130,7 +4124,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/278eadb1-7bcf-4f53-87f9-e9325a950998
         method: GET
       response:
         proto: HTTP/2.0
@@ -4138,20 +4132,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2289
+        content_length: 1996
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.380750+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-greider","id":"ee6b8302-d285-4412-9af2-b94bfecca21c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"304","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d5","maintenances":[],"modification_date":"2025-02-12T16:15:03.386466+00:00","name":"tf-srv-vigilant-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:24:16.595820Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:24:25.196682Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:24:15.720530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"7ece1fd0-856b-4d14-81d8-d604bbe0be27","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:24:15.720530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"d283d880-a865-4b90-8403-ea6dfd3a239e","ipam_config":null,"mac_address":"02:00:00:12:45:AE","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","status":"ready","updated_at":"2025-02-12T16:24:35.671554Z","zone":"fr-par-1"}],"id":"278eadb1-7bcf-4f53-87f9-e9325a950998","ip":{"address":"163.172.159.229","created_at":"2025-02-12T16:24:16.448125Z","gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"0650ad59-a7c2-4c38-b4c2-eff6527ca016","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.448125Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:24:35.855992Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2289"
+                - "1996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:42 GMT
+                - Wed, 12 Feb 2025 16:25:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4159,10 +4153,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1b2b8133-0498-4ffd-bf2b-35ffaaea9514
+                - 2b11d204-1f27-4686-b45e-32e87be548ba
         status: 200 OK
         code: 200
-        duration: 188.847416ms
+        duration: 45.296542ms
     - id: 84
       request:
         proto: HTTP/1.1
@@ -4179,7 +4173,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3bbc5634-ce11-4bce-adc4-39e0fac0db51
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/d283d880-a865-4b90-8403-ea6dfd3a239e
         method: GET
       response:
         proto: HTTP/2.0
@@ -4189,7 +4183,7 @@ interactions:
         trailer: {}
         content_length: 996
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"ready","updated_at":"2025-02-12T16:15:34.005146Z","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:24:25.196682Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:24:15.720530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"7ece1fd0-856b-4d14-81d8-d604bbe0be27","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:24:15.720530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"d283d880-a865-4b90-8403-ea6dfd3a239e","ipam_config":null,"mac_address":"02:00:00:12:45:AE","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","status":"ready","updated_at":"2025-02-12T16:24:35.671554Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "996"
@@ -4198,9 +4192,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:42 GMT
+                - Wed, 12 Feb 2025 16:25:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4208,10 +4202,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ffb0f88d-4a14-496f-bd3a-2d9998c71d42
+                - dfc4f4d8-14f9-418b-af0c-3cb3a5d990ee
         status: 200 OK
         code: 200
-        duration: 170.514292ms
+        duration: 83.233583ms
     - id: 85
       request:
         proto: HTTP/1.1
@@ -4228,7 +4222,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/a5c02cb7-8020-4442-8634-e5ee2eff2c2c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e
         method: GET
       response:
         proto: HTTP/2.0
@@ -4236,20 +4230,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 143
+        content_length: 2284
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","type":"not_found"}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:24:17.041400+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sharp-bardeen","id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"2002","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c8:6b","maintenances":[],"modification_date":"2025-02-12T16:24:24.867408+00:00","name":"tf-srv-sharp-bardeen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:24:29.642246+00:00","id":"af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab","ipam_ip_ids":["3d868c45-94ac-419f-84f2-8d5bd75bc78d","399674a2-9f70-400b-a35b-dff5e1319b67"],"mac_address":"02:00:00:1c:eb:bc","modification_date":"2025-02-12T16:25:01.635033+00:00","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","server_id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"3d19ea3d-4d7f-4800-8a16-76324b03ba16","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "143"
+                - "2284"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:42 GMT
+                - Wed, 12 Feb 2025 16:25:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4257,10 +4251,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1862c8c5-aa94-4c93-a30c-70566159c0cf
-        status: 404 Not Found
-        code: 404
-        duration: 49.610084ms
+                - ca949222-4f25-4dbb-97cc-a8411698ce9b
+        status: 200 OK
+        code: 200
+        duration: 278.342083ms
     - id: 86
       request:
         proto: HTTP/1.1
@@ -4277,7 +4271,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/3d19ea3d-4d7f-4800-8a16-76324b03ba16
         method: GET
       response:
         proto: HTTP/2.0
@@ -4285,20 +4279,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1996
+        content_length: 143
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:57.205022Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"ready","updated_at":"2025-02-12T16:15:34.005146Z","zone":"fr-par-1"}],"id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","ip":{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:34.260759Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"3d19ea3d-4d7f-4800-8a16-76324b03ba16","type":"not_found"}'
         headers:
             Content-Length:
-                - "1996"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:42 GMT
+                - Wed, 12 Feb 2025 16:25:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4306,10 +4300,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1b40b8c3-228f-47ae-b969-e70294ae1b1b
-        status: 200 OK
-        code: 200
-        duration: 47.496167ms
+                - 3c7ad28e-e4d3-4257-a1eb-7227f0af17a0
+        status: 404 Not Found
+        code: 404
+        duration: 56.111708ms
     - id: 87
       request:
         proto: HTTP/1.1
@@ -4326,7 +4320,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3bbc5634-ce11-4bce-adc4-39e0fac0db51
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/3d19ea3d-4d7f-4800-8a16-76324b03ba16
         method: GET
       response:
         proto: HTTP/2.0
@@ -4334,20 +4328,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 996
+        content_length: 701
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"ready","updated_at":"2025-02-12T16:15:34.005146Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:24:17.252844Z","id":"3d19ea3d-4d7f-4800-8a16-76324b03ba16","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:24:17.252844Z","id":"dbff681f-9b1f-49aa-a9eb-0e714f9d8792","product_resource_id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:24:17.252844Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "996"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:42 GMT
+                - Wed, 12 Feb 2025 16:25:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4355,10 +4349,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c4ea8443-bbb6-4654-b919-9db5a5c7d926
+                - 92169f7b-868c-4ab1-873c-6cb8d9842af1
         status: 200 OK
         code: 200
-        duration: 62.907667ms
+        duration: 85.15525ms
     - id: 88
       request:
         proto: HTTP/1.1
@@ -4375,56 +4369,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/a5c02cb7-8020-4442-8634-e5ee2eff2c2c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 701
-        uncompressed: false
-        body: '{"created_at":"2025-02-12T16:14:57.589514Z","id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:14:57.589514Z","id":"158fda61-e559-4737-996d-b3b846db132e","product_resource_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:14:57.589514Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "701"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 16:15:42 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - f05eb6b5-507a-47a0-8f93-8d7345f7f895
-        status: 200 OK
-        code: 200
-        duration: 94.791125ms
-    - id: 89
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/user_data
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -4443,9 +4388,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:43 GMT
+                - Wed, 12 Feb 2025 16:25:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4453,10 +4398,63 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8c382f2c-587b-4956-a9b6-4b2e2e84c24b
+                - d4d6b3b0-b535-4649-a0ab-9927f8d10af7
         status: 200 OK
         code: 200
-        duration: 584.985333ms
+        duration: 123.606458ms
+    - id: 89
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 478
+        uncompressed: false
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:24:29.642246+00:00","id":"af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab","ipam_ip_ids":["3d868c45-94ac-419f-84f2-8d5bd75bc78d","399674a2-9f70-400b-a35b-dff5e1319b67"],"mac_address":"02:00:00:1c:eb:bc","modification_date":"2025-02-12T16:25:01.635033+00:00","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","server_id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        headers:
+            Content-Length:
+                - "478"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:25:10 GMT
+            Link:
+                - </servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e/private_nics?page=1&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f983b7fa-2ca8-449a-9b63-7c8edc87beaf
+            X-Total-Count:
+                - "1"
+        status: 200 OK
+        code: 200
+        duration: 113.758583ms
     - id: 90
       request:
         proto: HTTP/1.1
@@ -4473,7 +4471,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=d283d880-a865-4b90-8403-ea6dfd3a239e&mac_address=02%3A00%3A00%3A1c%3Aeb%3Abc&order_by=created_at_asc&type=unknown
         method: GET
       response:
         proto: HTTP/2.0
@@ -4481,22 +4479,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 478
+        content_length: 369
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"dhcp_entries":[{"created_at":"2025-02-12T16:24:30.082956Z","gateway_network_id":"d283d880-a865-4b90-8403-ea6dfd3a239e","hostname":"tf-srv-sharp-bardeen","id":"3d868c45-94ac-419f-84f2-8d5bd75bc78d","ip_address":"192.168.1.2","mac_address":"02:00:00:1c:eb:bc","type":"reservation","updated_at":"2025-02-12T16:24:30.082956Z","zone":"fr-par-1"}],"total_count":1}'
         headers:
             Content-Length:
-                - "478"
+                - "369"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:43 GMT
-            Link:
-                - </servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics?page=1&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 16:25:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4504,12 +4500,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1988d89a-d1f4-4e28-a20c-74d60fc4614a
-            X-Total-Count:
-                - "1"
+                - d250c404-f428-4173-8a42-49798113ce44
         status: 200 OK
         code: 200
-        duration: 101.66675ms
+        duration: 82.611833ms
     - id: 91
       request:
         proto: HTTP/1.1
@@ -4526,7 +4520,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=3bbc5634-ce11-4bce-adc4-39e0fac0db51&mac_address=02%3A00%3A00%3A1a%3Ab9%3A0f&order_by=created_at_asc&type=unknown
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/3d868c45-94ac-419f-84f2-8d5bd75bc78d
         method: GET
       response:
         proto: HTTP/2.0
@@ -4534,20 +4528,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 371
+        content_length: 333
         uncompressed: false
-        body: '{"dhcp_entries":[{"created_at":"2025-02-12T16:15:06.192027Z","gateway_network_id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","hostname":"tf-srv-vigilant-greider","id":"a0e6c4af-1b58-48dc-8357-7f7e2795ad61","ip_address":"172.16.8.2","mac_address":"02:00:00:1a:b9:0f","type":"reservation","updated_at":"2025-02-12T16:15:06.192027Z","zone":"fr-par-1"}],"total_count":1}'
+        body: '{"created_at":"2025-02-12T16:24:30.082956Z","gateway_network_id":"d283d880-a865-4b90-8403-ea6dfd3a239e","hostname":"tf-srv-sharp-bardeen","id":"3d868c45-94ac-419f-84f2-8d5bd75bc78d","ip_address":"192.168.1.2","mac_address":"02:00:00:1c:eb:bc","type":"reservation","updated_at":"2025-02-12T16:24:30.082956Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "371"
+                - "333"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:43 GMT
+                - Wed, 12 Feb 2025 16:25:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4555,10 +4549,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 18f2aed8-1583-48d3-95da-aeb711c12dc4
+                - c752e8c5-1065-4228-86b0-ce32d47d3b80
         status: 200 OK
         code: 200
-        duration: 90.665541ms
+        duration: 82.433542ms
     - id: 92
       request:
         proto: HTTP/1.1
@@ -4575,7 +4569,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/a0e6c4af-1b58-48dc-8357-7f7e2795ad61
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=d283d880-a865-4b90-8403-ea6dfd3a239e&mac_address=02%3A00%3A00%3A1c%3Aeb%3Abc&order_by=created_at_asc&type=unknown
         method: GET
       response:
         proto: HTTP/2.0
@@ -4583,20 +4577,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 335
+        content_length: 369
         uncompressed: false
-        body: '{"created_at":"2025-02-12T16:15:06.192027Z","gateway_network_id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","hostname":"tf-srv-vigilant-greider","id":"a0e6c4af-1b58-48dc-8357-7f7e2795ad61","ip_address":"172.16.8.2","mac_address":"02:00:00:1a:b9:0f","type":"reservation","updated_at":"2025-02-12T16:15:06.192027Z","zone":"fr-par-1"}'
+        body: '{"dhcp_entries":[{"created_at":"2025-02-12T16:24:30.082956Z","gateway_network_id":"d283d880-a865-4b90-8403-ea6dfd3a239e","hostname":"tf-srv-sharp-bardeen","id":"3d868c45-94ac-419f-84f2-8d5bd75bc78d","ip_address":"192.168.1.2","mac_address":"02:00:00:1c:eb:bc","type":"reservation","updated_at":"2025-02-12T16:24:30.082956Z","zone":"fr-par-1"}],"total_count":1}'
         headers:
             Content-Length:
-                - "335"
+                - "369"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:43 GMT
+                - Wed, 12 Feb 2025 16:25:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4604,10 +4598,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 893b2b9c-7c61-4b36-a94e-2e5fb8367e27
+                - 159edda6-66f7-43d2-8462-0469de3a45eb
         status: 200 OK
         code: 200
-        duration: 99.729834ms
+        duration: 92.053875ms
     - id: 93
       request:
         proto: HTTP/1.1
@@ -4624,7 +4618,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=3bbc5634-ce11-4bce-adc4-39e0fac0db51&mac_address=02%3A00%3A00%3A1a%3Ab9%3A0f&order_by=created_at_asc&type=unknown
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/3d868c45-94ac-419f-84f2-8d5bd75bc78d
         method: GET
       response:
         proto: HTTP/2.0
@@ -4632,20 +4626,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 371
+        content_length: 333
         uncompressed: false
-        body: '{"dhcp_entries":[{"created_at":"2025-02-12T16:15:06.192027Z","gateway_network_id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","hostname":"tf-srv-vigilant-greider","id":"a0e6c4af-1b58-48dc-8357-7f7e2795ad61","ip_address":"172.16.8.2","mac_address":"02:00:00:1a:b9:0f","type":"reservation","updated_at":"2025-02-12T16:15:06.192027Z","zone":"fr-par-1"}],"total_count":1}'
+        body: '{"created_at":"2025-02-12T16:24:30.082956Z","gateway_network_id":"d283d880-a865-4b90-8403-ea6dfd3a239e","hostname":"tf-srv-sharp-bardeen","id":"3d868c45-94ac-419f-84f2-8d5bd75bc78d","ip_address":"192.168.1.2","mac_address":"02:00:00:1c:eb:bc","type":"reservation","updated_at":"2025-02-12T16:24:30.082956Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "371"
+                - "333"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:43 GMT
+                - Wed, 12 Feb 2025 16:25:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4653,10 +4647,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 694f1461-c13f-4548-aa10-c2fc1ee18ce2
+                - 5da4527f-8a4f-4007-8317-9c47d4ba17ad
         status: 200 OK
         code: 200
-        duration: 91.645166ms
+        duration: 82.149708ms
     - id: 94
       request:
         proto: HTTP/1.1
@@ -4673,7 +4667,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/a0e6c4af-1b58-48dc-8357-7f7e2795ad61
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/d283d880-a865-4b90-8403-ea6dfd3a239e
         method: GET
       response:
         proto: HTTP/2.0
@@ -4681,20 +4675,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 335
+        content_length: 996
         uncompressed: false
-        body: '{"created_at":"2025-02-12T16:15:06.192027Z","gateway_network_id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","hostname":"tf-srv-vigilant-greider","id":"a0e6c4af-1b58-48dc-8357-7f7e2795ad61","ip_address":"172.16.8.2","mac_address":"02:00:00:1a:b9:0f","type":"reservation","updated_at":"2025-02-12T16:15:06.192027Z","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:24:25.196682Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:24:15.720530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"7ece1fd0-856b-4d14-81d8-d604bbe0be27","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:24:15.720530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"d283d880-a865-4b90-8403-ea6dfd3a239e","ipam_config":null,"mac_address":"02:00:00:12:45:AE","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","status":"ready","updated_at":"2025-02-12T16:24:35.671554Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "335"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:43 GMT
+                - Wed, 12 Feb 2025 16:25:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4702,10 +4696,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3c4f818f-36ee-4bc1-beb4-11a4121b6a7a
+                - 35ddb1d9-6239-47da-9bce-d97cfb6c08f8
         status: 200 OK
         code: 200
-        duration: 115.099917ms
+        duration: 62.35975ms
     - id: 95
       request:
         proto: HTTP/1.1
@@ -4722,105 +4716,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3bbc5634-ce11-4bce-adc4-39e0fac0db51
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 996
-        uncompressed: false
-        body: '{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"ready","updated_at":"2025-02-12T16:15:34.005146Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "996"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 16:15:44 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - dbb0f289-32df-403d-9ed3-7739e02de958
-        status: 200 OK
-        code: 200
-        duration: 62.570625ms
-    - id: 96
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2289
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.380750+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-greider","id":"ee6b8302-d285-4412-9af2-b94bfecca21c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"304","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d5","maintenances":[],"modification_date":"2025-02-12T16:15:03.386466+00:00","name":"tf-srv-vigilant-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2289"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 16:15:43 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 4713061b-840e-410f-9b99-7af885d54076
-        status: 200 OK
-        code: 200
-        duration: 182.159041ms
-    - id: 97
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3bbc5634-ce11-4bce-adc4-39e0fac0db51?cleanup_dhcp=true
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/d283d880-a865-4b90-8403-ea6dfd3a239e?cleanup_dhcp=true
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -4837,9 +4733,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:44 GMT
+                - Wed, 12 Feb 2025 16:25:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4847,10 +4743,108 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 41ec04dd-ac03-4abf-bdea-255db272812b
+                - 70ca8933-855c-4dcc-8f81-f1e84bd0aac5
         status: 204 No Content
         code: 204
-        duration: 140.814125ms
+        duration: 90.082792ms
+    - id: 96
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2284
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:24:17.041400+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sharp-bardeen","id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"2002","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c8:6b","maintenances":[],"modification_date":"2025-02-12T16:24:24.867408+00:00","name":"tf-srv-sharp-bardeen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:24:29.642246+00:00","id":"af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab","ipam_ip_ids":["3d868c45-94ac-419f-84f2-8d5bd75bc78d","399674a2-9f70-400b-a35b-dff5e1319b67"],"mac_address":"02:00:00:1c:eb:bc","modification_date":"2025-02-12T16:25:01.635033+00:00","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","server_id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"3d19ea3d-4d7f-4800-8a16-76324b03ba16","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2284"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:25:11 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e0727ece-1f88-46aa-bf97-2c26ce729b72
+        status: 200 OK
+        code: 200
+        duration: 198.646125ms
+    - id: 97
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/d283d880-a865-4b90-8403-ea6dfd3a239e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1000
+        uncompressed: false
+        body: '{"address":null,"created_at":"2025-02-12T16:24:25.196682Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:24:15.720530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"7ece1fd0-856b-4d14-81d8-d604bbe0be27","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:24:15.720530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"d283d880-a865-4b90-8403-ea6dfd3a239e","ipam_config":null,"mac_address":"02:00:00:12:45:AE","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","status":"detaching","updated_at":"2025-02-12T16:25:11.621119Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "1000"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:25:11 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 496c3c93-bd1d-4e9c-8f11-27c3428c826b
+        status: 200 OK
+        code: 200
+        duration: 81.514917ms
     - id: 98
       request:
         proto: HTTP/1.1
@@ -4867,56 +4861,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3bbc5634-ce11-4bce-adc4-39e0fac0db51
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1000
-        uncompressed: false
-        body: '{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"detaching","updated_at":"2025-02-12T16:15:44.238822Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "1000"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 16:15:44 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 648c374a-d344-494c-9ad8-8509e155c855
-        status: 200 OK
-        code: 200
-        duration: 62.99375ms
-    - id: 99
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/a5c02cb7-8020-4442-8634-e5ee2eff2c2c
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/3d19ea3d-4d7f-4800-8a16-76324b03ba16
         method: GET
       response:
         proto: HTTP/2.0
@@ -4926,7 +4871,7 @@ interactions:
         trailer: {}
         content_length: 701
         uncompressed: false
-        body: '{"created_at":"2025-02-12T16:14:57.589514Z","id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:14:57.589514Z","id":"158fda61-e559-4737-996d-b3b846db132e","product_resource_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:14:57.589514Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:24:17.252844Z","id":"3d19ea3d-4d7f-4800-8a16-76324b03ba16","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:24:17.252844Z","id":"dbff681f-9b1f-49aa-a9eb-0e714f9d8792","product_resource_id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:24:17.252844Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "701"
@@ -4935,9 +4880,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:44 GMT
+                - Wed, 12 Feb 2025 16:25:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4945,11 +4890,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2f75e9b1-8170-41d6-8672-32678e8aa069
+                - d011cb44-32c1-4871-910a-fe2d9402cc90
         status: 200 OK
         code: 200
-        duration: 83.949667ms
-    - id: 100
+        duration: 96.437958ms
+    - id: 99
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4967,7 +4912,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/action
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -4977,7 +4922,7 @@ interactions:
         trailer: {}
         content_length: 352
         uncompressed: false
-        body: '{"task":{"description":"server_poweroff","href_from":"/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/action","href_result":"/servers/ee6b8302-d285-4412-9af2-b94bfecca21c","id":"b13299ea-80e2-4667-b30a-f914265802d5","progress":0,"started_at":"2025-02-12T16:15:44.560394+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_poweroff","href_from":"/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e/action","href_result":"/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e","id":"997e4a57-7b1c-4390-aa72-b1c360aab6ea","progress":0,"started_at":"2025-02-12T16:25:12.074935+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "352"
@@ -4986,11 +4931,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:44 GMT
+                - Wed, 12 Feb 2025 16:25:12 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/b13299ea-80e2-4667-b30a-f914265802d5
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/997e4a57-7b1c-4390-aa72-b1c360aab6ea
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4998,10 +4943,59 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cfc85fc7-cc17-4038-ac5c-fa11f66596fa
+                - cf356647-6024-4515-81fa-5b1e2b3d968d
         status: 202 Accepted
         code: 202
-        duration: 249.639833ms
+        duration: 326.354834ms
+    - id: 100
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2244
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:24:17.041400+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sharp-bardeen","id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"2002","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c8:6b","maintenances":[],"modification_date":"2025-02-12T16:25:11.840293+00:00","name":"tf-srv-sharp-bardeen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:24:29.642246+00:00","id":"af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab","ipam_ip_ids":["3d868c45-94ac-419f-84f2-8d5bd75bc78d","399674a2-9f70-400b-a35b-dff5e1319b67"],"mac_address":"02:00:00:1c:eb:bc","modification_date":"2025-02-12T16:25:01.635033+00:00","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","server_id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"3d19ea3d-4d7f-4800-8a16-76324b03ba16","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2244"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:25:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3f25641f-ad57-43de-9821-231897e4abb0
+        status: 200 OK
+        code: 200
+        duration: 232.16125ms
     - id: 101
       request:
         proto: HTTP/1.1
@@ -5018,7 +5012,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/d283d880-a865-4b90-8403-ea6dfd3a239e
         method: GET
       response:
         proto: HTTP/2.0
@@ -5026,20 +5020,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2249
+        content_length: 136
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.380750+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-greider","id":"ee6b8302-d285-4412-9af2-b94bfecca21c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"304","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d5","maintenances":[],"modification_date":"2025-02-12T16:15:44.380597+00:00","name":"tf-srv-vigilant-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"d283d880-a865-4b90-8403-ea6dfd3a239e","type":"not_found"}'
         headers:
             Content-Length:
-                - "2249"
+                - "136"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:44 GMT
+                - Wed, 12 Feb 2025 16:25:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5047,10 +5041,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 827690f3-40e7-4385-8eba-58affdfe75fa
-        status: 200 OK
-        code: 200
-        duration: 170.096417ms
+                - 815ed607-6b53-4757-9319-e558fa260075
+        status: 404 Not Found
+        code: 404
+        duration: 43.372708ms
     - id: 102
       request:
         proto: HTTP/1.1
@@ -5067,7 +5061,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3bbc5634-ce11-4bce-adc4-39e0fac0db51
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/278eadb1-7bcf-4f53-87f9-e9325a950998
         method: GET
       response:
         proto: HTTP/2.0
@@ -5075,20 +5069,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 136
+        content_length: 1000
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","type":"not_found"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:24:16.595820Z","gateway_networks":[],"id":"278eadb1-7bcf-4f53-87f9-e9325a950998","ip":{"address":"163.172.159.229","created_at":"2025-02-12T16:24:16.448125Z","gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"0650ad59-a7c2-4c38-b4c2-eff6527ca016","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.448125Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:24:35.855992Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "136"
+                - "1000"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:49 GMT
+                - Wed, 12 Feb 2025 16:25:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5096,10 +5090,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2c2091b2-2416-4c54-8d64-616664a54ba6
-        status: 404 Not Found
-        code: 404
-        duration: 44.889375ms
+                - e28a5c89-5b99-4e7c-88ed-2d0a21ab0fd8
+        status: 200 OK
+        code: 200
+        duration: 53.366917ms
     - id: 103
       request:
         proto: HTTP/1.1
@@ -5116,28 +5110,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7
-        method: GET
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/7ece1fd0-856b-4d14-81d8-d604bbe0be27
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1000
+        content_length: 125
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:57.205022Z","gateway_networks":[],"id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","ip":{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:34.260759Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"message":"resource is not found","resource":"dhcp","resource_id":"7ece1fd0-856b-4d14-81d8-d604bbe0be27","type":"not_found"}'
         headers:
             Content-Length:
-                - "1000"
+                - "125"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:49 GMT
+                - Wed, 12 Feb 2025 16:25:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5145,10 +5139,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dcbe3f70-d90e-4ed4-9a88-f65c1896e6f2
-        status: 200 OK
-        code: 200
-        duration: 50.099958ms
+                - af5d81ac-9622-47fe-add5-4540b5c1ccfc
+        status: 404 Not Found
+        code: 404
+        duration: 59.045666ms
     - id: 104
       request:
         proto: HTTP/1.1
@@ -5165,28 +5159,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/2572e954-7dde-486b-821f-38300c6d0173
-        method: DELETE
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/278eadb1-7bcf-4f53-87f9-e9325a950998
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 125
+        content_length: 1000
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"dhcp","resource_id":"2572e954-7dde-486b-821f-38300c6d0173","type":"not_found"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:24:16.595820Z","gateway_networks":[],"id":"278eadb1-7bcf-4f53-87f9-e9325a950998","ip":{"address":"163.172.159.229","created_at":"2025-02-12T16:24:16.448125Z","gateway_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","id":"0650ad59-a7c2-4c38-b4c2-eff6527ca016","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.448125Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:24:35.855992Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "125"
+                - "1000"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:49 GMT
+                - Wed, 12 Feb 2025 16:25:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5194,10 +5188,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a85b07b8-25e3-411a-af4e-c8a6f9fe84f9
-        status: 404 Not Found
-        code: 404
-        duration: 47.6635ms
+                - 7e4b477a-12a4-47b5-a92b-8e2e25866b9e
+        status: 200 OK
+        code: 200
+        duration: 74.107458ms
     - id: 105
       request:
         proto: HTTP/1.1
@@ -5214,28 +5208,26 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7
-        method: GET
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/278eadb1-7bcf-4f53-87f9-e9325a950998?cleanup_dhcp=false
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1000
+        content_length: 0
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:57.205022Z","gateway_networks":[],"id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","ip":{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:34.260759Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: ""
         headers:
-            Content-Length:
-                - "1000"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:49 GMT
+                - Wed, 12 Feb 2025 16:25:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5243,10 +5235,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - df4ab062-02de-4342-861b-e330d19ef7ae
-        status: 200 OK
-        code: 200
-        duration: 50.52725ms
+                - 86c82bf9-9681-4ca6-9bce-f8d2c649f2cb
+        status: 204 No Content
+        code: 204
+        duration: 93.066416ms
     - id: 106
       request:
         proto: HTTP/1.1
@@ -5263,26 +5255,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7?cleanup_dhcp=false
-        method: DELETE
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/278eadb1-7bcf-4f53-87f9-e9325a950998
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 128
         uncompressed: false
-        body: ""
+        body: '{"message":"resource is not found","resource":"gateway","resource_id":"278eadb1-7bcf-4f53-87f9-e9325a950998","type":"not_found"}'
         headers:
+            Content-Length:
+                - "128"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:49 GMT
+                - Wed, 12 Feb 2025 16:25:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5290,10 +5284,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 07d26cb7-6fbf-48ff-8959-8170f3f74597
-        status: 204 No Content
-        code: 204
-        duration: 56.604167ms
+                - 45ccd3b5-8994-4141-a9e7-f36e0d28a7a7
+        status: 404 Not Found
+        code: 404
+        duration: 44.444125ms
     - id: 107
       request:
         proto: HTTP/1.1
@@ -5310,7 +5304,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e
         method: GET
       response:
         proto: HTTP/2.0
@@ -5318,20 +5312,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 128
+        content_length: 2244
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"gateway","resource_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","type":"not_found"}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:24:17.041400+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sharp-bardeen","id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"2002","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c8:6b","maintenances":[],"modification_date":"2025-02-12T16:25:11.840293+00:00","name":"tf-srv-sharp-bardeen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:24:29.642246+00:00","id":"af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab","ipam_ip_ids":["3d868c45-94ac-419f-84f2-8d5bd75bc78d","399674a2-9f70-400b-a35b-dff5e1319b67"],"mac_address":"02:00:00:1c:eb:bc","modification_date":"2025-02-12T16:25:01.635033+00:00","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","server_id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"3d19ea3d-4d7f-4800-8a16-76324b03ba16","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "128"
+                - "2244"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:49 GMT
+                - Wed, 12 Feb 2025 16:25:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5339,10 +5333,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4051ce7a-6322-43fc-bede-5dee9227abd7
-        status: 404 Not Found
-        code: 404
-        duration: 40.91775ms
+                - d9861522-c54c-44d2-9ae7-dfc6ff8d9f50
+        status: 200 OK
+        code: 200
+        duration: 215.839209ms
     - id: 108
       request:
         proto: HTTP/1.1
@@ -5359,28 +5353,26 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
-        method: GET
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/0650ad59-a7c2-4c38-b4c2-eff6527ca016
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2249
+        content_length: 0
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.380750+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-greider","id":"ee6b8302-d285-4412-9af2-b94bfecca21c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"304","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d5","maintenances":[],"modification_date":"2025-02-12T16:15:44.380597+00:00","name":"tf-srv-vigilant-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: ""
         headers:
-            Content-Length:
-                - "2249"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:49 GMT
+                - Wed, 12 Feb 2025 16:25:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5388,10 +5380,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 94e3e8a5-bd21-482b-9738-7b7acb8dd5fc
-        status: 200 OK
-        code: 200
-        duration: 189.136042ms
+                - d0e8d969-860e-4848-baf2-3fb757d3ae69
+        status: 204 No Content
+        code: 204
+        duration: 873.277917ms
     - id: 109
       request:
         proto: HTTP/1.1
@@ -5408,26 +5400,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/da389c61-9c8f-475e-b2c5-b60333283fa5
-        method: DELETE
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 2244
         uncompressed: false
-        body: ""
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:24:17.041400+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sharp-bardeen","id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"2002","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c8:6b","maintenances":[],"modification_date":"2025-02-12T16:25:11.840293+00:00","name":"tf-srv-sharp-bardeen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:24:29.642246+00:00","id":"af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab","ipam_ip_ids":["3d868c45-94ac-419f-84f2-8d5bd75bc78d","399674a2-9f70-400b-a35b-dff5e1319b67"],"mac_address":"02:00:00:1c:eb:bc","modification_date":"2025-02-12T16:25:01.635033+00:00","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","server_id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"3d19ea3d-4d7f-4800-8a16-76324b03ba16","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
+            Content-Length:
+                - "2244"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:50 GMT
+                - Wed, 12 Feb 2025 16:25:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5435,10 +5429,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 13f74629-d2d7-4af9-b255-7a671374e88b
-        status: 204 No Content
-        code: 204
-        duration: 766.762625ms
+                - 35eb4100-4d60-4b9f-9368-ec4e024ac236
+        status: 200 OK
+        code: 200
+        duration: 272.659208ms
     - id: 110
       request:
         proto: HTTP/1.1
@@ -5455,7 +5449,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e
         method: GET
       response:
         proto: HTTP/2.0
@@ -5463,20 +5457,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2249
+        content_length: 2244
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.380750+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-greider","id":"ee6b8302-d285-4412-9af2-b94bfecca21c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"304","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d5","maintenances":[],"modification_date":"2025-02-12T16:15:44.380597+00:00","name":"tf-srv-vigilant-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:24:17.041400+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sharp-bardeen","id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"2002","node_id":"1","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c8:6b","maintenances":[],"modification_date":"2025-02-12T16:25:11.840293+00:00","name":"tf-srv-sharp-bardeen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:24:29.642246+00:00","id":"af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab","ipam_ip_ids":["3d868c45-94ac-419f-84f2-8d5bd75bc78d","399674a2-9f70-400b-a35b-dff5e1319b67"],"mac_address":"02:00:00:1c:eb:bc","modification_date":"2025-02-12T16:25:01.635033+00:00","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","server_id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"3d19ea3d-4d7f-4800-8a16-76324b03ba16","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2249"
+                - "2244"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:55 GMT
+                - Wed, 12 Feb 2025 16:25:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5484,10 +5478,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1e815ecd-17b2-4bf2-978d-e93788c48b17
+                - 09d1ef8b-51d9-4d80-9960-2619f63c514e
         status: 200 OK
         code: 200
-        duration: 185.562542ms
+        duration: 223.254166ms
     - id: 111
       request:
         proto: HTTP/1.1
@@ -5504,7 +5498,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e
         method: GET
       response:
         proto: HTTP/2.0
@@ -5512,20 +5506,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2249
+        content_length: 2128
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.380750+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-greider","id":"ee6b8302-d285-4412-9af2-b94bfecca21c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"304","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d5","maintenances":[],"modification_date":"2025-02-12T16:15:44.380597+00:00","name":"tf-srv-vigilant-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:24:17.041400+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sharp-bardeen","id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c8:6b","maintenances":[],"modification_date":"2025-02-12T16:25:30.819454+00:00","name":"tf-srv-sharp-bardeen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:24:29.642246+00:00","id":"af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab","ipam_ip_ids":["3d868c45-94ac-419f-84f2-8d5bd75bc78d","399674a2-9f70-400b-a35b-dff5e1319b67"],"mac_address":"02:00:00:1c:eb:bc","modification_date":"2025-02-12T16:25:01.635033+00:00","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","server_id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"3d19ea3d-4d7f-4800-8a16-76324b03ba16","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2249"
+                - "2128"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:16:00 GMT
+                - Wed, 12 Feb 2025 16:25:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5533,10 +5527,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a72eb2a6-1d95-4ee6-be22-d73935e41bff
+                - a659d6d9-a1a8-4940-9979-6a67541bc57b
         status: 200 OK
         code: 200
-        duration: 167.2015ms
+        duration: 221.585ms
     - id: 112
       request:
         proto: HTTP/1.1
@@ -5553,7 +5547,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -5561,20 +5555,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2249
+        content_length: 478
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.380750+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-greider","id":"ee6b8302-d285-4412-9af2-b94bfecca21c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"304","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d5","maintenances":[],"modification_date":"2025-02-12T16:15:44.380597+00:00","name":"tf-srv-vigilant-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:24:29.642246+00:00","id":"af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab","ipam_ip_ids":["3d868c45-94ac-419f-84f2-8d5bd75bc78d","399674a2-9f70-400b-a35b-dff5e1319b67"],"mac_address":"02:00:00:1c:eb:bc","modification_date":"2025-02-12T16:25:01.635033+00:00","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","server_id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "2249"
+                - "478"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:16:04 GMT
+                - Wed, 12 Feb 2025 16:25:33 GMT
+            Link:
+                - </servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e/private_nics?page=1&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5582,10 +5578,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0234392d-543f-4b07-8f52-a5957179bf4d
+                - a8f2bcef-1b2a-4ca0-aac4-fa80b6451ae7
+            X-Total-Count:
+                - "1"
         status: 200 OK
         code: 200
-        duration: 263.107084ms
+        duration: 108.888542ms
     - id: 113
       request:
         proto: HTTP/1.1
@@ -5602,7 +5600,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e/private_nics/af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab
         method: GET
       response:
         proto: HTTP/2.0
@@ -5610,20 +5608,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2134
+        content_length: 475
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.380750+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-greider","id":"ee6b8302-d285-4412-9af2-b94bfecca21c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:d5","maintenances":[],"modification_date":"2025-02-12T16:16:06.159287+00:00","name":"tf-srv-vigilant-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:24:29.642246+00:00","id":"af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab","ipam_ip_ids":["3d868c45-94ac-419f-84f2-8d5bd75bc78d","399674a2-9f70-400b-a35b-dff5e1319b67"],"mac_address":"02:00:00:1c:eb:bc","modification_date":"2025-02-12T16:25:01.635033+00:00","private_network_id":"7b3fa7ac-78de-4097-b7b8-a141ed2c0b82","server_id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2134"
+                - "475"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:16:10 GMT
+                - Wed, 12 Feb 2025 16:25:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5631,10 +5629,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c3bf5179-84e4-4a7b-b5d5-de60f6b50cab
+                - d2dcc748-48b2-4f2b-ae9e-900abb88ec1f
         status: 200 OK
         code: 200
-        duration: 186.585167ms
+        duration: 99.553875ms
     - id: 114
       request:
         proto: HTTP/1.1
@@ -5651,30 +5649,26 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics
-        method: GET
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e/private_nics/af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 478
+        content_length: 0
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: ""
         headers:
-            Content-Length:
-                - "478"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:16:10 GMT
-            Link:
-                - </servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics?page=1&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 16:25:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5682,12 +5676,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 09e53faa-83fd-4cf1-b843-a80ac551f3c4
-            X-Total-Count:
-                - "1"
-        status: 200 OK
-        code: 200
-        duration: 119.103542ms
+                - a03c6cb7-d0e1-4833-afee-ea2fa8b12c62
+        status: 204 No Content
+        code: 204
+        duration: 403.496ms
     - id: 115
       request:
         proto: HTTP/1.1
@@ -5704,7 +5696,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics/ba175159-76a5-4f16-b338-f91217d775e7
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e/private_nics/af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab
         method: GET
       response:
         proto: HTTP/2.0
@@ -5712,20 +5704,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 475
+        content_length: 148
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"af15bdd6-3bc2-47d4-b0f2-497ecd78b5ab","type":"not_found"}'
         headers:
             Content-Length:
-                - "475"
+                - "148"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:16:10 GMT
+                - Wed, 12 Feb 2025 16:25:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5733,10 +5725,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - edf00627-aed5-4880-86cc-4c5ad8055464
-        status: 200 OK
-        code: 200
-        duration: 114.382416ms
+                - f174cdf0-f0dc-4f97-b160-a34cb0887885
+        status: 404 Not Found
+        code: 404
+        duration: 99.933875ms
     - id: 116
       request:
         proto: HTTP/1.1
@@ -5753,26 +5745,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics/ba175159-76a5-4f16-b338-f91217d775e7
-        method: DELETE
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 1670
         uncompressed: false
-        body: ""
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:24:17.041400+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-sharp-bardeen","id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c8:6b","maintenances":[],"modification_date":"2025-02-12T16:25:30.819454+00:00","name":"tf-srv-sharp-bardeen","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"3d19ea3d-4d7f-4800-8a16-76324b03ba16","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
+            Content-Length:
+                - "1670"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:16:10 GMT
+                - Wed, 12 Feb 2025 16:25:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5780,10 +5774,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a4667d45-d37a-4823-af0c-66d84dcd3b5a
-        status: 204 No Content
-        code: 204
-        duration: 411.542125ms
+                - f6838c4a-6cb7-4a25-af1d-11d98c968acf
+        status: 200 OK
+        code: 200
+        duration: 205.923542ms
     - id: 117
       request:
         proto: HTTP/1.1
@@ -5800,28 +5794,26 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics/ba175159-76a5-4f16-b338-f91217d775e7
-        method: GET
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 148
+        content_length: 0
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"ba175159-76a5-4f16-b338-f91217d775e7","type":"not_found"}'
+        body: ""
         headers:
-            Content-Length:
-                - "148"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:16:11 GMT
+                - Wed, 12 Feb 2025 16:25:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5829,10 +5821,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a089443c-7a79-4101-9dea-baf9430c0820
-        status: 404 Not Found
-        code: 404
-        duration: 107.879041ms
+                - 5a84318f-7166-4803-a54e-6f95aaea973f
+        status: 204 No Content
+        code: 204
+        duration: 361.91625ms
     - id: 118
       request:
         proto: HTTP/1.1
@@ -5849,7 +5841,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a56ddf65-a2da-45d6-aeb3-47bd195bc01e
         method: GET
       response:
         proto: HTTP/2.0
@@ -5857,20 +5849,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1676
+        content_length: 143
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.380750+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-greider","id":"ee6b8302-d285-4412-9af2-b94bfecca21c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:d5","maintenances":[],"modification_date":"2025-02-12T16:16:06.159287+00:00","name":"tf-srv-vigilant-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"a56ddf65-a2da-45d6-aeb3-47bd195bc01e","type":"not_found"}'
         headers:
             Content-Length:
-                - "1676"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:16:11 GMT
+                - Wed, 12 Feb 2025 16:25:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5878,10 +5870,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c04c3cb5-1ac7-426a-bc68-c92dd57a7090
-        status: 200 OK
-        code: 200
-        duration: 300.237291ms
+                - 2371ff05-12ee-48c4-91e9-ec3c91ae940e
+        status: 404 Not Found
+        code: 404
+        duration: 108.415208ms
     - id: 119
       request:
         proto: HTTP/1.1
@@ -5898,26 +5890,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
-        method: DELETE
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/3d19ea3d-4d7f-4800-8a16-76324b03ba16
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 143
         uncompressed: false
-        body: ""
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"3d19ea3d-4d7f-4800-8a16-76324b03ba16","type":"not_found"}'
         headers:
+            Content-Length:
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:16:12 GMT
+                - Wed, 12 Feb 2025 16:25:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5925,10 +5919,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fc03cf45-431a-498c-8b65-6d837f088587
-        status: 204 No Content
-        code: 204
-        duration: 613.006666ms
+                - d2edbec0-6a8b-44b2-92c0-306d88f156d4
+        status: 404 Not Found
+        code: 404
+        duration: 50.820958ms
     - id: 120
       request:
         proto: HTTP/1.1
@@ -5945,7 +5939,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/3d19ea3d-4d7f-4800-8a16-76324b03ba16
         method: GET
       response:
         proto: HTTP/2.0
@@ -5953,20 +5947,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 143
+        content_length: 494
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","type":"not_found"}'
+        body: '{"created_at":"2025-02-12T16:24:17.252844Z","id":"3d19ea3d-4d7f-4800-8a16-76324b03ba16","last_detached_at":"2025-02-12T16:25:34.632492Z","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:25:34.632492Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "143"
+                - "494"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:16:12 GMT
+                - Wed, 12 Feb 2025 16:25:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5974,10 +5968,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 81b3f984-5f11-4850-b4ee-3710cffc9bbf
-        status: 404 Not Found
-        code: 404
-        duration: 128.503667ms
+                - 2a0d0c85-9921-4e02-b946-fb1f576aef35
+        status: 200 OK
+        code: 200
+        duration: 100.950542ms
     - id: 121
       request:
         proto: HTTP/1.1
@@ -5994,28 +5988,26 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/a5c02cb7-8020-4442-8634-e5ee2eff2c2c
-        method: GET
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/3d19ea3d-4d7f-4800-8a16-76324b03ba16
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 143
+        content_length: 0
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","type":"not_found"}'
+        body: ""
         headers:
-            Content-Length:
-                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:16:12 GMT
+                - Wed, 12 Feb 2025 16:25:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6023,10 +6015,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 73d50f46-c465-4894-a9df-b1d52c3e254b
-        status: 404 Not Found
-        code: 404
-        duration: 54.43125ms
+                - 43984f0f-e886-40a1-bb69-d573203c0215
+        status: 204 No Content
+        code: 204
+        duration: 142.421583ms
     - id: 122
       request:
         proto: HTTP/1.1
@@ -6043,28 +6035,26 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/a5c02cb7-8020-4442-8634-e5ee2eff2c2c
-        method: GET
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7b3fa7ac-78de-4097-b7b8-a141ed2c0b82
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 494
+        content_length: 0
         uncompressed: false
-        body: '{"created_at":"2025-02-12T16:14:57.589514Z","id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","last_detached_at":"2025-02-12T16:16:12.307337Z","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:16:12.307337Z","zone":"fr-par-1"}'
+        body: ""
         headers:
-            Content-Length:
-                - "494"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:16:12 GMT
+                - Wed, 12 Feb 2025 16:25:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6072,10 +6062,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a23c2e15-216f-486e-8d55-6cbfcd8aaa92
-        status: 200 OK
-        code: 200
-        duration: 98.469917ms
+                - e2ca0b39-e7c8-441a-bc2e-c43fe049298c
+        status: 204 No Content
+        code: 204
+        duration: 1.303808375s
     - id: 123
       request:
         proto: HTTP/1.1
@@ -6092,101 +6082,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/a5c02cb7-8020-4442-8634-e5ee2eff2c2c
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 16:16:12 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - f105bae2-ec99-4bb2-a6ab-388eabc0eacc
-        status: 204 No Content
-        code: 204
-        duration: 145.76ms
-    - id: 124
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b3a3ea6c-4758-41c7-b9ad-22f9a410c192
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 16:16:14 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 28b3ebbc-be36-438f-a5b0-6097850eb632
-        status: 204 No Content
-        code: 204
-        duration: 1.3018405s
-    - id: 125
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/2572e954-7dde-486b-821f-38300c6d0173
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/7ece1fd0-856b-4d14-81d8-d604bbe0be27
         method: GET
       response:
         proto: HTTP/2.0
@@ -6196,7 +6092,7 @@ interactions:
         trailer: {}
         content_length: 125
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"dhcp","resource_id":"2572e954-7dde-486b-821f-38300c6d0173","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"dhcp","resource_id":"7ece1fd0-856b-4d14-81d8-d604bbe0be27","type":"not_found"}'
         headers:
             Content-Length:
                 - "125"
@@ -6205,9 +6101,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:16:14 GMT
+                - Wed, 12 Feb 2025 16:25:36 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -6215,7 +6111,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 928d1650-bad1-4a64-ac03-7775b5d8a3b7
+                - 3dd60084-13fc-4eff-bd3e-27ae48cc66ab
         status: 404 Not Found
         code: 404
-        duration: 48.676459ms
+        duration: 46.599292ms

--- a/internal/services/vpcgw/testdata/data-source-vpc-public-gateway-dhcp-reservation-basic.cassette.yaml
+++ b/internal/services/vpcgw/testdata/data-source-vpc-public-gateway-dhcp-reservation-basic.cassette.yaml
@@ -18,7 +18,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps
         method: POST
       response:
@@ -27,18 +27,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 568
+        content_length: 586
         uncompressed: false
-        body: '{"address":"192.168.1.1","created_at":"2025-01-27T09:16:24.168023Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1fcc02aa-9cbf-4f39-86a0-b3809a1503ea","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:24.168023Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+        body: '{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "568"
+                - "586"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:24 GMT
+                - Wed, 12 Feb 2025 16:14:55 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5e3fca2e-0877-4e19-af50-ee44861839ee
+                - bb088a75-f6a0-477a-a3a5-04243603dee9
         status: 200 OK
         code: 200
-        duration: 161.591333ms
+        duration: 278.301541ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/1fcc02aa-9cbf-4f39-86a0-b3809a1503ea
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/2572e954-7dde-486b-821f-38300c6d0173
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,18 +76,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 568
+        content_length: 586
         uncompressed: false
-        body: '{"address":"192.168.1.1","created_at":"2025-01-27T09:16:24.168023Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1fcc02aa-9cbf-4f39-86a0-b3809a1503ea","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:24.168023Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+        body: '{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "568"
+                - "586"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:24 GMT
+                - Wed, 12 Feb 2025 16:14:55 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -97,62 +97,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a39cfb18-fbff-4d0f-ba4d-84d10137c120
+                - 9d56d66e-84aa-48bb-bb4a-0d9aa63f257c
         status: 200 OK
         code: 200
-        duration: 25.376333ms
+        duration: 41.790833ms
     - id: 2
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 63
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[]}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 358
-        uncompressed: false
-        body: '{"address":"51.15.236.157","created_at":"2025-01-27T09:16:24.787791Z","gateway_id":null,"id":"ba392279-67e2-4332-a903-f17d6ebbf763","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"157-236-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:24.787791Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "358"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:16:24 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 38f2d3c0-8df3-4895-ae8c-c7bfead9f5a3
-        status: 200 OK
-        code: 200
-        duration: 684.097083ms
-    - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -169,7 +118,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
         method: POST
       response:
@@ -178,18 +127,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1065
+        content_length: 1088
         uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:24.169710Z","dhcp_enabled":true,"id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T09:16:24.169710Z","id":"62e3abfa-d782-4d1f-85e4-35eee4a86c4f","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.0.0/22","updated_at":"2025-01-27T09:16:24.169710Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T09:16:24.169710Z","id":"917bd4ae-c131-4777-bb70-6656b7f70c0a","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:d7c0::/64","updated_at":"2025-01-27T09:16:24.169710Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T09:16:24.169710Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"created_at":"2025-02-12T16:14:56.161859Z","dhcp_enabled":true,"id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:14:56.161859Z","id":"1d110e71-77c2-4e0d-8b2a-44e5e61a0211","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.8.0/22","updated_at":"2025-02-12T16:14:56.161859Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-12T16:14:56.161859Z","id":"ad46a815-2df6-4e07-ad92-d99d79d18c7d","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:b62b::/64","updated_at":"2025-02-12T16:14:56.161859Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-12T16:14:56.161859Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "1065"
+                - "1088"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:24 GMT
+                - Wed, 12 Feb 2025 16:14:56 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -199,10 +148,59 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7e81166c-3c48-4dd3-846d-9edb72f47504
+                - c5a6bcbe-a8b6-4f7a-b639-6ce31beb2360
         status: 200 OK
         code: 200
-        duration: 691.614542ms
+        duration: 962.028667ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b3a3ea6c-4758-41c7-b9ad-22f9a410c192
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1088
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:14:56.161859Z","dhcp_enabled":true,"id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:14:56.161859Z","id":"1d110e71-77c2-4e0d-8b2a-44e5e61a0211","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.8.0/22","updated_at":"2025-02-12T16:14:56.161859Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-12T16:14:56.161859Z","id":"ad46a815-2df6-4e07-ad92-d99d79d18c7d","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:b62b::/64","updated_at":"2025-02-12T16:14:56.161859Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-12T16:14:56.161859Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        headers:
+            Content-Length:
+                - "1088"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:14:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 524cb59f-e71e-490a-a512-94183cfb71f9
+        status: 200 OK
+        code: 200
+        duration: 45.06375ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -218,8 +216,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/ba392279-67e2-4332-a903-f17d6ebbf763
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -227,18 +225,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 358
+        content_length: 35639
         uncompressed: false
-        body: '{"address":"51.15.236.157","created_at":"2025-01-27T09:16:24.787791Z","gateway_id":null,"id":"ba392279-67e2-4332-a903-f17d6ebbf763","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"157-236-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:24.787791Z","zone":"fr-par-1"}'
+        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
         headers:
             Content-Length:
-                - "358"
+                - "35639"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:24 GMT
+                - Wed, 12 Feb 2025 16:14:56 GMT
+            Link:
+                - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -248,10 +248,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e80b075b-45ee-41c8-8a63-2d8869071611
+                - 32895120-168a-4b6d-82ce-a57629b369a7
+            X-Total-Count:
+                - "68"
         status: 200 OK
         code: 200
-        duration: 28.142958ms
+        duration: 58.819834ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -267,8 +269,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/5c4fe589-7af7-40b2-ae00-98727ba37cff
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
         method: GET
       response:
         proto: HTTP/2.0
@@ -276,18 +278,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1065
+        content_length: 13164
         uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:24.169710Z","dhcp_enabled":true,"id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T09:16:24.169710Z","id":"62e3abfa-d782-4d1f-85e4-35eee4a86c4f","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.0.0/22","updated_at":"2025-01-27T09:16:24.169710Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T09:16:24.169710Z","id":"917bd4ae-c131-4777-bb70-6656b7f70c0a","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:d7c0::/64","updated_at":"2025-01-27T09:16:24.169710Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T09:16:24.169710Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
         headers:
             Content-Length:
-                - "1065"
+                - "13164"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:24 GMT
+                - Wed, 12 Feb 2025 16:14:56 GMT
+            Link:
+                - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -297,62 +301,13 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9329d2f9-3649-4990-ac9f-5d7162ee0231
+                - c359c11f-d5e9-4382-8054-663d7897bd8d
+            X-Total-Count:
+                - "68"
         status: 200 OK
         code: 200
-        duration: 33.49825ms
+        duration: 63.983041ms
     - id: 6
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 213
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"foobar","tags":[],"type":"VPC-GW-S","upstream_dns_servers":[],"ip_id":"ba392279-67e2-4332-a903-f17d6ebbf763","enable_smtp":false,"enable_bastion":false}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 968
-        uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:24.896770Z","gateway_networks":[],"id":"6b0c7102-c2a4-4497-b153-a63200c78895","ip":{"address":"51.15.236.157","created_at":"2025-01-27T09:16:24.787791Z","gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"ba392279-67e2-4332-a903-f17d6ebbf763","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"157-236-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:24.787791Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:24.896770Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "968"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:16:24 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - cfa7cac7-07ea-4555-88dc-dbf01e63a3c9
-        status: 200 OK
-        code: 200
-        duration: 115.156667ms
-    - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -367,8 +322,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_sbs&zone=fr-par-1
         method: GET
       response:
         proto: HTTP/2.0
@@ -376,20 +331,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 38539
+        content_length: 1296
         uncompressed: false
-        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
+        body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"57509e82-ac3b-49b7-9970-97b60f40ff72","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"9b647e1e-253a-41e7-8c15-911c622ee2dc","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"}],"total_count":2}'
         headers:
             Content-Length:
-                - "38539"
+                - "1296"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:24 GMT
-            Link:
-                - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 16:14:56 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -399,12 +352,61 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ebb1578e-9a33-4130-90bc-f7ca2db3e5c7
-            X-Total-Count:
-                - "68"
+                - ea92a29e-95cd-4141-99d6-11eade8468c3
         status: 200 OK
         code: 200
-        duration: 60.631125ms
+        duration: 93.43575ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 63
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[]}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 371
+        uncompressed: false
+        body: '{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":null,"id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "371"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:14:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - aa656ee6-31b4-4a72-964a-4d4a17a5eefe
+        status: 200 OK
+        code: 200
+        duration: 1.408300417s
     - id: 8
       request:
         proto: HTTP/1.1
@@ -420,8 +422,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b0c7102-c2a4-4497-b153-a63200c78895
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/da389c61-9c8f-475e-b2c5-b60333283fa5
         method: GET
       response:
         proto: HTTP/2.0
@@ -429,18 +431,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 970
+        content_length: 371
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:24.896770Z","gateway_networks":[],"id":"6b0c7102-c2a4-4497-b153-a63200c78895","ip":{"address":"51.15.236.157","created_at":"2025-01-27T09:16:24.787791Z","gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"ba392279-67e2-4332-a903-f17d6ebbf763","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"157-236-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:24.787791Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:24.935213Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":null,"id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "970"
+                - "371"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:24 GMT
+                - Wed, 12 Feb 2025 16:14:57 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -450,48 +452,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f42a8818-23a0-4f11-91f7-8831baff1ac6
+                - 063a987b-7ffa-47d5-9825-ba987130f41b
         status: 200 OK
         code: 200
-        duration: 36.745375ms
+        duration: 46.512875ms
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 213
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"foobar","tags":[],"type":"VPC-GW-S","upstream_dns_servers":[],"ip_id":"da389c61-9c8f-475e-b2c5-b60333283fa5","enable_smtp":false,"enable_bastion":false}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 14208
+        content_length: 1002
         uncompressed: false
-        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:57.205022Z","gateway_networks":[],"id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","ip":{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:14:57.205022Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "14208"
+                - "1002"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:24 GMT
-            Link:
-                - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 16:14:57 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -501,12 +503,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0caa2148-bece-442e-bd1b-2ba90ad27e83
-            X-Total-Count:
-                - "68"
+                - ca942828-7ea4-4b73-8e7f-6c534a4f8c47
         status: 200 OK
         code: 200
-        duration: 57.282958ms
+        duration: 121.448875ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -522,8 +522,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_local&zone=fr-par-1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7
         method: GET
       response:
         proto: HTTP/2.0
@@ -531,18 +531,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1220
+        content_length: 1004
         uncompressed: false
-        body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"56d4019c-8305-467a-a3f2-70498ad799df","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:57.205022Z","gateway_networks":[],"id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","ip":{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:14:57.251496Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1220"
+                - "1004"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:25 GMT
+                - Wed, 12 Feb 2025 16:14:57 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -552,28 +552,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c84df77b-c931-435a-919e-9041e8f5f116
+                - 6a884fab-50ab-4a81-995d-55ae6e364fe1
         status: 200 OK
         code: 200
-        duration: 70.249625ms
+        duration: 60.557834ms
     - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 283
+        content_length: 236
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-srv-admiring-proskuriakova","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+        body: '{"name":"tf-srv-vigilant-greider","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"57509e82-ac3b-49b7-9970-97b60f40ff72","volumes":{"0":{"boot":false}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
         method: POST
       response:
@@ -582,20 +582,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2139
+        content_length: 1676
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:25.382281+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-admiring-proskuriakova","id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ea:3d","maintenances":[],"modification_date":"2025-01-27T09:16:25.382281+00:00","name":"tf-srv-admiring-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:25.382281+00:00","export_uri":null,"id":"bf39a892-33e3-4235-9a37-da79b76f0546","modification_date":"2025-01-27T09:16:25.382281+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","name":"tf-srv-admiring-proskuriakova"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.380750+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-greider","id":"ee6b8302-d285-4412-9af2-b94bfecca21c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:d5","maintenances":[],"modification_date":"2025-02-12T16:14:57.380750+00:00","name":"tf-srv-vigilant-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2139"
+                - "1676"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:25 GMT
+                - Wed, 12 Feb 2025 16:14:57 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -605,10 +605,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ecda27f4-ac9d-420d-b687-6afbaf0d8659
+                - d1965402-64ad-497d-8e69-27a8109192cf
         status: 201 Created
         code: 201
-        duration: 582.656459ms
+        duration: 1.059627958s
     - id: 12
       request:
         proto: HTTP/1.1
@@ -624,8 +624,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
         method: GET
       response:
         proto: HTTP/2.0
@@ -633,18 +633,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2139
+        content_length: 1676
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:25.382281+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-admiring-proskuriakova","id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ea:3d","maintenances":[],"modification_date":"2025-01-27T09:16:25.382281+00:00","name":"tf-srv-admiring-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:25.382281+00:00","export_uri":null,"id":"bf39a892-33e3-4235-9a37-da79b76f0546","modification_date":"2025-01-27T09:16:25.382281+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","name":"tf-srv-admiring-proskuriakova"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.380750+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-greider","id":"ee6b8302-d285-4412-9af2-b94bfecca21c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:d5","maintenances":[],"modification_date":"2025-02-12T16:14:57.380750+00:00","name":"tf-srv-vigilant-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2139"
+                - "1676"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:25 GMT
+                - Wed, 12 Feb 2025 16:14:58 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -654,10 +654,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2de44f6a-418a-42f3-b689-95732f275509
+                - 760a8815-97dc-4424-90ea-5c4acda64482
         status: 200 OK
         code: 200
-        duration: 139.855291ms
+        duration: 139.462ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -673,8 +673,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
         method: GET
       response:
         proto: HTTP/2.0
@@ -682,18 +682,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2139
+        content_length: 1676
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:25.382281+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-admiring-proskuriakova","id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ea:3d","maintenances":[],"modification_date":"2025-01-27T09:16:25.382281+00:00","name":"tf-srv-admiring-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:25.382281+00:00","export_uri":null,"id":"bf39a892-33e3-4235-9a37-da79b76f0546","modification_date":"2025-01-27T09:16:25.382281+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","name":"tf-srv-admiring-proskuriakova"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.380750+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-greider","id":"ee6b8302-d285-4412-9af2-b94bfecca21c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:d5","maintenances":[],"modification_date":"2025-02-12T16:14:57.380750+00:00","name":"tf-srv-vigilant-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2139"
+                - "1676"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:25 GMT
+                - Wed, 12 Feb 2025 16:14:58 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -703,11 +703,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c34d27c9-1fb6-4f1f-b4c5-f6f2a4d7e368
+                - cd9b6e9e-514e-4e2a-a882-860a64eb21db
         status: 200 OK
         code: 200
-        duration: 136.901125ms
+        duration: 545.716125ms
     - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/a5c02cb7-8020-4442-8634-e5ee2eff2c2c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:14:57.589514Z","id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:14:57.589514Z","id":"158fda61-e559-4737-996d-b3b846db132e","product_resource_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:14:57.589514Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:14:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fc2efefa-a43d-4bf7-a7fa-5c890be65dda
+        status: 200 OK
+        code: 200
+        duration: 95.935666ms
+    - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -724,8 +773,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -735,7 +784,7 @@ interactions:
         trailer: {}
         content_length: 357
         uncompressed: false
-        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c/action","href_result":"/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c","id":"309bcdcd-9399-4ad8-a913-b2e589b3bc1f","progress":0,"started_at":"2025-01-27T09:16:26.296656+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/action","href_result":"/servers/ee6b8302-d285-4412-9af2-b94bfecca21c","id":"165f5ce1-3137-4074-b6c0-2b9e0c58f999","progress":0,"started_at":"2025-02-12T16:14:59.023368+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -744,9 +793,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:26 GMT
+                - Wed, 12 Feb 2025 16:14:58 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/309bcdcd-9399-4ad8-a913-b2e589b3bc1f
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/165f5ce1-3137-4074-b6c0-2b9e0c58f999
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -756,59 +805,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 02d1cbd9-130a-44a9-97a0-c3fbd2ccd85c
+                - e620c0ca-76fa-4a3d-be2f-7849a4bf37f2
         status: 202 Accepted
         code: 202
-        duration: 397.816459ms
-    - id: 15
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2161
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:25.382281+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-admiring-proskuriakova","id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ea:3d","maintenances":[],"modification_date":"2025-01-27T09:16:25.997481+00:00","name":"tf-srv-admiring-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:25.382281+00:00","export_uri":null,"id":"bf39a892-33e3-4235-9a37-da79b76f0546","modification_date":"2025-01-27T09:16:25.382281+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","name":"tf-srv-admiring-proskuriakova"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2161"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:16:26 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 97607705-b3ba-4ea9-a8a8-c2f4bfd1c4d1
-        status: 200 OK
-        code: 200
-        duration: 181.72475ms
+        duration: 299.936584ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -824,8 +824,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b0c7102-c2a4-4497-b153-a63200c78895
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
         method: GET
       response:
         proto: HTTP/2.0
@@ -833,18 +833,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 967
+        content_length: 1698
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:24.896770Z","gateway_networks":[],"id":"6b0c7102-c2a4-4497-b153-a63200c78895","ip":{"address":"51.15.236.157","created_at":"2025-01-27T09:16:24.787791Z","gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"ba392279-67e2-4332-a903-f17d6ebbf763","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"157-236-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:24.787791Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:27.852654Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.380750+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-greider","id":"ee6b8302-d285-4412-9af2-b94bfecca21c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:d5","maintenances":[],"modification_date":"2025-02-12T16:14:58.797053+00:00","name":"tf-srv-vigilant-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "967"
+                - "1698"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:30 GMT
+                - Wed, 12 Feb 2025 16:14:58 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -854,10 +854,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d43f10ca-cdeb-444e-8653-6bba94139867
+                - d3a6ef56-f187-4551-af42-b465737c1a36
         status: 200 OK
         code: 200
-        duration: 26.440958ms
+        duration: 203.421459ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -873,8 +873,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b0c7102-c2a4-4497-b153-a63200c78895
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7
         method: GET
       response:
         proto: HTTP/2.0
@@ -882,18 +882,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 967
+        content_length: 1001
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:24.896770Z","gateway_networks":[],"id":"6b0c7102-c2a4-4497-b153-a63200c78895","ip":{"address":"51.15.236.157","created_at":"2025-01-27T09:16:24.787791Z","gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"ba392279-67e2-4332-a903-f17d6ebbf763","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"157-236-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:24.787791Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:27.852654Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:57.205022Z","gateway_networks":[],"id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","ip":{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:02.135707Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "967"
+                - "1001"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:30 GMT
+                - Wed, 12 Feb 2025 16:15:02 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -903,10 +903,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e4c2458f-9eff-438f-a91b-16c1abbafb0d
+                - 91a6c97f-ce6f-454d-875e-cfa36081974a
         status: 200 OK
         code: 200
-        duration: 25.040208ms
+        duration: 47.928334ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -922,8 +922,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b0c7102-c2a4-4497-b153-a63200c78895
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7
         method: GET
       response:
         proto: HTTP/2.0
@@ -931,18 +931,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 967
+        content_length: 1001
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:24.896770Z","gateway_networks":[],"id":"6b0c7102-c2a4-4497-b153-a63200c78895","ip":{"address":"51.15.236.157","created_at":"2025-01-27T09:16:24.787791Z","gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"ba392279-67e2-4332-a903-f17d6ebbf763","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"157-236-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:24.787791Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:27.852654Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:57.205022Z","gateway_networks":[],"id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","ip":{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:02.135707Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "967"
+                - "1001"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:30 GMT
+                - Wed, 12 Feb 2025 16:15:02 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -952,10 +952,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 80b8ebbd-625d-4829-b0cc-a2efa11e5376
+                - e76aa58d-a571-45af-82dd-0b7b3942a419
         status: 200 OK
         code: 200
-        duration: 35.702416ms
+        duration: 50.559875ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -971,8 +971,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7
         method: GET
       response:
         proto: HTTP/2.0
@@ -980,18 +980,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2264
+        content_length: 1001
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:25.382281+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-admiring-proskuriakova","id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"49","hypervisor_id":"802","node_id":"54","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:3d","maintenances":[],"modification_date":"2025-01-27T09:16:25.997481+00:00","name":"tf-srv-admiring-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:25.382281+00:00","export_uri":null,"id":"bf39a892-33e3-4235-9a37-da79b76f0546","modification_date":"2025-01-27T09:16:25.382281+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","name":"tf-srv-admiring-proskuriakova"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:57.205022Z","gateway_networks":[],"id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","ip":{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:02.135707Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2264"
+                - "1001"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:31 GMT
+                - Wed, 12 Feb 2025 16:15:02 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1001,48 +1001,46 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 57740747-946d-4e07-9b3b-04a1a997fa95
+                - 9a8abfa1-5c27-490e-8693-0be17eaf165b
         status: 200 OK
         code: 200
-        duration: 157.861208ms
+        duration: 50.008958ms
     - id: 20
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 206
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"1fcc02aa-9cbf-4f39-86a0-b3809a1503ea"}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 953
+        content_length: 1831
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:31.904454Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:24.168023Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1fcc02aa-9cbf-4f39-86a0-b3809a1503ea","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:24.168023Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"6c8d2f06-2402-4b77-a3e4-f38f518c9d68","ipam_config":null,"mac_address":null,"private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","status":"created","updated_at":"2025-01-27T09:16:31.904454Z","zone":"fr-par-1"}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.380750+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-greider","id":"ee6b8302-d285-4412-9af2-b94bfecca21c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"304","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d5","maintenances":[],"modification_date":"2025-02-12T16:15:03.386466+00:00","name":"tf-srv-vigilant-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "953"
+                - "1831"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:32 GMT
+                - Wed, 12 Feb 2025 16:15:04 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1052,10 +1050,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bddedf88-6894-4ef6-a4fc-779b26f91a2b
+                - 8cd6657c-eacb-4002-9cb4-a8bc5659d99c
         status: 200 OK
         code: 200
-        duration: 2.147582083s
+        duration: 164.590834ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1071,8 +1069,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b0c7102-c2a4-4497-b153-a63200c78895
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b3a3ea6c-4758-41c7-b9ad-22f9a410c192
         method: GET
       response:
         proto: HTTP/2.0
@@ -1080,18 +1078,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1923
+        content_length: 1088
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:24.896770Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:31.904454Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:24.168023Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1fcc02aa-9cbf-4f39-86a0-b3809a1503ea","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:24.168023Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"6c8d2f06-2402-4b77-a3e4-f38f518c9d68","ipam_config":null,"mac_address":null,"private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","status":"created","updated_at":"2025-01-27T09:16:31.904454Z","zone":"fr-par-1"}],"id":"6b0c7102-c2a4-4497-b153-a63200c78895","ip":{"address":"51.15.236.157","created_at":"2025-01-27T09:16:24.787791Z","gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"ba392279-67e2-4332-a903-f17d6ebbf763","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"157-236-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:24.787791Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:32.050618Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:14:56.161859Z","dhcp_enabled":true,"id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:14:56.161859Z","id":"1d110e71-77c2-4e0d-8b2a-44e5e61a0211","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.8.0/22","updated_at":"2025-02-12T16:14:56.161859Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-12T16:14:56.161859Z","id":"ad46a815-2df6-4e07-ad92-d99d79d18c7d","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:b62b::/64","updated_at":"2025-02-12T16:14:56.161859Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-12T16:14:56.161859Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "1923"
+                - "1088"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:32 GMT
+                - Wed, 12 Feb 2025 16:15:04 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1101,10 +1099,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 974bb1a9-ab78-4ca0-87e2-3cc850d8b441
+                - 847237e9-6a74-4cf4-9ba2-b4870ebe2e0b
         status: 200 OK
         code: 200
-        duration: 28.195792ms
+        duration: 58.90775ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1120,8 +1118,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1129,18 +1127,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2264
+        content_length: 1831
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:25.382281+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-admiring-proskuriakova","id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"49","hypervisor_id":"802","node_id":"54","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:3d","maintenances":[],"modification_date":"2025-01-27T09:16:25.997481+00:00","name":"tf-srv-admiring-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:25.382281+00:00","export_uri":null,"id":"bf39a892-33e3-4235-9a37-da79b76f0546","modification_date":"2025-01-27T09:16:25.382281+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","name":"tf-srv-admiring-proskuriakova"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.380750+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-greider","id":"ee6b8302-d285-4412-9af2-b94bfecca21c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"304","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d5","maintenances":[],"modification_date":"2025-02-12T16:15:03.386466+00:00","name":"tf-srv-vigilant-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2264"
+                - "1831"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:36 GMT
+                - Wed, 12 Feb 2025 16:15:04 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1150,46 +1148,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 954985b9-5579-4f63-8b89-46ec69b7f1bc
+                - e8e0e488-05c5-4329-98cd-9b514b31c7c6
         status: 200 OK
         code: 200
-        duration: 160.572875ms
+        duration: 279.981375ms
     - id: 23
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 206
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"2572e954-7dde-486b-821f-38300c6d0173"}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b0c7102-c2a4-4497-b153-a63200c78895
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1923
+        content_length: 28
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:24.896770Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:31.904454Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:24.168023Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1fcc02aa-9cbf-4f39-86a0-b3809a1503ea","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:24.168023Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"6c8d2f06-2402-4b77-a3e4-f38f518c9d68","ipam_config":null,"mac_address":null,"private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","status":"created","updated_at":"2025-01-27T09:16:31.904454Z","zone":"fr-par-1"}],"id":"6b0c7102-c2a4-4497-b153-a63200c78895","ip":{"address":"51.15.236.157","created_at":"2025-01-27T09:16:24.787791Z","gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"ba392279-67e2-4332-a903-f17d6ebbf763","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"157-236-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:24.787791Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:32.050618Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"message":"internal error"}'
         headers:
             Content-Length:
-                - "1923"
+                - "28"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:37 GMT
+                - Wed, 12 Feb 2025 16:15:06 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1199,46 +1199,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4df5b440-5f1b-4701-93ee-294b9e7c08d2
-        status: 200 OK
-        code: 200
-        duration: 35.200917ms
+                - d299e554-04b3-4292-9087-a50f900e978c
+        status: 500 Internal Server Error
+        code: 500
+        duration: 4.316993708s
     - id: 24
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 61
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192"}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2264
+        content_length: 473
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:25.382281+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-admiring-proskuriakova","id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"49","hypervisor_id":"802","node_id":"54","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:3d","maintenances":[],"modification_date":"2025-01-27T09:16:25.997481+00:00","name":"tf-srv-admiring-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:25.382281+00:00","export_uri":null,"id":"bf39a892-33e3-4235-9a37-da79b76f0546","modification_date":"2025-01-27T09:16:25.382281+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","name":"tf-srv-admiring-proskuriakova"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:04.992700+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2264"
+                - "473"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:41 GMT
+                - Wed, 12 Feb 2025 16:15:06 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1248,10 +1250,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e1610cb5-c842-42f2-98d2-182d2e7f3424
-        status: 200 OK
-        code: 200
-        duration: 222.238ms
+                - 21de8669-b5cd-4be6-ad17-72bb2e6b34e0
+        status: 201 Created
+        code: 201
+        duration: 2.053207791s
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1267,8 +1269,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b0c7102-c2a4-4497-b153-a63200c78895
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics/ba175159-76a5-4f16-b338-f91217d775e7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1276,18 +1278,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1932
+        content_length: 473
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:24.896770Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:31.904454Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:24.168023Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1fcc02aa-9cbf-4f39-86a0-b3809a1503ea","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:24.168023Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"6c8d2f06-2402-4b77-a3e4-f38f518c9d68","ipam_config":null,"mac_address":"02:00:00:1E:EA:A9","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","status":"ready","updated_at":"2025-01-27T09:16:40.273671Z","zone":"fr-par-1"}],"id":"6b0c7102-c2a4-4497-b153-a63200c78895","ip":{"address":"51.15.236.157","created_at":"2025-01-27T09:16:24.787791Z","gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"ba392279-67e2-4332-a903-f17d6ebbf763","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"157-236-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:24.787791Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:40.396867Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:04.992700+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1932"
+                - "473"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:42 GMT
+                - Wed, 12 Feb 2025 16:15:06 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1297,46 +1299,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fdb12dca-eeee-4210-9290-89c137051273
+                - 05ac048f-9d3d-49cc-a996-06e858a900f1
         status: 200 OK
         code: 200
-        duration: 29.468625ms
+        duration: 93.644833ms
     - id: 26
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 206
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"2572e954-7dde-486b-821f-38300c6d0173"}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/6c8d2f06-2402-4b77-a3e4-f38f518c9d68
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 966
+        content_length: 28
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:31.904454Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:24.168023Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1fcc02aa-9cbf-4f39-86a0-b3809a1503ea","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:24.168023Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"6c8d2f06-2402-4b77-a3e4-f38f518c9d68","ipam_config":null,"mac_address":"02:00:00:1E:EA:A9","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","status":"ready","updated_at":"2025-01-27T09:16:40.273671Z","zone":"fr-par-1"}'
+        body: '{"message":"internal error"}'
         headers:
             Content-Length:
-                - "966"
+                - "28"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:42 GMT
+                - Wed, 12 Feb 2025 16:15:09 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1346,10 +1350,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3b16001e-78a4-47e9-ad33-39b77a3e25dd
-        status: 200 OK
-        code: 200
-        duration: 34.632041ms
+                - bca8d7d6-50f9-4044-8053-a5ec73d117fe
+        status: 500 Internal Server Error
+        code: 500
+        duration: 354.386583ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1365,8 +1369,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/6c8d2f06-2402-4b77-a3e4-f38f518c9d68
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics/ba175159-76a5-4f16-b338-f91217d775e7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1374,18 +1378,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 966
+        content_length: 473
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:31.904454Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:24.168023Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1fcc02aa-9cbf-4f39-86a0-b3809a1503ea","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:24.168023Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"6c8d2f06-2402-4b77-a3e4-f38f518c9d68","ipam_config":null,"mac_address":"02:00:00:1E:EA:A9","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","status":"ready","updated_at":"2025-01-27T09:16:40.273671Z","zone":"fr-par-1"}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:04.992700+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "966"
+                - "473"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:42 GMT
+                - Wed, 12 Feb 2025 16:15:11 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1395,46 +1399,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 63641ac1-b8e2-4d71-bca1-99091a5329b6
+                - 03e1d447-6786-48a2-8098-b617c616adb6
         status: 200 OK
         code: 200
-        duration: 51.206417ms
+        duration: 118.538875ms
     - id: 28
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 206
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"2572e954-7dde-486b-821f-38300c6d0173"}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b0c7102-c2a4-4497-b153-a63200c78895
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1932
+        content_length: 28
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:24.896770Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:31.904454Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:24.168023Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1fcc02aa-9cbf-4f39-86a0-b3809a1503ea","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:24.168023Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"6c8d2f06-2402-4b77-a3e4-f38f518c9d68","ipam_config":null,"mac_address":"02:00:00:1E:EA:A9","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","status":"ready","updated_at":"2025-01-27T09:16:40.273671Z","zone":"fr-par-1"}],"id":"6b0c7102-c2a4-4497-b153-a63200c78895","ip":{"address":"51.15.236.157","created_at":"2025-01-27T09:16:24.787791Z","gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"ba392279-67e2-4332-a903-f17d6ebbf763","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"157-236-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:24.787791Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:40.396867Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"message":"internal error"}'
         headers:
             Content-Length:
-                - "1932"
+                - "28"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:42 GMT
+                - Wed, 12 Feb 2025 16:15:13 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1444,10 +1450,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b60bb500-1d18-4ece-ae03-465321c11054
-        status: 200 OK
-        code: 200
-        duration: 27.538834ms
+                - 6b33be06-ecc8-4978-a958-1cdfbbe412a2
+        status: 500 Internal Server Error
+        code: 500
+        duration: 296.291542ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1463,8 +1469,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/6c8d2f06-2402-4b77-a3e4-f38f518c9d68
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics/ba175159-76a5-4f16-b338-f91217d775e7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1472,18 +1478,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 966
+        content_length: 473
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:31.904454Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:24.168023Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1fcc02aa-9cbf-4f39-86a0-b3809a1503ea","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:24.168023Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"6c8d2f06-2402-4b77-a3e4-f38f518c9d68","ipam_config":null,"mac_address":"02:00:00:1E:EA:A9","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","status":"ready","updated_at":"2025-01-27T09:16:40.273671Z","zone":"fr-par-1"}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:04.992700+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "966"
+                - "473"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:42 GMT
+                - Wed, 12 Feb 2025 16:15:16 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1493,10 +1499,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b1b8a2b1-0b79-43da-800c-13402b0f8d6f
+                - 7e374eb3-f85d-4cf2-b8ee-6742ae6e8f84
         status: 200 OK
         code: 200
-        duration: 46.251667ms
+        duration: 115.202917ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1512,8 +1518,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics/ba175159-76a5-4f16-b338-f91217d775e7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1521,18 +1527,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2264
+        content_length: 473
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:25.382281+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-admiring-proskuriakova","id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"49","hypervisor_id":"802","node_id":"54","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:3d","maintenances":[],"modification_date":"2025-01-27T09:16:25.997481+00:00","name":"tf-srv-admiring-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:25.382281+00:00","export_uri":null,"id":"bf39a892-33e3-4235-9a37-da79b76f0546","modification_date":"2025-01-27T09:16:25.382281+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","name":"tf-srv-admiring-proskuriakova"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:04.992700+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2264"
+                - "473"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:47 GMT
+                - Wed, 12 Feb 2025 16:15:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1542,46 +1548,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 653ba95c-26e9-48ba-9ca8-0ea8a4ac9687
+                - 0ea365cc-3d93-4224-a31a-738030e64cda
         status: 200 OK
         code: 200
-        duration: 308.616792ms
+        duration: 412.169667ms
     - id: 31
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 206
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"2572e954-7dde-486b-821f-38300c6d0173"}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2264
+        content_length: 983
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:25.382281+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-admiring-proskuriakova","id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"49","hypervisor_id":"802","node_id":"54","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:3d","maintenances":[],"modification_date":"2025-01-27T09:16:25.997481+00:00","name":"tf-srv-admiring-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:25.382281+00:00","export_uri":null,"id":"bf39a892-33e3-4235-9a37-da79b76f0546","modification_date":"2025-01-27T09:16:25.382281+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","name":"tf-srv-admiring-proskuriakova"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":null,"private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"created","updated_at":"2025-02-12T16:15:23.555839Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2264"
+                - "983"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:52 GMT
+                - Wed, 12 Feb 2025 16:15:23 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1591,10 +1599,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 258e281a-abef-423d-a7ff-ea08bc64d598
+                - 44512760-987e-44e9-96fa-126794b4f0f5
         status: 200 OK
         code: 200
-        duration: 184.508667ms
+        duration: 2.342331333s
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1610,8 +1618,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1619,18 +1627,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2295
+        content_length: 1987
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:25.382281+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-admiring-proskuriakova","id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"49","hypervisor_id":"802","node_id":"54","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:3d","maintenances":[],"modification_date":"2025-01-27T09:16:52.545227+00:00","name":"tf-srv-admiring-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:25.382281+00:00","export_uri":null,"id":"bf39a892-33e3-4235-9a37-da79b76f0546","modification_date":"2025-01-27T09:16:25.382281+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","name":"tf-srv-admiring-proskuriakova"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:57.205022Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":null,"private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"created","updated_at":"2025-02-12T16:15:23.555839Z","zone":"fr-par-1"}],"id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","ip":{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:23.710859Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2295"
+                - "1987"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:57 GMT
+                - Wed, 12 Feb 2025 16:15:23 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1640,10 +1648,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1ddffecd-2f92-4fd7-acd6-adb204c0805d
+                - a48fd194-7403-419c-8c10-1247f7de08cb
         status: 200 OK
         code: 200
-        duration: 232.934875ms
+        duration: 53.532542ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1659,8 +1667,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/5c4fe589-7af7-40b2-ae00-98727ba37cff
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics/ba175159-76a5-4f16-b338-f91217d775e7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1668,18 +1676,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1066
+        content_length: 473
         uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:24.169710Z","dhcp_enabled":true,"id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T09:16:24.169710Z","id":"62e3abfa-d782-4d1f-85e4-35eee4a86c4f","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:30.366016Z","vpc_id":"c1a6d6b0-1c7f-422b-bc06-d1a6adb751e2"},{"created_at":"2025-01-27T09:16:24.169710Z","id":"917bd4ae-c131-4777-bb70-6656b7f70c0a","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:d7c0::/64","updated_at":"2025-01-27T09:16:30.370295Z","vpc_id":"c1a6d6b0-1c7f-422b-bc06-d1a6adb751e2"}],"tags":[],"updated_at":"2025-01-27T09:16:38.435535Z","vpc_id":"c1a6d6b0-1c7f-422b-bc06-d1a6adb751e2"}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:04.992700+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1066"
+                - "473"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:57 GMT
+                - Wed, 12 Feb 2025 16:15:27 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1689,10 +1697,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ce92c922-b18e-4b07-9176-4de4b94a0d0d
+                - 76efc89b-5f7e-433a-bed1-1b06686577b9
         status: 200 OK
         code: 200
-        duration: 29.7685ms
+        duration: 117.063041ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1708,8 +1716,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1717,18 +1725,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2295
+        content_length: 1987
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:25.382281+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-admiring-proskuriakova","id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"49","hypervisor_id":"802","node_id":"54","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:3d","maintenances":[],"modification_date":"2025-01-27T09:16:52.545227+00:00","name":"tf-srv-admiring-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:25.382281+00:00","export_uri":null,"id":"bf39a892-33e3-4235-9a37-da79b76f0546","modification_date":"2025-01-27T09:16:25.382281+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","name":"tf-srv-admiring-proskuriakova"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:57.205022Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":null,"private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"created","updated_at":"2025-02-12T16:15:23.555839Z","zone":"fr-par-1"}],"id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","ip":{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:23.710859Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2295"
+                - "1987"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:57 GMT
+                - Wed, 12 Feb 2025 16:15:28 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1738,30 +1746,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ddfe55a5-3e77-44fa-8eaa-0efe32c0cbff
+                - 31350ebf-34c3-466e-b5be-2021fcc2e206
         status: 200 OK
         code: 200
-        duration: 168.750625ms
+        duration: 55.217041ms
     - id: 35
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 61
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff"}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c/private_nics
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics/ba175159-76a5-4f16-b338-f91217d775e7
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -1770,7 +1776,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:58.034166+00:00","id":"4f981b41-fe9a-43dc-b8d9-191aeae48de6","ipam_ip_ids":["d80f2638-f3d2-46ed-b9ec-a5a20888ef6b","8743156b-6aab-4ce8-b4e4-f07c6830edee"],"mac_address":"02:00:00:10:d4:b0","modification_date":"2025-01-27T09:16:58.282288+00:00","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","server_id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:04.992700+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -1779,7 +1785,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:59 GMT
+                - Wed, 12 Feb 2025 16:15:32 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1789,10 +1795,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cab99c62-3475-490d-836d-7ecb77f0825a
-        status: 201 Created
-        code: 201
-        duration: 1.430916625s
+                - d8285bf8-45f3-4bba-b306-aeee343bd033
+        status: 200 OK
+        code: 200
+        duration: 99.913625ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1808,8 +1814,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c/private_nics/4f981b41-fe9a-43dc-b8d9-191aeae48de6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1817,18 +1823,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 473
+        content_length: 2006
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:58.034166+00:00","id":"4f981b41-fe9a-43dc-b8d9-191aeae48de6","ipam_ip_ids":["d80f2638-f3d2-46ed-b9ec-a5a20888ef6b","8743156b-6aab-4ce8-b4e4-f07c6830edee"],"mac_address":"02:00:00:10:d4:b0","modification_date":"2025-01-27T09:16:58.282288+00:00","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","server_id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:57.205022Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"configuring","updated_at":"2025-02-12T16:15:29.357361Z","zone":"fr-par-1"}],"id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","ip":{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:23.710859Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "473"
+                - "2006"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:59 GMT
+                - Wed, 12 Feb 2025 16:15:33 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1838,10 +1844,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6b76dd14-3403-4d6c-8832-3cf78511b981
+                - 19a18bb8-429b-4780-bb0b-ab6e544e846e
         status: 200 OK
         code: 200
-        duration: 92.012ms
+        duration: 65.742584ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1857,8 +1863,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c/private_nics/4f981b41-fe9a-43dc-b8d9-191aeae48de6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics/ba175159-76a5-4f16-b338-f91217d775e7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1866,18 +1872,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 473
+        content_length: 475
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:58.034166+00:00","id":"4f981b41-fe9a-43dc-b8d9-191aeae48de6","ipam_ip_ids":["d80f2638-f3d2-46ed-b9ec-a5a20888ef6b","8743156b-6aab-4ce8-b4e4-f07c6830edee"],"mac_address":"02:00:00:10:d4:b0","modification_date":"2025-01-27T09:16:58.282288+00:00","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","server_id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "473"
+                - "475"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:04 GMT
+                - Wed, 12 Feb 2025 16:15:37 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1887,10 +1893,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6518a8a4-275e-4602-8c6a-394259ef119d
+                - 0ea817b2-2a27-4b8e-8ed2-248212a6c203
         status: 200 OK
         code: 200
-        duration: 73.473459ms
+        duration: 582.557792ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1906,8 +1912,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c/private_nics/4f981b41-fe9a-43dc-b8d9-191aeae48de6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics/ba175159-76a5-4f16-b338-f91217d775e7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1915,18 +1921,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 473
+        content_length: 475
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:58.034166+00:00","id":"4f981b41-fe9a-43dc-b8d9-191aeae48de6","ipam_ip_ids":["d80f2638-f3d2-46ed-b9ec-a5a20888ef6b","8743156b-6aab-4ce8-b4e4-f07c6830edee"],"mac_address":"02:00:00:10:d4:b0","modification_date":"2025-01-27T09:16:58.282288+00:00","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","server_id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "473"
+                - "475"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:09 GMT
+                - Wed, 12 Feb 2025 16:15:38 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1936,10 +1942,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 28e064d1-c916-4c16-8650-141023cf8845
+                - d03de657-3fed-4d17-9790-df5fb10139a3
         status: 200 OK
         code: 200
-        duration: 109.108459ms
+        duration: 100.719584ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1955,8 +1961,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c/private_nics/4f981b41-fe9a-43dc-b8d9-191aeae48de6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1964,18 +1970,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 473
+        content_length: 2289
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:58.034166+00:00","id":"4f981b41-fe9a-43dc-b8d9-191aeae48de6","ipam_ip_ids":["d80f2638-f3d2-46ed-b9ec-a5a20888ef6b","8743156b-6aab-4ce8-b4e4-f07c6830edee"],"mac_address":"02:00:00:10:d4:b0","modification_date":"2025-01-27T09:16:58.282288+00:00","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","server_id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.380750+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-greider","id":"ee6b8302-d285-4412-9af2-b94bfecca21c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"304","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d5","maintenances":[],"modification_date":"2025-02-12T16:15:03.386466+00:00","name":"tf-srv-vigilant-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "473"
+                - "2289"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:14 GMT
+                - Wed, 12 Feb 2025 16:15:38 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1985,10 +1991,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1e460646-ce1d-482c-9e08-17ec3e813315
+                - 031205d2-bf6d-4f12-8b4f-ca984ef98f8a
         status: 200 OK
         code: 200
-        duration: 226.738ms
+        duration: 194.335625ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2004,8 +2010,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c/private_nics/4f981b41-fe9a-43dc-b8d9-191aeae48de6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/a5c02cb7-8020-4442-8634-e5ee2eff2c2c
         method: GET
       response:
         proto: HTTP/2.0
@@ -2013,18 +2019,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 473
+        content_length: 143
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:58.034166+00:00","id":"4f981b41-fe9a-43dc-b8d9-191aeae48de6","ipam_ip_ids":["d80f2638-f3d2-46ed-b9ec-a5a20888ef6b","8743156b-6aab-4ce8-b4e4-f07c6830edee"],"mac_address":"02:00:00:10:d4:b0","modification_date":"2025-01-27T09:16:58.282288+00:00","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","server_id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","type":"not_found"}'
         headers:
             Content-Length:
-                - "473"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:19 GMT
+                - Wed, 12 Feb 2025 16:15:38 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2034,10 +2040,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b3c845da-ac67-48b9-9622-4d8f88c4383d
-        status: 200 OK
-        code: 200
-        duration: 88.480292ms
+                - 469e213f-f69b-4362-ac5c-8faf55d60426
+        status: 404 Not Found
+        code: 404
+        duration: 58.354584ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2053,8 +2059,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c/private_nics/4f981b41-fe9a-43dc-b8d9-191aeae48de6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/a5c02cb7-8020-4442-8634-e5ee2eff2c2c
         method: GET
       response:
         proto: HTTP/2.0
@@ -2062,18 +2068,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 473
+        content_length: 701
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:58.034166+00:00","id":"4f981b41-fe9a-43dc-b8d9-191aeae48de6","ipam_ip_ids":["d80f2638-f3d2-46ed-b9ec-a5a20888ef6b","8743156b-6aab-4ce8-b4e4-f07c6830edee"],"mac_address":"02:00:00:10:d4:b0","modification_date":"2025-01-27T09:16:58.282288+00:00","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","server_id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-12T16:14:57.589514Z","id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:14:57.589514Z","id":"158fda61-e559-4737-996d-b3b846db132e","product_resource_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:14:57.589514Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "473"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:25 GMT
+                - Wed, 12 Feb 2025 16:15:38 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2083,10 +2089,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - eea7e3f8-fa06-4afe-9ba0-1358ce73cab8
+                - 9de9d54f-2376-429e-991c-c91b0378450a
         status: 200 OK
         code: 200
-        duration: 229.537209ms
+        duration: 84.813875ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2102,8 +2108,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c/private_nics/4f981b41-fe9a-43dc-b8d9-191aeae48de6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -2111,18 +2117,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 475
+        content_length: 17
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:58.034166+00:00","id":"4f981b41-fe9a-43dc-b8d9-191aeae48de6","ipam_ip_ids":["d80f2638-f3d2-46ed-b9ec-a5a20888ef6b","8743156b-6aab-4ce8-b4e4-f07c6830edee"],"mac_address":"02:00:00:10:d4:b0","modification_date":"2025-01-27T09:17:30.198529+00:00","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","server_id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "475"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:30 GMT
+                - Wed, 12 Feb 2025 16:15:38 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2132,10 +2138,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2673567e-34d7-4054-afe8-8f5c385fa0ff
+                - 08920b58-508b-46e8-aab3-96a8a7e6b9ec
         status: 200 OK
         code: 200
-        duration: 97.983042ms
+        duration: 105.808625ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2151,8 +2157,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c/private_nics/4f981b41-fe9a-43dc-b8d9-191aeae48de6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2160,18 +2166,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 475
+        content_length: 1996
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:58.034166+00:00","id":"4f981b41-fe9a-43dc-b8d9-191aeae48de6","ipam_ip_ids":["d80f2638-f3d2-46ed-b9ec-a5a20888ef6b","8743156b-6aab-4ce8-b4e4-f07c6830edee"],"mac_address":"02:00:00:10:d4:b0","modification_date":"2025-01-27T09:17:30.198529+00:00","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","server_id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:57.205022Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"ready","updated_at":"2025-02-12T16:15:34.005146Z","zone":"fr-par-1"}],"id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","ip":{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:34.260759Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "475"
+                - "1996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:30 GMT
+                - Wed, 12 Feb 2025 16:15:39 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2181,10 +2187,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 048b8fd3-bcba-4203-82b1-151573e9dd08
+                - c49827e8-beca-4c7c-a010-5702aef9ed87
         status: 200 OK
         code: 200
-        duration: 79.566084ms
+        duration: 58.169542ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2200,8 +2206,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3bbc5634-ce11-4bce-adc4-39e0fac0db51
         method: GET
       response:
         proto: HTTP/2.0
@@ -2209,18 +2215,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2753
+        content_length: 996
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:25.382281+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-admiring-proskuriakova","id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"49","hypervisor_id":"802","node_id":"54","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:3d","maintenances":[],"modification_date":"2025-01-27T09:16:52.545227+00:00","name":"tf-srv-admiring-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:58.034166+00:00","id":"4f981b41-fe9a-43dc-b8d9-191aeae48de6","ipam_ip_ids":["d80f2638-f3d2-46ed-b9ec-a5a20888ef6b","8743156b-6aab-4ce8-b4e4-f07c6830edee"],"mac_address":"02:00:00:10:d4:b0","modification_date":"2025-01-27T09:17:30.198529+00:00","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","server_id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:25.382281+00:00","export_uri":null,"id":"bf39a892-33e3-4235-9a37-da79b76f0546","modification_date":"2025-01-27T09:16:25.382281+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","name":"tf-srv-admiring-proskuriakova"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"ready","updated_at":"2025-02-12T16:15:34.005146Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2753"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:30 GMT
+                - Wed, 12 Feb 2025 16:15:39 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2230,10 +2236,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9f12f313-f095-49e7-87c3-df96cd6a81f6
+                - 45abfd67-b4c2-4641-87d2-d21620ad6c3b
         status: 200 OK
         code: 200
-        duration: 175.530416ms
+        duration: 65.058083ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2249,8 +2255,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/bf39a892-33e3-4235-9a37-da79b76f0546
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -2258,18 +2264,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 529
+        content_length: 478
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T09:16:25.382281+00:00","export_uri":null,"id":"bf39a892-33e3-4235-9a37-da79b76f0546","modification_date":"2025-01-27T09:16:25.382281+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","name":"tf-srv-admiring-proskuriakova"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "529"
+                - "478"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:30 GMT
+                - Wed, 12 Feb 2025 16:15:38 GMT
+            Link:
+                - </servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics?page=1&per_page=50&>; rel="last"
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2279,10 +2287,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e2ec9834-3fd1-4535-b177-dbe0954c080d
+                - f1f9db21-9d6e-4eb3-b657-41723678d872
+            X-Total-Count:
+                - "1"
         status: 200 OK
         code: 200
-        duration: 93.291708ms
+        duration: 249.08125ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2298,8 +2308,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3bbc5634-ce11-4bce-adc4-39e0fac0db51
         method: GET
       response:
         proto: HTTP/2.0
@@ -2307,18 +2317,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 996
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"ready","updated_at":"2025-02-12T16:15:34.005146Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "17"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:30 GMT
+                - Wed, 12 Feb 2025 16:15:39 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2328,10 +2338,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0bbb4794-f137-4f1a-aa4b-5a512311882b
+                - 48e0b9e1-39ae-4a98-8b7c-593a902fb9a1
         status: 200 OK
         code: 200
-        duration: 82.270292ms
+        duration: 68.248709ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2347,8 +2357,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2356,20 +2366,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 478
+        content_length: 1996
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T09:16:58.034166+00:00","id":"4f981b41-fe9a-43dc-b8d9-191aeae48de6","ipam_ip_ids":["d80f2638-f3d2-46ed-b9ec-a5a20888ef6b","8743156b-6aab-4ce8-b4e4-f07c6830edee"],"mac_address":"02:00:00:10:d4:b0","modification_date":"2025-01-27T09:17:30.198529+00:00","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","server_id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:57.205022Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"ready","updated_at":"2025-02-12T16:15:34.005146Z","zone":"fr-par-1"}],"id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","ip":{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:34.260759Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "478"
+                - "1996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:30 GMT
-            Link:
-                - </servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c/private_nics?page=1&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 16:15:39 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2379,12 +2387,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fba2a734-c636-427a-8bfb-124292641884
-            X-Total-Count:
-                - "1"
+                - 8af6daab-37e3-4c6e-a267-2e1c887abc66
         status: 200 OK
         code: 200
-        duration: 84.742792ms
+        duration: 54.068583ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2400,8 +2406,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/ba392279-67e2-4332-a903-f17d6ebbf763
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3bbc5634-ce11-4bce-adc4-39e0fac0db51
         method: GET
       response:
         proto: HTTP/2.0
@@ -2409,18 +2415,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 392
+        content_length: 996
         uncompressed: false
-        body: '{"address":"51.15.236.157","created_at":"2025-01-27T09:16:24.787791Z","gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"ba392279-67e2-4332-a903-f17d6ebbf763","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"157-236-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:24.787791Z","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"ready","updated_at":"2025-02-12T16:15:34.005146Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "392"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:31 GMT
+                - Wed, 12 Feb 2025 16:15:39 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2430,10 +2436,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e2d45c32-b994-4436-8c95-7b59253fa869
+                - 0d34de6b-9a3e-445e-8d9b-7d56eb02688c
         status: 200 OK
         code: 200
-        duration: 23.274333ms
+        duration: 65.994458ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2449,8 +2455,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/1fcc02aa-9cbf-4f39-86a0-b3809a1503ea
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/2572e954-7dde-486b-821f-38300c6d0173
         method: GET
       response:
         proto: HTTP/2.0
@@ -2458,18 +2464,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 568
+        content_length: 586
         uncompressed: false
-        body: '{"address":"192.168.1.1","created_at":"2025-01-27T09:16:24.168023Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1fcc02aa-9cbf-4f39-86a0-b3809a1503ea","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:24.168023Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+        body: '{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "568"
+                - "586"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:31 GMT
+                - Wed, 12 Feb 2025 16:15:39 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2479,10 +2485,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1dbab55a-a93e-49e6-aec2-e8744025f3da
+                - 0728c60a-3ba5-49f9-81d7-d767b5d8f189
         status: 200 OK
         code: 200
-        duration: 22.54ms
+        duration: 44.9625ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -2498,8 +2504,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/5c4fe589-7af7-40b2-ae00-98727ba37cff
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/da389c61-9c8f-475e-b2c5-b60333283fa5
         method: GET
       response:
         proto: HTTP/2.0
@@ -2507,18 +2513,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1066
+        content_length: 405
         uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:24.169710Z","dhcp_enabled":true,"id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T09:16:24.169710Z","id":"62e3abfa-d782-4d1f-85e4-35eee4a86c4f","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:30.366016Z","vpc_id":"c1a6d6b0-1c7f-422b-bc06-d1a6adb751e2"},{"created_at":"2025-01-27T09:16:24.169710Z","id":"917bd4ae-c131-4777-bb70-6656b7f70c0a","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:d7c0::/64","updated_at":"2025-01-27T09:16:30.370295Z","vpc_id":"c1a6d6b0-1c7f-422b-bc06-d1a6adb751e2"}],"tags":[],"updated_at":"2025-01-27T09:16:38.435535Z","vpc_id":"c1a6d6b0-1c7f-422b-bc06-d1a6adb751e2"}'
+        body: '{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1066"
+                - "405"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:31 GMT
+                - Wed, 12 Feb 2025 16:15:39 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2528,10 +2534,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ccecf019-2a40-4431-b387-eb2b8b2833f5
+                - f366e9a0-194d-4787-9744-24e1742637ef
         status: 200 OK
         code: 200
-        duration: 29.352417ms
+        duration: 47.36475ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2547,8 +2553,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b0c7102-c2a4-4497-b153-a63200c78895
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b3a3ea6c-4758-41c7-b9ad-22f9a410c192
         method: GET
       response:
         proto: HTTP/2.0
@@ -2556,18 +2562,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1932
+        content_length: 1089
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:24.896770Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:31.904454Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:24.168023Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1fcc02aa-9cbf-4f39-86a0-b3809a1503ea","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:24.168023Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"6c8d2f06-2402-4b77-a3e4-f38f518c9d68","ipam_config":null,"mac_address":"02:00:00:1E:EA:A9","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","status":"ready","updated_at":"2025-01-27T09:16:40.273671Z","zone":"fr-par-1"}],"id":"6b0c7102-c2a4-4497-b153-a63200c78895","ip":{"address":"51.15.236.157","created_at":"2025-01-27T09:16:24.787791Z","gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"ba392279-67e2-4332-a903-f17d6ebbf763","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"157-236-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:24.787791Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:40.396867Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:14:56.161859Z","dhcp_enabled":true,"id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:14:56.161859Z","id":"1d110e71-77c2-4e0d-8b2a-44e5e61a0211","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:15:21.807710Z","vpc_id":"b388d228-a931-443f-87b2-379c9af5934b"},{"created_at":"2025-02-12T16:14:56.161859Z","id":"ad46a815-2df6-4e07-ad92-d99d79d18c7d","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:b62b::/64","updated_at":"2025-02-12T16:15:21.811374Z","vpc_id":"b388d228-a931-443f-87b2-379c9af5934b"}],"tags":[],"updated_at":"2025-02-12T16:15:30.215218Z","vpc_id":"b388d228-a931-443f-87b2-379c9af5934b"}'
         headers:
             Content-Length:
-                - "1932"
+                - "1089"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:31 GMT
+                - Wed, 12 Feb 2025 16:15:39 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2577,10 +2583,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 71363964-03e8-45ea-bd31-eb84d7c43a71
+                - 638be8d4-7e8d-4712-9718-23cfb5b67a41
         status: 200 OK
         code: 200
-        duration: 29.130042ms
+        duration: 90.367125ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -2596,8 +2602,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/6c8d2f06-2402-4b77-a3e4-f38f518c9d68
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2605,18 +2611,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 966
+        content_length: 1996
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:31.904454Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:24.168023Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1fcc02aa-9cbf-4f39-86a0-b3809a1503ea","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:24.168023Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"6c8d2f06-2402-4b77-a3e4-f38f518c9d68","ipam_config":null,"mac_address":"02:00:00:1E:EA:A9","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","status":"ready","updated_at":"2025-01-27T09:16:40.273671Z","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:57.205022Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"ready","updated_at":"2025-02-12T16:15:34.005146Z","zone":"fr-par-1"}],"id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","ip":{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:34.260759Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "966"
+                - "1996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:31 GMT
+                - Wed, 12 Feb 2025 16:15:39 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2626,10 +2632,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 69100523-e090-4d59-a153-de6f8cee16f0
+                - dac31f8a-ca3e-4718-858c-2c1c5b739888
         status: 200 OK
         code: 200
-        duration: 46.539125ms
+        duration: 48.073834ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -2645,8 +2651,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b0c7102-c2a4-4497-b153-a63200c78895
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3bbc5634-ce11-4bce-adc4-39e0fac0db51
         method: GET
       response:
         proto: HTTP/2.0
@@ -2654,18 +2660,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1932
+        content_length: 996
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:24.896770Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:31.904454Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:24.168023Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1fcc02aa-9cbf-4f39-86a0-b3809a1503ea","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:24.168023Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"6c8d2f06-2402-4b77-a3e4-f38f518c9d68","ipam_config":null,"mac_address":"02:00:00:1E:EA:A9","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","status":"ready","updated_at":"2025-01-27T09:16:40.273671Z","zone":"fr-par-1"}],"id":"6b0c7102-c2a4-4497-b153-a63200c78895","ip":{"address":"51.15.236.157","created_at":"2025-01-27T09:16:24.787791Z","gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"ba392279-67e2-4332-a903-f17d6ebbf763","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"157-236-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:24.787791Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:40.396867Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"ready","updated_at":"2025-02-12T16:15:34.005146Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1932"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:31 GMT
+                - Wed, 12 Feb 2025 16:15:39 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2675,10 +2681,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b931fd46-81cd-4cec-9a03-210d7f43d029
+                - fd7205f3-3873-46f7-9ab2-22ea56338b0c
         status: 200 OK
         code: 200
-        duration: 36.789125ms
+        duration: 61.978334ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -2694,8 +2700,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/6c8d2f06-2402-4b77-a3e4-f38f518c9d68
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2703,18 +2709,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 966
+        content_length: 1996
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:31.904454Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:24.168023Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1fcc02aa-9cbf-4f39-86a0-b3809a1503ea","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:24.168023Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"6c8d2f06-2402-4b77-a3e4-f38f518c9d68","ipam_config":null,"mac_address":"02:00:00:1E:EA:A9","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","status":"ready","updated_at":"2025-01-27T09:16:40.273671Z","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:57.205022Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"ready","updated_at":"2025-02-12T16:15:34.005146Z","zone":"fr-par-1"}],"id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","ip":{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:34.260759Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "966"
+                - "1996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:31 GMT
+                - Wed, 12 Feb 2025 16:15:39 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2724,10 +2730,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5cfeb547-fc7c-467a-a3ce-b4a8dcb74e04
+                - 254e11b7-2f9e-4579-92ef-fd415a539f7d
         status: 200 OK
         code: 200
-        duration: 44.235334ms
+        duration: 48.595292ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -2743,8 +2749,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
         method: GET
       response:
         proto: HTTP/2.0
@@ -2752,18 +2758,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2753
+        content_length: 2289
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:25.382281+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-admiring-proskuriakova","id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"49","hypervisor_id":"802","node_id":"54","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:3d","maintenances":[],"modification_date":"2025-01-27T09:16:52.545227+00:00","name":"tf-srv-admiring-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:58.034166+00:00","id":"4f981b41-fe9a-43dc-b8d9-191aeae48de6","ipam_ip_ids":["d80f2638-f3d2-46ed-b9ec-a5a20888ef6b","8743156b-6aab-4ce8-b4e4-f07c6830edee"],"mac_address":"02:00:00:10:d4:b0","modification_date":"2025-01-27T09:17:30.198529+00:00","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","server_id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:25.382281+00:00","export_uri":null,"id":"bf39a892-33e3-4235-9a37-da79b76f0546","modification_date":"2025-01-27T09:16:25.382281+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","name":"tf-srv-admiring-proskuriakova"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.380750+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-greider","id":"ee6b8302-d285-4412-9af2-b94bfecca21c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"304","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d5","maintenances":[],"modification_date":"2025-02-12T16:15:03.386466+00:00","name":"tf-srv-vigilant-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2753"
+                - "2289"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:31 GMT
+                - Wed, 12 Feb 2025 16:15:39 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2773,10 +2779,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 156d47b1-4e6f-4c41-82f4-7c488cd080d3
+                - 6f17b1fa-29ee-418a-bec6-b758ea0e7e24
         status: 200 OK
         code: 200
-        duration: 189.53675ms
+        duration: 185.404083ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2792,8 +2798,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/bf39a892-33e3-4235-9a37-da79b76f0546
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3bbc5634-ce11-4bce-adc4-39e0fac0db51
         method: GET
       response:
         proto: HTTP/2.0
@@ -2801,18 +2807,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 529
+        content_length: 996
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T09:16:25.382281+00:00","export_uri":null,"id":"bf39a892-33e3-4235-9a37-da79b76f0546","modification_date":"2025-01-27T09:16:25.382281+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","name":"tf-srv-admiring-proskuriakova"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"ready","updated_at":"2025-02-12T16:15:34.005146Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "529"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:31 GMT
+                - Wed, 12 Feb 2025 16:15:39 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2822,10 +2828,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6b79b402-0881-4fbf-820d-ac6ba198134c
+                - cbd9f51e-e0bb-44c0-8741-d7434e5c1b51
         status: 200 OK
         code: 200
-        duration: 100.752834ms
+        duration: 67.928875ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2841,8 +2847,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/a5c02cb7-8020-4442-8634-e5ee2eff2c2c
         method: GET
       response:
         proto: HTTP/2.0
@@ -2850,18 +2856,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 143
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","type":"not_found"}'
         headers:
             Content-Length:
-                - "17"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:32 GMT
+                - Wed, 12 Feb 2025 16:15:39 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2871,10 +2877,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e3587ca5-7401-4ae6-9692-b7a55f6b387e
-        status: 200 OK
-        code: 200
-        duration: 80.827917ms
+                - c5091cec-fe42-437d-9c69-6285c2635aff
+        status: 404 Not Found
+        code: 404
+        duration: 65.210125ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -2890,8 +2896,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/a5c02cb7-8020-4442-8634-e5ee2eff2c2c
         method: GET
       response:
         proto: HTTP/2.0
@@ -2899,20 +2905,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 478
+        content_length: 701
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T09:16:58.034166+00:00","id":"4f981b41-fe9a-43dc-b8d9-191aeae48de6","ipam_ip_ids":["d80f2638-f3d2-46ed-b9ec-a5a20888ef6b","8743156b-6aab-4ce8-b4e4-f07c6830edee"],"mac_address":"02:00:00:10:d4:b0","modification_date":"2025-01-27T09:17:30.198529+00:00","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","server_id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"created_at":"2025-02-12T16:14:57.589514Z","id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:14:57.589514Z","id":"158fda61-e559-4737-996d-b3b846db132e","product_resource_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:14:57.589514Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "478"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:31 GMT
-            Link:
-                - </servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c/private_nics?page=1&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 16:15:40 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2922,12 +2926,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4474fc8d-183e-43c3-9a39-c758fdbd1a56
-            X-Total-Count:
-                - "1"
+                - 0b65d959-fdd9-4182-a10d-609529fc4cc1
         status: 200 OK
         code: 200
-        duration: 82.688041ms
+        duration: 85.381292ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -2943,8 +2945,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/ba392279-67e2-4332-a903-f17d6ebbf763
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -2952,18 +2954,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 392
+        content_length: 17
         uncompressed: false
-        body: '{"address":"51.15.236.157","created_at":"2025-01-27T09:16:24.787791Z","gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"ba392279-67e2-4332-a903-f17d6ebbf763","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"157-236-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:24.787791Z","zone":"fr-par-1"}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "392"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:33 GMT
+                - Wed, 12 Feb 2025 16:15:39 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2973,10 +2975,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 183c6c4d-7bdb-46ae-9de4-b8e9a1abfc27
+                - 9a24aae5-61de-4243-9721-836a120f75b6
         status: 200 OK
         code: 200
-        duration: 22.037ms
+        duration: 101.813042ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -2992,8 +2994,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/1fcc02aa-9cbf-4f39-86a0-b3809a1503ea
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -3001,18 +3003,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 568
+        content_length: 478
         uncompressed: false
-        body: '{"address":"192.168.1.1","created_at":"2025-01-27T09:16:24.168023Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1fcc02aa-9cbf-4f39-86a0-b3809a1503ea","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:24.168023Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "568"
+                - "478"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:33 GMT
+                - Wed, 12 Feb 2025 16:15:40 GMT
+            Link:
+                - </servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics?page=1&per_page=50&>; rel="last"
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3022,10 +3026,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bec96766-40b0-4cd3-a6da-fc2c459402aa
+                - 1e853c8c-b8d4-4500-a31d-55feafd3f7a4
+            X-Total-Count:
+                - "1"
         status: 200 OK
         code: 200
-        duration: 21.94075ms
+        duration: 113.95425ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -3041,8 +3047,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/5c4fe589-7af7-40b2-ae00-98727ba37cff
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/2572e954-7dde-486b-821f-38300c6d0173
         method: GET
       response:
         proto: HTTP/2.0
@@ -3050,18 +3056,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1066
+        content_length: 586
         uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:24.169710Z","dhcp_enabled":true,"id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T09:16:24.169710Z","id":"62e3abfa-d782-4d1f-85e4-35eee4a86c4f","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:30.366016Z","vpc_id":"c1a6d6b0-1c7f-422b-bc06-d1a6adb751e2"},{"created_at":"2025-01-27T09:16:24.169710Z","id":"917bd4ae-c131-4777-bb70-6656b7f70c0a","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:d7c0::/64","updated_at":"2025-01-27T09:16:30.370295Z","vpc_id":"c1a6d6b0-1c7f-422b-bc06-d1a6adb751e2"}],"tags":[],"updated_at":"2025-01-27T09:16:38.435535Z","vpc_id":"c1a6d6b0-1c7f-422b-bc06-d1a6adb751e2"}'
+        body: '{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1066"
+                - "586"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:33 GMT
+                - Wed, 12 Feb 2025 16:15:40 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3071,10 +3077,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a1bab1ba-81e4-40d4-9a5e-ed78f84037e9
+                - b3dbb0f1-06f9-40af-bcb6-45eebdb441b4
         status: 200 OK
         code: 200
-        duration: 27.841333ms
+        duration: 42.986666ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -3090,8 +3096,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b0c7102-c2a4-4497-b153-a63200c78895
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/da389c61-9c8f-475e-b2c5-b60333283fa5
         method: GET
       response:
         proto: HTTP/2.0
@@ -3099,18 +3105,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1932
+        content_length: 405
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:24.896770Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:31.904454Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:24.168023Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1fcc02aa-9cbf-4f39-86a0-b3809a1503ea","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:24.168023Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"6c8d2f06-2402-4b77-a3e4-f38f518c9d68","ipam_config":null,"mac_address":"02:00:00:1E:EA:A9","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","status":"ready","updated_at":"2025-01-27T09:16:40.273671Z","zone":"fr-par-1"}],"id":"6b0c7102-c2a4-4497-b153-a63200c78895","ip":{"address":"51.15.236.157","created_at":"2025-01-27T09:16:24.787791Z","gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"ba392279-67e2-4332-a903-f17d6ebbf763","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"157-236-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:24.787791Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:40.396867Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1932"
+                - "405"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:33 GMT
+                - Wed, 12 Feb 2025 16:15:40 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3120,10 +3126,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6c4ce26a-80ea-4fbe-aaec-c2b5268ce6d1
+                - 50264912-b9e3-4431-bb76-ed3ca90537e6
         status: 200 OK
         code: 200
-        duration: 26.616375ms
+        duration: 43.362333ms
     - id: 63
       request:
         proto: HTTP/1.1
@@ -3139,8 +3145,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/6c8d2f06-2402-4b77-a3e4-f38f518c9d68
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b3a3ea6c-4758-41c7-b9ad-22f9a410c192
         method: GET
       response:
         proto: HTTP/2.0
@@ -3148,18 +3154,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 966
+        content_length: 1089
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:31.904454Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:24.168023Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1fcc02aa-9cbf-4f39-86a0-b3809a1503ea","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:24.168023Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"6c8d2f06-2402-4b77-a3e4-f38f518c9d68","ipam_config":null,"mac_address":"02:00:00:1E:EA:A9","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","status":"ready","updated_at":"2025-01-27T09:16:40.273671Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:14:56.161859Z","dhcp_enabled":true,"id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:14:56.161859Z","id":"1d110e71-77c2-4e0d-8b2a-44e5e61a0211","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:15:21.807710Z","vpc_id":"b388d228-a931-443f-87b2-379c9af5934b"},{"created_at":"2025-02-12T16:14:56.161859Z","id":"ad46a815-2df6-4e07-ad92-d99d79d18c7d","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:b62b::/64","updated_at":"2025-02-12T16:15:21.811374Z","vpc_id":"b388d228-a931-443f-87b2-379c9af5934b"}],"tags":[],"updated_at":"2025-02-12T16:15:30.215218Z","vpc_id":"b388d228-a931-443f-87b2-379c9af5934b"}'
         headers:
             Content-Length:
-                - "966"
+                - "1089"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:33 GMT
+                - Wed, 12 Feb 2025 16:15:40 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3169,10 +3175,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d491f1dc-e28b-4ff8-9df5-cd9efa21485c
+                - 7f5a029f-5cda-4707-b174-af070a6d08af
         status: 200 OK
         code: 200
-        duration: 49.038458ms
+        duration: 49.480834ms
     - id: 64
       request:
         proto: HTTP/1.1
@@ -3188,8 +3194,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b0c7102-c2a4-4497-b153-a63200c78895
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3197,18 +3203,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1932
+        content_length: 1996
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:24.896770Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:31.904454Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:24.168023Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1fcc02aa-9cbf-4f39-86a0-b3809a1503ea","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:24.168023Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"6c8d2f06-2402-4b77-a3e4-f38f518c9d68","ipam_config":null,"mac_address":"02:00:00:1E:EA:A9","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","status":"ready","updated_at":"2025-01-27T09:16:40.273671Z","zone":"fr-par-1"}],"id":"6b0c7102-c2a4-4497-b153-a63200c78895","ip":{"address":"51.15.236.157","created_at":"2025-01-27T09:16:24.787791Z","gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"ba392279-67e2-4332-a903-f17d6ebbf763","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"157-236-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:24.787791Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:40.396867Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:57.205022Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"ready","updated_at":"2025-02-12T16:15:34.005146Z","zone":"fr-par-1"}],"id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","ip":{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:34.260759Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1932"
+                - "1996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:33 GMT
+                - Wed, 12 Feb 2025 16:15:40 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3218,10 +3224,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a9abbfb9-08a7-45f6-b164-2b3fb9b9c7c9
+                - cb115cf3-7688-46f9-9808-a222b96ef4c1
         status: 200 OK
         code: 200
-        duration: 28.794209ms
+        duration: 48.026208ms
     - id: 65
       request:
         proto: HTTP/1.1
@@ -3237,8 +3243,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/6c8d2f06-2402-4b77-a3e4-f38f518c9d68
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3bbc5634-ce11-4bce-adc4-39e0fac0db51
         method: GET
       response:
         proto: HTTP/2.0
@@ -3246,18 +3252,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 966
+        content_length: 996
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:31.904454Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:24.168023Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1fcc02aa-9cbf-4f39-86a0-b3809a1503ea","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:24.168023Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"6c8d2f06-2402-4b77-a3e4-f38f518c9d68","ipam_config":null,"mac_address":"02:00:00:1E:EA:A9","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","status":"ready","updated_at":"2025-01-27T09:16:40.273671Z","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"ready","updated_at":"2025-02-12T16:15:34.005146Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "966"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:33 GMT
+                - Wed, 12 Feb 2025 16:15:40 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3267,10 +3273,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5ac56a1e-6759-484e-9727-b43d9bcdbe24
+                - 08e8c2bd-ec30-4501-a30e-1196feaf022b
         status: 200 OK
         code: 200
-        duration: 42.764792ms
+        duration: 67.089292ms
     - id: 66
       request:
         proto: HTTP/1.1
@@ -3286,8 +3292,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3295,18 +3301,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2753
+        content_length: 1996
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:25.382281+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-admiring-proskuriakova","id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"49","hypervisor_id":"802","node_id":"54","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:3d","maintenances":[],"modification_date":"2025-01-27T09:16:52.545227+00:00","name":"tf-srv-admiring-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:58.034166+00:00","id":"4f981b41-fe9a-43dc-b8d9-191aeae48de6","ipam_ip_ids":["d80f2638-f3d2-46ed-b9ec-a5a20888ef6b","8743156b-6aab-4ce8-b4e4-f07c6830edee"],"mac_address":"02:00:00:10:d4:b0","modification_date":"2025-01-27T09:17:30.198529+00:00","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","server_id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:25.382281+00:00","export_uri":null,"id":"bf39a892-33e3-4235-9a37-da79b76f0546","modification_date":"2025-01-27T09:16:25.382281+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","name":"tf-srv-admiring-proskuriakova"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:57.205022Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"ready","updated_at":"2025-02-12T16:15:34.005146Z","zone":"fr-par-1"}],"id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","ip":{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:34.260759Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2753"
+                - "1996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:33 GMT
+                - Wed, 12 Feb 2025 16:15:40 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3316,10 +3322,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9aefd61d-d331-40ac-b3cf-487007a9152a
+                - 885747b0-d442-486f-9be9-192b45646325
         status: 200 OK
         code: 200
-        duration: 171.892417ms
+        duration: 46.152125ms
     - id: 67
       request:
         proto: HTTP/1.1
@@ -3335,8 +3341,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/bf39a892-33e3-4235-9a37-da79b76f0546
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3bbc5634-ce11-4bce-adc4-39e0fac0db51
         method: GET
       response:
         proto: HTTP/2.0
@@ -3344,18 +3350,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 529
+        content_length: 996
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T09:16:25.382281+00:00","export_uri":null,"id":"bf39a892-33e3-4235-9a37-da79b76f0546","modification_date":"2025-01-27T09:16:25.382281+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","name":"tf-srv-admiring-proskuriakova"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"ready","updated_at":"2025-02-12T16:15:34.005146Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "529"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:33 GMT
+                - Wed, 12 Feb 2025 16:15:40 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3365,10 +3371,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - acd852a4-db1b-4750-912e-49d72f98138e
+                - b0fdb8fe-b183-4709-8954-b94957576b5e
         status: 200 OK
         code: 200
-        duration: 84.035458ms
+        duration: 71.531333ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -3384,8 +3390,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
         method: GET
       response:
         proto: HTTP/2.0
@@ -3393,18 +3399,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 2289
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.380750+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-greider","id":"ee6b8302-d285-4412-9af2-b94bfecca21c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"304","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d5","maintenances":[],"modification_date":"2025-02-12T16:15:03.386466+00:00","name":"tf-srv-vigilant-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "17"
+                - "2289"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:33 GMT
+                - Wed, 12 Feb 2025 16:15:40 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3414,10 +3420,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9b26d691-4675-4a14-8f9e-76455006f9fd
+                - 0911211c-98b4-4b8f-9980-3123c656175d
         status: 200 OK
         code: 200
-        duration: 78.264542ms
+        duration: 254.308083ms
     - id: 69
       request:
         proto: HTTP/1.1
@@ -3433,8 +3439,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/a5c02cb7-8020-4442-8634-e5ee2eff2c2c
         method: GET
       response:
         proto: HTTP/2.0
@@ -3442,20 +3448,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 478
+        content_length: 143
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T09:16:58.034166+00:00","id":"4f981b41-fe9a-43dc-b8d9-191aeae48de6","ipam_ip_ids":["d80f2638-f3d2-46ed-b9ec-a5a20888ef6b","8743156b-6aab-4ce8-b4e4-f07c6830edee"],"mac_address":"02:00:00:10:d4:b0","modification_date":"2025-01-27T09:17:30.198529+00:00","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","server_id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","type":"not_found"}'
         headers:
             Content-Length:
-                - "478"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:33 GMT
-            Link:
-                - </servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c/private_nics?page=1&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 16:15:40 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3465,12 +3469,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 399858a9-6ea0-4958-abd5-0670816d4440
-            X-Total-Count:
-                - "1"
-        status: 200 OK
-        code: 200
-        duration: 79.945541ms
+                - 98372324-f4f9-4305-95dd-598e0b1bfd66
+        status: 404 Not Found
+        code: 404
+        duration: 68.79275ms
     - id: 70
       request:
         proto: HTTP/1.1
@@ -3486,8 +3488,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=6c8d2f06-2402-4b77-a3e4-f38f518c9d68&mac_address=02%3A00%3A00%3A10%3Ad4%3Ab0&order_by=created_at_asc&type=unknown
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/a5c02cb7-8020-4442-8634-e5ee2eff2c2c
         method: GET
       response:
         proto: HTTP/2.0
@@ -3495,18 +3497,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 369
+        content_length: 701
         uncompressed: false
-        body: '{"dhcp_entries":[{"created_at":"2025-01-27T09:16:58.511906Z","gateway_network_id":"6c8d2f06-2402-4b77-a3e4-f38f518c9d68","hostname":"tf-srv-admiring-proskuriakova","id":"d80f2638-f3d2-46ed-b9ec-a5a20888ef6b","ip_address":"192.168.1.2","mac_address":"02:00:00:10:d4:b0","type":"reservation","updated_at":"2025-01-27T09:16:58.511906Z","zone":"fr-par-1"}],"total_count":1}'
+        body: '{"created_at":"2025-02-12T16:14:57.589514Z","id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:14:57.589514Z","id":"158fda61-e559-4737-996d-b3b846db132e","product_resource_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:14:57.589514Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "369"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:33 GMT
+                - Wed, 12 Feb 2025 16:15:40 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3516,10 +3518,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3f7abd90-a2a3-4e68-b799-783856defad0
+                - 42bc6e08-7f5e-4f88-b9cb-95729c6425da
         status: 200 OK
         code: 200
-        duration: 62.575708ms
+        duration: 93.464792ms
     - id: 71
       request:
         proto: HTTP/1.1
@@ -3535,694 +3537,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/d80f2638-f3d2-46ed-b9ec-a5a20888ef6b
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 334
-        uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:58.511906Z","gateway_network_id":"6c8d2f06-2402-4b77-a3e4-f38f518c9d68","hostname":"tf-srv-admiring-proskuriakova","id":"d80f2638-f3d2-46ed-b9ec-a5a20888ef6b","ip_address":"192.168.1.2","mac_address":"02:00:00:10:d4:b0","type":"reservation","updated_at":"2025-01-27T09:16:58.511906Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "334"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:33 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 9cd1c7e7-dab1-40bc-b0a7-3027e270dd37
-        status: 200 OK
-        code: 200
-        duration: 63.56675ms
-    - id: 72
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=6c8d2f06-2402-4b77-a3e4-f38f518c9d68&mac_address=02%3A00%3A00%3A10%3Ad4%3Ab0&order_by=created_at_asc&type=unknown
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 369
-        uncompressed: false
-        body: '{"dhcp_entries":[{"created_at":"2025-01-27T09:16:58.511906Z","gateway_network_id":"6c8d2f06-2402-4b77-a3e4-f38f518c9d68","hostname":"tf-srv-admiring-proskuriakova","id":"d80f2638-f3d2-46ed-b9ec-a5a20888ef6b","ip_address":"192.168.1.2","mac_address":"02:00:00:10:d4:b0","type":"reservation","updated_at":"2025-01-27T09:16:58.511906Z","zone":"fr-par-1"}],"total_count":1}'
-        headers:
-            Content-Length:
-                - "369"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:34 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - e8216b84-7833-453e-9caf-41296474f878
-        status: 200 OK
-        code: 200
-        duration: 71.7315ms
-    - id: 73
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/d80f2638-f3d2-46ed-b9ec-a5a20888ef6b
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 334
-        uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:58.511906Z","gateway_network_id":"6c8d2f06-2402-4b77-a3e4-f38f518c9d68","hostname":"tf-srv-admiring-proskuriakova","id":"d80f2638-f3d2-46ed-b9ec-a5a20888ef6b","ip_address":"192.168.1.2","mac_address":"02:00:00:10:d4:b0","type":"reservation","updated_at":"2025-01-27T09:16:58.511906Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "334"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:34 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 523a0b34-ff08-4b01-ad26-b0f0890e0da5
-        status: 200 OK
-        code: 200
-        duration: 68.105458ms
-    - id: 74
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=6c8d2f06-2402-4b77-a3e4-f38f518c9d68&mac_address=02%3A00%3A00%3A10%3Ad4%3Ab0&order_by=created_at_asc&type=unknown
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 369
-        uncompressed: false
-        body: '{"dhcp_entries":[{"created_at":"2025-01-27T09:16:58.511906Z","gateway_network_id":"6c8d2f06-2402-4b77-a3e4-f38f518c9d68","hostname":"tf-srv-admiring-proskuriakova","id":"d80f2638-f3d2-46ed-b9ec-a5a20888ef6b","ip_address":"192.168.1.2","mac_address":"02:00:00:10:d4:b0","type":"reservation","updated_at":"2025-01-27T09:16:58.511906Z","zone":"fr-par-1"}],"total_count":1}'
-        headers:
-            Content-Length:
-                - "369"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:35 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - cafa4db1-a07d-4744-ba8a-b17f4dd9ac81
-        status: 200 OK
-        code: 200
-        duration: 79.073208ms
-    - id: 75
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/d80f2638-f3d2-46ed-b9ec-a5a20888ef6b
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 334
-        uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:58.511906Z","gateway_network_id":"6c8d2f06-2402-4b77-a3e4-f38f518c9d68","hostname":"tf-srv-admiring-proskuriakova","id":"d80f2638-f3d2-46ed-b9ec-a5a20888ef6b","ip_address":"192.168.1.2","mac_address":"02:00:00:10:d4:b0","type":"reservation","updated_at":"2025-01-27T09:16:58.511906Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "334"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:35 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 5614b1ee-b1d7-409c-a7e5-807bfed27fd6
-        status: 200 OK
-        code: 200
-        duration: 65.821375ms
-    - id: 76
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/ba392279-67e2-4332-a903-f17d6ebbf763
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 392
-        uncompressed: false
-        body: '{"address":"51.15.236.157","created_at":"2025-01-27T09:16:24.787791Z","gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"ba392279-67e2-4332-a903-f17d6ebbf763","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"157-236-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:24.787791Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "392"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:35 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - a201551e-54bb-4c47-b1cf-9de930232dd1
-        status: 200 OK
-        code: 200
-        duration: 29.689583ms
-    - id: 77
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/1fcc02aa-9cbf-4f39-86a0-b3809a1503ea
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 568
-        uncompressed: false
-        body: '{"address":"192.168.1.1","created_at":"2025-01-27T09:16:24.168023Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1fcc02aa-9cbf-4f39-86a0-b3809a1503ea","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:24.168023Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "568"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:35 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 2836c9a8-9d67-4de6-a380-a2fb99dca13e
-        status: 200 OK
-        code: 200
-        duration: 23.361917ms
-    - id: 78
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/5c4fe589-7af7-40b2-ae00-98727ba37cff
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1066
-        uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:24.169710Z","dhcp_enabled":true,"id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T09:16:24.169710Z","id":"62e3abfa-d782-4d1f-85e4-35eee4a86c4f","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:30.366016Z","vpc_id":"c1a6d6b0-1c7f-422b-bc06-d1a6adb751e2"},{"created_at":"2025-01-27T09:16:24.169710Z","id":"917bd4ae-c131-4777-bb70-6656b7f70c0a","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:d7c0::/64","updated_at":"2025-01-27T09:16:30.370295Z","vpc_id":"c1a6d6b0-1c7f-422b-bc06-d1a6adb751e2"}],"tags":[],"updated_at":"2025-01-27T09:16:38.435535Z","vpc_id":"c1a6d6b0-1c7f-422b-bc06-d1a6adb751e2"}'
-        headers:
-            Content-Length:
-                - "1066"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:35 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 97a2ea8d-3725-4f24-a5c1-3aa4c150290b
-        status: 200 OK
-        code: 200
-        duration: 28.312042ms
-    - id: 79
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b0c7102-c2a4-4497-b153-a63200c78895
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1932
-        uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:24.896770Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:31.904454Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:24.168023Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1fcc02aa-9cbf-4f39-86a0-b3809a1503ea","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:24.168023Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"6c8d2f06-2402-4b77-a3e4-f38f518c9d68","ipam_config":null,"mac_address":"02:00:00:1E:EA:A9","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","status":"ready","updated_at":"2025-01-27T09:16:40.273671Z","zone":"fr-par-1"}],"id":"6b0c7102-c2a4-4497-b153-a63200c78895","ip":{"address":"51.15.236.157","created_at":"2025-01-27T09:16:24.787791Z","gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"ba392279-67e2-4332-a903-f17d6ebbf763","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"157-236-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:24.787791Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:40.396867Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "1932"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:35 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 38960382-56a9-428d-82f6-1f7a30fcc1e0
-        status: 200 OK
-        code: 200
-        duration: 31.2405ms
-    - id: 80
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/6c8d2f06-2402-4b77-a3e4-f38f518c9d68
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 966
-        uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:31.904454Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:24.168023Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1fcc02aa-9cbf-4f39-86a0-b3809a1503ea","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:24.168023Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"6c8d2f06-2402-4b77-a3e4-f38f518c9d68","ipam_config":null,"mac_address":"02:00:00:1E:EA:A9","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","status":"ready","updated_at":"2025-01-27T09:16:40.273671Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "966"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:35 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - a087752c-6f03-4d81-9a29-004dbf7864b1
-        status: 200 OK
-        code: 200
-        duration: 48.614375ms
-    - id: 81
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b0c7102-c2a4-4497-b153-a63200c78895
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1932
-        uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:24.896770Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:31.904454Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:24.168023Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1fcc02aa-9cbf-4f39-86a0-b3809a1503ea","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:24.168023Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"6c8d2f06-2402-4b77-a3e4-f38f518c9d68","ipam_config":null,"mac_address":"02:00:00:1E:EA:A9","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","status":"ready","updated_at":"2025-01-27T09:16:40.273671Z","zone":"fr-par-1"}],"id":"6b0c7102-c2a4-4497-b153-a63200c78895","ip":{"address":"51.15.236.157","created_at":"2025-01-27T09:16:24.787791Z","gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"ba392279-67e2-4332-a903-f17d6ebbf763","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"157-236-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:24.787791Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:40.396867Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "1932"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:35 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 3f0ddf74-7191-4cf9-b095-da0d181e7da6
-        status: 200 OK
-        code: 200
-        duration: 29.605583ms
-    - id: 82
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2753
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:25.382281+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-admiring-proskuriakova","id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"49","hypervisor_id":"802","node_id":"54","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:3d","maintenances":[],"modification_date":"2025-01-27T09:16:52.545227+00:00","name":"tf-srv-admiring-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:58.034166+00:00","id":"4f981b41-fe9a-43dc-b8d9-191aeae48de6","ipam_ip_ids":["d80f2638-f3d2-46ed-b9ec-a5a20888ef6b","8743156b-6aab-4ce8-b4e4-f07c6830edee"],"mac_address":"02:00:00:10:d4:b0","modification_date":"2025-01-27T09:17:30.198529+00:00","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","server_id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:25.382281+00:00","export_uri":null,"id":"bf39a892-33e3-4235-9a37-da79b76f0546","modification_date":"2025-01-27T09:16:25.382281+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","name":"tf-srv-admiring-proskuriakova"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2753"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:35 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 546859ad-07a7-4f66-91c9-733b65dda7c5
-        status: 200 OK
-        code: 200
-        duration: 606.264583ms
-    - id: 83
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/bf39a892-33e3-4235-9a37-da79b76f0546
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 529
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T09:16:25.382281+00:00","export_uri":null,"id":"bf39a892-33e3-4235-9a37-da79b76f0546","modification_date":"2025-01-27T09:16:25.382281+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","name":"tf-srv-admiring-proskuriakova"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "529"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:36 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 58adc324-3b78-411f-99a0-eb54f04eddfa
-        status: 200 OK
-        code: 200
-        duration: 97.373208ms
-    - id: 84
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/6c8d2f06-2402-4b77-a3e4-f38f518c9d68
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 966
-        uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:31.904454Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:24.168023Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1fcc02aa-9cbf-4f39-86a0-b3809a1503ea","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:24.168023Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"6c8d2f06-2402-4b77-a3e4-f38f518c9d68","ipam_config":null,"mac_address":"02:00:00:1E:EA:A9","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","status":"ready","updated_at":"2025-01-27T09:16:40.273671Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "966"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:36 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 0f844984-fd90-44af-a0d6-58b290d218da
-        status: 200 OK
-        code: 200
-        duration: 586.181708ms
-    - id: 85
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -4241,7 +3557,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:36 GMT
+                - Wed, 12 Feb 2025 16:15:40 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4251,10 +3567,700 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8dd558a3-d47c-4215-a687-c9f0444ffdb8
+                - 5a15f0b7-3dec-409b-b53f-f08a316de0e9
         status: 200 OK
         code: 200
-        duration: 94.796375ms
+        duration: 101.676917ms
+    - id: 72
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 478
+        uncompressed: false
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        headers:
+            Content-Length:
+                - "478"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:41 GMT
+            Link:
+                - </servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics?page=1&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8ae042a8-81e5-4e3f-9a81-7a21b152bca5
+            X-Total-Count:
+                - "1"
+        status: 200 OK
+        code: 200
+        duration: 99.224791ms
+    - id: 73
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=3bbc5634-ce11-4bce-adc4-39e0fac0db51&mac_address=02%3A00%3A00%3A1a%3Ab9%3A0f&order_by=created_at_asc&type=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 371
+        uncompressed: false
+        body: '{"dhcp_entries":[{"created_at":"2025-02-12T16:15:06.192027Z","gateway_network_id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","hostname":"tf-srv-vigilant-greider","id":"a0e6c4af-1b58-48dc-8357-7f7e2795ad61","ip_address":"172.16.8.2","mac_address":"02:00:00:1a:b9:0f","type":"reservation","updated_at":"2025-02-12T16:15:06.192027Z","zone":"fr-par-1"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "371"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3e2d3e33-1dc8-4b5b-b837-b0293486a826
+        status: 200 OK
+        code: 200
+        duration: 87.979958ms
+    - id: 74
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/a0e6c4af-1b58-48dc-8357-7f7e2795ad61
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 335
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:15:06.192027Z","gateway_network_id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","hostname":"tf-srv-vigilant-greider","id":"a0e6c4af-1b58-48dc-8357-7f7e2795ad61","ip_address":"172.16.8.2","mac_address":"02:00:00:1a:b9:0f","type":"reservation","updated_at":"2025-02-12T16:15:06.192027Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "335"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e1c22caf-ff51-41d2-bc82-4e2620990a59
+        status: 200 OK
+        code: 200
+        duration: 112.733209ms
+    - id: 75
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=3bbc5634-ce11-4bce-adc4-39e0fac0db51&mac_address=02%3A00%3A00%3A1a%3Ab9%3A0f&order_by=created_at_asc&type=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 371
+        uncompressed: false
+        body: '{"dhcp_entries":[{"created_at":"2025-02-12T16:15:06.192027Z","gateway_network_id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","hostname":"tf-srv-vigilant-greider","id":"a0e6c4af-1b58-48dc-8357-7f7e2795ad61","ip_address":"172.16.8.2","mac_address":"02:00:00:1a:b9:0f","type":"reservation","updated_at":"2025-02-12T16:15:06.192027Z","zone":"fr-par-1"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "371"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 54cb9a04-7577-4b15-9fd3-0b4c3ffa3da4
+        status: 200 OK
+        code: 200
+        duration: 96.77925ms
+    - id: 76
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/a0e6c4af-1b58-48dc-8357-7f7e2795ad61
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 335
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:15:06.192027Z","gateway_network_id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","hostname":"tf-srv-vigilant-greider","id":"a0e6c4af-1b58-48dc-8357-7f7e2795ad61","ip_address":"172.16.8.2","mac_address":"02:00:00:1a:b9:0f","type":"reservation","updated_at":"2025-02-12T16:15:06.192027Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "335"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9b17a850-fde7-4161-927c-f53559c2781f
+        status: 200 OK
+        code: 200
+        duration: 112.009375ms
+    - id: 77
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=3bbc5634-ce11-4bce-adc4-39e0fac0db51&mac_address=02%3A00%3A00%3A1a%3Ab9%3A0f&order_by=created_at_asc&type=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 371
+        uncompressed: false
+        body: '{"dhcp_entries":[{"created_at":"2025-02-12T16:15:06.192027Z","gateway_network_id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","hostname":"tf-srv-vigilant-greider","id":"a0e6c4af-1b58-48dc-8357-7f7e2795ad61","ip_address":"172.16.8.2","mac_address":"02:00:00:1a:b9:0f","type":"reservation","updated_at":"2025-02-12T16:15:06.192027Z","zone":"fr-par-1"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "371"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c9f165a7-816e-4d8b-b4ad-f22661a0da74
+        status: 200 OK
+        code: 200
+        duration: 95.373875ms
+    - id: 78
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/a0e6c4af-1b58-48dc-8357-7f7e2795ad61
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 335
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:15:06.192027Z","gateway_network_id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","hostname":"tf-srv-vigilant-greider","id":"a0e6c4af-1b58-48dc-8357-7f7e2795ad61","ip_address":"172.16.8.2","mac_address":"02:00:00:1a:b9:0f","type":"reservation","updated_at":"2025-02-12T16:15:06.192027Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "335"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b6bdd128-46e5-4928-968b-e4d0a89b35f0
+        status: 200 OK
+        code: 200
+        duration: 99.869792ms
+    - id: 79
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/da389c61-9c8f-475e-b2c5-b60333283fa5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 405
+        uncompressed: false
+        body: '{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "405"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 88ffec3b-7cbc-4915-ba11-a72d6867837f
+        status: 200 OK
+        code: 200
+        duration: 41.328542ms
+    - id: 80
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/2572e954-7dde-486b-821f-38300c6d0173
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 586
+        uncompressed: false
+        body: '{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "586"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5065c594-6090-4a2b-a841-c1fbbb5ff116
+        status: 200 OK
+        code: 200
+        duration: 45.846167ms
+    - id: 81
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b3a3ea6c-4758-41c7-b9ad-22f9a410c192
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1089
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:14:56.161859Z","dhcp_enabled":true,"id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:14:56.161859Z","id":"1d110e71-77c2-4e0d-8b2a-44e5e61a0211","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:15:21.807710Z","vpc_id":"b388d228-a931-443f-87b2-379c9af5934b"},{"created_at":"2025-02-12T16:14:56.161859Z","id":"ad46a815-2df6-4e07-ad92-d99d79d18c7d","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:b62b::/64","updated_at":"2025-02-12T16:15:21.811374Z","vpc_id":"b388d228-a931-443f-87b2-379c9af5934b"}],"tags":[],"updated_at":"2025-02-12T16:15:30.215218Z","vpc_id":"b388d228-a931-443f-87b2-379c9af5934b"}'
+        headers:
+            Content-Length:
+                - "1089"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 59e7236e-bae6-4a23-b225-1c2f3f0319be
+        status: 200 OK
+        code: 200
+        duration: 50.109625ms
+    - id: 82
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1996
+        uncompressed: false
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:57.205022Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"ready","updated_at":"2025-02-12T16:15:34.005146Z","zone":"fr-par-1"}],"id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","ip":{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:34.260759Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "1996"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b90fc793-3427-405d-9412-69cc3cc63d6c
+        status: 200 OK
+        code: 200
+        duration: 43.784958ms
+    - id: 83
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2289
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.380750+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-greider","id":"ee6b8302-d285-4412-9af2-b94bfecca21c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"304","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d5","maintenances":[],"modification_date":"2025-02-12T16:15:03.386466+00:00","name":"tf-srv-vigilant-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2289"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1b2b8133-0498-4ffd-bf2b-35ffaaea9514
+        status: 200 OK
+        code: 200
+        duration: 188.847416ms
+    - id: 84
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3bbc5634-ce11-4bce-adc4-39e0fac0db51
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 996
+        uncompressed: false
+        body: '{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"ready","updated_at":"2025-02-12T16:15:34.005146Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "996"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ffb0f88d-4a14-496f-bd3a-2d9998c71d42
+        status: 200 OK
+        code: 200
+        duration: 170.514292ms
+    - id: 85
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/a5c02cb7-8020-4442-8634-e5ee2eff2c2c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1862c8c5-aa94-4c93-a30c-70566159c0cf
+        status: 404 Not Found
+        code: 404
+        duration: 49.610084ms
     - id: 86
       request:
         proto: HTTP/1.1
@@ -4270,8 +4276,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7
         method: GET
       response:
         proto: HTTP/2.0
@@ -4279,20 +4285,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 478
+        content_length: 1996
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T09:16:58.034166+00:00","id":"4f981b41-fe9a-43dc-b8d9-191aeae48de6","ipam_ip_ids":["d80f2638-f3d2-46ed-b9ec-a5a20888ef6b","8743156b-6aab-4ce8-b4e4-f07c6830edee"],"mac_address":"02:00:00:10:d4:b0","modification_date":"2025-01-27T09:17:30.198529+00:00","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","server_id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:57.205022Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"ready","updated_at":"2025-02-12T16:15:34.005146Z","zone":"fr-par-1"}],"id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","ip":{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:34.260759Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "478"
+                - "1996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:36 GMT
-            Link:
-                - </servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c/private_nics?page=1&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 16:15:42 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4302,12 +4306,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f08bd61c-6a62-4141-9724-6bc8c01d3dc5
-            X-Total-Count:
-                - "1"
+                - 1b40b8c3-228f-47ae-b969-e70294ae1b1b
         status: 200 OK
         code: 200
-        duration: 85.26775ms
+        duration: 47.496167ms
     - id: 87
       request:
         proto: HTTP/1.1
@@ -4323,8 +4325,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=6c8d2f06-2402-4b77-a3e4-f38f518c9d68&mac_address=02%3A00%3A00%3A10%3Ad4%3Ab0&order_by=created_at_asc&type=unknown
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3bbc5634-ce11-4bce-adc4-39e0fac0db51
         method: GET
       response:
         proto: HTTP/2.0
@@ -4332,18 +4334,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 369
+        content_length: 996
         uncompressed: false
-        body: '{"dhcp_entries":[{"created_at":"2025-01-27T09:16:58.511906Z","gateway_network_id":"6c8d2f06-2402-4b77-a3e4-f38f518c9d68","hostname":"tf-srv-admiring-proskuriakova","id":"d80f2638-f3d2-46ed-b9ec-a5a20888ef6b","ip_address":"192.168.1.2","mac_address":"02:00:00:10:d4:b0","type":"reservation","updated_at":"2025-01-27T09:16:58.511906Z","zone":"fr-par-1"}],"total_count":1}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"ready","updated_at":"2025-02-12T16:15:34.005146Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "369"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:36 GMT
+                - Wed, 12 Feb 2025 16:15:42 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4353,10 +4355,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d1475176-da66-40ef-aa28-ef92aaa70b08
+                - c4ea8443-bbb6-4654-b919-9db5a5c7d926
         status: 200 OK
         code: 200
-        duration: 73.674625ms
+        duration: 62.907667ms
     - id: 88
       request:
         proto: HTTP/1.1
@@ -4372,8 +4374,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/d80f2638-f3d2-46ed-b9ec-a5a20888ef6b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/a5c02cb7-8020-4442-8634-e5ee2eff2c2c
         method: GET
       response:
         proto: HTTP/2.0
@@ -4381,18 +4383,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 334
+        content_length: 701
         uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:58.511906Z","gateway_network_id":"6c8d2f06-2402-4b77-a3e4-f38f518c9d68","hostname":"tf-srv-admiring-proskuriakova","id":"d80f2638-f3d2-46ed-b9ec-a5a20888ef6b","ip_address":"192.168.1.2","mac_address":"02:00:00:10:d4:b0","type":"reservation","updated_at":"2025-01-27T09:16:58.511906Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:14:57.589514Z","id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:14:57.589514Z","id":"158fda61-e559-4737-996d-b3b846db132e","product_resource_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:14:57.589514Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "334"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:36 GMT
+                - Wed, 12 Feb 2025 16:15:42 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4402,10 +4404,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 83c8bc2a-a78c-4b89-a231-1ca2428a3be9
+                - f05eb6b5-507a-47a0-8f93-8d7345f7f895
         status: 200 OK
         code: 200
-        duration: 71.884833ms
+        duration: 94.791125ms
     - id: 89
       request:
         proto: HTTP/1.1
@@ -4421,8 +4423,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=6c8d2f06-2402-4b77-a3e4-f38f518c9d68&mac_address=02%3A00%3A00%3A10%3Ad4%3Ab0&order_by=created_at_asc&type=unknown
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -4430,18 +4432,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 369
+        content_length: 17
         uncompressed: false
-        body: '{"dhcp_entries":[{"created_at":"2025-01-27T09:16:58.511906Z","gateway_network_id":"6c8d2f06-2402-4b77-a3e4-f38f518c9d68","hostname":"tf-srv-admiring-proskuriakova","id":"d80f2638-f3d2-46ed-b9ec-a5a20888ef6b","ip_address":"192.168.1.2","mac_address":"02:00:00:10:d4:b0","type":"reservation","updated_at":"2025-01-27T09:16:58.511906Z","zone":"fr-par-1"}],"total_count":1}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "369"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:37 GMT
+                - Wed, 12 Feb 2025 16:15:43 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4451,10 +4453,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 39a586df-6fb2-41b3-a96f-49c931327090
+                - 8c382f2c-587b-4956-a9b6-4b2e2e84c24b
         status: 200 OK
         code: 200
-        duration: 133.951333ms
+        duration: 584.985333ms
     - id: 90
       request:
         proto: HTTP/1.1
@@ -4470,8 +4472,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/d80f2638-f3d2-46ed-b9ec-a5a20888ef6b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -4479,18 +4481,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 334
+        content_length: 478
         uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:58.511906Z","gateway_network_id":"6c8d2f06-2402-4b77-a3e4-f38f518c9d68","hostname":"tf-srv-admiring-proskuriakova","id":"d80f2638-f3d2-46ed-b9ec-a5a20888ef6b","ip_address":"192.168.1.2","mac_address":"02:00:00:10:d4:b0","type":"reservation","updated_at":"2025-01-27T09:16:58.511906Z","zone":"fr-par-1"}'
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "334"
+                - "478"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:37 GMT
+                - Wed, 12 Feb 2025 16:15:43 GMT
+            Link:
+                - </servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics?page=1&per_page=50&>; rel="last"
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4500,10 +4504,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2e100b57-f4af-45b9-b54a-302fc258e762
+                - 1988d89a-d1f4-4e28-a20c-74d60fc4614a
+            X-Total-Count:
+                - "1"
         status: 200 OK
         code: 200
-        duration: 61.2175ms
+        duration: 101.66675ms
     - id: 91
       request:
         proto: HTTP/1.1
@@ -4519,8 +4525,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/6c8d2f06-2402-4b77-a3e4-f38f518c9d68
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=3bbc5634-ce11-4bce-adc4-39e0fac0db51&mac_address=02%3A00%3A00%3A1a%3Ab9%3A0f&order_by=created_at_asc&type=unknown
         method: GET
       response:
         proto: HTTP/2.0
@@ -4528,18 +4534,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 966
+        content_length: 371
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:31.904454Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:24.168023Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1fcc02aa-9cbf-4f39-86a0-b3809a1503ea","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:24.168023Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"6c8d2f06-2402-4b77-a3e4-f38f518c9d68","ipam_config":null,"mac_address":"02:00:00:1E:EA:A9","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","status":"ready","updated_at":"2025-01-27T09:16:40.273671Z","zone":"fr-par-1"}'
+        body: '{"dhcp_entries":[{"created_at":"2025-02-12T16:15:06.192027Z","gateway_network_id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","hostname":"tf-srv-vigilant-greider","id":"a0e6c4af-1b58-48dc-8357-7f7e2795ad61","ip_address":"172.16.8.2","mac_address":"02:00:00:1a:b9:0f","type":"reservation","updated_at":"2025-02-12T16:15:06.192027Z","zone":"fr-par-1"}],"total_count":1}'
         headers:
             Content-Length:
-                - "966"
+                - "371"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:38 GMT
+                - Wed, 12 Feb 2025 16:15:43 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4549,10 +4555,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5e9fbcd4-db0a-4955-9acc-bff4480f1cdb
+                - 18f2aed8-1583-48d3-95da-aeb711c12dc4
         status: 200 OK
         code: 200
-        duration: 44.292584ms
+        duration: 90.665541ms
     - id: 92
       request:
         proto: HTTP/1.1
@@ -4568,8 +4574,253 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/6c8d2f06-2402-4b77-a3e4-f38f518c9d68?cleanup_dhcp=true
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/a0e6c4af-1b58-48dc-8357-7f7e2795ad61
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 335
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:15:06.192027Z","gateway_network_id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","hostname":"tf-srv-vigilant-greider","id":"a0e6c4af-1b58-48dc-8357-7f7e2795ad61","ip_address":"172.16.8.2","mac_address":"02:00:00:1a:b9:0f","type":"reservation","updated_at":"2025-02-12T16:15:06.192027Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "335"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:43 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 893b2b9c-7c61-4b36-a94e-2e5fb8367e27
+        status: 200 OK
+        code: 200
+        duration: 99.729834ms
+    - id: 93
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=3bbc5634-ce11-4bce-adc4-39e0fac0db51&mac_address=02%3A00%3A00%3A1a%3Ab9%3A0f&order_by=created_at_asc&type=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 371
+        uncompressed: false
+        body: '{"dhcp_entries":[{"created_at":"2025-02-12T16:15:06.192027Z","gateway_network_id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","hostname":"tf-srv-vigilant-greider","id":"a0e6c4af-1b58-48dc-8357-7f7e2795ad61","ip_address":"172.16.8.2","mac_address":"02:00:00:1a:b9:0f","type":"reservation","updated_at":"2025-02-12T16:15:06.192027Z","zone":"fr-par-1"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "371"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:43 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 694f1461-c13f-4548-aa10-c2fc1ee18ce2
+        status: 200 OK
+        code: 200
+        duration: 91.645166ms
+    - id: 94
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/a0e6c4af-1b58-48dc-8357-7f7e2795ad61
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 335
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:15:06.192027Z","gateway_network_id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","hostname":"tf-srv-vigilant-greider","id":"a0e6c4af-1b58-48dc-8357-7f7e2795ad61","ip_address":"172.16.8.2","mac_address":"02:00:00:1a:b9:0f","type":"reservation","updated_at":"2025-02-12T16:15:06.192027Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "335"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:43 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3c4f818f-36ee-4bc1-beb4-11a4121b6a7a
+        status: 200 OK
+        code: 200
+        duration: 115.099917ms
+    - id: 95
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3bbc5634-ce11-4bce-adc4-39e0fac0db51
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 996
+        uncompressed: false
+        body: '{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"ready","updated_at":"2025-02-12T16:15:34.005146Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "996"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - dbb0f289-32df-403d-9ed3-7739e02de958
+        status: 200 OK
+        code: 200
+        duration: 62.570625ms
+    - id: 96
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2289
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.380750+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-greider","id":"ee6b8302-d285-4412-9af2-b94bfecca21c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"304","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d5","maintenances":[],"modification_date":"2025-02-12T16:15:03.386466+00:00","name":"tf-srv-vigilant-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2289"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:43 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4713061b-840e-410f-9b99-7af885d54076
+        status: 200 OK
+        code: 200
+        duration: 182.159041ms
+    - id: 97
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3bbc5634-ce11-4bce-adc4-39e0fac0db51?cleanup_dhcp=true
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -4586,7 +4837,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:38 GMT
+                - Wed, 12 Feb 2025 16:15:44 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4596,11 +4847,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 86487ea3-53e4-4d74-942d-f07658077feb
+                - 41ec04dd-ac03-4abf-bdea-255db272812b
         status: 204 No Content
         code: 204
-        duration: 83.878291ms
-    - id: 93
+        duration: 140.814125ms
+    - id: 98
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4615,8 +4866,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/6c8d2f06-2402-4b77-a3e4-f38f518c9d68
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3bbc5634-ce11-4bce-adc4-39e0fac0db51
         method: GET
       response:
         proto: HTTP/2.0
@@ -4624,18 +4875,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 970
+        content_length: 1000
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:31.904454Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:24.168023Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1fcc02aa-9cbf-4f39-86a0-b3809a1503ea","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:24.168023Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"6c8d2f06-2402-4b77-a3e4-f38f518c9d68","ipam_config":null,"mac_address":"02:00:00:1E:EA:A9","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","status":"detaching","updated_at":"2025-01-27T09:17:38.150633Z","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:23.555839Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.917095Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"2572e954-7dde-486b-821f-38300c6d0173","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.917095Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","ipam_config":null,"mac_address":"02:00:00:1A:66:4D","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","status":"detaching","updated_at":"2025-02-12T16:15:44.238822Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "970"
+                - "1000"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:38 GMT
+                - Wed, 12 Feb 2025 16:15:44 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4645,11 +4896,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 052b96ce-78ce-4343-9661-995b5d5af2c6
+                - 648c374a-d344-494c-9ad8-8509e155c855
         status: 200 OK
         code: 200
-        duration: 48.963125ms
-    - id: 94
+        duration: 62.99375ms
+    - id: 99
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4664,8 +4915,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/a5c02cb7-8020-4442-8634-e5ee2eff2c2c
         method: GET
       response:
         proto: HTTP/2.0
@@ -4673,18 +4924,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2753
+        content_length: 701
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:25.382281+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-admiring-proskuriakova","id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"49","hypervisor_id":"802","node_id":"54","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:3d","maintenances":[],"modification_date":"2025-01-27T09:16:52.545227+00:00","name":"tf-srv-admiring-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:58.034166+00:00","id":"4f981b41-fe9a-43dc-b8d9-191aeae48de6","ipam_ip_ids":["d80f2638-f3d2-46ed-b9ec-a5a20888ef6b","8743156b-6aab-4ce8-b4e4-f07c6830edee"],"mac_address":"02:00:00:10:d4:b0","modification_date":"2025-01-27T09:17:30.198529+00:00","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","server_id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:25.382281+00:00","export_uri":null,"id":"bf39a892-33e3-4235-9a37-da79b76f0546","modification_date":"2025-01-27T09:16:25.382281+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","name":"tf-srv-admiring-proskuriakova"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-12T16:14:57.589514Z","id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:14:57.589514Z","id":"158fda61-e559-4737-996d-b3b846db132e","product_resource_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:14:57.589514Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2753"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:38 GMT
+                - Wed, 12 Feb 2025 16:15:44 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4694,11 +4945,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4abe5806-b963-49e8-bc62-41deeb65e8c2
+                - 2f75e9b1-8170-41d6-8672-32678e8aa069
         status: 200 OK
         code: 200
-        duration: 357.255542ms
-    - id: 95
+        duration: 83.949667ms
+    - id: 100
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4715,8 +4966,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -4726,7 +4977,7 @@ interactions:
         trailer: {}
         content_length: 352
         uncompressed: false
-        body: '{"task":{"description":"server_poweroff","href_from":"/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c/action","href_result":"/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c","id":"6d04b158-d0a5-417d-93e3-6fe248e07611","progress":0,"started_at":"2025-01-27T09:17:38.607362+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_poweroff","href_from":"/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/action","href_result":"/servers/ee6b8302-d285-4412-9af2-b94bfecca21c","id":"b13299ea-80e2-4667-b30a-f914265802d5","progress":0,"started_at":"2025-02-12T16:15:44.560394+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "352"
@@ -4735,9 +4986,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:38 GMT
+                - Wed, 12 Feb 2025 16:15:44 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/6d04b158-d0a5-417d-93e3-6fe248e07611
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/b13299ea-80e2-4667-b30a-f914265802d5
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4747,255 +4998,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 13187f4b-d25a-4153-8eab-900c375e8afb
+                - cfc85fc7-cc17-4038-ac5c-fa11f66596fa
         status: 202 Accepted
         code: 202
-        duration: 244.402416ms
-    - id: 96
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2713
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:25.382281+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-admiring-proskuriakova","id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"49","hypervisor_id":"802","node_id":"54","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:3d","maintenances":[],"modification_date":"2025-01-27T09:17:38.427781+00:00","name":"tf-srv-admiring-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:58.034166+00:00","id":"4f981b41-fe9a-43dc-b8d9-191aeae48de6","ipam_ip_ids":["d80f2638-f3d2-46ed-b9ec-a5a20888ef6b","8743156b-6aab-4ce8-b4e4-f07c6830edee"],"mac_address":"02:00:00:10:d4:b0","modification_date":"2025-01-27T09:17:30.198529+00:00","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","server_id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:25.382281+00:00","export_uri":null,"id":"bf39a892-33e3-4235-9a37-da79b76f0546","modification_date":"2025-01-27T09:16:25.382281+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","name":"tf-srv-admiring-proskuriakova"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2713"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:38 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 9d47793f-05f8-4a7d-ab8d-1c7fff7db62f
-        status: 200 OK
-        code: 200
-        duration: 357.1955ms
-    - id: 97
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/6c8d2f06-2402-4b77-a3e4-f38f518c9d68
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 136
-        uncompressed: false
-        body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"6c8d2f06-2402-4b77-a3e4-f38f518c9d68","type":"not_found"}'
-        headers:
-            Content-Length:
-                - "136"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:43 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 17242230-6465-48b5-8199-d7436b75563a
-        status: 404 Not Found
-        code: 404
-        duration: 28.013709ms
-    - id: 98
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b0c7102-c2a4-4497-b153-a63200c78895
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 966
-        uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:24.896770Z","gateway_networks":[],"id":"6b0c7102-c2a4-4497-b153-a63200c78895","ip":{"address":"51.15.236.157","created_at":"2025-01-27T09:16:24.787791Z","gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"ba392279-67e2-4332-a903-f17d6ebbf763","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"157-236-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:24.787791Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:40.396867Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "966"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:43 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 5fa66d4a-3123-4653-a9f8-2ef88a7e3920
-        status: 200 OK
-        code: 200
-        duration: 28.78025ms
-    - id: 99
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/1fcc02aa-9cbf-4f39-86a0-b3809a1503ea
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 125
-        uncompressed: false
-        body: '{"message":"resource is not found","resource":"dhcp","resource_id":"1fcc02aa-9cbf-4f39-86a0-b3809a1503ea","type":"not_found"}'
-        headers:
-            Content-Length:
-                - "125"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:43 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 1ba91f3b-1323-4d5f-b12f-bbad943954e6
-        status: 404 Not Found
-        code: 404
-        duration: 21.814209ms
-    - id: 100
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b0c7102-c2a4-4497-b153-a63200c78895
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 966
-        uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:24.896770Z","gateway_networks":[],"id":"6b0c7102-c2a4-4497-b153-a63200c78895","ip":{"address":"51.15.236.157","created_at":"2025-01-27T09:16:24.787791Z","gateway_id":"6b0c7102-c2a4-4497-b153-a63200c78895","id":"ba392279-67e2-4332-a903-f17d6ebbf763","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"157-236-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:24.787791Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:40.396867Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "966"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:43 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - f72be10a-cb70-4c94-9a8f-c46a8400ed71
-        status: 200 OK
-        code: 200
-        duration: 26.369583ms
+        duration: 249.639833ms
     - id: 101
       request:
         proto: HTTP/1.1
@@ -5011,25 +5017,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b0c7102-c2a4-4497-b153-a63200c78895?cleanup_dhcp=false
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 2249
         uncompressed: false
-        body: ""
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.380750+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-greider","id":"ee6b8302-d285-4412-9af2-b94bfecca21c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"304","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d5","maintenances":[],"modification_date":"2025-02-12T16:15:44.380597+00:00","name":"tf-srv-vigilant-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
+            Content-Length:
+                - "2249"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:43 GMT
+                - Wed, 12 Feb 2025 16:15:44 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5039,10 +5047,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 73c108d5-6bfc-4758-8ebc-8e79d588b592
-        status: 204 No Content
-        code: 204
-        duration: 48.691917ms
+                - 827690f3-40e7-4385-8eba-58affdfe75fa
+        status: 200 OK
+        code: 200
+        duration: 170.096417ms
     - id: 102
       request:
         proto: HTTP/1.1
@@ -5058,8 +5066,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b0c7102-c2a4-4497-b153-a63200c78895
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3bbc5634-ce11-4bce-adc4-39e0fac0db51
         method: GET
       response:
         proto: HTTP/2.0
@@ -5067,18 +5075,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 128
+        content_length: 136
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"gateway","resource_id":"6b0c7102-c2a4-4497-b153-a63200c78895","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"3bbc5634-ce11-4bce-adc4-39e0fac0db51","type":"not_found"}'
         headers:
             Content-Length:
-                - "128"
+                - "136"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:43 GMT
+                - Wed, 12 Feb 2025 16:15:49 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5088,10 +5096,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cf37fddc-f830-4f4c-8fcd-03014073b58b
+                - 2c2091b2-2416-4c54-8d64-616664a54ba6
         status: 404 Not Found
         code: 404
-        duration: 23.802167ms
+        duration: 44.889375ms
     - id: 103
       request:
         proto: HTTP/1.1
@@ -5107,25 +5115,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/ba392279-67e2-4332-a903-f17d6ebbf763
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 1000
         uncompressed: false
-        body: ""
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:57.205022Z","gateway_networks":[],"id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","ip":{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:34.260759Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
+            Content-Length:
+                - "1000"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:44 GMT
+                - Wed, 12 Feb 2025 16:15:49 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5135,10 +5145,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 32a655b3-8d6a-4c3a-bd65-ed65e9644b7c
-        status: 204 No Content
-        code: 204
-        duration: 688.102083ms
+                - dcbe3f70-d90e-4ed4-9a88-f65c1896e6f2
+        status: 200 OK
+        code: 200
+        duration: 50.099958ms
     - id: 104
       request:
         proto: HTTP/1.1
@@ -5154,27 +5164,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/2572e954-7dde-486b-821f-38300c6d0173
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2713
+        content_length: 125
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:25.382281+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-admiring-proskuriakova","id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"49","hypervisor_id":"802","node_id":"54","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:3d","maintenances":[],"modification_date":"2025-01-27T09:17:38.427781+00:00","name":"tf-srv-admiring-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:58.034166+00:00","id":"4f981b41-fe9a-43dc-b8d9-191aeae48de6","ipam_ip_ids":["d80f2638-f3d2-46ed-b9ec-a5a20888ef6b","8743156b-6aab-4ce8-b4e4-f07c6830edee"],"mac_address":"02:00:00:10:d4:b0","modification_date":"2025-01-27T09:17:30.198529+00:00","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","server_id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:25.382281+00:00","export_uri":null,"id":"bf39a892-33e3-4235-9a37-da79b76f0546","modification_date":"2025-01-27T09:16:25.382281+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","name":"tf-srv-admiring-proskuriakova"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"dhcp","resource_id":"2572e954-7dde-486b-821f-38300c6d0173","type":"not_found"}'
         headers:
             Content-Length:
-                - "2713"
+                - "125"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:44 GMT
+                - Wed, 12 Feb 2025 16:15:49 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5184,10 +5194,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 742bddd0-2cdf-45d4-8c6b-c981bf7ccf2b
-        status: 200 OK
-        code: 200
-        duration: 169.13825ms
+                - a85b07b8-25e3-411a-af4e-c8a6f9fe84f9
+        status: 404 Not Found
+        code: 404
+        duration: 47.6635ms
     - id: 105
       request:
         proto: HTTP/1.1
@@ -5203,8 +5213,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7
         method: GET
       response:
         proto: HTTP/2.0
@@ -5212,18 +5222,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2713
+        content_length: 1000
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:25.382281+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-admiring-proskuriakova","id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"49","hypervisor_id":"802","node_id":"54","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:3d","maintenances":[],"modification_date":"2025-01-27T09:17:38.427781+00:00","name":"tf-srv-admiring-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:58.034166+00:00","id":"4f981b41-fe9a-43dc-b8d9-191aeae48de6","ipam_ip_ids":["d80f2638-f3d2-46ed-b9ec-a5a20888ef6b","8743156b-6aab-4ce8-b4e4-f07c6830edee"],"mac_address":"02:00:00:10:d4:b0","modification_date":"2025-01-27T09:17:30.198529+00:00","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","server_id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:25.382281+00:00","export_uri":null,"id":"bf39a892-33e3-4235-9a37-da79b76f0546","modification_date":"2025-01-27T09:16:25.382281+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","name":"tf-srv-admiring-proskuriakova"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:57.205022Z","gateway_networks":[],"id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","ip":{"address":"163.172.158.131","created_at":"2025-02-12T16:14:57.039516Z","gateway_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","id":"da389c61-9c8f-475e-b2c5-b60333283fa5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"131-158-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:57.039516Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:34.260759Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2713"
+                - "1000"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:48 GMT
+                - Wed, 12 Feb 2025 16:15:49 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5233,10 +5243,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4b29ed62-d49f-4a28-8ea4-55a6bf2afc05
+                - df4ab062-02de-4342-861b-e330d19ef7ae
         status: 200 OK
         code: 200
-        duration: 164.016834ms
+        duration: 50.52725ms
     - id: 106
       request:
         proto: HTTP/1.1
@@ -5252,27 +5262,25 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7?cleanup_dhcp=false
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2713
+        content_length: 0
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:25.382281+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-admiring-proskuriakova","id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"49","hypervisor_id":"802","node_id":"54","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:3d","maintenances":[],"modification_date":"2025-01-27T09:17:38.427781+00:00","name":"tf-srv-admiring-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:58.034166+00:00","id":"4f981b41-fe9a-43dc-b8d9-191aeae48de6","ipam_ip_ids":["d80f2638-f3d2-46ed-b9ec-a5a20888ef6b","8743156b-6aab-4ce8-b4e4-f07c6830edee"],"mac_address":"02:00:00:10:d4:b0","modification_date":"2025-01-27T09:17:30.198529+00:00","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","server_id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:25.382281+00:00","export_uri":null,"id":"bf39a892-33e3-4235-9a37-da79b76f0546","modification_date":"2025-01-27T09:16:25.382281+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","name":"tf-srv-admiring-proskuriakova"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: ""
         headers:
-            Content-Length:
-                - "2713"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:54 GMT
+                - Wed, 12 Feb 2025 16:15:49 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5282,10 +5290,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 79bcbc04-1435-496c-aaad-2ea56dc097a9
-        status: 200 OK
-        code: 200
-        duration: 164.032583ms
+                - 07d26cb7-6fbf-48ff-8959-8170f3f74597
+        status: 204 No Content
+        code: 204
+        duration: 56.604167ms
     - id: 107
       request:
         proto: HTTP/1.1
@@ -5301,8 +5309,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/edb6cea7-f8fc-4ff4-8b9a-332e24d484e7
         method: GET
       response:
         proto: HTTP/2.0
@@ -5310,18 +5318,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2713
+        content_length: 128
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:25.382281+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-admiring-proskuriakova","id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"49","hypervisor_id":"802","node_id":"54","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:3d","maintenances":[],"modification_date":"2025-01-27T09:17:38.427781+00:00","name":"tf-srv-admiring-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:58.034166+00:00","id":"4f981b41-fe9a-43dc-b8d9-191aeae48de6","ipam_ip_ids":["d80f2638-f3d2-46ed-b9ec-a5a20888ef6b","8743156b-6aab-4ce8-b4e4-f07c6830edee"],"mac_address":"02:00:00:10:d4:b0","modification_date":"2025-01-27T09:17:30.198529+00:00","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","server_id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:25.382281+00:00","export_uri":null,"id":"bf39a892-33e3-4235-9a37-da79b76f0546","modification_date":"2025-01-27T09:16:25.382281+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","name":"tf-srv-admiring-proskuriakova"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"gateway","resource_id":"edb6cea7-f8fc-4ff4-8b9a-332e24d484e7","type":"not_found"}'
         headers:
             Content-Length:
-                - "2713"
+                - "128"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:59 GMT
+                - Wed, 12 Feb 2025 16:15:49 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5331,10 +5339,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 651e1fff-afeb-44db-a6c2-66767d2a703a
-        status: 200 OK
-        code: 200
-        duration: 170.7715ms
+                - 4051ce7a-6322-43fc-bede-5dee9227abd7
+        status: 404 Not Found
+        code: 404
+        duration: 40.91775ms
     - id: 108
       request:
         proto: HTTP/1.1
@@ -5350,8 +5358,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
         method: GET
       response:
         proto: HTTP/2.0
@@ -5359,18 +5367,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2597
+        content_length: 2249
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:25.382281+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-admiring-proskuriakova","id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ea:3d","maintenances":[],"modification_date":"2025-01-27T09:18:01.150520+00:00","name":"tf-srv-admiring-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:58.034166+00:00","id":"4f981b41-fe9a-43dc-b8d9-191aeae48de6","ipam_ip_ids":["d80f2638-f3d2-46ed-b9ec-a5a20888ef6b","8743156b-6aab-4ce8-b4e4-f07c6830edee"],"mac_address":"02:00:00:10:d4:b0","modification_date":"2025-01-27T09:17:30.198529+00:00","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","server_id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:25.382281+00:00","export_uri":null,"id":"bf39a892-33e3-4235-9a37-da79b76f0546","modification_date":"2025-01-27T09:16:25.382281+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","name":"tf-srv-admiring-proskuriakova"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.380750+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-greider","id":"ee6b8302-d285-4412-9af2-b94bfecca21c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"304","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d5","maintenances":[],"modification_date":"2025-02-12T16:15:44.380597+00:00","name":"tf-srv-vigilant-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2597"
+                - "2249"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:18:04 GMT
+                - Wed, 12 Feb 2025 16:15:49 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5380,10 +5388,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1317089b-2907-49fd-b32f-8d324aaff0e3
+                - 94e3e8a5-bd21-482b-9738-7b7acb8dd5fc
         status: 200 OK
         code: 200
-        duration: 124.709333ms
+        duration: 189.136042ms
     - id: 109
       request:
         proto: HTTP/1.1
@@ -5399,29 +5407,25 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c/private_nics
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/da389c61-9c8f-475e-b2c5-b60333283fa5
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 478
+        content_length: 0
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T09:16:58.034166+00:00","id":"4f981b41-fe9a-43dc-b8d9-191aeae48de6","ipam_ip_ids":["d80f2638-f3d2-46ed-b9ec-a5a20888ef6b","8743156b-6aab-4ce8-b4e4-f07c6830edee"],"mac_address":"02:00:00:10:d4:b0","modification_date":"2025-01-27T09:17:30.198529+00:00","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","server_id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: ""
         headers:
-            Content-Length:
-                - "478"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:18:04 GMT
-            Link:
-                - </servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c/private_nics?page=1&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 16:15:50 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5431,12 +5435,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b050195e-c997-4488-9037-7b34bcee7dce
-            X-Total-Count:
-                - "1"
-        status: 200 OK
-        code: 200
-        duration: 91.588667ms
+                - 13f74629-d2d7-4af9-b255-7a671374e88b
+        status: 204 No Content
+        code: 204
+        duration: 766.762625ms
     - id: 110
       request:
         proto: HTTP/1.1
@@ -5452,8 +5454,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c/private_nics/4f981b41-fe9a-43dc-b8d9-191aeae48de6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
         method: GET
       response:
         proto: HTTP/2.0
@@ -5461,18 +5463,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 475
+        content_length: 2249
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:58.034166+00:00","id":"4f981b41-fe9a-43dc-b8d9-191aeae48de6","ipam_ip_ids":["d80f2638-f3d2-46ed-b9ec-a5a20888ef6b","8743156b-6aab-4ce8-b4e4-f07c6830edee"],"mac_address":"02:00:00:10:d4:b0","modification_date":"2025-01-27T09:17:30.198529+00:00","private_network_id":"5c4fe589-7af7-40b2-ae00-98727ba37cff","server_id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.380750+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-greider","id":"ee6b8302-d285-4412-9af2-b94bfecca21c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"304","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d5","maintenances":[],"modification_date":"2025-02-12T16:15:44.380597+00:00","name":"tf-srv-vigilant-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "475"
+                - "2249"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:18:04 GMT
+                - Wed, 12 Feb 2025 16:15:55 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5482,10 +5484,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d1538b3c-cecd-40a9-ba17-1d4fe951ada0
+                - 1e815ecd-17b2-4bf2-978d-e93788c48b17
         status: 200 OK
         code: 200
-        duration: 78.632792ms
+        duration: 185.562542ms
     - id: 111
       request:
         proto: HTTP/1.1
@@ -5501,25 +5503,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c/private_nics/4f981b41-fe9a-43dc-b8d9-191aeae48de6
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 2249
         uncompressed: false
-        body: ""
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.380750+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-greider","id":"ee6b8302-d285-4412-9af2-b94bfecca21c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"304","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d5","maintenances":[],"modification_date":"2025-02-12T16:15:44.380597+00:00","name":"tf-srv-vigilant-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
+            Content-Length:
+                - "2249"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:18:04 GMT
+                - Wed, 12 Feb 2025 16:16:00 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5529,10 +5533,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bb1cb21e-3a44-4c4c-a20d-5c3de8035094
-        status: 204 No Content
-        code: 204
-        duration: 259.192875ms
+                - a72eb2a6-1d95-4ee6-be22-d73935e41bff
+        status: 200 OK
+        code: 200
+        duration: 167.2015ms
     - id: 112
       request:
         proto: HTTP/1.1
@@ -5548,8 +5552,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c/private_nics/4f981b41-fe9a-43dc-b8d9-191aeae48de6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
         method: GET
       response:
         proto: HTTP/2.0
@@ -5557,18 +5561,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 148
+        content_length: 2249
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"4f981b41-fe9a-43dc-b8d9-191aeae48de6","type":"not_found"}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.380750+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-greider","id":"ee6b8302-d285-4412-9af2-b94bfecca21c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"304","node_id":"4","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d5","maintenances":[],"modification_date":"2025-02-12T16:15:44.380597+00:00","name":"tf-srv-vigilant-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "148"
+                - "2249"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:18:05 GMT
+                - Wed, 12 Feb 2025 16:16:04 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5578,10 +5582,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 38ec8ae5-6e18-4cba-b108-260fc504913a
-        status: 404 Not Found
-        code: 404
-        duration: 97.980458ms
+                - 0234392d-543f-4b07-8f52-a5957179bf4d
+        status: 200 OK
+        code: 200
+        duration: 263.107084ms
     - id: 113
       request:
         proto: HTTP/1.1
@@ -5597,8 +5601,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
         method: GET
       response:
         proto: HTTP/2.0
@@ -5606,18 +5610,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2139
+        content_length: 2134
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:25.382281+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-admiring-proskuriakova","id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ea:3d","maintenances":[],"modification_date":"2025-01-27T09:18:01.150520+00:00","name":"tf-srv-admiring-proskuriakova","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:25.382281+00:00","export_uri":null,"id":"bf39a892-33e3-4235-9a37-da79b76f0546","modification_date":"2025-01-27T09:16:25.382281+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","name":"tf-srv-admiring-proskuriakova"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.380750+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-greider","id":"ee6b8302-d285-4412-9af2-b94bfecca21c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:d5","maintenances":[],"modification_date":"2025-02-12T16:16:06.159287+00:00","name":"tf-srv-vigilant-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2139"
+                - "2134"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:18:05 GMT
+                - Wed, 12 Feb 2025 16:16:10 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5627,10 +5631,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 312e0511-200d-4401-9dfb-ca7e91896af1
+                - c3bf5179-84e4-4a7b-b5d5-de60f6b50cab
         status: 200 OK
         code: 200
-        duration: 144.411917ms
+        duration: 186.585167ms
     - id: 114
       request:
         proto: HTTP/1.1
@@ -5646,25 +5650,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 478
         uncompressed: false
-        body: ""
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
+            Content-Length:
+                - "478"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:18:05 GMT
+                - Wed, 12 Feb 2025 16:16:10 GMT
+            Link:
+                - </servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics?page=1&per_page=50&>; rel="last"
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5674,10 +5682,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b66a9665-757d-463a-b274-b9743fb55be0
-        status: 204 No Content
-        code: 204
-        duration: 168.839958ms
+                - 09e53faa-83fd-4cf1-b843-a80ac551f3c4
+            X-Total-Count:
+                - "1"
+        status: 200 OK
+        code: 200
+        duration: 119.103542ms
     - id: 115
       request:
         proto: HTTP/1.1
@@ -5693,8 +5703,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c18e3b71-18a0-45e4-87b8-be29bf7df12c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics/ba175159-76a5-4f16-b338-f91217d775e7
         method: GET
       response:
         proto: HTTP/2.0
@@ -5702,18 +5712,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 143
+        content_length: 475
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"c18e3b71-18a0-45e4-87b8-be29bf7df12c","type":"not_found"}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:04.802610+00:00","id":"ba175159-76a5-4f16-b338-f91217d775e7","ipam_ip_ids":["a0e6c4af-1b58-48dc-8357-7f7e2795ad61","e22ad276-5a77-4420-9840-cae43dfac20e"],"mac_address":"02:00:00:1a:b9:0f","modification_date":"2025-02-12T16:15:37.624393+00:00","private_network_id":"b3a3ea6c-4758-41c7-b9ad-22f9a410c192","server_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "143"
+                - "475"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:18:05 GMT
+                - Wed, 12 Feb 2025 16:16:10 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5723,10 +5733,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dbf59f6b-40b2-4d17-80e2-ba0cc26cf028
-        status: 404 Not Found
-        code: 404
-        duration: 83.178458ms
+                - edf00627-aed5-4880-86cc-4c5ad8055464
+        status: 200 OK
+        code: 200
+        duration: 114.382416ms
     - id: 116
       request:
         proto: HTTP/1.1
@@ -5742,27 +5752,25 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/bf39a892-33e3-4235-9a37-da79b76f0546
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics/ba175159-76a5-4f16-b338-f91217d775e7
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 446
+        content_length: 0
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T09:16:25.382281+00:00","export_uri":null,"id":"bf39a892-33e3-4235-9a37-da79b76f0546","modification_date":"2025-01-27T09:18:05.507486+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: ""
         headers:
-            Content-Length:
-                - "446"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:18:05 GMT
+                - Wed, 12 Feb 2025 16:16:10 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5772,10 +5780,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 21a81bf9-f724-4b75-ba50-8d6890f0b797
-        status: 200 OK
-        code: 200
-        duration: 78.635667ms
+                - a4667d45-d37a-4823-af0c-66d84dcd3b5a
+        status: 204 No Content
+        code: 204
+        duration: 411.542125ms
     - id: 117
       request:
         proto: HTTP/1.1
@@ -5791,25 +5799,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/bf39a892-33e3-4235-9a37-da79b76f0546
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c/private_nics/ba175159-76a5-4f16-b338-f91217d775e7
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 148
         uncompressed: false
-        body: ""
+        body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"ba175159-76a5-4f16-b338-f91217d775e7","type":"not_found"}'
         headers:
+            Content-Length:
+                - "148"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:18:05 GMT
+                - Wed, 12 Feb 2025 16:16:11 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5819,10 +5829,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 75f7fee3-f042-42e2-b527-26193709d7af
-        status: 204 No Content
-        code: 204
-        duration: 156.216958ms
+                - a089443c-7a79-4101-9dea-baf9430c0820
+        status: 404 Not Found
+        code: 404
+        duration: 107.879041ms
     - id: 118
       request:
         proto: HTTP/1.1
@@ -5838,8 +5848,57 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/5c4fe589-7af7-40b2-ae00-98727ba37cff
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1676
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.380750+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-greider","id":"ee6b8302-d285-4412-9af2-b94bfecca21c","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:d5","maintenances":[],"modification_date":"2025-02-12T16:16:06.159287+00:00","name":"tf-srv-vigilant-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1676"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:16:11 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c04c3cb5-1ac7-426a-bc68-c92dd57a7090
+        status: 200 OK
+        code: 200
+        duration: 300.237291ms
+    - id: 119
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5856,7 +5915,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:18:07 GMT
+                - Wed, 12 Feb 2025 16:16:12 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5866,11 +5925,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4b8990cd-103e-4f2a-b383-69cf5c5c381b
+                - fc03cf45-431a-498c-8b65-6d837f088587
         status: 204 No Content
         code: 204
-        duration: 1.345729s
-    - id: 119
+        duration: 613.006666ms
+    - id: 120
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -5885,8 +5944,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/1fcc02aa-9cbf-4f39-86a0-b3809a1503ea
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ee6b8302-d285-4412-9af2-b94bfecca21c
         method: GET
       response:
         proto: HTTP/2.0
@@ -5894,18 +5953,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 125
+        content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"dhcp","resource_id":"1fcc02aa-9cbf-4f39-86a0-b3809a1503ea","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"ee6b8302-d285-4412-9af2-b94bfecca21c","type":"not_found"}'
         headers:
             Content-Length:
-                - "125"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:18:07 GMT
+                - Wed, 12 Feb 2025 16:16:12 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5915,7 +5974,248 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2e30afb6-ca3c-4b0f-97d0-03f0d790f88a
+                - 81b3f984-5f11-4850-b4ee-3710cffc9bbf
         status: 404 Not Found
         code: 404
-        duration: 25.872834ms
+        duration: 128.503667ms
+    - id: 121
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/a5c02cb7-8020-4442-8634-e5ee2eff2c2c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:16:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 73d50f46-c465-4894-a9df-b1d52c3e254b
+        status: 404 Not Found
+        code: 404
+        duration: 54.43125ms
+    - id: 122
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/a5c02cb7-8020-4442-8634-e5ee2eff2c2c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 494
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:14:57.589514Z","id":"a5c02cb7-8020-4442-8634-e5ee2eff2c2c","last_detached_at":"2025-02-12T16:16:12.307337Z","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:16:12.307337Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "494"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:16:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a23c2e15-216f-486e-8d55-6cbfcd8aaa92
+        status: 200 OK
+        code: 200
+        duration: 98.469917ms
+    - id: 123
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/a5c02cb7-8020-4442-8634-e5ee2eff2c2c
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:16:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f105bae2-ec99-4bb2-a6ab-388eabc0eacc
+        status: 204 No Content
+        code: 204
+        duration: 145.76ms
+    - id: 124
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b3a3ea6c-4758-41c7-b9ad-22f9a410c192
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:16:14 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 28b3ebbc-be36-438f-a5b0-6097850eb632
+        status: 204 No Content
+        code: 204
+        duration: 1.3018405s
+    - id: 125
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/2572e954-7dde-486b-821f-38300c6d0173
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 125
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"dhcp","resource_id":"2572e954-7dde-486b-821f-38300c6d0173","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "125"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:16:14 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 928d1650-bad1-4a64-ac03-7775b5d8a3b7
+        status: 404 Not Found
+        code: 404
+        duration: 48.676459ms

--- a/internal/services/vpcgw/testdata/data-source-vpc-public-gateway-dhcp-reservation-static.cassette.yaml
+++ b/internal/services/vpcgw/testdata/data-source-vpc-public-gateway-dhcp-reservation-static.cassette.yaml
@@ -18,7 +18,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps
         method: POST
       response:
@@ -27,18 +27,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 568
+        content_length: 586
         uncompressed: false
-        body: '{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.242510Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"95c3edc0-cf35-40f9-bfb2-2af399b47a92","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.242510Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+        body: '{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.930530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"538c4a96-d996-45ca-b414-59e27b15ba9c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.930530Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "568"
+                - "586"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:01 GMT
+                - Wed, 12 Feb 2025 16:14:55 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2e4add2f-07ec-4d8d-972d-66f200299bae
+                - 2498c501-c4dd-4cbe-baf9-40bb361bc088
         status: 200 OK
         code: 200
-        duration: 58.885875ms
+        duration: 290.271125ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/95c3edc0-cf35-40f9-bfb2-2af399b47a92
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/538c4a96-d996-45ca-b414-59e27b15ba9c
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,18 +76,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 568
+        content_length: 586
         uncompressed: false
-        body: '{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.242510Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"95c3edc0-cf35-40f9-bfb2-2af399b47a92","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.242510Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+        body: '{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.930530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"538c4a96-d996-45ca-b414-59e27b15ba9c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.930530Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "568"
+                - "586"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:01 GMT
+                - Wed, 12 Feb 2025 16:14:55 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -97,28 +97,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 850d334e-bd5e-4b7f-b8ff-d1d9a6a9fe1e
+                - 4d485fdb-3b5b-4fa7-bb4e-e0657827f57d
         status: 200 OK
         code: 200
-        duration: 130.996541ms
+        duration: 41.996084ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 189
+        content_length: 197
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-sg-keen-wing","project":"105bdce1-64c0-48ab-899d-868455867ecf","stateful":true,"inbound_default_policy":"drop","outbound_default_policy":"accept","enable_default_security":true}'
+        body: '{"name":"tf-sg-nostalgic-hypatia","project":"105bdce1-64c0-48ab-899d-868455867ecf","stateful":true,"inbound_default_policy":"drop","outbound_default_policy":"accept","enable_default_security":true}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups
         method: POST
       response:
@@ -127,20 +127,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 579
+        content_length: 587
         uncompressed: false
-        body: '{"security_group":{"creation_date":"2025-01-27T09:16:01.344672+00:00","description":null,"enable_default_security":true,"id":"c8613b60-f84a-47f6-9357-3a15421f9b76","inbound_default_policy":"drop","modification_date":"2025-01-27T09:16:01.344672+00:00","name":"tf-sg-keen-wing","organization":"105bdce1-64c0-48ab-899d-868455867ecf","organization_default":false,"outbound_default_policy":"accept","project":"105bdce1-64c0-48ab-899d-868455867ecf","project_default":false,"servers":[],"state":"available","stateful":true,"tags":[],"zone":"fr-par-1"}}'
+        body: '{"security_group":{"creation_date":"2025-02-12T16:14:56.037005+00:00","description":null,"enable_default_security":true,"id":"7a435d2e-8efb-4aaa-bc61-18ca3499a8ac","inbound_default_policy":"drop","modification_date":"2025-02-12T16:14:56.037005+00:00","name":"tf-sg-nostalgic-hypatia","organization":"105bdce1-64c0-48ab-899d-868455867ecf","organization_default":false,"outbound_default_policy":"accept","project":"105bdce1-64c0-48ab-899d-868455867ecf","project_default":false,"servers":[],"state":"available","stateful":true,"tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "579"
+                - "587"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:00 GMT
+                - Wed, 12 Feb 2025 16:14:55 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/c8613b60-f84a-47f6-9357-3a15421f9b76
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/7a435d2e-8efb-4aaa-bc61-18ca3499a8ac
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -150,10 +150,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3b14d346-301f-4d46-b1b7-03f6c710ee4d
+                - 210a6da6-a1ef-42a4-906c-e6fd05d2d171
         status: 201 Created
         code: 201
-        duration: 183.589416ms
+        duration: 430.666ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -171,8 +171,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/c8613b60-f84a-47f6-9357-3a15421f9b76
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/7a435d2e-8efb-4aaa-bc61-18ca3499a8ac
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -180,18 +180,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 579
+        content_length: 587
         uncompressed: false
-        body: '{"security_group":{"creation_date":"2025-01-27T09:16:01.344672+00:00","description":null,"enable_default_security":true,"id":"c8613b60-f84a-47f6-9357-3a15421f9b76","inbound_default_policy":"drop","modification_date":"2025-01-27T09:16:01.344672+00:00","name":"tf-sg-keen-wing","organization":"105bdce1-64c0-48ab-899d-868455867ecf","organization_default":false,"outbound_default_policy":"accept","project":"105bdce1-64c0-48ab-899d-868455867ecf","project_default":false,"servers":[],"state":"available","stateful":true,"tags":[],"zone":"fr-par-1"}}'
+        body: '{"security_group":{"creation_date":"2025-02-12T16:14:56.037005+00:00","description":null,"enable_default_security":true,"id":"7a435d2e-8efb-4aaa-bc61-18ca3499a8ac","inbound_default_policy":"drop","modification_date":"2025-02-12T16:14:56.037005+00:00","name":"tf-sg-nostalgic-hypatia","organization":"105bdce1-64c0-48ab-899d-868455867ecf","organization_default":false,"outbound_default_policy":"accept","project":"105bdce1-64c0-48ab-899d-868455867ecf","project_default":false,"servers":[],"state":"available","stateful":true,"tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "579"
+                - "587"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:01 GMT
+                - Wed, 12 Feb 2025 16:14:55 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -201,111 +201,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5eb37063-f9d1-48f0-8a73-088e07781702
+                - 2500fc0d-b85c-4720-8d4f-00a1121cb16b
         status: 200 OK
         code: 200
-        duration: 155.268791ms
+        duration: 177.745625ms
     - id: 4
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 151
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"subnets":null}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1067
-        uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:01.252990Z","dhcp_enabled":true,"id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T09:16:01.252990Z","id":"f7ebc451-4f4d-4cd0-a12d-bafae62f04db","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.28.0/22","updated_at":"2025-01-27T09:16:01.252990Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T09:16:01.252990Z","id":"21961ecd-3d04-40c7-b889-8f1b2e10500c","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:5aaf::/64","updated_at":"2025-01-27T09:16:01.252990Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T09:16:01.252990Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
-        headers:
-            Content-Length:
-                - "1067"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:16:01 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 6c31ecec-1c8b-460f-9a3f-a38d04d30635
-        status: 200 OK
-        code: 200
-        duration: 532.0145ms
-    - id: 5
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a25b8a28-50ff-4347-a5ba-3dbabb3ae79b
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1067
-        uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:01.252990Z","dhcp_enabled":true,"id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T09:16:01.252990Z","id":"f7ebc451-4f4d-4cd0-a12d-bafae62f04db","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.28.0/22","updated_at":"2025-01-27T09:16:01.252990Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T09:16:01.252990Z","id":"21961ecd-3d04-40c7-b889-8f1b2e10500c","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:5aaf::/64","updated_at":"2025-01-27T09:16:01.252990Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T09:16:01.252990Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
-        headers:
-            Content-Length:
-                - "1067"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:16:01 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 12a66a6c-5532-46a8-b946-fec009010434
-        status: 200 OK
-        code: 200
-        duration: 23.336167ms
-    - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -322,8 +222,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/c8613b60-f84a-47f6-9357-3a15421f9b76/rules
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/7a435d2e-8efb-4aaa-bc61-18ca3499a8ac/rules
         method: PUT
       response:
         proto: HTTP/2.0
@@ -333,7 +233,7 @@ interactions:
         trailer: {}
         content_length: 1792
         uncompressed: false
-        body: '{"rules":[{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"58909be7-d17c-4ac8-9eb3-23d5fc58abc5","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"25680235-108b-4bbc-8e25-114303d950bd","ip_range":"0.0.0.0/0","position":2,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"4a31b633-118e-4900-bd52-facf1085fc8d","ip_range":"0.0.0.0/0","position":3,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"e7dd28e8-3747-4c7c-9a4f-35ae3f0ae2cd","ip_range":"::/0","position":4,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"f37d9e7c-8ed7-4e0f-baff-7f5e7ede0baf","ip_range":"::/0","position":5,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"68054851-54e3-46c9-9cd7-83219751248b","ip_range":"::/0","position":6,"protocol":"TCP","zone":"fr-par-1"},{"action":"accept","dest_ip_range":null,"dest_port_from":22,"dest_port_to":null,"direction":"inbound","editable":true,"id":"eb013f5b-7777-4715-8675-9331158361fa","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"}]}'
+        body: '{"rules":[{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"58909be7-d17c-4ac8-9eb3-23d5fc58abc5","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"25680235-108b-4bbc-8e25-114303d950bd","ip_range":"0.0.0.0/0","position":2,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"4a31b633-118e-4900-bd52-facf1085fc8d","ip_range":"0.0.0.0/0","position":3,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"e7dd28e8-3747-4c7c-9a4f-35ae3f0ae2cd","ip_range":"::/0","position":4,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"f37d9e7c-8ed7-4e0f-baff-7f5e7ede0baf","ip_range":"::/0","position":5,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"68054851-54e3-46c9-9cd7-83219751248b","ip_range":"::/0","position":6,"protocol":"TCP","zone":"fr-par-1"},{"action":"accept","dest_ip_range":null,"dest_port_from":22,"dest_port_to":null,"direction":"inbound","editable":true,"id":"e1486e4b-6ee9-443c-b216-b112d339ad8e","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"}]}'
         headers:
             Content-Length:
                 - "1792"
@@ -342,7 +242,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:01 GMT
+                - Wed, 12 Feb 2025 16:14:56 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -352,109 +252,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b6ad0445-df21-4270-83f7-6bd39d550318
+                - 401a7977-678a-4bb8-a3cc-116b5ce7043c
         status: 200 OK
         code: 200
-        duration: 322.266375ms
-    - id: 7
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/c8613b60-f84a-47f6-9357-3a15421f9b76
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 577
-        uncompressed: false
-        body: '{"security_group":{"creation_date":"2025-01-27T09:16:01.344672+00:00","description":null,"enable_default_security":true,"id":"c8613b60-f84a-47f6-9357-3a15421f9b76","inbound_default_policy":"drop","modification_date":"2025-01-27T09:16:01.573358+00:00","name":"tf-sg-keen-wing","organization":"105bdce1-64c0-48ab-899d-868455867ecf","organization_default":false,"outbound_default_policy":"accept","project":"105bdce1-64c0-48ab-899d-868455867ecf","project_default":false,"servers":[],"state":"syncing","stateful":true,"tags":[],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "577"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:16:01 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 1925a349-4dd2-4d47-8d96-d78f126b6e1c
-        status: 200 OK
-        code: 200
-        duration: 97.006291ms
-    - id: 8
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/c8613b60-f84a-47f6-9357-3a15421f9b76/rules?page=1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1792
-        uncompressed: false
-        body: '{"rules":[{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"58909be7-d17c-4ac8-9eb3-23d5fc58abc5","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"25680235-108b-4bbc-8e25-114303d950bd","ip_range":"0.0.0.0/0","position":2,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"4a31b633-118e-4900-bd52-facf1085fc8d","ip_range":"0.0.0.0/0","position":3,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"e7dd28e8-3747-4c7c-9a4f-35ae3f0ae2cd","ip_range":"::/0","position":4,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"f37d9e7c-8ed7-4e0f-baff-7f5e7ede0baf","ip_range":"::/0","position":5,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"68054851-54e3-46c9-9cd7-83219751248b","ip_range":"::/0","position":6,"protocol":"TCP","zone":"fr-par-1"},{"action":"accept","dest_ip_range":null,"dest_port_from":22,"dest_port_to":null,"direction":"inbound","editable":true,"id":"eb013f5b-7777-4715-8675-9331158361fa","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"}]}'
-        headers:
-            Content-Length:
-                - "1792"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:16:01 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 7a3f42bf-fd28-46f5-addd-c98fc4d7080e
-        status: 200 OK
-        code: 200
-        duration: 114.643459ms
-    - id: 9
+        duration: 349.453ms
+    - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -471,7 +273,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips
         method: POST
       response:
@@ -480,18 +282,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 358
+        content_length: 371
         uncompressed: false
-        body: '{"address":"51.15.130.186","created_at":"2025-01-27T09:16:02.110630Z","gateway_id":null,"id":"937192c3-38db-45ff-a692-e6d9646fc020","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:02.110630Z","zone":"fr-par-1"}'
+        body: '{"address":"163.172.162.186","created_at":"2025-02-12T16:14:56.616626Z","gateway_id":null,"id":"258fe83b-cf30-4221-9188-ba19bc703ec0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.616626Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "358"
+                - "371"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:02 GMT
+                - Wed, 12 Feb 2025 16:14:56 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -501,11 +303,62 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b7eb9a86-29a9-4cea-acc6-3c02004bda0f
+                - 3e2cc469-935d-4200-bf28-d05fd8c96219
         status: 200 OK
         code: 200
-        duration: 931.597833ms
-    - id: 10
+        duration: 985.623792ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 151
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"subnets":null}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1089
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:14:56.227413Z","dhcp_enabled":true,"id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:14:56.227413Z","id":"17f49657-2f39-44d9-a132-cab370633996","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.32.0/22","updated_at":"2025-02-12T16:14:56.227413Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-12T16:14:56.227413Z","id":"8bec6edb-5cc4-4482-8d40-8b7b69d9de78","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:ed6::/64","updated_at":"2025-02-12T16:14:56.227413Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-12T16:14:56.227413Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        headers:
+            Content-Length:
+                - "1089"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:14:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 094d7436-d013-4289-a9d2-545fcaafe5a1
+        status: 200 OK
+        code: 200
+        duration: 1.028460917s
+    - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -520,8 +373,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/937192c3-38db-45ff-a692-e6d9646fc020
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/258fe83b-cf30-4221-9188-ba19bc703ec0
         method: GET
       response:
         proto: HTTP/2.0
@@ -529,18 +382,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 358
+        content_length: 371
         uncompressed: false
-        body: '{"address":"51.15.130.186","created_at":"2025-01-27T09:16:02.110630Z","gateway_id":null,"id":"937192c3-38db-45ff-a692-e6d9646fc020","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:02.110630Z","zone":"fr-par-1"}'
+        body: '{"address":"163.172.162.186","created_at":"2025-02-12T16:14:56.616626Z","gateway_id":null,"id":"258fe83b-cf30-4221-9188-ba19bc703ec0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.616626Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "358"
+                - "371"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:02 GMT
+                - Wed, 12 Feb 2025 16:14:56 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -550,10 +403,159 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9f7d6cde-661f-480b-8f78-5eab5dde3057
+                - 75d1aedf-8e0f-46ae-b5c3-102da7d12a22
         status: 200 OK
         code: 200
-        duration: 24.203875ms
+        duration: 66.578542ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/0c6bc523-27f7-44c3-8a6a-e0c049abeda3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1089
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:14:56.227413Z","dhcp_enabled":true,"id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:14:56.227413Z","id":"17f49657-2f39-44d9-a132-cab370633996","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.32.0/22","updated_at":"2025-02-12T16:14:56.227413Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-12T16:14:56.227413Z","id":"8bec6edb-5cc4-4482-8d40-8b7b69d9de78","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:ed6::/64","updated_at":"2025-02-12T16:14:56.227413Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-12T16:14:56.227413Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        headers:
+            Content-Length:
+                - "1089"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:14:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 25487046-7b58-4ee4-b022-659ef4ebfb84
+        status: 200 OK
+        code: 200
+        duration: 45.338125ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/7a435d2e-8efb-4aaa-bc61-18ca3499a8ac
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 587
+        uncompressed: false
+        body: '{"security_group":{"creation_date":"2025-02-12T16:14:56.037005+00:00","description":null,"enable_default_security":true,"id":"7a435d2e-8efb-4aaa-bc61-18ca3499a8ac","inbound_default_policy":"drop","modification_date":"2025-02-12T16:14:56.632319+00:00","name":"tf-sg-nostalgic-hypatia","organization":"105bdce1-64c0-48ab-899d-868455867ecf","organization_default":false,"outbound_default_policy":"accept","project":"105bdce1-64c0-48ab-899d-868455867ecf","project_default":false,"servers":[],"state":"available","stateful":true,"tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "587"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:14:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8869858b-baaf-439e-bf37-095885a4c96b
+        status: 200 OK
+        code: 200
+        duration: 155.193458ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 213
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"foobar","tags":[],"type":"VPC-GW-S","upstream_dns_servers":[],"ip_id":"258fe83b-cf30-4221-9188-ba19bc703ec0","enable_smtp":false,"enable_bastion":false}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1002
+        uncompressed: false
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.811685Z","gateway_networks":[],"id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:14:56.616626Z","gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"258fe83b-cf30-4221-9188-ba19bc703ec0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.616626Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:14:56.811685Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "1002"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:14:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e8c0eace-050a-40bf-946d-e7773fe04d5c
+        status: 200 OK
+        code: 200
+        duration: 121.01925ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -569,8 +571,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f
         method: GET
       response:
         proto: HTTP/2.0
@@ -578,20 +580,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 38539
+        content_length: 1004
         uncompressed: false
-        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.811685Z","gateway_networks":[],"id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:14:56.616626Z","gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"258fe83b-cf30-4221-9188-ba19bc703ec0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.616626Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:14:56.856803Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "38539"
+                - "1004"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:02 GMT
-            Link:
-                - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 16:14:56 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -601,12 +601,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8d3f3741-3595-48f8-849d-2d7e37fd2175
-            X-Total-Count:
-                - "68"
+                - 8093828d-6828-4d24-b9cf-6803ca2690e9
         status: 200 OK
         code: 200
-        duration: 52.052833ms
+        duration: 55.89925ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -622,8 +620,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/7a435d2e-8efb-4aaa-bc61-18ca3499a8ac/rules?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -631,20 +629,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 14208
+        content_length: 1792
         uncompressed: false
-        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+        body: '{"rules":[{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"58909be7-d17c-4ac8-9eb3-23d5fc58abc5","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"25680235-108b-4bbc-8e25-114303d950bd","ip_range":"0.0.0.0/0","position":2,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"4a31b633-118e-4900-bd52-facf1085fc8d","ip_range":"0.0.0.0/0","position":3,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"e7dd28e8-3747-4c7c-9a4f-35ae3f0ae2cd","ip_range":"::/0","position":4,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"f37d9e7c-8ed7-4e0f-baff-7f5e7ede0baf","ip_range":"::/0","position":5,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"68054851-54e3-46c9-9cd7-83219751248b","ip_range":"::/0","position":6,"protocol":"TCP","zone":"fr-par-1"},{"action":"accept","dest_ip_range":null,"dest_port_from":22,"dest_port_to":null,"direction":"inbound","editable":true,"id":"e1486e4b-6ee9-443c-b216-b112d339ad8e","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "14208"
+                - "1792"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:01 GMT
-            Link:
-                - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 16:14:56 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -654,50 +650,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 47f05b45-358b-45f9-aa82-ec630fb62a1a
-            X-Total-Count:
-                - "68"
+                - 77c82049-f7d0-4f94-a528-a6fd5853b927
         status: 200 OK
         code: 200
-        duration: 73.488ms
+        duration: 143.26425ms
     - id: 13
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 213
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"foobar","tags":[],"type":"VPC-GW-S","upstream_dns_servers":[],"ip_id":"937192c3-38db-45ff-a692-e6d9646fc020","enable_smtp":false,"enable_bastion":false}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 968
+        content_length: 35639
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:02.214959Z","gateway_networks":[],"id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","ip":{"address":"51.15.130.186","created_at":"2025-01-27T09:16:02.110630Z","gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"937192c3-38db-45ff-a692-e6d9646fc020","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:02.110630Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:02.214959Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
+        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
         headers:
             Content-Length:
-                - "968"
+                - "35639"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:02 GMT
+                - Wed, 12 Feb 2025 16:14:56 GMT
+            Link:
+                - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -707,10 +701,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 94e61472-ca60-4d47-b528-ce7f053e8f1b
+                - 93f0ced3-1e8f-4f45-8f78-c0860d5c04ce
+            X-Total-Count:
+                - "68"
         status: 200 OK
         code: 200
-        duration: 82.505083ms
+        duration: 65.141709ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -726,8 +722,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
         method: GET
       response:
         proto: HTTP/2.0
@@ -735,18 +731,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 970
+        content_length: 13164
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:02.214959Z","gateway_networks":[],"id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","ip":{"address":"51.15.130.186","created_at":"2025-01-27T09:16:02.110630Z","gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"937192c3-38db-45ff-a692-e6d9646fc020","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:02.110630Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:02.252003Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
         headers:
             Content-Length:
-                - "970"
+                - "13164"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:02 GMT
+                - Wed, 12 Feb 2025 16:14:56 GMT
+            Link:
+                - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -756,10 +754,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c51248a3-a622-4baa-9963-41862256c92a
+                - ac9df178-185a-4dcb-94db-de2c5093c19e
+            X-Total-Count:
+                - "68"
         status: 200 OK
         code: 200
-        duration: 33.085917ms
+        duration: 66.208375ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -775,8 +775,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_local&zone=fr-par-1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_sbs&zone=fr-par-1
         method: GET
       response:
         proto: HTTP/2.0
@@ -784,18 +784,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1220
+        content_length: 1296
         uncompressed: false
-        body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"56d4019c-8305-467a-a3f2-70498ad799df","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
+        body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"57509e82-ac3b-49b7-9970-97b60f40ff72","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"9b647e1e-253a-41e7-8c15-911c622ee2dc","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"}],"total_count":2}'
         headers:
             Content-Length:
-                - "1220"
+                - "1296"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:02 GMT
+                - Wed, 12 Feb 2025 16:14:57 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -805,28 +805,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 791be60b-0770-46e9-8b0e-3b33f7d11076
+                - dc47d17b-9265-4154-b430-d686ebe74192
         status: 200 OK
         code: 200
-        duration: 83.531041ms
+        duration: 103.740167ms
     - id: 16
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 327
+        content_length: 296
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-srv-happy-benz","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf","security_group":"c8613b60-f84a-47f6-9357-3a15421f9b76"}'
+        body: '{"name":"tf-srv-strange-visvesvaraya","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"57509e82-ac3b-49b7-9970-97b60f40ff72","volumes":{"0":{"boot":false}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf","security_group":"7a435d2e-8efb-4aaa-bc61-18ca3499a8ac"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
         method: POST
       response:
@@ -835,20 +835,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2096
+        content_length: 1685
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.974673+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-benz","id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ea:21","maintenances":[],"modification_date":"2025-01-27T09:16:02.974673+00:00","name":"tf-srv-happy-benz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"c8613b60-f84a-47f6-9357-3a15421f9b76","name":"tf-sg-keen-wing"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.974673+00:00","export_uri":null,"id":"80ea48b3-70a2-4b5a-8665-bcda6853e98d","modification_date":"2025-01-27T09:16:02.974673+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","name":"tf-srv-happy-benz"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.450538+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-visvesvaraya","id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:dd","maintenances":[],"modification_date":"2025-02-12T16:14:57.450538+00:00","name":"tf-srv-strange-visvesvaraya","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"7a435d2e-8efb-4aaa-bc61-18ca3499a8ac","name":"tf-sg-nostalgic-hypatia"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"0310ce0d-2ff0-4cab-b5fe-1b17a2b6da68","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2096"
+                - "1685"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:03 GMT
+                - Wed, 12 Feb 2025 16:14:58 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -858,10 +858,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 79e1a66f-351c-425b-9ed0-357c2ee9d3b0
+                - 99e3271d-f9c3-425d-b3a5-dcb43baf1f98
         status: 201 Created
         code: 201
-        duration: 1.096521959s
+        duration: 1.472172208s
     - id: 17
       request:
         proto: HTTP/1.1
@@ -877,8 +877,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b
         method: GET
       response:
         proto: HTTP/2.0
@@ -886,18 +886,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2096
+        content_length: 1685
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.974673+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-benz","id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ea:21","maintenances":[],"modification_date":"2025-01-27T09:16:02.974673+00:00","name":"tf-srv-happy-benz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"c8613b60-f84a-47f6-9357-3a15421f9b76","name":"tf-sg-keen-wing"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.974673+00:00","export_uri":null,"id":"80ea48b3-70a2-4b5a-8665-bcda6853e98d","modification_date":"2025-01-27T09:16:02.974673+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","name":"tf-srv-happy-benz"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.450538+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-visvesvaraya","id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:dd","maintenances":[],"modification_date":"2025-02-12T16:14:57.450538+00:00","name":"tf-srv-strange-visvesvaraya","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"7a435d2e-8efb-4aaa-bc61-18ca3499a8ac","name":"tf-sg-nostalgic-hypatia"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"0310ce0d-2ff0-4cab-b5fe-1b17a2b6da68","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2096"
+                - "1685"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:03 GMT
+                - Wed, 12 Feb 2025 16:14:58 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -907,10 +907,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0e1d2de2-ae03-45a4-8f63-0b9c758d339a
+                - a5cc0a90-320f-407b-a5fb-3b503a225835
         status: 200 OK
         code: 200
-        duration: 125.6385ms
+        duration: 179.363292ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -926,8 +926,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b
         method: GET
       response:
         proto: HTTP/2.0
@@ -935,18 +935,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2096
+        content_length: 1685
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.974673+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-benz","id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ea:21","maintenances":[],"modification_date":"2025-01-27T09:16:02.974673+00:00","name":"tf-srv-happy-benz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"c8613b60-f84a-47f6-9357-3a15421f9b76","name":"tf-sg-keen-wing"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.974673+00:00","export_uri":null,"id":"80ea48b3-70a2-4b5a-8665-bcda6853e98d","modification_date":"2025-01-27T09:16:02.974673+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","name":"tf-srv-happy-benz"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.450538+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-visvesvaraya","id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:dd","maintenances":[],"modification_date":"2025-02-12T16:14:57.450538+00:00","name":"tf-srv-strange-visvesvaraya","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"7a435d2e-8efb-4aaa-bc61-18ca3499a8ac","name":"tf-sg-nostalgic-hypatia"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"0310ce0d-2ff0-4cab-b5fe-1b17a2b6da68","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2096"
+                - "1685"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:03 GMT
+                - Wed, 12 Feb 2025 16:14:58 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -956,11 +956,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 151a727d-6f00-4257-ae47-4274c503bf4d
+                - f18b92ca-a6b4-4616-8ce0-29a87dc07e02
         status: 200 OK
         code: 200
-        duration: 163.618291ms
+        duration: 165.6185ms
     - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/0310ce0d-2ff0-4cab-b5fe-1b17a2b6da68
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:14:57.876261Z","id":"0310ce0d-2ff0-4cab-b5fe-1b17a2b6da68","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:14:57.876261Z","id":"162e9203-8f06-49ed-a114-12a6d80c5055","product_resource_id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:14:57.876261Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:14:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - eb4333d3-ef64-4f4f-ba6d-6f21d215ec89
+        status: 200 OK
+        code: 200
+        duration: 94.096333ms
+    - id: 20
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -977,8 +1026,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -988,7 +1037,7 @@ interactions:
         trailer: {}
         content_length: 357
         uncompressed: false
-        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2/action","href_result":"/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","id":"eea390bf-c9c3-4807-a91a-1ff92f34e0df","progress":0,"started_at":"2025-01-27T09:16:03.960494+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b/action","href_result":"/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b","id":"e208288d-ebef-472e-b82a-85547e95a17f","progress":0,"started_at":"2025-02-12T16:14:59.354054+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -997,9 +1046,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:03 GMT
+                - Wed, 12 Feb 2025 16:14:59 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/eea390bf-c9c3-4807-a91a-1ff92f34e0df
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/e208288d-ebef-472e-b82a-85547e95a17f
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1009,59 +1058,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0ad5e6d5-25b9-452f-9b58-aa8b22c3a31a
+                - 142bda4e-fb91-4b2d-beeb-6a758b764b2a
         status: 202 Accepted
         code: 202
-        duration: 288.837959ms
-    - id: 20
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2118
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.974673+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-benz","id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ea:21","maintenances":[],"modification_date":"2025-01-27T09:16:03.748154+00:00","name":"tf-srv-happy-benz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"c8613b60-f84a-47f6-9357-3a15421f9b76","name":"tf-sg-keen-wing"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.974673+00:00","export_uri":null,"id":"80ea48b3-70a2-4b5a-8665-bcda6853e98d","modification_date":"2025-01-27T09:16:02.974673+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","name":"tf-srv-happy-benz"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2118"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:16:04 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - ca68ac74-e62c-406e-b448-cd978cde6693
-        status: 200 OK
-        code: 200
-        duration: 220.017459ms
+        duration: 284.718ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1077,8 +1077,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1086,18 +1086,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 967
+        content_length: 1707
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:02.214959Z","gateway_networks":[],"id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","ip":{"address":"51.15.130.186","created_at":"2025-01-27T09:16:02.110630Z","gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"937192c3-38db-45ff-a692-e6d9646fc020","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:02.110630Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:05.468190Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.450538+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-visvesvaraya","id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:dd","maintenances":[],"modification_date":"2025-02-12T16:14:59.132989+00:00","name":"tf-srv-strange-visvesvaraya","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"7a435d2e-8efb-4aaa-bc61-18ca3499a8ac","name":"tf-sg-nostalgic-hypatia"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"id":"0310ce0d-2ff0-4cab-b5fe-1b17a2b6da68","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "967"
+                - "1707"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:07 GMT
+                - Wed, 12 Feb 2025 16:14:59 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1107,10 +1107,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7e93eb08-a947-45ac-a619-15b324e3e4d4
+                - 19a8a941-4db2-4ea6-9ff5-a263c0e242f4
         status: 200 OK
         code: 200
-        duration: 25.594ms
+        duration: 234.928083ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1126,8 +1126,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1135,18 +1135,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 967
+        content_length: 1001
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:02.214959Z","gateway_networks":[],"id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","ip":{"address":"51.15.130.186","created_at":"2025-01-27T09:16:02.110630Z","gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"937192c3-38db-45ff-a692-e6d9646fc020","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:02.110630Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:05.468190Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.811685Z","gateway_networks":[],"id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:14:56.616626Z","gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"258fe83b-cf30-4221-9188-ba19bc703ec0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.616626Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:01.661316Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "967"
+                - "1001"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:07 GMT
+                - Wed, 12 Feb 2025 16:15:01 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1156,10 +1156,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 48e07cdf-f595-4a85-9783-7d88e1f947bc
+                - 9909b7bd-88fe-4a56-94fb-e80d8cd7024b
         status: 200 OK
         code: 200
-        duration: 29.44225ms
+        duration: 55.134042ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1175,8 +1175,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1184,18 +1184,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 967
+        content_length: 1001
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:02.214959Z","gateway_networks":[],"id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","ip":{"address":"51.15.130.186","created_at":"2025-01-27T09:16:02.110630Z","gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"937192c3-38db-45ff-a692-e6d9646fc020","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:02.110630Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:05.468190Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.811685Z","gateway_networks":[],"id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:14:56.616626Z","gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"258fe83b-cf30-4221-9188-ba19bc703ec0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.616626Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:01.661316Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "967"
+                - "1001"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:07 GMT
+                - Wed, 12 Feb 2025 16:15:02 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1205,10 +1205,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a42ab246-9120-4819-a349-76945df3ac8a
+                - a304a3d7-55d1-4bf0-a66c-13813ce907ec
         status: 200 OK
         code: 200
-        duration: 26.490042ms
+        duration: 52.010708ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1224,8 +1224,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1233,18 +1233,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2222
+        content_length: 1001
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.974673+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-benz","id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1501","node_id":"48","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:21","maintenances":[],"modification_date":"2025-01-27T09:16:03.748154+00:00","name":"tf-srv-happy-benz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"c8613b60-f84a-47f6-9357-3a15421f9b76","name":"tf-sg-keen-wing"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.974673+00:00","export_uri":null,"id":"80ea48b3-70a2-4b5a-8665-bcda6853e98d","modification_date":"2025-01-27T09:16:02.974673+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","name":"tf-srv-happy-benz"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.811685Z","gateway_networks":[],"id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:14:56.616626Z","gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"258fe83b-cf30-4221-9188-ba19bc703ec0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.616626Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:01.661316Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2222"
+                - "1001"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:09 GMT
+                - Wed, 12 Feb 2025 16:15:02 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1254,62 +1254,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 69cc4515-6db0-48c8-afa9-65a8a851e575
+                - 7332c531-dad1-4361-ba53-757102465fac
         status: 200 OK
         code: 200
-        duration: 180.028208ms
+        duration: 46.111459ms
     - id: 25
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 206
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"95c3edc0-cf35-40f9-bfb2-2af399b47a92"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 953
-        uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:09.893402Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.242510Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"95c3edc0-cf35-40f9-bfb2-2af399b47a92","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.242510Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"90d04b2a-83c6-40ae-9112-4e127d7e9245","ipam_config":null,"mac_address":null,"private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","status":"created","updated_at":"2025-01-27T09:16:09.893402Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "953"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:16:10 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - d932ec57-4399-4c46-9c58-bbb36bb50c0d
-        status: 200 OK
-        code: 200
-        duration: 2.64521425s
-    - id: 26
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1324,8 +1273,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1333,18 +1282,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1923
+        content_length: 1811
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:02.214959Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:09.893402Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.242510Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"95c3edc0-cf35-40f9-bfb2-2af399b47a92","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.242510Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"90d04b2a-83c6-40ae-9112-4e127d7e9245","ipam_config":null,"mac_address":null,"private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","status":"created","updated_at":"2025-01-27T09:16:09.893402Z","zone":"fr-par-1"}],"id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","ip":{"address":"51.15.130.186","created_at":"2025-01-27T09:16:02.110630Z","gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"937192c3-38db-45ff-a692-e6d9646fc020","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:02.110630Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:10.023149Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.450538+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-visvesvaraya","id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1901","node_id":"38","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:dd","maintenances":[],"modification_date":"2025-02-12T16:14:59.132989+00:00","name":"tf-srv-strange-visvesvaraya","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"7a435d2e-8efb-4aaa-bc61-18ca3499a8ac","name":"tf-sg-nostalgic-hypatia"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"id":"0310ce0d-2ff0-4cab-b5fe-1b17a2b6da68","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1923"
+                - "1811"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:10 GMT
+                - Wed, 12 Feb 2025 16:15:04 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1354,10 +1303,61 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cc4963a5-c784-4ddb-bd3d-2b92d460d726
+                - de0c3a3c-5c10-4b50-b82c-a2cb31cbfd58
         status: 200 OK
         code: 200
-        duration: 29.279541ms
+        duration: 258.910208ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 206
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"538c4a96-d996-45ca-b414-59e27b15ba9c"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 983
+        uncompressed: false
+        body: '{"address":null,"created_at":"2025-02-12T16:15:05.808562Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.930530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"538c4a96-d996-45ca-b414-59e27b15ba9c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.930530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"238269b1-9ef4-4935-9cb1-94a37e10fd48","ipam_config":null,"mac_address":null,"private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","status":"created","updated_at":"2025-02-12T16:15:05.808562Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "983"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ab64686e-b927-4b91-9182-9bf25bed7f7d
+        status: 200 OK
+        code: 200
+        duration: 4.006001625s
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1373,8 +1373,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1382,18 +1382,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2222
+        content_length: 1987
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.974673+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-benz","id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1501","node_id":"48","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:21","maintenances":[],"modification_date":"2025-01-27T09:16:03.748154+00:00","name":"tf-srv-happy-benz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"c8613b60-f84a-47f6-9357-3a15421f9b76","name":"tf-sg-keen-wing"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.974673+00:00","export_uri":null,"id":"80ea48b3-70a2-4b5a-8665-bcda6853e98d","modification_date":"2025-01-27T09:16:02.974673+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","name":"tf-srv-happy-benz"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.811685Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:05.808562Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.930530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"538c4a96-d996-45ca-b414-59e27b15ba9c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.930530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"238269b1-9ef4-4935-9cb1-94a37e10fd48","ipam_config":null,"mac_address":null,"private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","status":"created","updated_at":"2025-02-12T16:15:05.808562Z","zone":"fr-par-1"}],"id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:14:56.616626Z","gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"258fe83b-cf30-4221-9188-ba19bc703ec0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.616626Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:05.986621Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2222"
+                - "1987"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:14 GMT
+                - Wed, 12 Feb 2025 16:15:06 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1403,10 +1403,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b3aa85ae-dc99-4558-a6c0-6540b862db70
+                - 152ea15b-3c46-4b10-a3d3-4ad8f43c6bc3
         status: 200 OK
         code: 200
-        duration: 215.068458ms
+        duration: 75.410708ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1422,8 +1422,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1431,18 +1431,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1923
+        content_length: 1842
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:02.214959Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:09.893402Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.242510Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"95c3edc0-cf35-40f9-bfb2-2af399b47a92","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.242510Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"90d04b2a-83c6-40ae-9112-4e127d7e9245","ipam_config":null,"mac_address":null,"private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","status":"created","updated_at":"2025-01-27T09:16:09.893402Z","zone":"fr-par-1"}],"id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","ip":{"address":"51.15.130.186","created_at":"2025-01-27T09:16:02.110630Z","gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"937192c3-38db-45ff-a692-e6d9646fc020","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:02.110630Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:10.023149Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.450538+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-visvesvaraya","id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1901","node_id":"38","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:dd","maintenances":[],"modification_date":"2025-02-12T16:15:04.909328+00:00","name":"tf-srv-strange-visvesvaraya","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"7a435d2e-8efb-4aaa-bc61-18ca3499a8ac","name":"tf-sg-nostalgic-hypatia"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"0310ce0d-2ff0-4cab-b5fe-1b17a2b6da68","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1923"
+                - "1842"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:15 GMT
+                - Wed, 12 Feb 2025 16:15:09 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1452,10 +1452,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6c8f4d30-92d2-4208-b288-07fa5b33500c
+                - 7bca0c20-99ad-4a39-8708-540fcab12b17
         status: 200 OK
         code: 200
-        duration: 25.23525ms
+        duration: 201.399292ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1471,8 +1471,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/0c6bc523-27f7-44c3-8a6a-e0c049abeda3
         method: GET
       response:
         proto: HTTP/2.0
@@ -1480,18 +1480,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2222
+        content_length: 1089
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.974673+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-benz","id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1501","node_id":"48","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:21","maintenances":[],"modification_date":"2025-01-27T09:16:03.748154+00:00","name":"tf-srv-happy-benz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"c8613b60-f84a-47f6-9357-3a15421f9b76","name":"tf-sg-keen-wing"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.974673+00:00","export_uri":null,"id":"80ea48b3-70a2-4b5a-8665-bcda6853e98d","modification_date":"2025-01-27T09:16:02.974673+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","name":"tf-srv-happy-benz"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-12T16:14:56.227413Z","dhcp_enabled":true,"id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:14:56.227413Z","id":"17f49657-2f39-44d9-a132-cab370633996","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:15:02.387872Z","vpc_id":"40198cae-234b-4971-8c6a-c15a4ea697cb"},{"created_at":"2025-02-12T16:14:56.227413Z","id":"8bec6edb-5cc4-4482-8d40-8b7b69d9de78","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:ed6::/64","updated_at":"2025-02-12T16:15:02.395052Z","vpc_id":"40198cae-234b-4971-8c6a-c15a4ea697cb"}],"tags":[],"updated_at":"2025-02-12T16:15:02.383831Z","vpc_id":"40198cae-234b-4971-8c6a-c15a4ea697cb"}'
         headers:
             Content-Length:
-                - "2222"
+                - "1089"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:19 GMT
+                - Wed, 12 Feb 2025 16:15:10 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1501,10 +1501,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ca2428f7-fc73-4b64-85d5-454027a4c030
+                - caa33d09-641b-424e-a1f7-7aa6b8b78858
         status: 200 OK
         code: 200
-        duration: 155.656042ms
+        duration: 48.979667ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1520,8 +1520,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b
         method: GET
       response:
         proto: HTTP/2.0
@@ -1529,18 +1529,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1942
+        content_length: 1842
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:02.214959Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:09.893402Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.242510Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"95c3edc0-cf35-40f9-bfb2-2af399b47a92","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.242510Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"90d04b2a-83c6-40ae-9112-4e127d7e9245","ipam_config":null,"mac_address":"02:00:00:11:96:81","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","status":"configuring","updated_at":"2025-01-27T09:16:15.622633Z","zone":"fr-par-1"}],"id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","ip":{"address":"51.15.130.186","created_at":"2025-01-27T09:16:02.110630Z","gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"937192c3-38db-45ff-a692-e6d9646fc020","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:02.110630Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:10.023149Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.450538+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-visvesvaraya","id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1901","node_id":"38","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:dd","maintenances":[],"modification_date":"2025-02-12T16:15:04.909328+00:00","name":"tf-srv-strange-visvesvaraya","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"7a435d2e-8efb-4aaa-bc61-18ca3499a8ac","name":"tf-sg-nostalgic-hypatia"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"0310ce0d-2ff0-4cab-b5fe-1b17a2b6da68","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1942"
+                - "1842"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:20 GMT
+                - Wed, 12 Feb 2025 16:15:10 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1550,10 +1550,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c32a32dc-20b5-4d08-9371-d414fd619830
+                - 846ade13-5cf1-4d94-88e9-1d77116e0851
         status: 200 OK
         code: 200
-        duration: 28.788833ms
+        duration: 246.283917ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1569,8 +1569,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1578,18 +1578,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2253
+        content_length: 1987
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.974673+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-benz","id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1501","node_id":"48","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:21","maintenances":[],"modification_date":"2025-01-27T09:16:20.592701+00:00","name":"tf-srv-happy-benz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"c8613b60-f84a-47f6-9357-3a15421f9b76","name":"tf-sg-keen-wing"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.974673+00:00","export_uri":null,"id":"80ea48b3-70a2-4b5a-8665-bcda6853e98d","modification_date":"2025-01-27T09:16:02.974673+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","name":"tf-srv-happy-benz"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.811685Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:05.808562Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.930530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"538c4a96-d996-45ca-b414-59e27b15ba9c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.930530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"238269b1-9ef4-4935-9cb1-94a37e10fd48","ipam_config":null,"mac_address":null,"private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","status":"created","updated_at":"2025-02-12T16:15:05.808562Z","zone":"fr-par-1"}],"id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:14:56.616626Z","gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"258fe83b-cf30-4221-9188-ba19bc703ec0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.616626Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:05.986621Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2253"
+                - "1987"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:24 GMT
+                - Wed, 12 Feb 2025 16:15:11 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1599,46 +1599,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 443c256b-e8f0-4c59-8a67-53e6908d9693
+                - d3b92a91-25c9-4c1d-9fa1-2e9e19e7d713
         status: 200 OK
         code: 200
-        duration: 191.830459ms
+        duration: 53.122416ms
     - id: 32
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 61
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3"}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a25b8a28-50ff-4347-a5ba-3dbabb3ae79b
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b/private_nics
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1067
+        content_length: 473
         uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:01.252990Z","dhcp_enabled":true,"id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T09:16:01.252990Z","id":"f7ebc451-4f4d-4cd0-a12d-bafae62f04db","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:07.610304Z","vpc_id":"55bdd955-2e0a-4274-8bff-6036570e8f94"},{"created_at":"2025-01-27T09:16:01.252990Z","id":"21961ecd-3d04-40c7-b889-8f1b2e10500c","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:5aaf::/64","updated_at":"2025-01-27T09:16:07.613992Z","vpc_id":"55bdd955-2e0a-4274-8bff-6036570e8f94"}],"tags":[],"updated_at":"2025-01-27T09:16:16.425154Z","vpc_id":"55bdd955-2e0a-4274-8bff-6036570e8f94"}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.422881+00:00","id":"4b9eefc5-41db-4c4d-8662-cf9202eab68f","ipam_ip_ids":["512fea6c-17d0-4487-a8d6-a03f75ee2368","58ca6b90-1ffa-4d83-9e1d-c84a21bab54f"],"mac_address":"02:00:00:1d:7b:57","modification_date":"2025-02-12T16:15:10.627880+00:00","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","server_id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1067"
+                - "473"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:24 GMT
+                - Wed, 12 Feb 2025 16:15:11 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1648,10 +1650,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e7988a9f-9db9-46fe-a590-6389810dfb16
-        status: 200 OK
-        code: 200
-        duration: 38.330375ms
+                - 6159aec7-d0ca-4a94-8892-66483ee3d335
+        status: 201 Created
+        code: 201
+        duration: 1.125388917s
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1667,8 +1669,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b/private_nics/4b9eefc5-41db-4c4d-8662-cf9202eab68f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1676,18 +1678,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1932
+        content_length: 473
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:02.214959Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:09.893402Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.242510Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"95c3edc0-cf35-40f9-bfb2-2af399b47a92","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.242510Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"90d04b2a-83c6-40ae-9112-4e127d7e9245","ipam_config":null,"mac_address":"02:00:00:11:96:81","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","status":"ready","updated_at":"2025-01-27T09:16:20.242261Z","zone":"fr-par-1"}],"id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","ip":{"address":"51.15.130.186","created_at":"2025-01-27T09:16:02.110630Z","gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"937192c3-38db-45ff-a692-e6d9646fc020","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:02.110630Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:20.389912Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.422881+00:00","id":"4b9eefc5-41db-4c4d-8662-cf9202eab68f","ipam_ip_ids":["512fea6c-17d0-4487-a8d6-a03f75ee2368","58ca6b90-1ffa-4d83-9e1d-c84a21bab54f"],"mac_address":"02:00:00:1d:7b:57","modification_date":"2025-02-12T16:15:10.627880+00:00","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","server_id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1932"
+                - "473"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:25 GMT
+                - Wed, 12 Feb 2025 16:15:11 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1697,10 +1699,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9273ef4b-8a3a-454a-85e4-f3a4c2148407
+                - c0f927ee-60b3-4cb5-91b4-af3ac3dba709
         status: 200 OK
         code: 200
-        duration: 32.094709ms
+        duration: 119.162833ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1716,8 +1718,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/90d04b2a-83c6-40ae-9112-4e127d7e9245
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1725,18 +1727,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 966
+        content_length: 2006
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:09.893402Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.242510Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"95c3edc0-cf35-40f9-bfb2-2af399b47a92","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.242510Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"90d04b2a-83c6-40ae-9112-4e127d7e9245","ipam_config":null,"mac_address":"02:00:00:11:96:81","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","status":"ready","updated_at":"2025-01-27T09:16:20.242261Z","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.811685Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:05.808562Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.930530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"538c4a96-d996-45ca-b414-59e27b15ba9c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.930530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"238269b1-9ef4-4935-9cb1-94a37e10fd48","ipam_config":null,"mac_address":"02:00:00:11:3A:55","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","status":"configuring","updated_at":"2025-02-12T16:15:11.722145Z","zone":"fr-par-1"}],"id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:14:56.616626Z","gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"258fe83b-cf30-4221-9188-ba19bc703ec0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.616626Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:05.986621Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "966"
+                - "2006"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:25 GMT
+                - Wed, 12 Feb 2025 16:15:16 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1746,10 +1748,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f9419ff6-af84-457c-b6b0-d2224e24f74b
+                - d2d26035-f9db-479a-bf03-4831caeba9ce
         status: 200 OK
         code: 200
-        duration: 47.102583ms
+        duration: 50.565875ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1765,8 +1767,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b/private_nics/4b9eefc5-41db-4c4d-8662-cf9202eab68f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1774,18 +1776,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2253
+        content_length: 473
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.974673+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-benz","id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1501","node_id":"48","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:21","maintenances":[],"modification_date":"2025-01-27T09:16:20.592701+00:00","name":"tf-srv-happy-benz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"c8613b60-f84a-47f6-9357-3a15421f9b76","name":"tf-sg-keen-wing"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.974673+00:00","export_uri":null,"id":"80ea48b3-70a2-4b5a-8665-bcda6853e98d","modification_date":"2025-01-27T09:16:02.974673+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","name":"tf-srv-happy-benz"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.422881+00:00","id":"4b9eefc5-41db-4c4d-8662-cf9202eab68f","ipam_ip_ids":["512fea6c-17d0-4487-a8d6-a03f75ee2368","58ca6b90-1ffa-4d83-9e1d-c84a21bab54f"],"mac_address":"02:00:00:1d:7b:57","modification_date":"2025-02-12T16:15:10.627880+00:00","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","server_id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2253"
+                - "473"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:25 GMT
+                - Wed, 12 Feb 2025 16:15:16 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1795,10 +1797,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7c606d49-0cc6-4a18-9a4c-98c188a45332
+                - 01049741-9041-44fb-83b5-7ba293e60b41
         status: 200 OK
         code: 200
-        duration: 218.303458ms
+        duration: 96.388458ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1814,8 +1816,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/90d04b2a-83c6-40ae-9112-4e127d7e9245
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1823,18 +1825,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 966
+        content_length: 1996
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:09.893402Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.242510Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"95c3edc0-cf35-40f9-bfb2-2af399b47a92","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.242510Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"90d04b2a-83c6-40ae-9112-4e127d7e9245","ipam_config":null,"mac_address":"02:00:00:11:96:81","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","status":"ready","updated_at":"2025-01-27T09:16:20.242261Z","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.811685Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:05.808562Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.930530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"538c4a96-d996-45ca-b414-59e27b15ba9c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.930530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"238269b1-9ef4-4935-9cb1-94a37e10fd48","ipam_config":null,"mac_address":"02:00:00:11:3A:55","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","status":"ready","updated_at":"2025-02-12T16:15:16.458661Z","zone":"fr-par-1"}],"id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:14:56.616626Z","gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"258fe83b-cf30-4221-9188-ba19bc703ec0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.616626Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:16.653882Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "966"
+                - "1996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:25 GMT
+                - Wed, 12 Feb 2025 16:15:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1844,10 +1846,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b2124731-94a5-4481-9d82-8acf9c9d2eee
+                - 1bd5b81f-9152-4350-8e99-bf58e5c7a411
         status: 200 OK
         code: 200
-        duration: 55.910125ms
+        duration: 60.442917ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1863,8 +1865,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/238269b1-9ef4-4935-9cb1-94a37e10fd48
         method: GET
       response:
         proto: HTTP/2.0
@@ -1872,18 +1874,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1932
+        content_length: 996
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:02.214959Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:09.893402Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.242510Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"95c3edc0-cf35-40f9-bfb2-2af399b47a92","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.242510Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"90d04b2a-83c6-40ae-9112-4e127d7e9245","ipam_config":null,"mac_address":"02:00:00:11:96:81","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","status":"ready","updated_at":"2025-01-27T09:16:20.242261Z","zone":"fr-par-1"}],"id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","ip":{"address":"51.15.130.186","created_at":"2025-01-27T09:16:02.110630Z","gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"937192c3-38db-45ff-a692-e6d9646fc020","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:02.110630Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:20.389912Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:05.808562Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.930530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"538c4a96-d996-45ca-b414-59e27b15ba9c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.930530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"238269b1-9ef4-4935-9cb1-94a37e10fd48","ipam_config":null,"mac_address":"02:00:00:11:3A:55","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","status":"ready","updated_at":"2025-02-12T16:15:16.458661Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1932"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:25 GMT
+                - Wed, 12 Feb 2025 16:15:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1893,10 +1895,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c4c6bd02-518f-4293-81c5-c85286e64a15
+                - 50111657-b7fc-460c-8c79-8a38889c0a25
         status: 200 OK
         code: 200
-        duration: 33.449834ms
+        duration: 66.9695ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1912,8 +1914,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/90d04b2a-83c6-40ae-9112-4e127d7e9245
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/238269b1-9ef4-4935-9cb1-94a37e10fd48
         method: GET
       response:
         proto: HTTP/2.0
@@ -1921,18 +1923,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 966
+        content_length: 996
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:09.893402Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.242510Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"95c3edc0-cf35-40f9-bfb2-2af399b47a92","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.242510Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"90d04b2a-83c6-40ae-9112-4e127d7e9245","ipam_config":null,"mac_address":"02:00:00:11:96:81","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","status":"ready","updated_at":"2025-01-27T09:16:20.242261Z","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:05.808562Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.930530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"538c4a96-d996-45ca-b414-59e27b15ba9c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.930530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"238269b1-9ef4-4935-9cb1-94a37e10fd48","ipam_config":null,"mac_address":"02:00:00:11:3A:55","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","status":"ready","updated_at":"2025-02-12T16:15:16.458661Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "966"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:25 GMT
+                - Wed, 12 Feb 2025 16:15:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1942,48 +1944,46 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f469d78c-4f51-42ac-bd8e-334dfa1ab27e
+                - 953105c6-e0ca-4745-8587-3b770d7813a3
         status: 200 OK
         code: 200
-        duration: 54.883708ms
+        duration: 66.850583ms
     - id: 39
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 61
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b"}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2/private_nics
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 473
+        content_length: 1996
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:25.252781+00:00","id":"295dc8af-772a-4491-bac3-a30e6db5d124","ipam_ip_ids":["bf551b50-ecfd-47af-b775-b04c859b5fb3","d0c10238-7188-4d3a-a961-fd636a63afad"],"mac_address":"02:00:00:1e:8c:99","modification_date":"2025-01-27T09:16:25.460171+00:00","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","server_id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.811685Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:05.808562Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.930530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"538c4a96-d996-45ca-b414-59e27b15ba9c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.930530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"238269b1-9ef4-4935-9cb1-94a37e10fd48","ipam_config":null,"mac_address":"02:00:00:11:3A:55","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","status":"ready","updated_at":"2025-02-12T16:15:16.458661Z","zone":"fr-par-1"}],"id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:14:56.616626Z","gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"258fe83b-cf30-4221-9188-ba19bc703ec0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.616626Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:16.653882Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "473"
+                - "1996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:26 GMT
+                - Wed, 12 Feb 2025 16:15:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1993,10 +1993,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e5f0c52c-2099-420d-a60e-01e4e45d6988
-        status: 201 Created
-        code: 201
-        duration: 1.147620458s
+                - 95bff336-69b5-4a68-9931-625e16389148
+        status: 200 OK
+        code: 200
+        duration: 52.996375ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2012,8 +2012,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2/private_nics/295dc8af-772a-4491-bac3-a30e6db5d124
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/238269b1-9ef4-4935-9cb1-94a37e10fd48
         method: GET
       response:
         proto: HTTP/2.0
@@ -2021,18 +2021,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 473
+        content_length: 996
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:25.252781+00:00","id":"295dc8af-772a-4491-bac3-a30e6db5d124","ipam_ip_ids":["bf551b50-ecfd-47af-b775-b04c859b5fb3","d0c10238-7188-4d3a-a961-fd636a63afad"],"mac_address":"02:00:00:1e:8c:99","modification_date":"2025-01-27T09:16:25.460171+00:00","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","server_id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:05.808562Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.930530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"538c4a96-d996-45ca-b414-59e27b15ba9c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.930530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"238269b1-9ef4-4935-9cb1-94a37e10fd48","ipam_config":null,"mac_address":"02:00:00:11:3A:55","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","status":"ready","updated_at":"2025-02-12T16:15:16.458661Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "473"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:26 GMT
+                - Wed, 12 Feb 2025 16:15:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2042,10 +2042,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ea26c1c3-ad95-4a32-be01-75118d7080d9
+                - 15c40bc5-b4d3-4091-a1ff-7c7c5f50fd28
         status: 200 OK
         code: 200
-        duration: 93.581792ms
+        duration: 73.922125ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2061,8 +2061,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2/private_nics/295dc8af-772a-4491-bac3-a30e6db5d124
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b/private_nics/4b9eefc5-41db-4c4d-8662-cf9202eab68f
         method: GET
       response:
         proto: HTTP/2.0
@@ -2072,7 +2072,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:25.252781+00:00","id":"295dc8af-772a-4491-bac3-a30e6db5d124","ipam_ip_ids":["bf551b50-ecfd-47af-b775-b04c859b5fb3","d0c10238-7188-4d3a-a961-fd636a63afad"],"mac_address":"02:00:00:1e:8c:99","modification_date":"2025-01-27T09:16:25.460171+00:00","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","server_id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.422881+00:00","id":"4b9eefc5-41db-4c4d-8662-cf9202eab68f","ipam_ip_ids":["512fea6c-17d0-4487-a8d6-a03f75ee2368","58ca6b90-1ffa-4d83-9e1d-c84a21bab54f"],"mac_address":"02:00:00:1d:7b:57","modification_date":"2025-02-12T16:15:10.627880+00:00","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","server_id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -2081,7 +2081,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:31 GMT
+                - Wed, 12 Feb 2025 16:15:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2091,10 +2091,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bb2e7caa-65dd-4f6e-9090-0a9d2dd506ea
+                - 8bc6d830-3586-40f5-9f4b-b7e626fea408
         status: 200 OK
         code: 200
-        duration: 96.747416ms
+        duration: 113.523292ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2110,8 +2110,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2/private_nics/295dc8af-772a-4491-bac3-a30e6db5d124
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b/private_nics/4b9eefc5-41db-4c4d-8662-cf9202eab68f
         method: GET
       response:
         proto: HTTP/2.0
@@ -2121,7 +2121,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:25.252781+00:00","id":"295dc8af-772a-4491-bac3-a30e6db5d124","ipam_ip_ids":["bf551b50-ecfd-47af-b775-b04c859b5fb3","d0c10238-7188-4d3a-a961-fd636a63afad"],"mac_address":"02:00:00:1e:8c:99","modification_date":"2025-01-27T09:16:25.460171+00:00","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","server_id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.422881+00:00","id":"4b9eefc5-41db-4c4d-8662-cf9202eab68f","ipam_ip_ids":["512fea6c-17d0-4487-a8d6-a03f75ee2368","58ca6b90-1ffa-4d83-9e1d-c84a21bab54f"],"mac_address":"02:00:00:1d:7b:57","modification_date":"2025-02-12T16:15:10.627880+00:00","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","server_id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -2130,7 +2130,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:36 GMT
+                - Wed, 12 Feb 2025 16:15:26 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2140,10 +2140,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 04ec993f-19bb-4f92-ac8b-3f4f6674069a
+                - ddd02fe1-1a57-4d56-90fc-e943682501bb
         status: 200 OK
         code: 200
-        duration: 84.676416ms
+        duration: 110.388708ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2159,8 +2159,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2/private_nics/295dc8af-772a-4491-bac3-a30e6db5d124
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b/private_nics/4b9eefc5-41db-4c4d-8662-cf9202eab68f
         method: GET
       response:
         proto: HTTP/2.0
@@ -2170,7 +2170,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:25.252781+00:00","id":"295dc8af-772a-4491-bac3-a30e6db5d124","ipam_ip_ids":["bf551b50-ecfd-47af-b775-b04c859b5fb3","d0c10238-7188-4d3a-a961-fd636a63afad"],"mac_address":"02:00:00:1e:8c:99","modification_date":"2025-01-27T09:16:25.460171+00:00","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","server_id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.422881+00:00","id":"4b9eefc5-41db-4c4d-8662-cf9202eab68f","ipam_ip_ids":["512fea6c-17d0-4487-a8d6-a03f75ee2368","58ca6b90-1ffa-4d83-9e1d-c84a21bab54f"],"mac_address":"02:00:00:1d:7b:57","modification_date":"2025-02-12T16:15:10.627880+00:00","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","server_id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -2179,7 +2179,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:41 GMT
+                - Wed, 12 Feb 2025 16:15:31 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2189,10 +2189,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 98a0e6d9-d4be-49ca-93e0-f89d45b811b4
+                - ebc04376-43d5-4c73-8ea3-7eea1f6c921b
         status: 200 OK
         code: 200
-        duration: 86.150083ms
+        duration: 110.077459ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2208,8 +2208,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2/private_nics/295dc8af-772a-4491-bac3-a30e6db5d124
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b/private_nics/4b9eefc5-41db-4c4d-8662-cf9202eab68f
         method: GET
       response:
         proto: HTTP/2.0
@@ -2219,7 +2219,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:25.252781+00:00","id":"295dc8af-772a-4491-bac3-a30e6db5d124","ipam_ip_ids":["bf551b50-ecfd-47af-b775-b04c859b5fb3","d0c10238-7188-4d3a-a961-fd636a63afad"],"mac_address":"02:00:00:1e:8c:99","modification_date":"2025-01-27T09:16:25.460171+00:00","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","server_id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.422881+00:00","id":"4b9eefc5-41db-4c4d-8662-cf9202eab68f","ipam_ip_ids":["512fea6c-17d0-4487-a8d6-a03f75ee2368","58ca6b90-1ffa-4d83-9e1d-c84a21bab54f"],"mac_address":"02:00:00:1d:7b:57","modification_date":"2025-02-12T16:15:10.627880+00:00","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","server_id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -2228,7 +2228,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:46 GMT
+                - Wed, 12 Feb 2025 16:15:36 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2238,10 +2238,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9829c977-060e-404c-ab17-60c2a7a5b8a1
+                - 62df5eca-bee3-4417-be2f-c1f449bdae0a
         status: 200 OK
         code: 200
-        duration: 84.20925ms
+        duration: 118.466083ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2257,8 +2257,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2/private_nics/295dc8af-772a-4491-bac3-a30e6db5d124
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b/private_nics/4b9eefc5-41db-4c4d-8662-cf9202eab68f
         method: GET
       response:
         proto: HTTP/2.0
@@ -2268,7 +2268,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:25.252781+00:00","id":"295dc8af-772a-4491-bac3-a30e6db5d124","ipam_ip_ids":["bf551b50-ecfd-47af-b775-b04c859b5fb3","d0c10238-7188-4d3a-a961-fd636a63afad"],"mac_address":"02:00:00:1e:8c:99","modification_date":"2025-01-27T09:16:25.460171+00:00","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","server_id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.422881+00:00","id":"4b9eefc5-41db-4c4d-8662-cf9202eab68f","ipam_ip_ids":["512fea6c-17d0-4487-a8d6-a03f75ee2368","58ca6b90-1ffa-4d83-9e1d-c84a21bab54f"],"mac_address":"02:00:00:1d:7b:57","modification_date":"2025-02-12T16:15:10.627880+00:00","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","server_id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -2277,7 +2277,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:52 GMT
+                - Wed, 12 Feb 2025 16:15:42 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2287,10 +2287,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e6d6061f-c122-4d68-821e-0f33508ce78b
+                - 36e6d016-c1c1-4a25-a69c-e75a325219d0
         status: 200 OK
         code: 200
-        duration: 782.667666ms
+        duration: 101.742917ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2306,8 +2306,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2/private_nics/295dc8af-772a-4491-bac3-a30e6db5d124
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b/private_nics/4b9eefc5-41db-4c4d-8662-cf9202eab68f
         method: GET
       response:
         proto: HTTP/2.0
@@ -2317,7 +2317,7 @@ interactions:
         trailer: {}
         content_length: 475
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:25.252781+00:00","id":"295dc8af-772a-4491-bac3-a30e6db5d124","ipam_ip_ids":["bf551b50-ecfd-47af-b775-b04c859b5fb3","d0c10238-7188-4d3a-a961-fd636a63afad"],"mac_address":"02:00:00:1e:8c:99","modification_date":"2025-01-27T09:16:57.338850+00:00","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","server_id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.422881+00:00","id":"4b9eefc5-41db-4c4d-8662-cf9202eab68f","ipam_ip_ids":["512fea6c-17d0-4487-a8d6-a03f75ee2368","58ca6b90-1ffa-4d83-9e1d-c84a21bab54f"],"mac_address":"02:00:00:1d:7b:57","modification_date":"2025-02-12T16:15:42.390078+00:00","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","server_id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "475"
@@ -2326,7 +2326,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:57 GMT
+                - Wed, 12 Feb 2025 16:15:47 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2336,10 +2336,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 867a54f3-a177-4296-ae18-753906d0f940
+                - 366d6d5e-ab9f-479a-96e2-1930a68b9b94
         status: 200 OK
         code: 200
-        duration: 72.956708ms
+        duration: 122.427584ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2355,8 +2355,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2/private_nics/295dc8af-772a-4491-bac3-a30e6db5d124
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b/private_nics/4b9eefc5-41db-4c4d-8662-cf9202eab68f
         method: GET
       response:
         proto: HTTP/2.0
@@ -2366,7 +2366,7 @@ interactions:
         trailer: {}
         content_length: 475
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:25.252781+00:00","id":"295dc8af-772a-4491-bac3-a30e6db5d124","ipam_ip_ids":["bf551b50-ecfd-47af-b775-b04c859b5fb3","d0c10238-7188-4d3a-a961-fd636a63afad"],"mac_address":"02:00:00:1e:8c:99","modification_date":"2025-01-27T09:16:57.338850+00:00","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","server_id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.422881+00:00","id":"4b9eefc5-41db-4c4d-8662-cf9202eab68f","ipam_ip_ids":["512fea6c-17d0-4487-a8d6-a03f75ee2368","58ca6b90-1ffa-4d83-9e1d-c84a21bab54f"],"mac_address":"02:00:00:1d:7b:57","modification_date":"2025-02-12T16:15:42.390078+00:00","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","server_id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "475"
@@ -2375,7 +2375,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:57 GMT
+                - Wed, 12 Feb 2025 16:15:47 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2385,10 +2385,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 31069533-7195-487d-96bc-92ab9da01fb9
+                - d2038eee-5481-4b91-aa4d-1f333151bc2a
         status: 200 OK
         code: 200
-        duration: 78.552958ms
+        duration: 117.986167ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2404,8 +2404,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b
         method: GET
       response:
         proto: HTTP/2.0
@@ -2413,18 +2413,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2711
+        content_length: 2300
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.974673+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-benz","id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1501","node_id":"48","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:21","maintenances":[],"modification_date":"2025-01-27T09:16:20.592701+00:00","name":"tf-srv-happy-benz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:25.252781+00:00","id":"295dc8af-772a-4491-bac3-a30e6db5d124","ipam_ip_ids":["bf551b50-ecfd-47af-b775-b04c859b5fb3","d0c10238-7188-4d3a-a961-fd636a63afad"],"mac_address":"02:00:00:1e:8c:99","modification_date":"2025-01-27T09:16:57.338850+00:00","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","server_id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"c8613b60-f84a-47f6-9357-3a15421f9b76","name":"tf-sg-keen-wing"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.974673+00:00","export_uri":null,"id":"80ea48b3-70a2-4b5a-8665-bcda6853e98d","modification_date":"2025-01-27T09:16:02.974673+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","name":"tf-srv-happy-benz"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.450538+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-visvesvaraya","id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1901","node_id":"38","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:dd","maintenances":[],"modification_date":"2025-02-12T16:15:04.909328+00:00","name":"tf-srv-strange-visvesvaraya","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:10.422881+00:00","id":"4b9eefc5-41db-4c4d-8662-cf9202eab68f","ipam_ip_ids":["512fea6c-17d0-4487-a8d6-a03f75ee2368","58ca6b90-1ffa-4d83-9e1d-c84a21bab54f"],"mac_address":"02:00:00:1d:7b:57","modification_date":"2025-02-12T16:15:42.390078+00:00","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","server_id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"7a435d2e-8efb-4aaa-bc61-18ca3499a8ac","name":"tf-sg-nostalgic-hypatia"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"0310ce0d-2ff0-4cab-b5fe-1b17a2b6da68","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2711"
+                - "2300"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:57 GMT
+                - Wed, 12 Feb 2025 16:15:47 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2434,10 +2434,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ebb45c6d-3c1c-4150-bb0e-e40691ad81a1
+                - 85e6e2cc-8803-4034-9fab-5b0735cf1b8a
         status: 200 OK
         code: 200
-        duration: 191.121334ms
+        duration: 196.799875ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2453,8 +2453,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/80ea48b3-70a2-4b5a-8665-bcda6853e98d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0310ce0d-2ff0-4cab-b5fe-1b17a2b6da68
         method: GET
       response:
         proto: HTTP/2.0
@@ -2462,18 +2462,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 517
+        content_length: 143
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T09:16:02.974673+00:00","export_uri":null,"id":"80ea48b3-70a2-4b5a-8665-bcda6853e98d","modification_date":"2025-01-27T09:16:02.974673+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","name":"tf-srv-happy-benz"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"0310ce0d-2ff0-4cab-b5fe-1b17a2b6da68","type":"not_found"}'
         headers:
             Content-Length:
-                - "517"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:57 GMT
+                - Wed, 12 Feb 2025 16:15:47 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2483,10 +2483,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c79bf519-517d-4f10-af96-aa9601224d37
-        status: 200 OK
-        code: 200
-        duration: 90.148125ms
+                - 27e0ad57-7a65-461f-8373-06765bb39e62
+        status: 404 Not Found
+        code: 404
+        duration: 51.004125ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -2502,8 +2502,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/0310ce0d-2ff0-4cab-b5fe-1b17a2b6da68
         method: GET
       response:
         proto: HTTP/2.0
@@ -2511,18 +2511,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 701
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"created_at":"2025-02-12T16:14:57.876261Z","id":"0310ce0d-2ff0-4cab-b5fe-1b17a2b6da68","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:14:57.876261Z","id":"162e9203-8f06-49ed-a114-12a6d80c5055","product_resource_id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:14:57.876261Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "17"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:57 GMT
+                - Wed, 12 Feb 2025 16:15:47 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2532,10 +2532,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1f23b291-ffd2-4b19-abe2-b22bed4b032c
+                - 89ae75f3-29f6-4ce4-9945-3c41710e16c2
         status: 200 OK
         code: 200
-        duration: 107.213208ms
+        duration: 78.309875ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2551,1143 +2551,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2/private_nics
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 478
-        uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T09:16:25.252781+00:00","id":"295dc8af-772a-4491-bac3-a30e6db5d124","ipam_ip_ids":["bf551b50-ecfd-47af-b775-b04c859b5fb3","d0c10238-7188-4d3a-a961-fd636a63afad"],"mac_address":"02:00:00:1e:8c:99","modification_date":"2025-01-27T09:16:57.338850+00:00","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","server_id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","state":"available","tags":[],"zone":"fr-par-1"}]}'
-        headers:
-            Content-Length:
-                - "478"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:16:58 GMT
-            Link:
-                - </servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2/private_nics?page=1&per_page=50&>; rel="last"
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 29c5fcc2-ee6e-426a-a188-c28816c93a66
-            X-Total-Count:
-                - "1"
-        status: 200 OK
-        code: 200
-        duration: 107.012834ms
-    - id: 52
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/90d04b2a-83c6-40ae-9112-4e127d7e9245
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 966
-        uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:09.893402Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.242510Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"95c3edc0-cf35-40f9-bfb2-2af399b47a92","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.242510Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"90d04b2a-83c6-40ae-9112-4e127d7e9245","ipam_config":null,"mac_address":"02:00:00:11:96:81","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","status":"ready","updated_at":"2025-01-27T09:16:20.242261Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "966"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:16:58 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 2ff5ddeb-de89-426e-82eb-1a2a5f09c79b
-        status: 200 OK
-        code: 200
-        duration: 43.737084ms
-    - id: 53
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 122
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"gateway_network_id":"90d04b2a-83c6-40ae-9112-4e127d7e9245","mac_address":"02:00:00:1e:8c:99","ip_address":"192.168.1.4"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 322
-        uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:25.699965Z","gateway_network_id":"90d04b2a-83c6-40ae-9112-4e127d7e9245","hostname":"tf-srv-happy-benz","id":"bf551b50-ecfd-47af-b775-b04c859b5fb3","ip_address":"192.168.1.4","mac_address":"02:00:00:1e:8c:99","type":"reservation","updated_at":"2025-01-27T09:16:58.830716Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "322"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:16:58 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - c5267b6a-d873-4503-a4c7-7774f5d9d234
-        status: 200 OK
-        code: 200
-        duration: 549.496875ms
-    - id: 54
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/90d04b2a-83c6-40ae-9112-4e127d7e9245
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 966
-        uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:09.893402Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.242510Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"95c3edc0-cf35-40f9-bfb2-2af399b47a92","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.242510Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"90d04b2a-83c6-40ae-9112-4e127d7e9245","ipam_config":null,"mac_address":"02:00:00:11:96:81","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","status":"ready","updated_at":"2025-01-27T09:16:20.242261Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "966"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:16:58 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - eafc52d3-1ef6-43e2-b822-a7ad860ae823
-        status: 200 OK
-        code: 200
-        duration: 49.311417ms
-    - id: 55
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/bf551b50-ecfd-47af-b775-b04c859b5fb3
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 322
-        uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:25.699965Z","gateway_network_id":"90d04b2a-83c6-40ae-9112-4e127d7e9245","hostname":"tf-srv-happy-benz","id":"bf551b50-ecfd-47af-b775-b04c859b5fb3","ip_address":"192.168.1.4","mac_address":"02:00:00:1e:8c:99","type":"reservation","updated_at":"2025-01-27T09:16:58.830716Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "322"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:16:58 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 9130663a-d664-4899-a25f-f7236e06da3d
-        status: 200 OK
-        code: 200
-        duration: 66.001667ms
-    - id: 56
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1932
-        uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:02.214959Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:09.893402Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.242510Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"95c3edc0-cf35-40f9-bfb2-2af399b47a92","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.242510Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"90d04b2a-83c6-40ae-9112-4e127d7e9245","ipam_config":null,"mac_address":"02:00:00:11:96:81","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","status":"ready","updated_at":"2025-01-27T09:16:20.242261Z","zone":"fr-par-1"}],"id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","ip":{"address":"51.15.130.186","created_at":"2025-01-27T09:16:02.110630Z","gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"937192c3-38db-45ff-a692-e6d9646fc020","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:02.110630Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:20.389912Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "1932"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:16:58 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - c91b4620-2404-4abf-9672-9f393ae5b5b2
-        status: 200 OK
-        code: 200
-        duration: 24.1575ms
-    - id: 57
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1932
-        uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:02.214959Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:09.893402Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.242510Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"95c3edc0-cf35-40f9-bfb2-2af399b47a92","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.242510Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"90d04b2a-83c6-40ae-9112-4e127d7e9245","ipam_config":null,"mac_address":"02:00:00:11:96:81","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","status":"ready","updated_at":"2025-01-27T09:16:20.242261Z","zone":"fr-par-1"}],"id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","ip":{"address":"51.15.130.186","created_at":"2025-01-27T09:16:02.110630Z","gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"937192c3-38db-45ff-a692-e6d9646fc020","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:02.110630Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:20.389912Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "1932"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:16:59 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 2e0e5c92-a82d-4dd2-bb4a-763db48989d4
-        status: 200 OK
-        code: 200
-        duration: 39.181041ms
-    - id: 58
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/bf551b50-ecfd-47af-b775-b04c859b5fb3
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 322
-        uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:25.699965Z","gateway_network_id":"90d04b2a-83c6-40ae-9112-4e127d7e9245","hostname":"tf-srv-happy-benz","id":"bf551b50-ecfd-47af-b775-b04c859b5fb3","ip_address":"192.168.1.4","mac_address":"02:00:00:1e:8c:99","type":"reservation","updated_at":"2025-01-27T09:16:58.830716Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "322"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:16:59 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 02be2d8e-f20f-49c1-88c3-69a1b4644114
-        status: 200 OK
-        code: 200
-        duration: 88.348167ms
-    - id: 59
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 134
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","public_port":2222,"private_ip":"192.168.1.4","private_port":22,"protocol":"tcp"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 282
-        uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:59.087347Z","gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"dbf27378-a27a-4be4-b9f0-d3649d5321aa","private_ip":"192.168.1.4","private_port":22,"protocol":"tcp","public_port":2222,"updated_at":"2025-01-27T09:16:59.087347Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "282"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:16:59 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 7e728a46-daca-42b9-8cc9-13678750e272
-        status: 200 OK
-        code: 200
-        duration: 91.765292ms
-    - id: 60
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1932
-        uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:02.214959Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:09.893402Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.242510Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"95c3edc0-cf35-40f9-bfb2-2af399b47a92","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.242510Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"90d04b2a-83c6-40ae-9112-4e127d7e9245","ipam_config":null,"mac_address":"02:00:00:11:96:81","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","status":"ready","updated_at":"2025-01-27T09:16:20.242261Z","zone":"fr-par-1"}],"id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","ip":{"address":"51.15.130.186","created_at":"2025-01-27T09:16:02.110630Z","gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"937192c3-38db-45ff-a692-e6d9646fc020","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:02.110630Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:20.389912Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "1932"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:16:59 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - b1088be6-6b99-4378-ad55-a20b37a75c69
-        status: 200 OK
-        code: 200
-        duration: 30.96325ms
-    - id: 61
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/dbf27378-a27a-4be4-b9f0-d3649d5321aa
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 282
-        uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:59.087347Z","gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"dbf27378-a27a-4be4-b9f0-d3649d5321aa","private_ip":"192.168.1.4","private_port":22,"protocol":"tcp","public_port":2222,"updated_at":"2025-01-27T09:16:59.087347Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "282"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:16:59 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - df3ae50c-cac8-44ad-833f-a01c1a23ec9c
-        status: 200 OK
-        code: 200
-        duration: 24.452ms
-    - id: 62
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/bf551b50-ecfd-47af-b775-b04c859b5fb3
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 322
-        uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:25.699965Z","gateway_network_id":"90d04b2a-83c6-40ae-9112-4e127d7e9245","hostname":"tf-srv-happy-benz","id":"bf551b50-ecfd-47af-b775-b04c859b5fb3","ip_address":"192.168.1.4","mac_address":"02:00:00:1e:8c:99","type":"reservation","updated_at":"2025-01-27T09:16:58.830716Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "322"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:16:59 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - d430ecf3-258b-4e5c-a4be-17fee7427b40
-        status: 200 OK
-        code: 200
-        duration: 70.207916ms
-    - id: 63
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/937192c3-38db-45ff-a692-e6d9646fc020
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 392
-        uncompressed: false
-        body: '{"address":"51.15.130.186","created_at":"2025-01-27T09:16:02.110630Z","gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"937192c3-38db-45ff-a692-e6d9646fc020","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:02.110630Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "392"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:00 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - b3ac6ced-308f-4798-9f48-5c38391b2184
-        status: 200 OK
-        code: 200
-        duration: 27.345708ms
-    - id: 64
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/95c3edc0-cf35-40f9-bfb2-2af399b47a92
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 568
-        uncompressed: false
-        body: '{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.242510Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"95c3edc0-cf35-40f9-bfb2-2af399b47a92","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.242510Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "568"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:00 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 4d57eebd-45e9-43f2-b31f-4c97c9acf9f1
-        status: 200 OK
-        code: 200
-        duration: 24.440042ms
-    - id: 65
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a25b8a28-50ff-4347-a5ba-3dbabb3ae79b
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1067
-        uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:01.252990Z","dhcp_enabled":true,"id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T09:16:01.252990Z","id":"f7ebc451-4f4d-4cd0-a12d-bafae62f04db","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:07.610304Z","vpc_id":"55bdd955-2e0a-4274-8bff-6036570e8f94"},{"created_at":"2025-01-27T09:16:01.252990Z","id":"21961ecd-3d04-40c7-b889-8f1b2e10500c","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:5aaf::/64","updated_at":"2025-01-27T09:16:07.613992Z","vpc_id":"55bdd955-2e0a-4274-8bff-6036570e8f94"}],"tags":[],"updated_at":"2025-01-27T09:16:16.425154Z","vpc_id":"55bdd955-2e0a-4274-8bff-6036570e8f94"}'
-        headers:
-            Content-Length:
-                - "1067"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:00 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 5e35bf2d-a84a-4cc1-a218-7598d942b5bf
-        status: 200 OK
-        code: 200
-        duration: 29.139375ms
-    - id: 66
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1932
-        uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:02.214959Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:09.893402Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.242510Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"95c3edc0-cf35-40f9-bfb2-2af399b47a92","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.242510Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"90d04b2a-83c6-40ae-9112-4e127d7e9245","ipam_config":null,"mac_address":"02:00:00:11:96:81","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","status":"ready","updated_at":"2025-01-27T09:16:20.242261Z","zone":"fr-par-1"}],"id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","ip":{"address":"51.15.130.186","created_at":"2025-01-27T09:16:02.110630Z","gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"937192c3-38db-45ff-a692-e6d9646fc020","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:02.110630Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:20.389912Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "1932"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:00 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - f0433ebe-aba7-418c-b170-39b909700e7f
-        status: 200 OK
-        code: 200
-        duration: 34.628625ms
-    - id: 67
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/c8613b60-f84a-47f6-9357-3a15421f9b76
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 654
-        uncompressed: false
-        body: '{"security_group":{"creation_date":"2025-01-27T09:16:01.344672+00:00","description":null,"enable_default_security":true,"id":"c8613b60-f84a-47f6-9357-3a15421f9b76","inbound_default_policy":"drop","modification_date":"2025-01-27T09:16:01.871967+00:00","name":"tf-sg-keen-wing","organization":"105bdce1-64c0-48ab-899d-868455867ecf","organization_default":false,"outbound_default_policy":"accept","project":"105bdce1-64c0-48ab-899d-868455867ecf","project_default":false,"servers":[{"id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","name":"tf-srv-happy-benz"}],"state":"available","stateful":true,"tags":[],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "654"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:16:59 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 7370b3f2-b3ed-4a8d-8aea-e044d068b5fe
-        status: 200 OK
-        code: 200
-        duration: 108.452708ms
-    - id: 68
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/90d04b2a-83c6-40ae-9112-4e127d7e9245
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 966
-        uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:09.893402Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.242510Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"95c3edc0-cf35-40f9-bfb2-2af399b47a92","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.242510Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"90d04b2a-83c6-40ae-9112-4e127d7e9245","ipam_config":null,"mac_address":"02:00:00:11:96:81","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","status":"ready","updated_at":"2025-01-27T09:16:20.242261Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "966"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:00 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 0edb694b-c0e5-4a33-87a2-ee36b84515b4
-        status: 200 OK
-        code: 200
-        duration: 114.26225ms
-    - id: 69
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1932
-        uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:02.214959Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:09.893402Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.242510Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"95c3edc0-cf35-40f9-bfb2-2af399b47a92","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.242510Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"90d04b2a-83c6-40ae-9112-4e127d7e9245","ipam_config":null,"mac_address":"02:00:00:11:96:81","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","status":"ready","updated_at":"2025-01-27T09:16:20.242261Z","zone":"fr-par-1"}],"id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","ip":{"address":"51.15.130.186","created_at":"2025-01-27T09:16:02.110630Z","gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"937192c3-38db-45ff-a692-e6d9646fc020","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:02.110630Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:20.389912Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "1932"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:00 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 3d46c79b-34f2-4f3b-b9c4-9b3b5b21e69e
-        status: 200 OK
-        code: 200
-        duration: 31.908042ms
-    - id: 70
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/90d04b2a-83c6-40ae-9112-4e127d7e9245
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 966
-        uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:09.893402Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.242510Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"95c3edc0-cf35-40f9-bfb2-2af399b47a92","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.242510Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"90d04b2a-83c6-40ae-9112-4e127d7e9245","ipam_config":null,"mac_address":"02:00:00:11:96:81","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","status":"ready","updated_at":"2025-01-27T09:16:20.242261Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "966"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:00 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 5fdee66e-bcce-4614-bad1-a524469bab9f
-        status: 200 OK
-        code: 200
-        duration: 50.307375ms
-    - id: 71
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/c8613b60-f84a-47f6-9357-3a15421f9b76/rules?page=1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1792
-        uncompressed: false
-        body: '{"rules":[{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"58909be7-d17c-4ac8-9eb3-23d5fc58abc5","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"25680235-108b-4bbc-8e25-114303d950bd","ip_range":"0.0.0.0/0","position":2,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"4a31b633-118e-4900-bd52-facf1085fc8d","ip_range":"0.0.0.0/0","position":3,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"e7dd28e8-3747-4c7c-9a4f-35ae3f0ae2cd","ip_range":"::/0","position":4,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"f37d9e7c-8ed7-4e0f-baff-7f5e7ede0baf","ip_range":"::/0","position":5,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"68054851-54e3-46c9-9cd7-83219751248b","ip_range":"::/0","position":6,"protocol":"TCP","zone":"fr-par-1"},{"action":"accept","dest_ip_range":null,"dest_port_from":22,"dest_port_to":null,"direction":"inbound","editable":true,"id":"eb013f5b-7777-4715-8675-9331158361fa","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"}]}'
-        headers:
-            Content-Length:
-                - "1792"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:00 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - af4a35ce-2e0a-44cc-a404-dfe2a3851646
-        status: 200 OK
-        code: 200
-        duration: 247.24925ms
-    - id: 72
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2711
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.974673+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-benz","id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1501","node_id":"48","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:21","maintenances":[],"modification_date":"2025-01-27T09:16:20.592701+00:00","name":"tf-srv-happy-benz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:25.252781+00:00","id":"295dc8af-772a-4491-bac3-a30e6db5d124","ipam_ip_ids":["bf551b50-ecfd-47af-b775-b04c859b5fb3","d0c10238-7188-4d3a-a961-fd636a63afad"],"mac_address":"02:00:00:1e:8c:99","modification_date":"2025-01-27T09:16:57.338850+00:00","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","server_id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"c8613b60-f84a-47f6-9357-3a15421f9b76","name":"tf-sg-keen-wing"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.974673+00:00","export_uri":null,"id":"80ea48b3-70a2-4b5a-8665-bcda6853e98d","modification_date":"2025-01-27T09:16:02.974673+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","name":"tf-srv-happy-benz"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2711"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:00 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 41ad623d-aaf7-4ecd-bdef-33a7e65922a9
-        status: 200 OK
-        code: 200
-        duration: 175.530625ms
-    - id: 73
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/80ea48b3-70a2-4b5a-8665-bcda6853e98d
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 517
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T09:16:02.974673+00:00","export_uri":null,"id":"80ea48b3-70a2-4b5a-8665-bcda6853e98d","modification_date":"2025-01-27T09:16:02.974673+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","name":"tf-srv-happy-benz"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "517"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:01 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 31a39fa4-9b8d-4a1d-a510-dee787f20ec2
-        status: 200 OK
-        code: 200
-        duration: 351.864041ms
-    - id: 74
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -3706,7 +2571,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:00 GMT
+                - Wed, 12 Feb 2025 16:15:47 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3716,10 +2581,1145 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d2dad1e0-c12c-450c-820e-f7ba42f81005
+                - 6c3d87d8-f57d-491f-ba10-10062d6b99e0
         status: 200 OK
         code: 200
-        duration: 85.271708ms
+        duration: 143.208084ms
+    - id: 52
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 478
+        uncompressed: false
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:15:10.422881+00:00","id":"4b9eefc5-41db-4c4d-8662-cf9202eab68f","ipam_ip_ids":["512fea6c-17d0-4487-a8d6-a03f75ee2368","58ca6b90-1ffa-4d83-9e1d-c84a21bab54f"],"mac_address":"02:00:00:1d:7b:57","modification_date":"2025-02-12T16:15:42.390078+00:00","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","server_id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        headers:
+            Content-Length:
+                - "478"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:47 GMT
+            Link:
+                - </servers/9c7a1a9d-2047-4712-86f0-ba076f86118b/private_nics?page=1&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8750497e-b681-4fd6-bd4a-09fde67beedd
+            X-Total-Count:
+                - "1"
+        status: 200 OK
+        code: 200
+        duration: 102.659708ms
+    - id: 53
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/238269b1-9ef4-4935-9cb1-94a37e10fd48
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 996
+        uncompressed: false
+        body: '{"address":null,"created_at":"2025-02-12T16:15:05.808562Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.930530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"538c4a96-d996-45ca-b414-59e27b15ba9c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.930530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"238269b1-9ef4-4935-9cb1-94a37e10fd48","ipam_config":null,"mac_address":"02:00:00:11:3A:55","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","status":"ready","updated_at":"2025-02-12T16:15:16.458661Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "996"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f7a3d72a-09bb-48f3-8607-c76b0f45d83f
+        status: 200 OK
+        code: 200
+        duration: 58.958833ms
+    - id: 54
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 122
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"gateway_network_id":"238269b1-9ef4-4935-9cb1-94a37e10fd48","mac_address":"02:00:00:1d:7b:57","ip_address":"192.168.1.4"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 340
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:15:10.834593Z","gateway_network_id":"238269b1-9ef4-4935-9cb1-94a37e10fd48","hostname":"tf-srv-strange-visvesvaraya","id":"512fea6c-17d0-4487-a8d6-a03f75ee2368","ip_address":"192.168.1.4","mac_address":"02:00:00:1d:7b:57","type":"reservation","updated_at":"2025-02-12T16:15:48.855556Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "340"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7f7d9dac-6f13-4aba-8099-2f56433e2d50
+        status: 200 OK
+        code: 200
+        duration: 711.660458ms
+    - id: 55
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/238269b1-9ef4-4935-9cb1-94a37e10fd48
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 996
+        uncompressed: false
+        body: '{"address":null,"created_at":"2025-02-12T16:15:05.808562Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.930530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"538c4a96-d996-45ca-b414-59e27b15ba9c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.930530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"238269b1-9ef4-4935-9cb1-94a37e10fd48","ipam_config":null,"mac_address":"02:00:00:11:3A:55","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","status":"ready","updated_at":"2025-02-12T16:15:16.458661Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "996"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b7c9caf4-5c7a-4e7e-9c68-23dd0c7016ef
+        status: 200 OK
+        code: 200
+        duration: 102.2555ms
+    - id: 56
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/512fea6c-17d0-4487-a8d6-a03f75ee2368
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 340
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:15:10.834593Z","gateway_network_id":"238269b1-9ef4-4935-9cb1-94a37e10fd48","hostname":"tf-srv-strange-visvesvaraya","id":"512fea6c-17d0-4487-a8d6-a03f75ee2368","ip_address":"192.168.1.4","mac_address":"02:00:00:1d:7b:57","type":"reservation","updated_at":"2025-02-12T16:15:48.855556Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "340"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - da3807d4-ec4e-4ec2-867a-71ddd7c21d99
+        status: 200 OK
+        code: 200
+        duration: 92.393667ms
+    - id: 57
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1996
+        uncompressed: false
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.811685Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:05.808562Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.930530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"538c4a96-d996-45ca-b414-59e27b15ba9c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.930530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"238269b1-9ef4-4935-9cb1-94a37e10fd48","ipam_config":null,"mac_address":"02:00:00:11:3A:55","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","status":"ready","updated_at":"2025-02-12T16:15:16.458661Z","zone":"fr-par-1"}],"id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:14:56.616626Z","gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"258fe83b-cf30-4221-9188-ba19bc703ec0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.616626Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:16.653882Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "1996"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 84a354aa-90e6-403f-952e-8146c2e81fde
+        status: 200 OK
+        code: 200
+        duration: 66.626ms
+    - id: 58
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/512fea6c-17d0-4487-a8d6-a03f75ee2368
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 340
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:15:10.834593Z","gateway_network_id":"238269b1-9ef4-4935-9cb1-94a37e10fd48","hostname":"tf-srv-strange-visvesvaraya","id":"512fea6c-17d0-4487-a8d6-a03f75ee2368","ip_address":"192.168.1.4","mac_address":"02:00:00:1d:7b:57","type":"reservation","updated_at":"2025-02-12T16:15:48.855556Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "340"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e5640ffe-e1cb-4766-98a0-d3a0b5205ae4
+        status: 200 OK
+        code: 200
+        duration: 73.860125ms
+    - id: 59
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1996
+        uncompressed: false
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.811685Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:05.808562Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.930530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"538c4a96-d996-45ca-b414-59e27b15ba9c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.930530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"238269b1-9ef4-4935-9cb1-94a37e10fd48","ipam_config":null,"mac_address":"02:00:00:11:3A:55","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","status":"ready","updated_at":"2025-02-12T16:15:16.458661Z","zone":"fr-par-1"}],"id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:14:56.616626Z","gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"258fe83b-cf30-4221-9188-ba19bc703ec0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.616626Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:16.653882Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "1996"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 329dee31-4966-4001-b74f-9732a4855981
+        status: 200 OK
+        code: 200
+        duration: 47.184334ms
+    - id: 60
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 134
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","public_port":2222,"private_ip":"192.168.1.4","private_port":22,"protocol":"tcp"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 290
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:15:49.265493Z","gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"0a021712-93a9-4a6c-b80f-b6373494ccde","private_ip":"192.168.1.4","private_port":22,"protocol":"tcp","public_port":2222,"updated_at":"2025-02-12T16:15:49.265493Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "290"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4d9bb558-f282-4765-be30-b00ba6362fe5
+        status: 200 OK
+        code: 200
+        duration: 97.451292ms
+    - id: 61
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1996
+        uncompressed: false
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.811685Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:05.808562Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.930530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"538c4a96-d996-45ca-b414-59e27b15ba9c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.930530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"238269b1-9ef4-4935-9cb1-94a37e10fd48","ipam_config":null,"mac_address":"02:00:00:11:3A:55","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","status":"ready","updated_at":"2025-02-12T16:15:16.458661Z","zone":"fr-par-1"}],"id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:14:56.616626Z","gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"258fe83b-cf30-4221-9188-ba19bc703ec0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.616626Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:16.653882Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "1996"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 30553dd3-3f08-428d-acfc-20a57b028bf0
+        status: 200 OK
+        code: 200
+        duration: 56.848416ms
+    - id: 62
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/0a021712-93a9-4a6c-b80f-b6373494ccde
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 290
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:15:49.265493Z","gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"0a021712-93a9-4a6c-b80f-b6373494ccde","private_ip":"192.168.1.4","private_port":22,"protocol":"tcp","public_port":2222,"updated_at":"2025-02-12T16:15:49.265493Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "290"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 196d00da-6a2d-4358-8f68-e7642a53a783
+        status: 200 OK
+        code: 200
+        duration: 41.361458ms
+    - id: 63
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/512fea6c-17d0-4487-a8d6-a03f75ee2368
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 340
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:15:10.834593Z","gateway_network_id":"238269b1-9ef4-4935-9cb1-94a37e10fd48","hostname":"tf-srv-strange-visvesvaraya","id":"512fea6c-17d0-4487-a8d6-a03f75ee2368","ip_address":"192.168.1.4","mac_address":"02:00:00:1d:7b:57","type":"reservation","updated_at":"2025-02-12T16:15:48.855556Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "340"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d698501a-0cc6-49ad-b27a-ac88870052bf
+        status: 200 OK
+        code: 200
+        duration: 85.208083ms
+    - id: 64
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/538c4a96-d996-45ca-b414-59e27b15ba9c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 586
+        uncompressed: false
+        body: '{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.930530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"538c4a96-d996-45ca-b414-59e27b15ba9c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.930530Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "586"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3f73b461-3d6b-4c06-8c9e-24a79c8430fc
+        status: 200 OK
+        code: 200
+        duration: 44.799375ms
+    - id: 65
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/0c6bc523-27f7-44c3-8a6a-e0c049abeda3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1089
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:14:56.227413Z","dhcp_enabled":true,"id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:14:56.227413Z","id":"17f49657-2f39-44d9-a132-cab370633996","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:15:02.387872Z","vpc_id":"40198cae-234b-4971-8c6a-c15a4ea697cb"},{"created_at":"2025-02-12T16:14:56.227413Z","id":"8bec6edb-5cc4-4482-8d40-8b7b69d9de78","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:ed6::/64","updated_at":"2025-02-12T16:15:02.395052Z","vpc_id":"40198cae-234b-4971-8c6a-c15a4ea697cb"}],"tags":[],"updated_at":"2025-02-12T16:15:12.567913Z","vpc_id":"40198cae-234b-4971-8c6a-c15a4ea697cb"}'
+        headers:
+            Content-Length:
+                - "1089"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6e46d772-6fcf-4dea-8830-bc0442c48f77
+        status: 200 OK
+        code: 200
+        duration: 49.026167ms
+    - id: 66
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/258fe83b-cf30-4221-9188-ba19bc703ec0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 405
+        uncompressed: false
+        body: '{"address":"163.172.162.186","created_at":"2025-02-12T16:14:56.616626Z","gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"258fe83b-cf30-4221-9188-ba19bc703ec0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.616626Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "405"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3f0a1149-e9f2-4372-9b9a-cc681e755701
+        status: 200 OK
+        code: 200
+        duration: 52.42475ms
+    - id: 67
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1996
+        uncompressed: false
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.811685Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:05.808562Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.930530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"538c4a96-d996-45ca-b414-59e27b15ba9c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.930530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"238269b1-9ef4-4935-9cb1-94a37e10fd48","ipam_config":null,"mac_address":"02:00:00:11:3A:55","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","status":"ready","updated_at":"2025-02-12T16:15:16.458661Z","zone":"fr-par-1"}],"id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:14:56.616626Z","gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"258fe83b-cf30-4221-9188-ba19bc703ec0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.616626Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:16.653882Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "1996"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 76b48099-77f4-400c-ade1-f55c934f1151
+        status: 200 OK
+        code: 200
+        duration: 49.720959ms
+    - id: 68
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/7a435d2e-8efb-4aaa-bc61-18ca3499a8ac
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 672
+        uncompressed: false
+        body: '{"security_group":{"creation_date":"2025-02-12T16:14:56.037005+00:00","description":null,"enable_default_security":true,"id":"7a435d2e-8efb-4aaa-bc61-18ca3499a8ac","inbound_default_policy":"drop","modification_date":"2025-02-12T16:14:56.632319+00:00","name":"tf-sg-nostalgic-hypatia","organization":"105bdce1-64c0-48ab-899d-868455867ecf","organization_default":false,"outbound_default_policy":"accept","project":"105bdce1-64c0-48ab-899d-868455867ecf","project_default":false,"servers":[{"id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","name":"tf-srv-strange-visvesvaraya"}],"state":"available","stateful":true,"tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "672"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 74f0b108-6f41-4393-9bd1-f58700692aec
+        status: 200 OK
+        code: 200
+        duration: 136.11775ms
+    - id: 69
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/238269b1-9ef4-4935-9cb1-94a37e10fd48
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 996
+        uncompressed: false
+        body: '{"address":null,"created_at":"2025-02-12T16:15:05.808562Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.930530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"538c4a96-d996-45ca-b414-59e27b15ba9c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.930530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"238269b1-9ef4-4935-9cb1-94a37e10fd48","ipam_config":null,"mac_address":"02:00:00:11:3A:55","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","status":"ready","updated_at":"2025-02-12T16:15:16.458661Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "996"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6060d395-67b1-46f2-b02f-ea7e794e2df8
+        status: 200 OK
+        code: 200
+        duration: 60.95525ms
+    - id: 70
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1996
+        uncompressed: false
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.811685Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:05.808562Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.930530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"538c4a96-d996-45ca-b414-59e27b15ba9c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.930530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"238269b1-9ef4-4935-9cb1-94a37e10fd48","ipam_config":null,"mac_address":"02:00:00:11:3A:55","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","status":"ready","updated_at":"2025-02-12T16:15:16.458661Z","zone":"fr-par-1"}],"id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:14:56.616626Z","gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"258fe83b-cf30-4221-9188-ba19bc703ec0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.616626Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:16.653882Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "1996"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0800c533-e279-4e8f-af4c-512810efeac4
+        status: 200 OK
+        code: 200
+        duration: 44.69875ms
+    - id: 71
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/7a435d2e-8efb-4aaa-bc61-18ca3499a8ac/rules?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1792
+        uncompressed: false
+        body: '{"rules":[{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"58909be7-d17c-4ac8-9eb3-23d5fc58abc5","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"25680235-108b-4bbc-8e25-114303d950bd","ip_range":"0.0.0.0/0","position":2,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"4a31b633-118e-4900-bd52-facf1085fc8d","ip_range":"0.0.0.0/0","position":3,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"e7dd28e8-3747-4c7c-9a4f-35ae3f0ae2cd","ip_range":"::/0","position":4,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"f37d9e7c-8ed7-4e0f-baff-7f5e7ede0baf","ip_range":"::/0","position":5,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"68054851-54e3-46c9-9cd7-83219751248b","ip_range":"::/0","position":6,"protocol":"TCP","zone":"fr-par-1"},{"action":"accept","dest_ip_range":null,"dest_port_from":22,"dest_port_to":null,"direction":"inbound","editable":true,"id":"e1486e4b-6ee9-443c-b216-b112d339ad8e","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"}]}'
+        headers:
+            Content-Length:
+                - "1792"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2e86f6ec-71e0-44e2-b50c-0fb4af4f9087
+        status: 200 OK
+        code: 200
+        duration: 138.175375ms
+    - id: 72
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/238269b1-9ef4-4935-9cb1-94a37e10fd48
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 996
+        uncompressed: false
+        body: '{"address":null,"created_at":"2025-02-12T16:15:05.808562Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.930530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"538c4a96-d996-45ca-b414-59e27b15ba9c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.930530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"238269b1-9ef4-4935-9cb1-94a37e10fd48","ipam_config":null,"mac_address":"02:00:00:11:3A:55","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","status":"ready","updated_at":"2025-02-12T16:15:16.458661Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "996"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6154a58a-47ca-4f91-ae22-ba3aca5c7ac8
+        status: 200 OK
+        code: 200
+        duration: 63.694583ms
+    - id: 73
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2300
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.450538+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-visvesvaraya","id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1901","node_id":"38","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:dd","maintenances":[],"modification_date":"2025-02-12T16:15:04.909328+00:00","name":"tf-srv-strange-visvesvaraya","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:10.422881+00:00","id":"4b9eefc5-41db-4c4d-8662-cf9202eab68f","ipam_ip_ids":["512fea6c-17d0-4487-a8d6-a03f75ee2368","58ca6b90-1ffa-4d83-9e1d-c84a21bab54f"],"mac_address":"02:00:00:1d:7b:57","modification_date":"2025-02-12T16:15:42.390078+00:00","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","server_id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"7a435d2e-8efb-4aaa-bc61-18ca3499a8ac","name":"tf-sg-nostalgic-hypatia"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"0310ce0d-2ff0-4cab-b5fe-1b17a2b6da68","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2300"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8c54edf8-cf4a-4a4c-867c-a852f09b5ef3
+        status: 200 OK
+        code: 200
+        duration: 333.677292ms
+    - id: 74
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0310ce0d-2ff0-4cab-b5fe-1b17a2b6da68
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"0310ce0d-2ff0-4cab-b5fe-1b17a2b6da68","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3b656cf2-af72-4511-9545-0565440bcb8a
+        status: 404 Not Found
+        code: 404
+        duration: 51.831333ms
     - id: 75
       request:
         proto: HTTP/1.1
@@ -3735,8 +3735,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/0310ce0d-2ff0-4cab-b5fe-1b17a2b6da68
         method: GET
       response:
         proto: HTTP/2.0
@@ -3744,20 +3744,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 478
+        content_length: 701
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T09:16:25.252781+00:00","id":"295dc8af-772a-4491-bac3-a30e6db5d124","ipam_ip_ids":["bf551b50-ecfd-47af-b775-b04c859b5fb3","d0c10238-7188-4d3a-a961-fd636a63afad"],"mac_address":"02:00:00:1e:8c:99","modification_date":"2025-01-27T09:16:57.338850+00:00","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","server_id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"created_at":"2025-02-12T16:14:57.876261Z","id":"0310ce0d-2ff0-4cab-b5fe-1b17a2b6da68","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:14:57.876261Z","id":"162e9203-8f06-49ed-a114-12a6d80c5055","product_resource_id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:14:57.876261Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "478"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:01 GMT
-            Link:
-                - </servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2/private_nics?page=1&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 16:15:50 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3767,12 +3765,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 00af63bc-6c95-49d9-b75a-45e40e9bfe56
-            X-Total-Count:
-                - "1"
+                - ec31cdfb-78ef-4681-8ac4-13ca73cf210f
         status: 200 OK
         code: 200
-        duration: 85.917375ms
+        duration: 82.369209ms
     - id: 76
       request:
         proto: HTTP/1.1
@@ -3788,8 +3784,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/bf551b50-ecfd-47af-b775-b04c859b5fb3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -3797,18 +3793,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 322
+        content_length: 17
         uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:25.699965Z","gateway_network_id":"90d04b2a-83c6-40ae-9112-4e127d7e9245","hostname":"tf-srv-happy-benz","id":"bf551b50-ecfd-47af-b775-b04c859b5fb3","ip_address":"192.168.1.4","mac_address":"02:00:00:1e:8c:99","type":"reservation","updated_at":"2025-01-27T09:16:58.830716Z","zone":"fr-par-1"}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "322"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:01 GMT
+                - Wed, 12 Feb 2025 16:15:50 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3818,10 +3814,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b0823903-9ec5-4123-9dd3-6703efce1fd2
+                - 2320cd64-74ea-4428-b64d-e7b5b59d0295
         status: 200 OK
         code: 200
-        duration: 69.949208ms
+        duration: 125.314833ms
     - id: 77
       request:
         proto: HTTP/1.1
@@ -3837,8 +3833,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/dbf27378-a27a-4be4-b9f0-d3649d5321aa
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -3846,18 +3842,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 282
+        content_length: 478
         uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:59.087347Z","gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"dbf27378-a27a-4be4-b9f0-d3649d5321aa","private_ip":"192.168.1.4","private_port":22,"protocol":"tcp","public_port":2222,"updated_at":"2025-01-27T09:16:59.087347Z","zone":"fr-par-1"}'
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:15:10.422881+00:00","id":"4b9eefc5-41db-4c4d-8662-cf9202eab68f","ipam_ip_ids":["512fea6c-17d0-4487-a8d6-a03f75ee2368","58ca6b90-1ffa-4d83-9e1d-c84a21bab54f"],"mac_address":"02:00:00:1d:7b:57","modification_date":"2025-02-12T16:15:42.390078+00:00","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","server_id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "282"
+                - "478"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:01 GMT
+                - Wed, 12 Feb 2025 16:15:50 GMT
+            Link:
+                - </servers/9c7a1a9d-2047-4712-86f0-ba076f86118b/private_nics?page=1&per_page=50&>; rel="last"
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3867,10 +3865,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f2a27a73-d73f-46f7-a6bf-11f3eea60a48
+                - 9eb69a56-299d-4ae1-b3d3-302d99cc959d
+            X-Total-Count:
+                - "1"
         status: 200 OK
         code: 200
-        duration: 28.068917ms
+        duration: 112.697875ms
     - id: 78
       request:
         proto: HTTP/1.1
@@ -3886,8 +3886,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/bf551b50-ecfd-47af-b775-b04c859b5fb3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/512fea6c-17d0-4487-a8d6-a03f75ee2368
         method: GET
       response:
         proto: HTTP/2.0
@@ -3895,18 +3895,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 322
+        content_length: 340
         uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:25.699965Z","gateway_network_id":"90d04b2a-83c6-40ae-9112-4e127d7e9245","hostname":"tf-srv-happy-benz","id":"bf551b50-ecfd-47af-b775-b04c859b5fb3","ip_address":"192.168.1.4","mac_address":"02:00:00:1e:8c:99","type":"reservation","updated_at":"2025-01-27T09:16:58.830716Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:15:10.834593Z","gateway_network_id":"238269b1-9ef4-4935-9cb1-94a37e10fd48","hostname":"tf-srv-strange-visvesvaraya","id":"512fea6c-17d0-4487-a8d6-a03f75ee2368","ip_address":"192.168.1.4","mac_address":"02:00:00:1d:7b:57","type":"reservation","updated_at":"2025-02-12T16:15:48.855556Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "322"
+                - "340"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:01 GMT
+                - Wed, 12 Feb 2025 16:15:50 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3916,10 +3916,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b8c134d7-c270-432d-ac44-c4cbc5e12457
+                - 30f7709a-fdad-431a-983a-864da00c1e0f
         status: 200 OK
         code: 200
-        duration: 76.519542ms
+        duration: 81.680959ms
     - id: 79
       request:
         proto: HTTP/1.1
@@ -3935,8 +3935,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/bf551b50-ecfd-47af-b775-b04c859b5fb3
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/0a021712-93a9-4a6c-b80f-b6373494ccde
         method: GET
       response:
         proto: HTTP/2.0
@@ -3944,18 +3944,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 322
+        content_length: 290
         uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:25.699965Z","gateway_network_id":"90d04b2a-83c6-40ae-9112-4e127d7e9245","hostname":"tf-srv-happy-benz","id":"bf551b50-ecfd-47af-b775-b04c859b5fb3","ip_address":"192.168.1.4","mac_address":"02:00:00:1e:8c:99","type":"reservation","updated_at":"2025-01-27T09:16:58.830716Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:15:49.265493Z","gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"0a021712-93a9-4a6c-b80f-b6373494ccde","private_ip":"192.168.1.4","private_port":22,"protocol":"tcp","public_port":2222,"updated_at":"2025-02-12T16:15:49.265493Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "322"
+                - "290"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:01 GMT
+                - Wed, 12 Feb 2025 16:15:50 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3965,10 +3965,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5923f331-4feb-4758-b3b5-1153ead2c434
+                - 54067f4c-ae2b-4fac-acc7-2e0f5ad71762
         status: 200 OK
         code: 200
-        duration: 76.278708ms
+        duration: 44.214209ms
     - id: 80
       request:
         proto: HTTP/1.1
@@ -3984,8 +3984,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/dbf27378-a27a-4be4-b9f0-d3649d5321aa
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/512fea6c-17d0-4487-a8d6-a03f75ee2368
         method: GET
       response:
         proto: HTTP/2.0
@@ -3993,18 +3993,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 282
+        content_length: 340
         uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:59.087347Z","gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"dbf27378-a27a-4be4-b9f0-d3649d5321aa","private_ip":"192.168.1.4","private_port":22,"protocol":"tcp","public_port":2222,"updated_at":"2025-01-27T09:16:59.087347Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:15:10.834593Z","gateway_network_id":"238269b1-9ef4-4935-9cb1-94a37e10fd48","hostname":"tf-srv-strange-visvesvaraya","id":"512fea6c-17d0-4487-a8d6-a03f75ee2368","ip_address":"192.168.1.4","mac_address":"02:00:00:1d:7b:57","type":"reservation","updated_at":"2025-02-12T16:15:48.855556Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "282"
+                - "340"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:02 GMT
+                - Wed, 12 Feb 2025 16:15:50 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4014,10 +4014,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3a15c3c9-f5e1-44d9-af90-dc05093635c4
+                - ffc9b8a4-50ab-49d5-9244-da39b6dbf705
         status: 200 OK
         code: 200
-        duration: 30.628333ms
+        duration: 91.010334ms
     - id: 81
       request:
         proto: HTTP/1.1
@@ -4033,8 +4033,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/512fea6c-17d0-4487-a8d6-a03f75ee2368
         method: GET
       response:
         proto: HTTP/2.0
@@ -4042,18 +4042,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1932
+        content_length: 340
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:02.214959Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:09.893402Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.242510Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"95c3edc0-cf35-40f9-bfb2-2af399b47a92","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.242510Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"90d04b2a-83c6-40ae-9112-4e127d7e9245","ipam_config":null,"mac_address":"02:00:00:11:96:81","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","status":"ready","updated_at":"2025-01-27T09:16:20.242261Z","zone":"fr-par-1"}],"id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","ip":{"address":"51.15.130.186","created_at":"2025-01-27T09:16:02.110630Z","gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"937192c3-38db-45ff-a692-e6d9646fc020","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:02.110630Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:20.389912Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:15:10.834593Z","gateway_network_id":"238269b1-9ef4-4935-9cb1-94a37e10fd48","hostname":"tf-srv-strange-visvesvaraya","id":"512fea6c-17d0-4487-a8d6-a03f75ee2368","ip_address":"192.168.1.4","mac_address":"02:00:00:1d:7b:57","type":"reservation","updated_at":"2025-02-12T16:15:48.855556Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1932"
+                - "340"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:02 GMT
+                - Wed, 12 Feb 2025 16:15:51 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4063,10 +4063,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 453c7840-7166-4066-a027-c0d8ca69b04d
+                - 870f3d84-6ec6-4018-8808-27ac22142635
         status: 200 OK
         code: 200
-        duration: 31.73825ms
+        duration: 94.8685ms
     - id: 82
       request:
         proto: HTTP/1.1
@@ -4082,25 +4082,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/dbf27378-a27a-4be4-b9f0-d3649d5321aa
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/0a021712-93a9-4a6c-b80f-b6373494ccde
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 290
         uncompressed: false
-        body: ""
+        body: '{"created_at":"2025-02-12T16:15:49.265493Z","gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"0a021712-93a9-4a6c-b80f-b6373494ccde","private_ip":"192.168.1.4","private_port":22,"protocol":"tcp","public_port":2222,"updated_at":"2025-02-12T16:15:49.265493Z","zone":"fr-par-1"}'
         headers:
+            Content-Length:
+                - "290"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:02 GMT
+                - Wed, 12 Feb 2025 16:15:51 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4110,10 +4112,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f6d7abb9-e09d-445b-9efe-9a89d6bfb453
-        status: 204 No Content
-        code: 204
-        duration: 42.645416ms
+                - 4c409200-30e8-46e3-8736-8966743a0e87
+        status: 200 OK
+        code: 200
+        duration: 42.119458ms
     - id: 83
       request:
         proto: HTTP/1.1
@@ -4129,8 +4131,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f
         method: GET
       response:
         proto: HTTP/2.0
@@ -4138,18 +4140,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1932
+        content_length: 1996
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:02.214959Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:09.893402Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.242510Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"95c3edc0-cf35-40f9-bfb2-2af399b47a92","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.242510Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"90d04b2a-83c6-40ae-9112-4e127d7e9245","ipam_config":null,"mac_address":"02:00:00:11:96:81","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","status":"ready","updated_at":"2025-01-27T09:16:20.242261Z","zone":"fr-par-1"}],"id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","ip":{"address":"51.15.130.186","created_at":"2025-01-27T09:16:02.110630Z","gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"937192c3-38db-45ff-a692-e6d9646fc020","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:02.110630Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:20.389912Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.811685Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:05.808562Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.930530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"538c4a96-d996-45ca-b414-59e27b15ba9c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.930530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"238269b1-9ef4-4935-9cb1-94a37e10fd48","ipam_config":null,"mac_address":"02:00:00:11:3A:55","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","status":"ready","updated_at":"2025-02-12T16:15:16.458661Z","zone":"fr-par-1"}],"id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:14:56.616626Z","gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"258fe83b-cf30-4221-9188-ba19bc703ec0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.616626Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:16.653882Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1932"
+                - "1996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:02 GMT
+                - Wed, 12 Feb 2025 16:15:51 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4159,10 +4161,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 683d8673-80f2-4eea-ba32-fe52ab8d48b5
+                - e87db98e-2e88-4a77-a11f-1585625f8442
         status: 200 OK
         code: 200
-        duration: 32.098541ms
+        duration: 43.818625ms
     - id: 84
       request:
         proto: HTTP/1.1
@@ -4178,27 +4180,25 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/90d04b2a-83c6-40ae-9112-4e127d7e9245
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/0a021712-93a9-4a6c-b80f-b6373494ccde
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 966
+        content_length: 0
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:09.893402Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.242510Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"95c3edc0-cf35-40f9-bfb2-2af399b47a92","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.242510Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"90d04b2a-83c6-40ae-9112-4e127d7e9245","ipam_config":null,"mac_address":"02:00:00:11:96:81","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","status":"ready","updated_at":"2025-01-27T09:16:20.242261Z","zone":"fr-par-1"}'
+        body: ""
         headers:
-            Content-Length:
-                - "966"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:02 GMT
+                - Wed, 12 Feb 2025 16:15:51 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4208,10 +4208,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1820cb7e-5920-4fa1-a103-0218c51e4dcf
-        status: 200 OK
-        code: 200
-        duration: 49.843625ms
+                - 8a84ec42-34c4-4854-b4ba-2561b9672fcc
+        status: 204 No Content
+        code: 204
+        duration: 77.373583ms
     - id: 85
       request:
         proto: HTTP/1.1
@@ -4227,25 +4227,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/bf551b50-ecfd-47af-b775-b04c859b5fb3
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 1996
         uncompressed: false
-        body: ""
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.811685Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:05.808562Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.930530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"538c4a96-d996-45ca-b414-59e27b15ba9c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.930530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"238269b1-9ef4-4935-9cb1-94a37e10fd48","ipam_config":null,"mac_address":"02:00:00:11:3A:55","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","status":"ready","updated_at":"2025-02-12T16:15:16.458661Z","zone":"fr-par-1"}],"id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:14:56.616626Z","gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"258fe83b-cf30-4221-9188-ba19bc703ec0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.616626Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:16.653882Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
+            Content-Length:
+                - "1996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:02 GMT
+                - Wed, 12 Feb 2025 16:15:51 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4255,10 +4257,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 59da27c3-2bf0-47bc-a5e0-94a1613b5053
-        status: 204 No Content
-        code: 204
-        duration: 82.498542ms
+                - d53d4352-01c5-402e-bfc4-884bf4be5639
+        status: 200 OK
+        code: 200
+        duration: 51.000375ms
     - id: 86
       request:
         proto: HTTP/1.1
@@ -4274,8 +4276,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/90d04b2a-83c6-40ae-9112-4e127d7e9245
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/238269b1-9ef4-4935-9cb1-94a37e10fd48
         method: GET
       response:
         proto: HTTP/2.0
@@ -4283,18 +4285,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 966
+        content_length: 996
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:09.893402Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.242510Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"95c3edc0-cf35-40f9-bfb2-2af399b47a92","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.242510Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"90d04b2a-83c6-40ae-9112-4e127d7e9245","ipam_config":null,"mac_address":"02:00:00:11:96:81","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","status":"ready","updated_at":"2025-01-27T09:16:20.242261Z","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:05.808562Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.930530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"538c4a96-d996-45ca-b414-59e27b15ba9c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.930530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"238269b1-9ef4-4935-9cb1-94a37e10fd48","ipam_config":null,"mac_address":"02:00:00:11:3A:55","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","status":"ready","updated_at":"2025-02-12T16:15:16.458661Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "966"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:02 GMT
+                - Wed, 12 Feb 2025 16:15:51 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4304,10 +4306,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 388dfef3-cc38-4177-93b3-131b64aef8f1
+                - a687b8b8-6574-4946-8f98-f17076e699ca
         status: 200 OK
         code: 200
-        duration: 44.681792ms
+        duration: 63.650417ms
     - id: 87
       request:
         proto: HTTP/1.1
@@ -4323,57 +4325,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/90d04b2a-83c6-40ae-9112-4e127d7e9245
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 966
-        uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:09.893402Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.242510Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"95c3edc0-cf35-40f9-bfb2-2af399b47a92","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.242510Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"90d04b2a-83c6-40ae-9112-4e127d7e9245","ipam_config":null,"mac_address":"02:00:00:11:96:81","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","status":"ready","updated_at":"2025-01-27T09:16:20.242261Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "966"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:03 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - add33f29-279c-4b39-a97e-509ee0770eb0
-        status: 200 OK
-        code: 200
-        duration: 43.949917ms
-    - id: 88
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/90d04b2a-83c6-40ae-9112-4e127d7e9245?cleanup_dhcp=true
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/512fea6c-17d0-4487-a8d6-a03f75ee2368
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -4390,7 +4343,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:03 GMT
+                - Wed, 12 Feb 2025 16:15:51 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4400,10 +4353,59 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 114ece8c-1cd0-4f6f-8ebd-e6c44da21802
+                - 22b7adec-1867-46bc-9362-9637ad112354
         status: 204 No Content
         code: 204
-        duration: 69.146583ms
+        duration: 83.378375ms
+    - id: 88
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/238269b1-9ef4-4935-9cb1-94a37e10fd48
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 996
+        uncompressed: false
+        body: '{"address":null,"created_at":"2025-02-12T16:15:05.808562Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.930530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"538c4a96-d996-45ca-b414-59e27b15ba9c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.930530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"238269b1-9ef4-4935-9cb1-94a37e10fd48","ipam_config":null,"mac_address":"02:00:00:11:3A:55","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","status":"ready","updated_at":"2025-02-12T16:15:16.458661Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "996"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 904a58ac-ac9f-4901-ac5f-e26516fe6583
+        status: 200 OK
+        code: 200
+        duration: 64.276417ms
     - id: 89
       request:
         proto: HTTP/1.1
@@ -4419,8 +4421,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/90d04b2a-83c6-40ae-9112-4e127d7e9245
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/238269b1-9ef4-4935-9cb1-94a37e10fd48
         method: GET
       response:
         proto: HTTP/2.0
@@ -4428,18 +4430,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 970
+        content_length: 996
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:09.893402Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.242510Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"95c3edc0-cf35-40f9-bfb2-2af399b47a92","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.242510Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"90d04b2a-83c6-40ae-9112-4e127d7e9245","ipam_config":null,"mac_address":"02:00:00:11:96:81","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","status":"detaching","updated_at":"2025-01-27T09:17:03.072270Z","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:05.808562Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.930530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"538c4a96-d996-45ca-b414-59e27b15ba9c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.930530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"238269b1-9ef4-4935-9cb1-94a37e10fd48","ipam_config":null,"mac_address":"02:00:00:11:3A:55","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","status":"ready","updated_at":"2025-02-12T16:15:16.458661Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "970"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:03 GMT
+                - Wed, 12 Feb 2025 16:15:51 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4449,10 +4451,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f53db1dc-8da9-4a3c-a03f-e0ca6a269c4f
+                - 02780aa6-07c3-4022-9c45-6494771acde4
         status: 200 OK
         code: 200
-        duration: 55.696458ms
+        duration: 85.743042ms
     - id: 90
       request:
         proto: HTTP/1.1
@@ -4468,27 +4470,25 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/238269b1-9ef4-4935-9cb1-94a37e10fd48?cleanup_dhcp=true
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2711
+        content_length: 0
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.974673+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-benz","id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1501","node_id":"48","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:21","maintenances":[],"modification_date":"2025-01-27T09:16:20.592701+00:00","name":"tf-srv-happy-benz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:25.252781+00:00","id":"295dc8af-772a-4491-bac3-a30e6db5d124","ipam_ip_ids":["bf551b50-ecfd-47af-b775-b04c859b5fb3","d0c10238-7188-4d3a-a961-fd636a63afad"],"mac_address":"02:00:00:1e:8c:99","modification_date":"2025-01-27T09:16:57.338850+00:00","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","server_id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"c8613b60-f84a-47f6-9357-3a15421f9b76","name":"tf-sg-keen-wing"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.974673+00:00","export_uri":null,"id":"80ea48b3-70a2-4b5a-8665-bcda6853e98d","modification_date":"2025-01-27T09:16:02.974673+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","name":"tf-srv-happy-benz"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: ""
         headers:
-            Content-Length:
-                - "2711"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:02 GMT
+                - Wed, 12 Feb 2025 16:15:51 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4498,11 +4498,158 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f09647cf-6b2d-418e-95d0-06c553708aca
+                - c197231e-f779-4744-8316-db26077187e6
+        status: 204 No Content
+        code: 204
+        duration: 86.248416ms
+    - id: 91
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2300
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.450538+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-visvesvaraya","id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1901","node_id":"38","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:dd","maintenances":[],"modification_date":"2025-02-12T16:15:04.909328+00:00","name":"tf-srv-strange-visvesvaraya","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:10.422881+00:00","id":"4b9eefc5-41db-4c4d-8662-cf9202eab68f","ipam_ip_ids":["512fea6c-17d0-4487-a8d6-a03f75ee2368","58ca6b90-1ffa-4d83-9e1d-c84a21bab54f"],"mac_address":"02:00:00:1d:7b:57","modification_date":"2025-02-12T16:15:42.390078+00:00","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","server_id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"7a435d2e-8efb-4aaa-bc61-18ca3499a8ac","name":"tf-sg-nostalgic-hypatia"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"0310ce0d-2ff0-4cab-b5fe-1b17a2b6da68","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2300"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f0327e1e-71c0-4647-b491-7b9c7137aed8
         status: 200 OK
         code: 200
-        duration: 202.768208ms
-    - id: 91
+        duration: 183.735625ms
+    - id: 92
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/238269b1-9ef4-4935-9cb1-94a37e10fd48
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1000
+        uncompressed: false
+        body: '{"address":null,"created_at":"2025-02-12T16:15:05.808562Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.930530Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"538c4a96-d996-45ca-b414-59e27b15ba9c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.930530Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"238269b1-9ef4-4935-9cb1-94a37e10fd48","ipam_config":null,"mac_address":"02:00:00:11:3A:55","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","status":"detaching","updated_at":"2025-02-12T16:15:51.927340Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "1000"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 91ba92b2-de5b-46ac-8b24-db6ccf3828d2
+        status: 200 OK
+        code: 200
+        duration: 63.514333ms
+    - id: 93
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/0310ce0d-2ff0-4cab-b5fe-1b17a2b6da68
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:14:57.876261Z","id":"0310ce0d-2ff0-4cab-b5fe-1b17a2b6da68","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:14:57.876261Z","id":"162e9203-8f06-49ed-a114-12a6d80c5055","product_resource_id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:14:57.876261Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 42be3370-f66d-4ebe-875b-a2e7999b2147
+        status: 200 OK
+        code: 200
+        duration: 84.197125ms
+    - id: 94
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4519,8 +4666,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -4530,7 +4677,7 @@ interactions:
         trailer: {}
         content_length: 352
         uncompressed: false
-        body: '{"task":{"description":"server_poweroff","href_from":"/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2/action","href_result":"/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","id":"6a69849d-c4a7-4c84-8cb1-044d96a41a78","progress":0,"started_at":"2025-01-27T09:17:03.431234+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_poweroff","href_from":"/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b/action","href_result":"/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b","id":"4f00629a-21b8-477c-ac7f-149cdb774a8a","progress":0,"started_at":"2025-02-12T16:15:52.485558+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "352"
@@ -4539,9 +4686,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:03 GMT
+                - Wed, 12 Feb 2025 16:15:52 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/6a69849d-c4a7-4c84-8cb1-044d96a41a78
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/4f00629a-21b8-477c-ac7f-149cdb774a8a
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4551,157 +4698,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2f7e3861-194a-4a17-8ad1-32ef352007b9
+                - 8adf7fd2-b061-4a0e-9fdd-f77625a9f642
         status: 202 Accepted
         code: 202
-        duration: 269.664833ms
-    - id: 92
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2671
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.974673+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-benz","id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1501","node_id":"48","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:21","maintenances":[],"modification_date":"2025-01-27T09:17:03.236391+00:00","name":"tf-srv-happy-benz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:25.252781+00:00","id":"295dc8af-772a-4491-bac3-a30e6db5d124","ipam_ip_ids":["bf551b50-ecfd-47af-b775-b04c859b5fb3","d0c10238-7188-4d3a-a961-fd636a63afad"],"mac_address":"02:00:00:1e:8c:99","modification_date":"2025-01-27T09:16:57.338850+00:00","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","server_id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"c8613b60-f84a-47f6-9357-3a15421f9b76","name":"tf-sg-keen-wing"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.974673+00:00","export_uri":null,"id":"80ea48b3-70a2-4b5a-8665-bcda6853e98d","modification_date":"2025-01-27T09:16:02.974673+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","name":"tf-srv-happy-benz"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2671"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:03 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - e5068082-bb99-4708-9801-b0ee0543b6be
-        status: 200 OK
-        code: 200
-        duration: 439.705083ms
-    - id: 93
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/90d04b2a-83c6-40ae-9112-4e127d7e9245
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 136
-        uncompressed: false
-        body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"90d04b2a-83c6-40ae-9112-4e127d7e9245","type":"not_found"}'
-        headers:
-            Content-Length:
-                - "136"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:08 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 0c079975-25c0-4343-b6cf-54dfe01b0839
-        status: 404 Not Found
-        code: 404
-        duration: 21.651875ms
-    - id: 94
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 966
-        uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:02.214959Z","gateway_networks":[],"id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","ip":{"address":"51.15.130.186","created_at":"2025-01-27T09:16:02.110630Z","gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"937192c3-38db-45ff-a692-e6d9646fc020","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:02.110630Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:20.389912Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "966"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:08 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 522f2885-9393-40ac-a1b8-f478038df872
-        status: 200 OK
-        code: 200
-        duration: 27.855542ms
+        duration: 467.668459ms
     - id: 95
       request:
         proto: HTTP/1.1
@@ -4717,27 +4717,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/95c3edc0-cf35-40f9-bfb2-2af399b47a92
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 125
+        content_length: 2260
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"dhcp","resource_id":"95c3edc0-cf35-40f9-bfb2-2af399b47a92","type":"not_found"}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.450538+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-visvesvaraya","id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1901","node_id":"38","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:dd","maintenances":[],"modification_date":"2025-02-12T16:15:52.091045+00:00","name":"tf-srv-strange-visvesvaraya","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:10.422881+00:00","id":"4b9eefc5-41db-4c4d-8662-cf9202eab68f","ipam_ip_ids":["512fea6c-17d0-4487-a8d6-a03f75ee2368","58ca6b90-1ffa-4d83-9e1d-c84a21bab54f"],"mac_address":"02:00:00:1d:7b:57","modification_date":"2025-02-12T16:15:42.390078+00:00","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","server_id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"7a435d2e-8efb-4aaa-bc61-18ca3499a8ac","name":"tf-sg-nostalgic-hypatia"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"0310ce0d-2ff0-4cab-b5fe-1b17a2b6da68","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "125"
+                - "2260"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:08 GMT
+                - Wed, 12 Feb 2025 16:15:52 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4747,10 +4747,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ce392bb0-6f94-4aab-a949-b8f6df771b73
-        status: 404 Not Found
-        code: 404
-        duration: 22.424458ms
+                - b88d746b-15cc-4a88-abe3-72995178960f
+        status: 200 OK
+        code: 200
+        duration: 171.062834ms
     - id: 96
       request:
         proto: HTTP/1.1
@@ -4766,8 +4766,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/238269b1-9ef4-4935-9cb1-94a37e10fd48
         method: GET
       response:
         proto: HTTP/2.0
@@ -4775,18 +4775,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 966
+        content_length: 136
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:02.214959Z","gateway_networks":[],"id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","ip":{"address":"51.15.130.186","created_at":"2025-01-27T09:16:02.110630Z","gateway_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","id":"937192c3-38db-45ff-a692-e6d9646fc020","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:02.110630Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:20.389912Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"238269b1-9ef4-4935-9cb1-94a37e10fd48","type":"not_found"}'
         headers:
             Content-Length:
-                - "966"
+                - "136"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:08 GMT
+                - Wed, 12 Feb 2025 16:15:57 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4796,10 +4796,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 03a6e0ef-b380-42e1-ad3a-d9f1de7cd909
-        status: 200 OK
-        code: 200
-        duration: 27.777833ms
+                - 4de89b3f-5194-46ce-8327-cc49d8a852eb
+        status: 404 Not Found
+        code: 404
+        duration: 51.208708ms
     - id: 97
       request:
         proto: HTTP/1.1
@@ -4815,25 +4815,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b?cleanup_dhcp=false
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 1000
         uncompressed: false
-        body: ""
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.811685Z","gateway_networks":[],"id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:14:56.616626Z","gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"258fe83b-cf30-4221-9188-ba19bc703ec0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.616626Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:16.653882Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
+            Content-Length:
+                - "1000"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:08 GMT
+                - Wed, 12 Feb 2025 16:15:57 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4843,10 +4845,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8f1a9671-304c-4d34-859d-e66ad508c65d
-        status: 204 No Content
-        code: 204
-        duration: 48.938458ms
+                - 102834b0-3708-4fe7-bc0a-80950623cd3f
+        status: 200 OK
+        code: 200
+        duration: 51.573875ms
     - id: 98
       request:
         proto: HTTP/1.1
@@ -4862,27 +4864,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/538c4a96-d996-45ca-b414-59e27b15ba9c
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 128
+        content_length: 125
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"gateway","resource_id":"1bdaaa28-f80b-4d08-8086-ab03fdbc6d9b","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"dhcp","resource_id":"538c4a96-d996-45ca-b414-59e27b15ba9c","type":"not_found"}'
         headers:
             Content-Length:
-                - "128"
+                - "125"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:08 GMT
+                - Wed, 12 Feb 2025 16:15:57 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4892,10 +4894,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - eae6bef5-d091-4ba4-b05d-21e1f90debdc
+                - 2b4e91be-28ed-45e7-8347-3078216ad5a5
         status: 404 Not Found
         code: 404
-        duration: 20.36875ms
+        duration: 49.2475ms
     - id: 99
       request:
         proto: HTTP/1.1
@@ -4911,8 +4913,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f
         method: GET
       response:
         proto: HTTP/2.0
@@ -4920,18 +4922,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2671
+        content_length: 1000
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.974673+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-benz","id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1501","node_id":"48","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:21","maintenances":[],"modification_date":"2025-01-27T09:17:03.236391+00:00","name":"tf-srv-happy-benz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:25.252781+00:00","id":"295dc8af-772a-4491-bac3-a30e6db5d124","ipam_ip_ids":["bf551b50-ecfd-47af-b775-b04c859b5fb3","d0c10238-7188-4d3a-a961-fd636a63afad"],"mac_address":"02:00:00:1e:8c:99","modification_date":"2025-01-27T09:16:57.338850+00:00","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","server_id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"c8613b60-f84a-47f6-9357-3a15421f9b76","name":"tf-sg-keen-wing"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.974673+00:00","export_uri":null,"id":"80ea48b3-70a2-4b5a-8665-bcda6853e98d","modification_date":"2025-01-27T09:16:02.974673+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","name":"tf-srv-happy-benz"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.811685Z","gateway_networks":[],"id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:14:56.616626Z","gateway_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","id":"258fe83b-cf30-4221-9188-ba19bc703ec0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.616626Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:16.653882Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2671"
+                - "1000"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:09 GMT
+                - Wed, 12 Feb 2025 16:15:57 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4941,10 +4943,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 671564aa-70aa-4fad-97fb-51dc3624ddf1
+                - e1646c67-41d6-401b-81f3-24f9dec550da
         status: 200 OK
         code: 200
-        duration: 189.109417ms
+        duration: 49.690833ms
     - id: 100
       request:
         proto: HTTP/1.1
@@ -4960,8 +4962,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/937192c3-38db-45ff-a692-e6d9646fc020
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f?cleanup_dhcp=false
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -4978,7 +4980,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:09 GMT
+                - Wed, 12 Feb 2025 16:15:57 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4988,10 +4990,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 727b18fa-0c65-4cc1-85cd-fdbd93e25217
+                - b356fb7f-80f5-47e2-adfd-84975e16c682
         status: 204 No Content
         code: 204
-        duration: 836.692209ms
+        duration: 72.372583ms
     - id: 101
       request:
         proto: HTTP/1.1
@@ -5007,8 +5009,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f
         method: GET
       response:
         proto: HTTP/2.0
@@ -5016,18 +5018,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2671
+        content_length: 128
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.974673+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-benz","id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1501","node_id":"48","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:21","maintenances":[],"modification_date":"2025-01-27T09:17:03.236391+00:00","name":"tf-srv-happy-benz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:25.252781+00:00","id":"295dc8af-772a-4491-bac3-a30e6db5d124","ipam_ip_ids":["bf551b50-ecfd-47af-b775-b04c859b5fb3","d0c10238-7188-4d3a-a961-fd636a63afad"],"mac_address":"02:00:00:1e:8c:99","modification_date":"2025-01-27T09:16:57.338850+00:00","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","server_id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"c8613b60-f84a-47f6-9357-3a15421f9b76","name":"tf-sg-keen-wing"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.974673+00:00","export_uri":null,"id":"80ea48b3-70a2-4b5a-8665-bcda6853e98d","modification_date":"2025-01-27T09:16:02.974673+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","name":"tf-srv-happy-benz"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"gateway","resource_id":"10b85aa2-5ae2-4c3d-9fd5-ea8040a47e8f","type":"not_found"}'
         headers:
             Content-Length:
-                - "2671"
+                - "128"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:14 GMT
+                - Wed, 12 Feb 2025 16:15:57 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5037,10 +5039,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6e19514d-63f6-4740-a495-095819cc64ec
-        status: 200 OK
-        code: 200
-        duration: 464.892625ms
+                - 40f96f65-69c3-465d-8bb6-410e2fd888c1
+        status: 404 Not Found
+        code: 404
+        duration: 42.431333ms
     - id: 102
       request:
         proto: HTTP/1.1
@@ -5056,8 +5058,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b
         method: GET
       response:
         proto: HTTP/2.0
@@ -5065,18 +5067,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2671
+        content_length: 2260
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.974673+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-benz","id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1501","node_id":"48","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:21","maintenances":[],"modification_date":"2025-01-27T09:17:03.236391+00:00","name":"tf-srv-happy-benz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:25.252781+00:00","id":"295dc8af-772a-4491-bac3-a30e6db5d124","ipam_ip_ids":["bf551b50-ecfd-47af-b775-b04c859b5fb3","d0c10238-7188-4d3a-a961-fd636a63afad"],"mac_address":"02:00:00:1e:8c:99","modification_date":"2025-01-27T09:16:57.338850+00:00","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","server_id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"c8613b60-f84a-47f6-9357-3a15421f9b76","name":"tf-sg-keen-wing"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.974673+00:00","export_uri":null,"id":"80ea48b3-70a2-4b5a-8665-bcda6853e98d","modification_date":"2025-01-27T09:16:02.974673+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","name":"tf-srv-happy-benz"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.450538+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-visvesvaraya","id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1901","node_id":"38","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:dd","maintenances":[],"modification_date":"2025-02-12T16:15:52.091045+00:00","name":"tf-srv-strange-visvesvaraya","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:10.422881+00:00","id":"4b9eefc5-41db-4c4d-8662-cf9202eab68f","ipam_ip_ids":["512fea6c-17d0-4487-a8d6-a03f75ee2368","58ca6b90-1ffa-4d83-9e1d-c84a21bab54f"],"mac_address":"02:00:00:1d:7b:57","modification_date":"2025-02-12T16:15:42.390078+00:00","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","server_id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"7a435d2e-8efb-4aaa-bc61-18ca3499a8ac","name":"tf-sg-nostalgic-hypatia"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"0310ce0d-2ff0-4cab-b5fe-1b17a2b6da68","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2671"
+                - "2260"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:19 GMT
+                - Wed, 12 Feb 2025 16:15:57 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5086,10 +5088,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6ccf7187-7f5b-498a-ae53-4118087be735
+                - d263914d-4053-46cb-8235-7513d0d376be
         status: 200 OK
         code: 200
-        duration: 199.268083ms
+        duration: 184.689834ms
     - id: 103
       request:
         proto: HTTP/1.1
@@ -5105,27 +5107,25 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/258fe83b-cf30-4221-9188-ba19bc703ec0
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2671
+        content_length: 0
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.974673+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-benz","id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1501","node_id":"48","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:21","maintenances":[],"modification_date":"2025-01-27T09:17:03.236391+00:00","name":"tf-srv-happy-benz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:25.252781+00:00","id":"295dc8af-772a-4491-bac3-a30e6db5d124","ipam_ip_ids":["bf551b50-ecfd-47af-b775-b04c859b5fb3","d0c10238-7188-4d3a-a961-fd636a63afad"],"mac_address":"02:00:00:1e:8c:99","modification_date":"2025-01-27T09:16:57.338850+00:00","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","server_id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"c8613b60-f84a-47f6-9357-3a15421f9b76","name":"tf-sg-keen-wing"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.974673+00:00","export_uri":null,"id":"80ea48b3-70a2-4b5a-8665-bcda6853e98d","modification_date":"2025-01-27T09:16:02.974673+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","name":"tf-srv-happy-benz"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: ""
         headers:
-            Content-Length:
-                - "2671"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:24 GMT
+                - Wed, 12 Feb 2025 16:15:58 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5135,10 +5135,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1568f677-514a-4c7e-999a-5cc180bb253c
-        status: 200 OK
-        code: 200
-        duration: 150.941ms
+                - 4fbab3b6-b9c7-468f-8cb3-7b66f7d228a6
+        status: 204 No Content
+        code: 204
+        duration: 1.22974875s
     - id: 104
       request:
         proto: HTTP/1.1
@@ -5154,8 +5154,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b
         method: GET
       response:
         proto: HTTP/2.0
@@ -5163,18 +5163,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2671
+        content_length: 2260
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.974673+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-benz","id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1501","node_id":"48","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:21","maintenances":[],"modification_date":"2025-01-27T09:17:03.236391+00:00","name":"tf-srv-happy-benz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:25.252781+00:00","id":"295dc8af-772a-4491-bac3-a30e6db5d124","ipam_ip_ids":["bf551b50-ecfd-47af-b775-b04c859b5fb3","d0c10238-7188-4d3a-a961-fd636a63afad"],"mac_address":"02:00:00:1e:8c:99","modification_date":"2025-01-27T09:16:57.338850+00:00","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","server_id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"c8613b60-f84a-47f6-9357-3a15421f9b76","name":"tf-sg-keen-wing"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.974673+00:00","export_uri":null,"id":"80ea48b3-70a2-4b5a-8665-bcda6853e98d","modification_date":"2025-01-27T09:16:02.974673+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","name":"tf-srv-happy-benz"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.450538+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-visvesvaraya","id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1901","node_id":"38","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:dd","maintenances":[],"modification_date":"2025-02-12T16:15:52.091045+00:00","name":"tf-srv-strange-visvesvaraya","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:10.422881+00:00","id":"4b9eefc5-41db-4c4d-8662-cf9202eab68f","ipam_ip_ids":["512fea6c-17d0-4487-a8d6-a03f75ee2368","58ca6b90-1ffa-4d83-9e1d-c84a21bab54f"],"mac_address":"02:00:00:1d:7b:57","modification_date":"2025-02-12T16:15:42.390078+00:00","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","server_id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"7a435d2e-8efb-4aaa-bc61-18ca3499a8ac","name":"tf-sg-nostalgic-hypatia"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"0310ce0d-2ff0-4cab-b5fe-1b17a2b6da68","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2671"
+                - "2260"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:29 GMT
+                - Wed, 12 Feb 2025 16:16:03 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5184,10 +5184,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1ed2f797-1116-44f9-aabf-b9f997f74061
+                - 490193af-740a-4a1f-8cd8-53f1710ca6fa
         status: 200 OK
         code: 200
-        duration: 195.969084ms
+        duration: 207.59475ms
     - id: 105
       request:
         proto: HTTP/1.1
@@ -5203,8 +5203,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b
         method: GET
       response:
         proto: HTTP/2.0
@@ -5212,18 +5212,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2671
+        content_length: 2260
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.974673+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-benz","id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1501","node_id":"48","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:21","maintenances":[],"modification_date":"2025-01-27T09:17:03.236391+00:00","name":"tf-srv-happy-benz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:25.252781+00:00","id":"295dc8af-772a-4491-bac3-a30e6db5d124","ipam_ip_ids":["bf551b50-ecfd-47af-b775-b04c859b5fb3","d0c10238-7188-4d3a-a961-fd636a63afad"],"mac_address":"02:00:00:1e:8c:99","modification_date":"2025-01-27T09:16:57.338850+00:00","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","server_id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"c8613b60-f84a-47f6-9357-3a15421f9b76","name":"tf-sg-keen-wing"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.974673+00:00","export_uri":null,"id":"80ea48b3-70a2-4b5a-8665-bcda6853e98d","modification_date":"2025-01-27T09:16:02.974673+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","name":"tf-srv-happy-benz"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.450538+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-visvesvaraya","id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1901","node_id":"38","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:dd","maintenances":[],"modification_date":"2025-02-12T16:15:52.091045+00:00","name":"tf-srv-strange-visvesvaraya","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:10.422881+00:00","id":"4b9eefc5-41db-4c4d-8662-cf9202eab68f","ipam_ip_ids":["512fea6c-17d0-4487-a8d6-a03f75ee2368","58ca6b90-1ffa-4d83-9e1d-c84a21bab54f"],"mac_address":"02:00:00:1d:7b:57","modification_date":"2025-02-12T16:15:42.390078+00:00","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","server_id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"7a435d2e-8efb-4aaa-bc61-18ca3499a8ac","name":"tf-sg-nostalgic-hypatia"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"0310ce0d-2ff0-4cab-b5fe-1b17a2b6da68","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2671"
+                - "2260"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:35 GMT
+                - Wed, 12 Feb 2025 16:16:08 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5233,10 +5233,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 272db24c-b777-4a08-9b18-349d38609bc1
+                - 020b296b-100c-48fa-8275-269ccafe159d
         status: 200 OK
         code: 200
-        duration: 169.301125ms
+        duration: 206.809083ms
     - id: 106
       request:
         proto: HTTP/1.1
@@ -5252,8 +5252,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b
         method: GET
       response:
         proto: HTTP/2.0
@@ -5261,18 +5261,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2554
+        content_length: 2260
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.974673+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-benz","id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ea:21","maintenances":[],"modification_date":"2025-01-27T09:17:36.578280+00:00","name":"tf-srv-happy-benz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:25.252781+00:00","id":"295dc8af-772a-4491-bac3-a30e6db5d124","ipam_ip_ids":["bf551b50-ecfd-47af-b775-b04c859b5fb3","d0c10238-7188-4d3a-a961-fd636a63afad"],"mac_address":"02:00:00:1e:8c:99","modification_date":"2025-01-27T09:16:57.338850+00:00","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","server_id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"c8613b60-f84a-47f6-9357-3a15421f9b76","name":"tf-sg-keen-wing"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.974673+00:00","export_uri":null,"id":"80ea48b3-70a2-4b5a-8665-bcda6853e98d","modification_date":"2025-01-27T09:16:02.974673+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","name":"tf-srv-happy-benz"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.450538+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-visvesvaraya","id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1901","node_id":"38","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:dd","maintenances":[],"modification_date":"2025-02-12T16:15:52.091045+00:00","name":"tf-srv-strange-visvesvaraya","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:10.422881+00:00","id":"4b9eefc5-41db-4c4d-8662-cf9202eab68f","ipam_ip_ids":["512fea6c-17d0-4487-a8d6-a03f75ee2368","58ca6b90-1ffa-4d83-9e1d-c84a21bab54f"],"mac_address":"02:00:00:1d:7b:57","modification_date":"2025-02-12T16:15:42.390078+00:00","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","server_id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"7a435d2e-8efb-4aaa-bc61-18ca3499a8ac","name":"tf-sg-nostalgic-hypatia"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"0310ce0d-2ff0-4cab-b5fe-1b17a2b6da68","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2554"
+                - "2260"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:40 GMT
+                - Wed, 12 Feb 2025 16:16:13 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5282,10 +5282,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4198adc5-dbd6-47f3-a15f-ff9670fce891
+                - ccb4d979-eac8-4788-b1ae-e09b886240c7
         status: 200 OK
         code: 200
-        duration: 124.0795ms
+        duration: 181.674916ms
     - id: 107
       request:
         proto: HTTP/1.1
@@ -5301,8 +5301,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b
         method: GET
       response:
         proto: HTTP/2.0
@@ -5310,20 +5310,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 478
+        content_length: 2260
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T09:16:25.252781+00:00","id":"295dc8af-772a-4491-bac3-a30e6db5d124","ipam_ip_ids":["bf551b50-ecfd-47af-b775-b04c859b5fb3","d0c10238-7188-4d3a-a961-fd636a63afad"],"mac_address":"02:00:00:1e:8c:99","modification_date":"2025-01-27T09:16:57.338850+00:00","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","server_id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.450538+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-visvesvaraya","id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1901","node_id":"38","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:dd","maintenances":[],"modification_date":"2025-02-12T16:15:52.091045+00:00","name":"tf-srv-strange-visvesvaraya","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:10.422881+00:00","id":"4b9eefc5-41db-4c4d-8662-cf9202eab68f","ipam_ip_ids":["512fea6c-17d0-4487-a8d6-a03f75ee2368","58ca6b90-1ffa-4d83-9e1d-c84a21bab54f"],"mac_address":"02:00:00:1d:7b:57","modification_date":"2025-02-12T16:15:42.390078+00:00","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","server_id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"7a435d2e-8efb-4aaa-bc61-18ca3499a8ac","name":"tf-sg-nostalgic-hypatia"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"0310ce0d-2ff0-4cab-b5fe-1b17a2b6da68","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "478"
+                - "2260"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:40 GMT
-            Link:
-                - </servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2/private_nics?page=1&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 16:16:18 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5333,12 +5331,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2294b5d6-a21f-4362-8e8d-33611afcf600
-            X-Total-Count:
-                - "1"
+                - d53d82a7-c1c0-4b4f-baed-e46af51d8f16
         status: 200 OK
         code: 200
-        duration: 108.395708ms
+        duration: 195.275042ms
     - id: 108
       request:
         proto: HTTP/1.1
@@ -5354,8 +5350,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2/private_nics/295dc8af-772a-4491-bac3-a30e6db5d124
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b
         method: GET
       response:
         proto: HTTP/2.0
@@ -5363,18 +5359,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 475
+        content_length: 2143
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:25.252781+00:00","id":"295dc8af-772a-4491-bac3-a30e6db5d124","ipam_ip_ids":["bf551b50-ecfd-47af-b775-b04c859b5fb3","d0c10238-7188-4d3a-a961-fd636a63afad"],"mac_address":"02:00:00:1e:8c:99","modification_date":"2025-01-27T09:16:57.338850+00:00","private_network_id":"a25b8a28-50ff-4347-a5ba-3dbabb3ae79b","server_id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.450538+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-visvesvaraya","id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:dd","maintenances":[],"modification_date":"2025-02-12T16:16:18.792463+00:00","name":"tf-srv-strange-visvesvaraya","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:10.422881+00:00","id":"4b9eefc5-41db-4c4d-8662-cf9202eab68f","ipam_ip_ids":["512fea6c-17d0-4487-a8d6-a03f75ee2368","58ca6b90-1ffa-4d83-9e1d-c84a21bab54f"],"mac_address":"02:00:00:1d:7b:57","modification_date":"2025-02-12T16:15:42.390078+00:00","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","server_id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"7a435d2e-8efb-4aaa-bc61-18ca3499a8ac","name":"tf-sg-nostalgic-hypatia"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"0310ce0d-2ff0-4cab-b5fe-1b17a2b6da68","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "475"
+                - "2143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:40 GMT
+                - Wed, 12 Feb 2025 16:16:23 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5384,10 +5380,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - df959176-ba28-4b4c-af78-9cd05ccf9755
+                - 52111a1f-34e3-4744-a275-52b94a08652e
         status: 200 OK
         code: 200
-        duration: 95.3275ms
+        duration: 229.055083ms
     - id: 109
       request:
         proto: HTTP/1.1
@@ -5403,25 +5399,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2/private_nics/295dc8af-772a-4491-bac3-a30e6db5d124
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b/private_nics
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 478
         uncompressed: false
-        body: ""
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:15:10.422881+00:00","id":"4b9eefc5-41db-4c4d-8662-cf9202eab68f","ipam_ip_ids":["512fea6c-17d0-4487-a8d6-a03f75ee2368","58ca6b90-1ffa-4d83-9e1d-c84a21bab54f"],"mac_address":"02:00:00:1d:7b:57","modification_date":"2025-02-12T16:15:42.390078+00:00","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","server_id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
+            Content-Length:
+                - "478"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:40 GMT
+                - Wed, 12 Feb 2025 16:16:23 GMT
+            Link:
+                - </servers/9c7a1a9d-2047-4712-86f0-ba076f86118b/private_nics?page=1&per_page=50&>; rel="last"
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5431,10 +5431,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4a9e73d7-868f-4084-8e08-d4ab8f675453
-        status: 204 No Content
-        code: 204
-        duration: 252.159167ms
+                - 9fc6d6b9-8062-4fb2-badc-789244d3878d
+            X-Total-Count:
+                - "1"
+        status: 200 OK
+        code: 200
+        duration: 97.422042ms
     - id: 110
       request:
         proto: HTTP/1.1
@@ -5450,8 +5452,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2/private_nics/295dc8af-772a-4491-bac3-a30e6db5d124
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b/private_nics/4b9eefc5-41db-4c4d-8662-cf9202eab68f
         method: GET
       response:
         proto: HTTP/2.0
@@ -5459,18 +5461,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 148
+        content_length: 475
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"295dc8af-772a-4491-bac3-a30e6db5d124","type":"not_found"}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.422881+00:00","id":"4b9eefc5-41db-4c4d-8662-cf9202eab68f","ipam_ip_ids":["512fea6c-17d0-4487-a8d6-a03f75ee2368","58ca6b90-1ffa-4d83-9e1d-c84a21bab54f"],"mac_address":"02:00:00:1d:7b:57","modification_date":"2025-02-12T16:15:42.390078+00:00","private_network_id":"0c6bc523-27f7-44c3-8a6a-e0c049abeda3","server_id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "148"
+                - "475"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:40 GMT
+                - Wed, 12 Feb 2025 16:16:24 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5480,10 +5482,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 69f3daf3-59c2-4f90-8e37-bc10ab965fd7
-        status: 404 Not Found
-        code: 404
-        duration: 97.107042ms
+                - 537786e1-2d39-4abc-9192-634a8c874739
+        status: 200 OK
+        code: 200
+        duration: 96.836708ms
     - id: 111
       request:
         proto: HTTP/1.1
@@ -5499,27 +5501,25 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b/private_nics/4b9eefc5-41db-4c4d-8662-cf9202eab68f
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2096
+        content_length: 0
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.974673+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-benz","id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ea:21","maintenances":[],"modification_date":"2025-01-27T09:17:36.578280+00:00","name":"tf-srv-happy-benz","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"c8613b60-f84a-47f6-9357-3a15421f9b76","name":"tf-sg-keen-wing"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.974673+00:00","export_uri":null,"id":"80ea48b3-70a2-4b5a-8665-bcda6853e98d","modification_date":"2025-01-27T09:16:02.974673+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","name":"tf-srv-happy-benz"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: ""
         headers:
-            Content-Length:
-                - "2096"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:40 GMT
+                - Wed, 12 Feb 2025 16:16:24 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5529,10 +5529,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bfe238f8-dfbb-403c-9d4f-841781396c21
-        status: 200 OK
-        code: 200
-        duration: 142.428417ms
+                - 570513c6-2526-4d9d-8886-f04a14ca2fa4
+        status: 204 No Content
+        code: 204
+        duration: 317.649917ms
     - id: 112
       request:
         proto: HTTP/1.1
@@ -5548,25 +5548,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b/private_nics/4b9eefc5-41db-4c4d-8662-cf9202eab68f
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 148
         uncompressed: false
-        body: ""
+        body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"4b9eefc5-41db-4c4d-8662-cf9202eab68f","type":"not_found"}'
         headers:
+            Content-Length:
+                - "148"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:41 GMT
+                - Wed, 12 Feb 2025 16:16:24 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5576,10 +5578,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a3b11c11-a002-4b34-9b8c-3e529772e9a5
-        status: 204 No Content
-        code: 204
-        duration: 249.923333ms
+                - 003f5bd1-c2d3-4628-a1b0-62f4455daf31
+        status: 404 Not Found
+        code: 404
+        duration: 106.084958ms
     - id: 113
       request:
         proto: HTTP/1.1
@@ -5595,8 +5597,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b
         method: GET
       response:
         proto: HTTP/2.0
@@ -5604,18 +5606,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 143
+        content_length: 1685
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"e018f5dc-83bb-4d7f-baa5-3d5a527bf4f2","type":"not_found"}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.450538+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-visvesvaraya","id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:dd","maintenances":[],"modification_date":"2025-02-12T16:16:18.792463+00:00","name":"tf-srv-strange-visvesvaraya","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"7a435d2e-8efb-4aaa-bc61-18ca3499a8ac","name":"tf-sg-nostalgic-hypatia"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"0310ce0d-2ff0-4cab-b5fe-1b17a2b6da68","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "143"
+                - "1685"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:41 GMT
+                - Wed, 12 Feb 2025 16:16:24 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5625,10 +5627,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 782bd8d2-5405-4a2c-bb96-a0350c78181d
-        status: 404 Not Found
-        code: 404
-        duration: 88.303ms
+                - 508e61b7-6a08-4277-91e6-0596ffaaf273
+        status: 200 OK
+        code: 200
+        duration: 185.276375ms
     - id: 114
       request:
         proto: HTTP/1.1
@@ -5644,27 +5646,25 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/80ea48b3-70a2-4b5a-8665-bcda6853e98d
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 446
+        content_length: 0
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T09:16:02.974673+00:00","export_uri":null,"id":"80ea48b3-70a2-4b5a-8665-bcda6853e98d","modification_date":"2025-01-27T09:17:41.188329+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: ""
         headers:
-            Content-Length:
-                - "446"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:41 GMT
+                - Wed, 12 Feb 2025 16:16:24 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5674,10 +5674,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2869c91a-33a8-4267-8e01-05b6a324ebfe
-        status: 200 OK
-        code: 200
-        duration: 73.741792ms
+                - e1780378-e47b-400f-9144-0f5cf88e45bd
+        status: 204 No Content
+        code: 204
+        duration: 315.357292ms
     - id: 115
       request:
         proto: HTTP/1.1
@@ -5693,25 +5693,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/80ea48b3-70a2-4b5a-8665-bcda6853e98d
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9c7a1a9d-2047-4712-86f0-ba076f86118b
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 143
         uncompressed: false
-        body: ""
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"9c7a1a9d-2047-4712-86f0-ba076f86118b","type":"not_found"}'
         headers:
+            Content-Length:
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:41 GMT
+                - Wed, 12 Feb 2025 16:16:24 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5721,10 +5723,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1c9bf55b-1a27-4f88-8387-9d8bc61d2aa1
-        status: 204 No Content
-        code: 204
-        duration: 181.352625ms
+                - 034e095b-1d0d-4b86-b558-05da60896e8d
+        status: 404 Not Found
+        code: 404
+        duration: 130.470666ms
     - id: 116
       request:
         proto: HTTP/1.1
@@ -5740,25 +5742,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/c8613b60-f84a-47f6-9357-3a15421f9b76
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0310ce0d-2ff0-4cab-b5fe-1b17a2b6da68
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 143
         uncompressed: false
-        body: ""
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"0310ce0d-2ff0-4cab-b5fe-1b17a2b6da68","type":"not_found"}'
         headers:
+            Content-Length:
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:41 GMT
+                - Wed, 12 Feb 2025 16:16:25 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5768,10 +5772,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0b92c191-8871-4e6e-a5e2-f6fba11cd669
-        status: 204 No Content
-        code: 204
-        duration: 197.198042ms
+                - 2a69aa83-c98f-44a1-b184-1faae297d0f0
+        status: 404 Not Found
+        code: 404
+        duration: 56.913542ms
     - id: 117
       request:
         proto: HTTP/1.1
@@ -5787,8 +5791,57 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a25b8a28-50ff-4347-a5ba-3dbabb3ae79b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/0310ce0d-2ff0-4cab-b5fe-1b17a2b6da68
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 494
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:14:57.876261Z","id":"0310ce0d-2ff0-4cab-b5fe-1b17a2b6da68","last_detached_at":"2025-02-12T16:16:25.066765Z","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:16:25.066765Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "494"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:16:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fb4743c3-86aa-44af-86ba-9ddd1aaa6a4c
+        status: 200 OK
+        code: 200
+        duration: 94.273125ms
+    - id: 118
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/0310ce0d-2ff0-4cab-b5fe-1b17a2b6da68
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5805,7 +5858,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:42 GMT
+                - Wed, 12 Feb 2025 16:16:25 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5815,11 +5868,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9735b9c3-6ac2-4d93-9b02-791b80f0701e
+                - 89fed6f8-d37c-4859-adcf-4bf63d01975f
         status: 204 No Content
         code: 204
-        duration: 1.09062375s
-    - id: 118
+        duration: 146.267041ms
+    - id: 119
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -5834,27 +5887,25 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/95c3edc0-cf35-40f9-bfb2-2af399b47a92
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/7a435d2e-8efb-4aaa-bc61-18ca3499a8ac
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 125
+        content_length: 0
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"dhcp","resource_id":"95c3edc0-cf35-40f9-bfb2-2af399b47a92","type":"not_found"}'
+        body: ""
         headers:
-            Content-Length:
-                - "125"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:42 GMT
+                - Wed, 12 Feb 2025 16:16:25 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5864,7 +5915,103 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9a4e1574-98d0-42c2-b58a-0d847160c408
+                - b13c95c0-95d7-41d7-aeef-ce62552bd277
+        status: 204 No Content
+        code: 204
+        duration: 375.607875ms
+    - id: 120
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/0c6bc523-27f7-44c3-8a6a-e0c049abeda3
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:16:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ac0f8870-42a7-4a04-8c42-9ae84bc02535
+        status: 204 No Content
+        code: 204
+        duration: 1.192985708s
+    - id: 121
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/538c4a96-d996-45ca-b414-59e27b15ba9c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 125
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"dhcp","resource_id":"538c4a96-d996-45ca-b414-59e27b15ba9c","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "125"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:16:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 38056e3f-1136-48e1-9bb3-56a4b793decb
         status: 404 Not Found
         code: 404
-        duration: 26.739833ms
+        duration: 42.371459ms

--- a/internal/services/vpcgw/testdata/vpc-public-gateway-dhcp-entry-basic.cassette.yaml
+++ b/internal/services/vpcgw/testdata/vpc-public-gateway-dhcp-entry-basic.cassette.yaml
@@ -18,7 +18,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps
         method: POST
       response:
@@ -27,18 +27,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 568
+        content_length: 586
         uncompressed: false
-        body: '{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.045621Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecc5e6f-8e74-41b0-b33a-f29a2448293c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.045621Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+        body: '{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.950362Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0a76d947-25bb-4d14-9c1c-4f48deceb1a6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.950362Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "568"
+                - "586"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:01 GMT
+                - Wed, 12 Feb 2025 16:14:55 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 887e3c40-a0e5-451c-9831-6c4721433f72
+                - c54fc5e9-f325-45c1-891a-8d043e460836
         status: 200 OK
         code: 200
-        duration: 54.348416ms
+        duration: 313.64475ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/1ecc5e6f-8e74-41b0-b33a-f29a2448293c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/0a76d947-25bb-4d14-9c1c-4f48deceb1a6
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,18 +76,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 568
+        content_length: 586
         uncompressed: false
-        body: '{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.045621Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecc5e6f-8e74-41b0-b33a-f29a2448293c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.045621Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+        body: '{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.950362Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0a76d947-25bb-4d14-9c1c-4f48deceb1a6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.950362Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "568"
+                - "586"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:01 GMT
+                - Wed, 12 Feb 2025 16:14:56 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c1adbbdd-1d36-41a6-a2a5-78e26a9c0898
+                - a1a5901f-369f-485f-8841-adcdca48d009
         status: 200 OK
         code: 200
-        duration: 22.215041ms
+        duration: 104.3925ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -118,7 +118,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
         method: POST
       response:
@@ -127,18 +127,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1018
+        content_length: 1041
         uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:01.080341Z","dhcp_enabled":true,"id":"f96914f9-4114-4d1f-aa48-077fab624873","name":"pn_test_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T09:16:01.080341Z","id":"c6e3530a-51ec-428b-8e49-4863d5d267de","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.0.0/22","updated_at":"2025-01-27T09:16:01.080341Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T09:16:01.080341Z","id":"1498f716-3ced-4cf5-8f1c-8ef67fb0d50e","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:4c24::/64","updated_at":"2025-01-27T09:16:01.080341Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T09:16:01.080341Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"created_at":"2025-02-12T16:14:55.931102Z","dhcp_enabled":true,"id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","name":"pn_test_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:14:55.931102Z","id":"5e027010-cd96-4711-b69d-480bb60a697e","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.0.0/22","updated_at":"2025-02-12T16:14:55.931102Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-12T16:14:55.931102Z","id":"e4dcfa97-3290-480c-a712-7c50de07a6ea","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:c29e::/64","updated_at":"2025-02-12T16:14:55.931102Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-12T16:14:55.931102Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "1018"
+                - "1041"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:01 GMT
+                - Wed, 12 Feb 2025 16:14:56 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -148,10 +148,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 95de1771-76bd-4f51-9fa9-0355e659d35f
+                - 508a1194-1566-402b-ba92-ad7c684e5099
         status: 200 OK
         code: 200
-        duration: 579.940042ms
+        duration: 899.187875ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -167,8 +167,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f96914f9-4114-4d1f-aa48-077fab624873
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7a3b6ed2-5295-4ce1-a78f-e24d90879aec
         method: GET
       response:
         proto: HTTP/2.0
@@ -176,18 +176,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1018
+        content_length: 1041
         uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:01.080341Z","dhcp_enabled":true,"id":"f96914f9-4114-4d1f-aa48-077fab624873","name":"pn_test_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T09:16:01.080341Z","id":"c6e3530a-51ec-428b-8e49-4863d5d267de","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.0.0/22","updated_at":"2025-01-27T09:16:01.080341Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T09:16:01.080341Z","id":"1498f716-3ced-4cf5-8f1c-8ef67fb0d50e","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:4c24::/64","updated_at":"2025-01-27T09:16:01.080341Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T09:16:01.080341Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"created_at":"2025-02-12T16:14:55.931102Z","dhcp_enabled":true,"id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","name":"pn_test_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:14:55.931102Z","id":"5e027010-cd96-4711-b69d-480bb60a697e","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.0.0/22","updated_at":"2025-02-12T16:14:55.931102Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-12T16:14:55.931102Z","id":"e4dcfa97-3290-480c-a712-7c50de07a6ea","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:c29e::/64","updated_at":"2025-02-12T16:14:55.931102Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-12T16:14:55.931102Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "1018"
+                - "1041"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:01 GMT
+                - Wed, 12 Feb 2025 16:14:56 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -197,117 +197,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b41d7213-a8b5-4af2-9e8f-efd44f4e7a3c
+                - c2d18e6f-cc87-4ce0-8c10-421a98b31834
         status: 200 OK
         code: 200
-        duration: 24.93675ms
+        duration: 50.178125ms
     - id: 4
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 38539
-        uncompressed: false
-        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
-        headers:
-            Content-Length:
-                - "38539"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:16:01 GMT
-            Link:
-                - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - f5c3bd32-3a90-4289-8abe-c621e533e5f3
-            X-Total-Count:
-                - "68"
-        status: 200 OK
-        code: 200
-        duration: 58.386083ms
-    - id: 5
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 14208
-        uncompressed: false
-        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
-        headers:
-            Content-Length:
-                - "14208"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:16:01 GMT
-            Link:
-                - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - b85b2ec3-fb3c-47d6-99b2-2024588d8250
-            X-Total-Count:
-                - "68"
-        status: 200 OK
-        code: 200
-        duration: 48.485917ms
-    - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -324,7 +218,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips
         method: POST
       response:
@@ -333,18 +227,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 358
+        content_length: 371
         uncompressed: false
-        body: '{"address":"51.15.224.245","created_at":"2025-01-27T09:16:01.788664Z","gateway_id":null,"id":"c7144bb0-d67d-4ef1-ba4c-0ec0ee3f69c7","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"245-224-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.788664Z","zone":"fr-par-1"}'
+        body: '{"address":"163.172.159.229","created_at":"2025-02-12T16:14:56.642158Z","gateway_id":null,"id":"f6a6b831-81a9-463c-9b7d-2b0f4c38bf0e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.642158Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "358"
+                - "371"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:01 GMT
+                - Wed, 12 Feb 2025 16:14:56 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -354,10 +248,112 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b8ffdbdd-2b1c-4656-8863-1560e92b34f5
+                - d9904f85-47b9-45b4-ac15-28dd3145d501
         status: 200 OK
         code: 200
-        duration: 818.705916ms
+        duration: 1.0122335s
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 35639
+        uncompressed: false
+        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
+        headers:
+            Content-Length:
+                - "35639"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:14:56 GMT
+            Link:
+                - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 17f39484-21fd-4102-9b1b-03853977739f
+            X-Total-Count:
+                - "68"
+        status: 200 OK
+        code: 200
+        duration: 66.950541ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/f6a6b831-81a9-463c-9b7d-2b0f4c38bf0e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 371
+        uncompressed: false
+        body: '{"address":"163.172.159.229","created_at":"2025-02-12T16:14:56.642158Z","gateway_id":null,"id":"f6a6b831-81a9-463c-9b7d-2b0f4c38bf0e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.642158Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "371"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:14:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 94e9347d-af9c-4bca-b014-fed3a53e8df4
+        status: 200 OK
+        code: 200
+        duration: 49.75575ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -373,8 +369,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/c7144bb0-d67d-4ef1-ba4c-0ec0ee3f69c7
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
         method: GET
       response:
         proto: HTTP/2.0
@@ -382,18 +378,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 358
+        content_length: 13164
         uncompressed: false
-        body: '{"address":"51.15.224.245","created_at":"2025-01-27T09:16:01.788664Z","gateway_id":null,"id":"c7144bb0-d67d-4ef1-ba4c-0ec0ee3f69c7","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"245-224-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.788664Z","zone":"fr-par-1"}'
+        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
         headers:
             Content-Length:
-                - "358"
+                - "13164"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:01 GMT
+                - Wed, 12 Feb 2025 16:14:56 GMT
+            Link:
+                - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -403,11 +401,64 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7470745b-9cf8-4be2-a672-8ce0daec2053
+                - 85679dbc-9c7d-41b4-bc9f-9f4ca2eb1cf5
+            X-Total-Count:
+                - "68"
         status: 200 OK
         code: 200
-        duration: 22.227ms
+        duration: 81.227208ms
     - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 213
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"foobar","tags":[],"type":"VPC-GW-S","upstream_dns_servers":[],"ip_id":"f6a6b831-81a9-463c-9b7d-2b0f4c38bf0e","enable_smtp":false,"enable_bastion":false}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1002
+        uncompressed: false
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.788246Z","gateway_networks":[],"id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","ip":{"address":"163.172.159.229","created_at":"2025-02-12T16:14:56.642158Z","gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"f6a6b831-81a9-463c-9b7d-2b0f4c38bf0e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.642158Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:14:56.788246Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "1002"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:14:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 76bff796-2443-410b-8d2e-a1f5adf48239
+        status: 200 OK
+        code: 200
+        duration: 107.24675ms
+    - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -422,8 +473,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_local&zone=fr-par-1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/01fdf5a9-c2a0-4632-b5a5-03ccab13224f
         method: GET
       response:
         proto: HTTP/2.0
@@ -431,18 +482,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1220
+        content_length: 1004
         uncompressed: false
-        body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"56d4019c-8305-467a-a3f2-70498ad799df","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.788246Z","gateway_networks":[],"id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","ip":{"address":"163.172.159.229","created_at":"2025-02-12T16:14:56.642158Z","gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"f6a6b831-81a9-463c-9b7d-2b0f4c38bf0e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.642158Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:14:56.835160Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1220"
+                - "1004"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:01 GMT
+                - Wed, 12 Feb 2025 16:14:56 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -452,61 +503,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c796b521-923a-4913-88d9-fa519be46cb3
+                - 39dc05a9-6641-4bae-849e-9da01b4201b0
         status: 200 OK
         code: 200
-        duration: 76.927375ms
-    - id: 9
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 213
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"foobar","tags":[],"type":"VPC-GW-S","upstream_dns_servers":[],"ip_id":"c7144bb0-d67d-4ef1-ba4c-0ec0ee3f69c7","enable_smtp":false,"enable_bastion":false}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 968
-        uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:01.901705Z","gateway_networks":[],"id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","ip":{"address":"51.15.224.245","created_at":"2025-01-27T09:16:01.788664Z","gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"c7144bb0-d67d-4ef1-ba4c-0ec0ee3f69c7","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"245-224-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.788664Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:01.901705Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "968"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:16:01 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 7df26ada-90dc-4bdd-94d8-b31ad00df08e
-        status: 200 OK
-        code: 200
-        duration: 100.928416ms
+        duration: 64.039875ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -522,8 +522,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/7d99e9ca-2141-4914-8e5e-5526e22eea5e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_sbs&zone=fr-par-1
         method: GET
       response:
         proto: HTTP/2.0
@@ -531,18 +531,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 968
+        content_length: 1296
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:01.901705Z","gateway_networks":[],"id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","ip":{"address":"51.15.224.245","created_at":"2025-01-27T09:16:01.788664Z","gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"c7144bb0-d67d-4ef1-ba4c-0ec0ee3f69c7","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"245-224-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.788664Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:01.901705Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
+        body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"57509e82-ac3b-49b7-9970-97b60f40ff72","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"9b647e1e-253a-41e7-8c15-911c622ee2dc","label":"ubuntu_focal","type":"instance_sbs","zone":"fr-par-1"}],"total_count":2}'
         headers:
             Content-Length:
-                - "968"
+                - "1296"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:01 GMT
+                - Wed, 12 Feb 2025 16:14:56 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -552,28 +552,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1d8bbcc7-4177-4a08-a223-c52b9915b0f9
+                - 5ebfdcca-8da3-46ff-9e82-88a993923bbf
         status: 200 OK
         code: 200
-        duration: 28.444375ms
+        duration: 108.235541ms
     - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 278
+        content_length: 232
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-srv-funny-stonebraker","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+        body: '{"name":"tf-srv-eager-panini","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"57509e82-ac3b-49b7-9970-97b60f40ff72","volumes":{"0":{"boot":false}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
         method: POST
       response:
@@ -582,20 +582,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2124
+        content_length: 1668
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.059639+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-stonebraker","id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ea:1d","maintenances":[],"modification_date":"2025-01-27T09:16:02.059639+00:00","name":"tf-srv-funny-stonebraker","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.059639+00:00","export_uri":null,"id":"89d36a9f-ba55-4c09-a3a6-ef9520673300","modification_date":"2025-01-27T09:16:02.059639+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","name":"tf-srv-funny-stonebraker"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.167923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-panini","id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:d7","maintenances":[],"modification_date":"2025-02-12T16:14:57.167923+00:00","name":"tf-srv-eager-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"b3862f05-55df-4387-ab1e-f975957752e5","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2124"
+                - "1668"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:02 GMT
+                - Wed, 12 Feb 2025 16:14:57 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -605,10 +605,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - abe28fd7-02ba-4131-a0c2-f75ec6e5b480
+                - 118ccba8-38b7-43da-831d-5d4ea763b591
         status: 201 Created
         code: 201
-        duration: 495.492541ms
+        duration: 1.752017625s
     - id: 12
       request:
         proto: HTTP/1.1
@@ -624,8 +624,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664
         method: GET
       response:
         proto: HTTP/2.0
@@ -633,18 +633,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2124
+        content_length: 1668
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.059639+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-stonebraker","id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ea:1d","maintenances":[],"modification_date":"2025-01-27T09:16:02.059639+00:00","name":"tf-srv-funny-stonebraker","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.059639+00:00","export_uri":null,"id":"89d36a9f-ba55-4c09-a3a6-ef9520673300","modification_date":"2025-01-27T09:16:02.059639+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","name":"tf-srv-funny-stonebraker"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.167923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-panini","id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:d7","maintenances":[],"modification_date":"2025-02-12T16:14:57.167923+00:00","name":"tf-srv-eager-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"b3862f05-55df-4387-ab1e-f975957752e5","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2124"
+                - "1668"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:02 GMT
+                - Wed, 12 Feb 2025 16:14:58 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -654,10 +654,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 485b6d72-6a5c-4314-9e30-de08c9fe9c06
+                - 47a8b0f5-bb48-4ee6-b636-f00ddce7e437
         status: 200 OK
         code: 200
-        duration: 246.135375ms
+        duration: 180.936875ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -673,8 +673,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664
         method: GET
       response:
         proto: HTTP/2.0
@@ -682,18 +682,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2124
+        content_length: 1668
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.059639+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-stonebraker","id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ea:1d","maintenances":[],"modification_date":"2025-01-27T09:16:02.059639+00:00","name":"tf-srv-funny-stonebraker","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.059639+00:00","export_uri":null,"id":"89d36a9f-ba55-4c09-a3a6-ef9520673300","modification_date":"2025-01-27T09:16:02.059639+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","name":"tf-srv-funny-stonebraker"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.167923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-panini","id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:d7","maintenances":[],"modification_date":"2025-02-12T16:14:57.167923+00:00","name":"tf-srv-eager-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"b3862f05-55df-4387-ab1e-f975957752e5","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2124"
+                - "1668"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:02 GMT
+                - Wed, 12 Feb 2025 16:14:58 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -703,11 +703,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f947170d-3e4e-48c0-92f3-24201bea7cea
+                - 102d03bf-e316-4854-96ce-fab298d1e1d4
         status: 200 OK
         code: 200
-        duration: 190.48525ms
+        duration: 186.94925ms
     - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/b3862f05-55df-4387-ab1e-f975957752e5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:14:57.634432Z","id":"b3862f05-55df-4387-ab1e-f975957752e5","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:14:57.634432Z","id":"2e55d1b6-aa93-4d99-91a5-cf2874697e34","product_resource_id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:14:57.634432Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:14:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ea702ce7-1615-4904-aba8-2360fab413ec
+        status: 200 OK
+        code: 200
+        duration: 81.11025ms
+    - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -724,8 +773,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -735,7 +784,7 @@ interactions:
         trailer: {}
         content_length: 357
         uncompressed: false
-        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb/action","href_result":"/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb","id":"699d38e3-3b3e-48bd-b93b-66ae94bad9e4","progress":0,"started_at":"2025-01-27T09:16:03.012629+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664/action","href_result":"/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664","id":"b520e89e-295b-4a7d-aeab-67dd4e4ef976","progress":0,"started_at":"2025-02-12T16:14:59.352775+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -744,9 +793,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:02 GMT
+                - Wed, 12 Feb 2025 16:14:59 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/699d38e3-3b3e-48bd-b93b-66ae94bad9e4
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/b520e89e-295b-4a7d-aeab-67dd4e4ef976
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -756,59 +805,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ecceaa00-79b6-49d7-8bc0-a18a6221189c
+                - 2889823c-7247-4ed2-8042-8b924a650466
         status: 202 Accepted
         code: 202
-        duration: 342.708084ms
-    - id: 15
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2146
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.059639+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-stonebraker","id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ea:1d","maintenances":[],"modification_date":"2025-01-27T09:16:02.790638+00:00","name":"tf-srv-funny-stonebraker","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.059639+00:00","export_uri":null,"id":"89d36a9f-ba55-4c09-a3a6-ef9520673300","modification_date":"2025-01-27T09:16:02.059639+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","name":"tf-srv-funny-stonebraker"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2146"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:16:03 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 3d711519-c3f1-4350-8176-2c92b8c0e1cd
-        status: 200 OK
-        code: 200
-        duration: 194.418834ms
+        duration: 284.730583ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -824,8 +824,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/7d99e9ca-2141-4914-8e5e-5526e22eea5e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664
         method: GET
       response:
         proto: HTTP/2.0
@@ -833,18 +833,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 971
+        content_length: 1690
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:01.901705Z","gateway_networks":[],"id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","ip":{"address":"51.15.224.245","created_at":"2025-01-27T09:16:01.788664Z","gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"c7144bb0-d67d-4ef1-ba4c-0ec0ee3f69c7","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"245-224-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.788664Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:02.658259Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.167923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-panini","id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:d7","maintenances":[],"modification_date":"2025-02-12T16:14:59.142161+00:00","name":"tf-srv-eager-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"id":"b3862f05-55df-4387-ab1e-f975957752e5","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "971"
+                - "1690"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:06 GMT
+                - Wed, 12 Feb 2025 16:14:59 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -854,10 +854,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a6672a34-edea-4ff3-860c-732d2183757d
+                - 476f3168-7564-4274-aa14-ddd624d7e002
         status: 200 OK
         code: 200
-        duration: 28.870708ms
+        duration: 200.590042ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -873,8 +873,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/01fdf5a9-c2a0-4632-b5a5-03ccab13224f
         method: GET
       response:
         proto: HTTP/2.0
@@ -882,18 +882,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2250
+        content_length: 1001
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.059639+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-stonebraker","id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1401","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:1d","maintenances":[],"modification_date":"2025-01-27T09:16:02.790638+00:00","name":"tf-srv-funny-stonebraker","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.059639+00:00","export_uri":null,"id":"89d36a9f-ba55-4c09-a3a6-ef9520673300","modification_date":"2025-01-27T09:16:02.059639+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","name":"tf-srv-funny-stonebraker"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.788246Z","gateway_networks":[],"id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","ip":{"address":"163.172.159.229","created_at":"2025-02-12T16:14:56.642158Z","gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"f6a6b831-81a9-463c-9b7d-2b0f4c38bf0e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.642158Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:14:59.917356Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2250"
+                - "1001"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:08 GMT
+                - Wed, 12 Feb 2025 16:15:01 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -903,10 +903,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 795cfbb2-8e50-481b-9bf7-971ab0d3444d
+                - 8cdce035-2636-4cd1-b995-7265e8b2e32c
         status: 200 OK
         code: 200
-        duration: 178.877875ms
+        duration: 54.315583ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -922,8 +922,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/7d99e9ca-2141-4914-8e5e-5526e22eea5e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/01fdf5a9-c2a0-4632-b5a5-03ccab13224f
         method: GET
       response:
         proto: HTTP/2.0
@@ -931,18 +931,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 967
+        content_length: 1001
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:01.901705Z","gateway_networks":[],"id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","ip":{"address":"51.15.224.245","created_at":"2025-01-27T09:16:01.788664Z","gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"c7144bb0-d67d-4ef1-ba4c-0ec0ee3f69c7","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"245-224-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.788664Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:07.099803Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.788246Z","gateway_networks":[],"id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","ip":{"address":"163.172.159.229","created_at":"2025-02-12T16:14:56.642158Z","gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"f6a6b831-81a9-463c-9b7d-2b0f4c38bf0e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.642158Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:14:59.917356Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "967"
+                - "1001"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:12 GMT
+                - Wed, 12 Feb 2025 16:15:02 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -952,10 +952,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b090decc-8373-4266-89a0-61d92df32ded
+                - 246f50a6-705d-4cc5-a9c7-2bdfdca70928
         status: 200 OK
         code: 200
-        duration: 26.7605ms
+        duration: 51.553625ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -971,8 +971,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/7d99e9ca-2141-4914-8e5e-5526e22eea5e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/01fdf5a9-c2a0-4632-b5a5-03ccab13224f
         method: GET
       response:
         proto: HTTP/2.0
@@ -980,18 +980,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 967
+        content_length: 1001
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:01.901705Z","gateway_networks":[],"id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","ip":{"address":"51.15.224.245","created_at":"2025-01-27T09:16:01.788664Z","gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"c7144bb0-d67d-4ef1-ba4c-0ec0ee3f69c7","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"245-224-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.788664Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:07.099803Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.788246Z","gateway_networks":[],"id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","ip":{"address":"163.172.159.229","created_at":"2025-02-12T16:14:56.642158Z","gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"f6a6b831-81a9-463c-9b7d-2b0f4c38bf0e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.642158Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:14:59.917356Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "967"
+                - "1001"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:12 GMT
+                - Wed, 12 Feb 2025 16:15:02 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1001,10 +1001,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c08c557f-14b9-413f-a9d3-8ded9cfcabde
+                - 1f0cae67-9e1a-46f8-8f83-292f0e843ce5
         status: 200 OK
         code: 200
-        duration: 27.026792ms
+        duration: 46.395417ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1020,8 +1020,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/7d99e9ca-2141-4914-8e5e-5526e22eea5e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664
         method: GET
       response:
         proto: HTTP/2.0
@@ -1029,18 +1029,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 967
+        content_length: 1793
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:01.901705Z","gateway_networks":[],"id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","ip":{"address":"51.15.224.245","created_at":"2025-01-27T09:16:01.788664Z","gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"c7144bb0-d67d-4ef1-ba4c-0ec0ee3f69c7","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"245-224-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.788664Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:07.099803Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.167923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-panini","id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"402","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d7","maintenances":[],"modification_date":"2025-02-12T16:14:59.142161+00:00","name":"tf-srv-eager-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"id":"b3862f05-55df-4387-ab1e-f975957752e5","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "967"
+                - "1793"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:12 GMT
+                - Wed, 12 Feb 2025 16:15:04 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1050,11 +1050,62 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cd0a9694-99c6-46bf-834c-4ba95358a386
+                - fcabae23-b61b-4b86-9f0e-a644ea50f1d1
         status: 200 OK
         code: 200
-        duration: 28.751333ms
+        duration: 222.969791ms
     - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 206
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"0a76d947-25bb-4d14-9c1c-4f48deceb1a6"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 983
+        uncompressed: false
+        body: '{"address":null,"created_at":"2025-02-12T16:15:05.808795Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.950362Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0a76d947-25bb-4d14-9c1c-4f48deceb1a6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.950362Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","ipam_config":null,"mac_address":null,"private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","status":"created","updated_at":"2025-02-12T16:15:05.808795Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "983"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e77ee338-c579-4657-9531-305de60e3449
+        status: 200 OK
+        code: 200
+        duration: 4.003708417s
+    - id: 22
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1069,8 +1120,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/01fdf5a9-c2a0-4632-b5a5-03ccab13224f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1078,18 +1129,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2250
+        content_length: 1987
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.059639+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-stonebraker","id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1401","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:1d","maintenances":[],"modification_date":"2025-01-27T09:16:02.790638+00:00","name":"tf-srv-funny-stonebraker","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.059639+00:00","export_uri":null,"id":"89d36a9f-ba55-4c09-a3a6-ef9520673300","modification_date":"2025-01-27T09:16:02.059639+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","name":"tf-srv-funny-stonebraker"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.788246Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:05.808795Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.950362Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0a76d947-25bb-4d14-9c1c-4f48deceb1a6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.950362Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","ipam_config":null,"mac_address":null,"private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","status":"created","updated_at":"2025-02-12T16:15:05.808795Z","zone":"fr-par-1"}],"id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","ip":{"address":"163.172.159.229","created_at":"2025-02-12T16:14:56.642158Z","gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"f6a6b831-81a9-463c-9b7d-2b0f4c38bf0e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.642158Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:06.000074Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2250"
+                - "1987"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:13 GMT
+                - Wed, 12 Feb 2025 16:15:06 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1099,61 +1150,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ab65c158-750e-4e7b-911e-535126e20f03
+                - 4f973976-ea49-46c3-9597-6aac2eec8ca0
         status: 200 OK
         code: 200
-        duration: 179.22275ms
-    - id: 22
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 206
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"1ecc5e6f-8e74-41b0-b33a-f29a2448293c"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 953
-        uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:14.342411Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.045621Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecc5e6f-8e74-41b0-b33a-f29a2448293c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.045621Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"3c102c56-68a9-4da8-9fd6-d58c88441353","ipam_config":null,"mac_address":null,"private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","status":"created","updated_at":"2025-01-27T09:16:14.342411Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "953"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:16:14 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 397b2bd6-e87c-4387-b8c9-6488dc3a4d5f
-        status: 200 OK
-        code: 200
-        duration: 2.3752375s
+        duration: 65.5515ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1169,8 +1169,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/7d99e9ca-2141-4914-8e5e-5526e22eea5e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664
         method: GET
       response:
         proto: HTTP/2.0
@@ -1178,18 +1178,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1923
+        content_length: 1824
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:01.901705Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:14.342411Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.045621Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecc5e6f-8e74-41b0-b33a-f29a2448293c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.045621Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"3c102c56-68a9-4da8-9fd6-d58c88441353","ipam_config":null,"mac_address":null,"private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","status":"created","updated_at":"2025-01-27T09:16:14.342411Z","zone":"fr-par-1"}],"id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","ip":{"address":"51.15.224.245","created_at":"2025-01-27T09:16:01.788664Z","gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"c7144bb0-d67d-4ef1-ba4c-0ec0ee3f69c7","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"245-224-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.788664Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:14.469821Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.167923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-panini","id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"402","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d7","maintenances":[],"modification_date":"2025-02-12T16:15:05.175736+00:00","name":"tf-srv-eager-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"b3862f05-55df-4387-ab1e-f975957752e5","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1923"
+                - "1824"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:14 GMT
+                - Wed, 12 Feb 2025 16:15:09 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1199,10 +1199,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 77761a92-6b7f-497a-85d2-b087576bd700
+                - 34c9a91e-3cba-4794-b8e3-dafd6f1c1c50
         status: 200 OK
         code: 200
-        duration: 27.887708ms
+        duration: 254.797167ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1218,8 +1218,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7a3b6ed2-5295-4ce1-a78f-e24d90879aec
         method: GET
       response:
         proto: HTTP/2.0
@@ -1227,18 +1227,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2281
+        content_length: 1042
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.059639+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-stonebraker","id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1401","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:1d","maintenances":[],"modification_date":"2025-01-27T09:16:15.581118+00:00","name":"tf-srv-funny-stonebraker","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.059639+00:00","export_uri":null,"id":"89d36a9f-ba55-4c09-a3a6-ef9520673300","modification_date":"2025-01-27T09:16:02.059639+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","name":"tf-srv-funny-stonebraker"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-12T16:14:55.931102Z","dhcp_enabled":true,"id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","name":"pn_test_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:14:55.931102Z","id":"5e027010-cd96-4711-b69d-480bb60a697e","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:15:02.351322Z","vpc_id":"21689b9a-7cd1-4cf4-a47d-3bdd0f69315c"},{"created_at":"2025-02-12T16:14:55.931102Z","id":"e4dcfa97-3290-480c-a712-7c50de07a6ea","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:c29e::/64","updated_at":"2025-02-12T16:15:02.357183Z","vpc_id":"21689b9a-7cd1-4cf4-a47d-3bdd0f69315c"}],"tags":[],"updated_at":"2025-02-12T16:15:02.346987Z","vpc_id":"21689b9a-7cd1-4cf4-a47d-3bdd0f69315c"}'
         headers:
             Content-Length:
-                - "2281"
+                - "1042"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:18 GMT
+                - Wed, 12 Feb 2025 16:15:10 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1248,10 +1248,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a5340064-ca7e-4ed3-8dd8-350ee7c3ffcd
+                - 1c086a53-f1b7-494c-80ad-13a245eca946
         status: 200 OK
         code: 200
-        duration: 499.198875ms
+        duration: 50.488542ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1267,8 +1267,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f96914f9-4114-4d1f-aa48-077fab624873
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664
         method: GET
       response:
         proto: HTTP/2.0
@@ -1276,18 +1276,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1019
+        content_length: 1824
         uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:01.080341Z","dhcp_enabled":true,"id":"f96914f9-4114-4d1f-aa48-077fab624873","name":"pn_test_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T09:16:01.080341Z","id":"c6e3530a-51ec-428b-8e49-4863d5d267de","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:12.351404Z","vpc_id":"c77c01c3-0e24-4343-81fd-841906ccc123"},{"created_at":"2025-01-27T09:16:01.080341Z","id":"1498f716-3ced-4cf5-8f1c-8ef67fb0d50e","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:4c24::/64","updated_at":"2025-01-27T09:16:12.355245Z","vpc_id":"c77c01c3-0e24-4343-81fd-841906ccc123"}],"tags":[],"updated_at":"2025-01-27T09:16:12.347967Z","vpc_id":"c77c01c3-0e24-4343-81fd-841906ccc123"}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.167923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-panini","id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"402","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d7","maintenances":[],"modification_date":"2025-02-12T16:15:05.175736+00:00","name":"tf-srv-eager-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"b3862f05-55df-4387-ab1e-f975957752e5","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1019"
+                - "1824"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:19 GMT
+                - Wed, 12 Feb 2025 16:15:09 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1297,10 +1297,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6a5ed949-4700-4d23-9504-509c8f7f2717
+                - b07444bb-a865-4684-85c8-7c5bcc87b986
         status: 200 OK
         code: 200
-        duration: 24.962ms
+        duration: 245.310375ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1316,8 +1316,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/01fdf5a9-c2a0-4632-b5a5-03ccab13224f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1325,18 +1325,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2281
+        content_length: 1987
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.059639+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-stonebraker","id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1401","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:1d","maintenances":[],"modification_date":"2025-01-27T09:16:15.581118+00:00","name":"tf-srv-funny-stonebraker","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.059639+00:00","export_uri":null,"id":"89d36a9f-ba55-4c09-a3a6-ef9520673300","modification_date":"2025-01-27T09:16:02.059639+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","name":"tf-srv-funny-stonebraker"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.788246Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:05.808795Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.950362Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0a76d947-25bb-4d14-9c1c-4f48deceb1a6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.950362Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","ipam_config":null,"mac_address":null,"private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","status":"created","updated_at":"2025-02-12T16:15:05.808795Z","zone":"fr-par-1"}],"id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","ip":{"address":"163.172.159.229","created_at":"2025-02-12T16:14:56.642158Z","gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"f6a6b831-81a9-463c-9b7d-2b0f4c38bf0e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.642158Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:06.000074Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2281"
+                - "1987"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:19 GMT
+                - Wed, 12 Feb 2025 16:15:11 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1346,11 +1346,62 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cd1c3b6c-8317-48ab-8c34-0d7622d5f7e8
+                - 97665c5a-77fa-4f96-b384-a4585ba564b3
         status: 200 OK
         code: 200
-        duration: 174.54775ms
+        duration: 57.266209ms
     - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 61
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664/private_nics
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 473
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.419887+00:00","id":"65a6cef8-6606-4214-a8db-3d3bafb8327a","ipam_ip_ids":["3e273272-2b9c-4913-89c1-3423bf76990c","e80124d6-c1fe-42be-a73e-82653465a258"],"mac_address":"02:00:00:1f:a9:3e","modification_date":"2025-02-12T16:15:10.618558+00:00","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","server_id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "473"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:11 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 72066c44-7dbf-474c-ac78-22db0d53b995
+        status: 201 Created
+        code: 201
+        duration: 1.125709834s
+    - id: 28
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1365,60 +1416,9 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/7d99e9ca-2141-4914-8e5e-5526e22eea5e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664/private_nics/65a6cef8-6606-4214-a8db-3d3bafb8327a
         method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1923
-        uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:01.901705Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:14.342411Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.045621Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecc5e6f-8e74-41b0-b33a-f29a2448293c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.045621Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"3c102c56-68a9-4da8-9fd6-d58c88441353","ipam_config":null,"mac_address":null,"private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","status":"created","updated_at":"2025-01-27T09:16:14.342411Z","zone":"fr-par-1"}],"id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","ip":{"address":"51.15.224.245","created_at":"2025-01-27T09:16:01.788664Z","gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"c7144bb0-d67d-4ef1-ba4c-0ec0ee3f69c7","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"245-224-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.788664Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:14.469821Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "1923"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:16:19 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 21688e66-68b2-4d98-8570-b536805cdf98
-        status: 200 OK
-        code: 200
-        duration: 31.843667ms
-    - id: 28
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 61
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb/private_nics
-        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -1427,7 +1427,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:19.391848+00:00","id":"a6008d1e-b295-4a3a-a95e-ee520905082a","ipam_ip_ids":["1d82d8f6-cb7b-4a0f-bdb2-b393da83d382","9d60bed2-52c8-4ffa-a014-9edfeb74825a"],"mac_address":"02:00:00:13:ce:84","modification_date":"2025-01-27T09:16:19.603154+00:00","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","server_id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.419887+00:00","id":"65a6cef8-6606-4214-a8db-3d3bafb8327a","ipam_ip_ids":["3e273272-2b9c-4913-89c1-3423bf76990c","e80124d6-c1fe-42be-a73e-82653465a258"],"mac_address":"02:00:00:1f:a9:3e","modification_date":"2025-02-12T16:15:10.618558+00:00","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","server_id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -1436,7 +1436,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:20 GMT
+                - Wed, 12 Feb 2025 16:15:11 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1446,10 +1446,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e0869abf-4172-4891-ae27-e2faa9c5d8c8
-        status: 201 Created
-        code: 201
-        duration: 1.140051167s
+                - 50e2bb1c-f210-488f-b8c8-4a96a70cdfaf
+        status: 200 OK
+        code: 200
+        duration: 101.599167ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1465,8 +1465,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb/private_nics/a6008d1e-b295-4a3a-a95e-ee520905082a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/01fdf5a9-c2a0-4632-b5a5-03ccab13224f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1474,18 +1474,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 473
+        content_length: 2006
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:19.391848+00:00","id":"a6008d1e-b295-4a3a-a95e-ee520905082a","ipam_ip_ids":["1d82d8f6-cb7b-4a0f-bdb2-b393da83d382","9d60bed2-52c8-4ffa-a014-9edfeb74825a"],"mac_address":"02:00:00:13:ce:84","modification_date":"2025-01-27T09:16:19.603154+00:00","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","server_id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.788246Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:05.808795Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.950362Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0a76d947-25bb-4d14-9c1c-4f48deceb1a6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.950362Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","ipam_config":null,"mac_address":"02:00:00:13:B7:CF","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","status":"configuring","updated_at":"2025-02-12T16:15:11.719377Z","zone":"fr-par-1"}],"id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","ip":{"address":"163.172.159.229","created_at":"2025-02-12T16:14:56.642158Z","gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"f6a6b831-81a9-463c-9b7d-2b0f4c38bf0e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.642158Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:06.000074Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "473"
+                - "2006"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:20 GMT
+                - Wed, 12 Feb 2025 16:15:16 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1495,10 +1495,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 65c1892e-07c7-4ddb-8da1-bd74ba8ccbc5
+                - 3ba26081-996f-4e9b-89f4-660d4d8354bd
         status: 200 OK
         code: 200
-        duration: 121.312292ms
+        duration: 56.206667ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1514,8 +1514,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/7d99e9ca-2141-4914-8e5e-5526e22eea5e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664/private_nics/65a6cef8-6606-4214-a8db-3d3bafb8327a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1523,18 +1523,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1942
+        content_length: 473
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:01.901705Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:14.342411Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.045621Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecc5e6f-8e74-41b0-b33a-f29a2448293c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.045621Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"3c102c56-68a9-4da8-9fd6-d58c88441353","ipam_config":null,"mac_address":"02:00:00:13:DB:46","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","status":"configuring","updated_at":"2025-01-27T09:16:19.949140Z","zone":"fr-par-1"}],"id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","ip":{"address":"51.15.224.245","created_at":"2025-01-27T09:16:01.788664Z","gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"c7144bb0-d67d-4ef1-ba4c-0ec0ee3f69c7","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"245-224-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.788664Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:14.469821Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.419887+00:00","id":"65a6cef8-6606-4214-a8db-3d3bafb8327a","ipam_ip_ids":["3e273272-2b9c-4913-89c1-3423bf76990c","e80124d6-c1fe-42be-a73e-82653465a258"],"mac_address":"02:00:00:1f:a9:3e","modification_date":"2025-02-12T16:15:10.618558+00:00","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","server_id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1942"
+                - "473"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:24 GMT
+                - Wed, 12 Feb 2025 16:15:16 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1544,10 +1544,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 559eaab8-9b57-4536-a97f-1616a3344f8b
+                - 50ad5297-767d-4943-9881-b44c914736b2
         status: 200 OK
         code: 200
-        duration: 36.416ms
+        duration: 103.85175ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1563,8 +1563,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb/private_nics/a6008d1e-b295-4a3a-a95e-ee520905082a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/01fdf5a9-c2a0-4632-b5a5-03ccab13224f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1572,18 +1572,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 473
+        content_length: 1996
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:19.391848+00:00","id":"a6008d1e-b295-4a3a-a95e-ee520905082a","ipam_ip_ids":["1d82d8f6-cb7b-4a0f-bdb2-b393da83d382","9d60bed2-52c8-4ffa-a014-9edfeb74825a"],"mac_address":"02:00:00:13:ce:84","modification_date":"2025-01-27T09:16:19.603154+00:00","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","server_id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.788246Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:05.808795Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.950362Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0a76d947-25bb-4d14-9c1c-4f48deceb1a6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.950362Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","ipam_config":null,"mac_address":"02:00:00:13:B7:CF","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","status":"ready","updated_at":"2025-02-12T16:15:16.433992Z","zone":"fr-par-1"}],"id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","ip":{"address":"163.172.159.229","created_at":"2025-02-12T16:14:56.642158Z","gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"f6a6b831-81a9-463c-9b7d-2b0f4c38bf0e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.642158Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:16.743346Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "473"
+                - "1996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:25 GMT
+                - Wed, 12 Feb 2025 16:15:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1593,10 +1593,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a71d92b0-1523-4739-9ec8-076bb9305b59
+                - 7e21513f-af1c-4535-9746-f07e734421f7
         status: 200 OK
         code: 200
-        duration: 106.473458ms
+        duration: 52.920959ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1612,8 +1612,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/7d99e9ca-2141-4914-8e5e-5526e22eea5e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13
         method: GET
       response:
         proto: HTTP/2.0
@@ -1621,18 +1621,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1932
+        content_length: 996
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:01.901705Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:14.342411Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.045621Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecc5e6f-8e74-41b0-b33a-f29a2448293c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.045621Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"3c102c56-68a9-4da8-9fd6-d58c88441353","ipam_config":null,"mac_address":"02:00:00:13:DB:46","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","status":"ready","updated_at":"2025-01-27T09:16:24.704221Z","zone":"fr-par-1"}],"id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","ip":{"address":"51.15.224.245","created_at":"2025-01-27T09:16:01.788664Z","gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"c7144bb0-d67d-4ef1-ba4c-0ec0ee3f69c7","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"245-224-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.788664Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:24.893410Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:05.808795Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.950362Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0a76d947-25bb-4d14-9c1c-4f48deceb1a6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.950362Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","ipam_config":null,"mac_address":"02:00:00:13:B7:CF","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","status":"ready","updated_at":"2025-02-12T16:15:16.433992Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1932"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:29 GMT
+                - Wed, 12 Feb 2025 16:15:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1642,10 +1642,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 73806c5e-4960-47a4-ab1b-3fb7ff973ae2
+                - 0851a798-e0b1-4720-8a59-79ba1ee2f237
         status: 200 OK
         code: 200
-        duration: 35.43225ms
+        duration: 67.6715ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1661,8 +1661,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3c102c56-68a9-4da8-9fd6-d58c88441353
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13
         method: GET
       response:
         proto: HTTP/2.0
@@ -1670,18 +1670,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 966
+        content_length: 996
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:14.342411Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.045621Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecc5e6f-8e74-41b0-b33a-f29a2448293c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.045621Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"3c102c56-68a9-4da8-9fd6-d58c88441353","ipam_config":null,"mac_address":"02:00:00:13:DB:46","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","status":"ready","updated_at":"2025-01-27T09:16:24.704221Z","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:05.808795Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.950362Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0a76d947-25bb-4d14-9c1c-4f48deceb1a6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.950362Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","ipam_config":null,"mac_address":"02:00:00:13:B7:CF","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","status":"ready","updated_at":"2025-02-12T16:15:16.433992Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "966"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:29 GMT
+                - Wed, 12 Feb 2025 16:15:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1691,10 +1691,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8d99931c-0ed9-470a-9a35-6ecc7f90bad1
+                - 1ca71362-2e1f-4c6a-8ad4-4bf5746e9c49
         status: 200 OK
         code: 200
-        duration: 48.176791ms
+        duration: 63.419417ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1710,8 +1710,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3c102c56-68a9-4da8-9fd6-d58c88441353
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/01fdf5a9-c2a0-4632-b5a5-03ccab13224f
         method: GET
       response:
         proto: HTTP/2.0
@@ -1719,18 +1719,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 966
+        content_length: 1996
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:14.342411Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.045621Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecc5e6f-8e74-41b0-b33a-f29a2448293c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.045621Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"3c102c56-68a9-4da8-9fd6-d58c88441353","ipam_config":null,"mac_address":"02:00:00:13:DB:46","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","status":"ready","updated_at":"2025-01-27T09:16:24.704221Z","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.788246Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:05.808795Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.950362Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0a76d947-25bb-4d14-9c1c-4f48deceb1a6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.950362Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","ipam_config":null,"mac_address":"02:00:00:13:B7:CF","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","status":"ready","updated_at":"2025-02-12T16:15:16.433992Z","zone":"fr-par-1"}],"id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","ip":{"address":"163.172.159.229","created_at":"2025-02-12T16:14:56.642158Z","gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"f6a6b831-81a9-463c-9b7d-2b0f4c38bf0e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.642158Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:16.743346Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "966"
+                - "1996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:29 GMT
+                - Wed, 12 Feb 2025 16:15:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1740,10 +1740,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3b101f64-e8e9-45b9-880a-7596fde9b49e
+                - 44335c47-7ab3-48f7-9a09-cd8e1cf1a621
         status: 200 OK
         code: 200
-        duration: 140.576917ms
+        duration: 53.026583ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1759,8 +1759,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/7d99e9ca-2141-4914-8e5e-5526e22eea5e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13
         method: GET
       response:
         proto: HTTP/2.0
@@ -1768,18 +1768,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1932
+        content_length: 996
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:01.901705Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:14.342411Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.045621Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecc5e6f-8e74-41b0-b33a-f29a2448293c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.045621Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"3c102c56-68a9-4da8-9fd6-d58c88441353","ipam_config":null,"mac_address":"02:00:00:13:DB:46","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","status":"ready","updated_at":"2025-01-27T09:16:24.704221Z","zone":"fr-par-1"}],"id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","ip":{"address":"51.15.224.245","created_at":"2025-01-27T09:16:01.788664Z","gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"c7144bb0-d67d-4ef1-ba4c-0ec0ee3f69c7","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"245-224-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.788664Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:24.893410Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:05.808795Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.950362Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0a76d947-25bb-4d14-9c1c-4f48deceb1a6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.950362Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","ipam_config":null,"mac_address":"02:00:00:13:B7:CF","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","status":"ready","updated_at":"2025-02-12T16:15:16.433992Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1932"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:29 GMT
+                - Wed, 12 Feb 2025 16:15:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1789,10 +1789,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3d56088c-e101-444e-a167-bac9ad65b51c
+                - eb58d5e1-9ca2-411c-939b-f5dcc6caf67a
         status: 200 OK
         code: 200
-        duration: 26.681958ms
+        duration: 80.785833ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1808,8 +1808,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3c102c56-68a9-4da8-9fd6-d58c88441353
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664/private_nics/65a6cef8-6606-4214-a8db-3d3bafb8327a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1817,18 +1817,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 966
+        content_length: 473
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:14.342411Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.045621Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecc5e6f-8e74-41b0-b33a-f29a2448293c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.045621Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"3c102c56-68a9-4da8-9fd6-d58c88441353","ipam_config":null,"mac_address":"02:00:00:13:DB:46","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","status":"ready","updated_at":"2025-01-27T09:16:24.704221Z","zone":"fr-par-1"}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.419887+00:00","id":"65a6cef8-6606-4214-a8db-3d3bafb8327a","ipam_ip_ids":["3e273272-2b9c-4913-89c1-3423bf76990c","e80124d6-c1fe-42be-a73e-82653465a258"],"mac_address":"02:00:00:1f:a9:3e","modification_date":"2025-02-12T16:15:10.618558+00:00","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","server_id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "966"
+                - "473"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:29 GMT
+                - Wed, 12 Feb 2025 16:15:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1838,10 +1838,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3931a2e0-992f-44f3-a552-808ef84dd46e
+                - 43b86459-7563-4b1c-be51-8651100a4ea8
         status: 200 OK
         code: 200
-        duration: 47.174584ms
+        duration: 140.470333ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1857,8 +1857,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb/private_nics/a6008d1e-b295-4a3a-a95e-ee520905082a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664/private_nics/65a6cef8-6606-4214-a8db-3d3bafb8327a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1868,7 +1868,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:19.391848+00:00","id":"a6008d1e-b295-4a3a-a95e-ee520905082a","ipam_ip_ids":["1d82d8f6-cb7b-4a0f-bdb2-b393da83d382","9d60bed2-52c8-4ffa-a014-9edfeb74825a"],"mac_address":"02:00:00:13:ce:84","modification_date":"2025-01-27T09:16:19.603154+00:00","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","server_id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.419887+00:00","id":"65a6cef8-6606-4214-a8db-3d3bafb8327a","ipam_ip_ids":["3e273272-2b9c-4913-89c1-3423bf76990c","e80124d6-c1fe-42be-a73e-82653465a258"],"mac_address":"02:00:00:1f:a9:3e","modification_date":"2025-02-12T16:15:10.618558+00:00","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","server_id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -1877,7 +1877,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:30 GMT
+                - Wed, 12 Feb 2025 16:15:26 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1887,10 +1887,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4eda061a-2ff2-4ea6-8b9d-dc9527139aab
+                - 4fcbe6bc-13b9-4385-b28a-bc145b78a5fe
         status: 200 OK
         code: 200
-        duration: 88.722875ms
+        duration: 116.534334ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1906,8 +1906,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb/private_nics/a6008d1e-b295-4a3a-a95e-ee520905082a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664/private_nics/65a6cef8-6606-4214-a8db-3d3bafb8327a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1917,7 +1917,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:19.391848+00:00","id":"a6008d1e-b295-4a3a-a95e-ee520905082a","ipam_ip_ids":["1d82d8f6-cb7b-4a0f-bdb2-b393da83d382","9d60bed2-52c8-4ffa-a014-9edfeb74825a"],"mac_address":"02:00:00:13:ce:84","modification_date":"2025-01-27T09:16:19.603154+00:00","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","server_id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.419887+00:00","id":"65a6cef8-6606-4214-a8db-3d3bafb8327a","ipam_ip_ids":["3e273272-2b9c-4913-89c1-3423bf76990c","e80124d6-c1fe-42be-a73e-82653465a258"],"mac_address":"02:00:00:1f:a9:3e","modification_date":"2025-02-12T16:15:10.618558+00:00","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","server_id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -1926,7 +1926,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:35 GMT
+                - Wed, 12 Feb 2025 16:15:31 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1936,10 +1936,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c6810748-a56c-48d8-918e-5e99e08a8c53
+                - 6e9378fe-7168-40ba-a2ae-3c610430cc1b
         status: 200 OK
         code: 200
-        duration: 106.7255ms
+        duration: 147.473916ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1955,8 +1955,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb/private_nics/a6008d1e-b295-4a3a-a95e-ee520905082a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664/private_nics/65a6cef8-6606-4214-a8db-3d3bafb8327a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1966,7 +1966,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:19.391848+00:00","id":"a6008d1e-b295-4a3a-a95e-ee520905082a","ipam_ip_ids":["1d82d8f6-cb7b-4a0f-bdb2-b393da83d382","9d60bed2-52c8-4ffa-a014-9edfeb74825a"],"mac_address":"02:00:00:13:ce:84","modification_date":"2025-01-27T09:16:19.603154+00:00","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","server_id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.419887+00:00","id":"65a6cef8-6606-4214-a8db-3d3bafb8327a","ipam_ip_ids":["3e273272-2b9c-4913-89c1-3423bf76990c","e80124d6-c1fe-42be-a73e-82653465a258"],"mac_address":"02:00:00:1f:a9:3e","modification_date":"2025-02-12T16:15:10.618558+00:00","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","server_id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -1975,7 +1975,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:40 GMT
+                - Wed, 12 Feb 2025 16:15:37 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1985,10 +1985,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - de204488-3a2f-4e9f-adf5-f1fddee8e6eb
+                - 41498382-9e9b-4160-9e2d-94e18339c046
         status: 200 OK
         code: 200
-        duration: 90.337583ms
+        duration: 116.117583ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2004,8 +2004,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb/private_nics/a6008d1e-b295-4a3a-a95e-ee520905082a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664/private_nics/65a6cef8-6606-4214-a8db-3d3bafb8327a
         method: GET
       response:
         proto: HTTP/2.0
@@ -2015,7 +2015,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:19.391848+00:00","id":"a6008d1e-b295-4a3a-a95e-ee520905082a","ipam_ip_ids":["1d82d8f6-cb7b-4a0f-bdb2-b393da83d382","9d60bed2-52c8-4ffa-a014-9edfeb74825a"],"mac_address":"02:00:00:13:ce:84","modification_date":"2025-01-27T09:16:19.603154+00:00","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","server_id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.419887+00:00","id":"65a6cef8-6606-4214-a8db-3d3bafb8327a","ipam_ip_ids":["3e273272-2b9c-4913-89c1-3423bf76990c","e80124d6-c1fe-42be-a73e-82653465a258"],"mac_address":"02:00:00:1f:a9:3e","modification_date":"2025-02-12T16:15:10.618558+00:00","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","server_id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -2024,7 +2024,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:45 GMT
+                - Wed, 12 Feb 2025 16:15:41 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2034,10 +2034,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 741bc3bd-f2c7-4fb3-8d2c-b6df00ff208f
+                - 32b2d0b4-5e6c-4816-8514-761cc870408f
         status: 200 OK
         code: 200
-        duration: 71.27125ms
+        duration: 110.618583ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2053,8 +2053,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb/private_nics/a6008d1e-b295-4a3a-a95e-ee520905082a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664/private_nics/65a6cef8-6606-4214-a8db-3d3bafb8327a
         method: GET
       response:
         proto: HTTP/2.0
@@ -2062,18 +2062,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 473
+        content_length: 475
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:19.391848+00:00","id":"a6008d1e-b295-4a3a-a95e-ee520905082a","ipam_ip_ids":["1d82d8f6-cb7b-4a0f-bdb2-b393da83d382","9d60bed2-52c8-4ffa-a014-9edfeb74825a"],"mac_address":"02:00:00:13:ce:84","modification_date":"2025-01-27T09:16:19.603154+00:00","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","server_id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.419887+00:00","id":"65a6cef8-6606-4214-a8db-3d3bafb8327a","ipam_ip_ids":["3e273272-2b9c-4913-89c1-3423bf76990c","e80124d6-c1fe-42be-a73e-82653465a258"],"mac_address":"02:00:00:1f:a9:3e","modification_date":"2025-02-12T16:15:42.433310+00:00","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","server_id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "473"
+                - "475"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:51 GMT
+                - Wed, 12 Feb 2025 16:15:47 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2083,10 +2083,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ce11531a-0cfd-4988-ae05-a245e8628ed7
+                - 75f4b28a-7258-47f0-a277-97b27f4990da
         status: 200 OK
         code: 200
-        duration: 647.759375ms
+        duration: 87.742083ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2102,8 +2102,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb/private_nics/a6008d1e-b295-4a3a-a95e-ee520905082a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664/private_nics/65a6cef8-6606-4214-a8db-3d3bafb8327a
         method: GET
       response:
         proto: HTTP/2.0
@@ -2113,7 +2113,7 @@ interactions:
         trailer: {}
         content_length: 475
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:19.391848+00:00","id":"a6008d1e-b295-4a3a-a95e-ee520905082a","ipam_ip_ids":["1d82d8f6-cb7b-4a0f-bdb2-b393da83d382","9d60bed2-52c8-4ffa-a014-9edfeb74825a"],"mac_address":"02:00:00:13:ce:84","modification_date":"2025-01-27T09:16:51.719632+00:00","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","server_id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.419887+00:00","id":"65a6cef8-6606-4214-a8db-3d3bafb8327a","ipam_ip_ids":["3e273272-2b9c-4913-89c1-3423bf76990c","e80124d6-c1fe-42be-a73e-82653465a258"],"mac_address":"02:00:00:1f:a9:3e","modification_date":"2025-02-12T16:15:42.433310+00:00","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","server_id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "475"
@@ -2122,7 +2122,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:56 GMT
+                - Wed, 12 Feb 2025 16:15:47 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2132,10 +2132,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6537a886-b46c-4efb-b120-141fb23a3888
+                - 50469b7b-c8ed-445c-bd35-fa7db600a914
         status: 200 OK
         code: 200
-        duration: 94.539375ms
+        duration: 99.020334ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2151,8 +2151,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb/private_nics/a6008d1e-b295-4a3a-a95e-ee520905082a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664
         method: GET
       response:
         proto: HTTP/2.0
@@ -2160,18 +2160,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 475
+        content_length: 2282
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:19.391848+00:00","id":"a6008d1e-b295-4a3a-a95e-ee520905082a","ipam_ip_ids":["1d82d8f6-cb7b-4a0f-bdb2-b393da83d382","9d60bed2-52c8-4ffa-a014-9edfeb74825a"],"mac_address":"02:00:00:13:ce:84","modification_date":"2025-01-27T09:16:51.719632+00:00","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","server_id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.167923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-panini","id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"402","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d7","maintenances":[],"modification_date":"2025-02-12T16:15:05.175736+00:00","name":"tf-srv-eager-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:10.419887+00:00","id":"65a6cef8-6606-4214-a8db-3d3bafb8327a","ipam_ip_ids":["3e273272-2b9c-4913-89c1-3423bf76990c","e80124d6-c1fe-42be-a73e-82653465a258"],"mac_address":"02:00:00:1f:a9:3e","modification_date":"2025-02-12T16:15:42.433310+00:00","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","server_id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"b3862f05-55df-4387-ab1e-f975957752e5","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "475"
+                - "2282"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:56 GMT
+                - Wed, 12 Feb 2025 16:15:47 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2181,10 +2181,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3371d505-c01d-45af-98cc-075009b6a659
+                - 4debc9f5-9201-460c-aea4-8d4c04084010
         status: 200 OK
         code: 200
-        duration: 81.630083ms
+        duration: 171.881541ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2200,8 +2200,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b3862f05-55df-4387-ab1e-f975957752e5
         method: GET
       response:
         proto: HTTP/2.0
@@ -2209,18 +2209,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2739
+        content_length: 143
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.059639+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-stonebraker","id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1401","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:1d","maintenances":[],"modification_date":"2025-01-27T09:16:15.581118+00:00","name":"tf-srv-funny-stonebraker","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:19.391848+00:00","id":"a6008d1e-b295-4a3a-a95e-ee520905082a","ipam_ip_ids":["1d82d8f6-cb7b-4a0f-bdb2-b393da83d382","9d60bed2-52c8-4ffa-a014-9edfeb74825a"],"mac_address":"02:00:00:13:ce:84","modification_date":"2025-01-27T09:16:51.719632+00:00","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","server_id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.059639+00:00","export_uri":null,"id":"89d36a9f-ba55-4c09-a3a6-ef9520673300","modification_date":"2025-01-27T09:16:02.059639+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","name":"tf-srv-funny-stonebraker"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"b3862f05-55df-4387-ab1e-f975957752e5","type":"not_found"}'
         headers:
             Content-Length:
-                - "2739"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:56 GMT
+                - Wed, 12 Feb 2025 16:15:47 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2230,10 +2230,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 94c78f20-eb7e-4e91-b6a9-3577cafc6ccf
-        status: 200 OK
-        code: 200
-        duration: 169.357875ms
+                - bd57b03b-0b02-4e72-9664-a61683f208a0
+        status: 404 Not Found
+        code: 404
+        duration: 57.588708ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2249,8 +2249,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/89d36a9f-ba55-4c09-a3a6-ef9520673300
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/b3862f05-55df-4387-ab1e-f975957752e5
         method: GET
       response:
         proto: HTTP/2.0
@@ -2258,18 +2258,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 524
+        content_length: 701
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T09:16:02.059639+00:00","export_uri":null,"id":"89d36a9f-ba55-4c09-a3a6-ef9520673300","modification_date":"2025-01-27T09:16:02.059639+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","name":"tf-srv-funny-stonebraker"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-12T16:14:57.634432Z","id":"b3862f05-55df-4387-ab1e-f975957752e5","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:14:57.634432Z","id":"2e55d1b6-aa93-4d99-91a5-cf2874697e34","product_resource_id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:14:57.634432Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "524"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:56 GMT
+                - Wed, 12 Feb 2025 16:15:47 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2279,10 +2279,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3e687e69-f2ae-4913-918c-ecbb2604653b
+                - fbc39f5a-b820-4620-8bf8-3caca7d9149d
         status: 200 OK
         code: 200
-        duration: 96.251291ms
+        duration: 84.818209ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2298,8 +2298,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -2318,7 +2318,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:57 GMT
+                - Wed, 12 Feb 2025 16:15:47 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2328,10 +2328,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b8fc1988-f48e-4947-a5aa-02ef28481c5d
+                - 9aef9f71-1843-4cb5-887c-e947f19e1528
         status: 200 OK
         code: 200
-        duration: 98.351083ms
+        duration: 129.068041ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2347,8 +2347,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -2358,7 +2358,7 @@ interactions:
         trailer: {}
         content_length: 478
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T09:16:19.391848+00:00","id":"a6008d1e-b295-4a3a-a95e-ee520905082a","ipam_ip_ids":["1d82d8f6-cb7b-4a0f-bdb2-b393da83d382","9d60bed2-52c8-4ffa-a014-9edfeb74825a"],"mac_address":"02:00:00:13:ce:84","modification_date":"2025-01-27T09:16:51.719632+00:00","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","server_id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:15:10.419887+00:00","id":"65a6cef8-6606-4214-a8db-3d3bafb8327a","ipam_ip_ids":["3e273272-2b9c-4913-89c1-3423bf76990c","e80124d6-c1fe-42be-a73e-82653465a258"],"mac_address":"02:00:00:1f:a9:3e","modification_date":"2025-02-12T16:15:42.433310+00:00","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","server_id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
                 - "478"
@@ -2367,9 +2367,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:57 GMT
+                - Wed, 12 Feb 2025 16:15:48 GMT
             Link:
-                - </servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb/private_nics?page=1&per_page=50&>; rel="last"
+                - </servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664/private_nics?page=1&per_page=50&>; rel="last"
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2379,12 +2379,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bc6768cd-e83d-4b73-8154-8447b94ee23c
+                - 0668b0e1-d5dc-49e2-94e1-5c6a7fb48f5b
             X-Total-Count:
                 - "1"
         status: 200 OK
         code: 200
-        duration: 104.23825ms
+        duration: 118.242ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2400,8 +2400,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3c102c56-68a9-4da8-9fd6-d58c88441353
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13
         method: GET
       response:
         proto: HTTP/2.0
@@ -2409,18 +2409,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 966
+        content_length: 996
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:14.342411Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.045621Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecc5e6f-8e74-41b0-b33a-f29a2448293c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.045621Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"3c102c56-68a9-4da8-9fd6-d58c88441353","ipam_config":null,"mac_address":"02:00:00:13:DB:46","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","status":"ready","updated_at":"2025-01-27T09:16:24.704221Z","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:05.808795Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.950362Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0a76d947-25bb-4d14-9c1c-4f48deceb1a6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.950362Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","ipam_config":null,"mac_address":"02:00:00:13:B7:CF","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","status":"ready","updated_at":"2025-02-12T16:15:16.433992Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "966"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:57 GMT
+                - Wed, 12 Feb 2025 16:15:48 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2430,10 +2430,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a7d2adb8-de0b-4992-9d41-e0f4aec38f23
+                - 02631ac0-85d3-4eb9-923b-f2ba6312af8d
         status: 200 OK
         code: 200
-        duration: 48.177958ms
+        duration: 62.913583ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2445,13 +2445,13 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"gateway_network_id":"3c102c56-68a9-4da8-9fd6-d58c88441353","mac_address":"02:00:00:13:ce:84","ip_address":"192.168.1.1"}'
+        body: '{"gateway_network_id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","mac_address":"02:00:00:1f:a9:3e","ip_address":"192.168.1.1"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries
         method: POST
       response:
@@ -2460,18 +2460,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 329
+        content_length: 332
         uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:19.829417Z","gateway_network_id":"3c102c56-68a9-4da8-9fd6-d58c88441353","hostname":"tf-srv-funny-stonebraker","id":"1d82d8f6-cb7b-4a0f-bdb2-b393da83d382","ip_address":"192.168.1.1","mac_address":"02:00:00:13:ce:84","type":"reservation","updated_at":"2025-01-27T09:16:57.854308Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:15:10.833284Z","gateway_network_id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","hostname":"tf-srv-eager-panini","id":"3e273272-2b9c-4913-89c1-3423bf76990c","ip_address":"192.168.1.1","mac_address":"02:00:00:1f:a9:3e","type":"reservation","updated_at":"2025-02-12T16:15:48.633492Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "329"
+                - "332"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:57 GMT
+                - Wed, 12 Feb 2025 16:15:48 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2481,10 +2481,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b270275a-dd2f-4010-9352-d5411b3bf301
+                - 82a5fa9a-18b8-4f41-8403-1f94222dfd94
         status: 200 OK
         code: 200
-        duration: 422.892875ms
+        duration: 598.923708ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -2500,8 +2500,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3c102c56-68a9-4da8-9fd6-d58c88441353
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13
         method: GET
       response:
         proto: HTTP/2.0
@@ -2509,18 +2509,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 966
+        content_length: 996
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:14.342411Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.045621Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecc5e6f-8e74-41b0-b33a-f29a2448293c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.045621Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"3c102c56-68a9-4da8-9fd6-d58c88441353","ipam_config":null,"mac_address":"02:00:00:13:DB:46","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","status":"ready","updated_at":"2025-01-27T09:16:24.704221Z","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:05.808795Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.950362Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0a76d947-25bb-4d14-9c1c-4f48deceb1a6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.950362Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","ipam_config":null,"mac_address":"02:00:00:13:B7:CF","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","status":"ready","updated_at":"2025-02-12T16:15:16.433992Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "966"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:57 GMT
+                - Wed, 12 Feb 2025 16:15:48 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2530,10 +2530,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ef6198b5-1dad-4a87-a2a0-41a415f8b2af
+                - f2c8c839-01ca-4b26-9242-63792c565323
         status: 200 OK
         code: 200
-        duration: 45.354167ms
+        duration: 66.963209ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2549,8 +2549,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/1d82d8f6-cb7b-4a0f-bdb2-b393da83d382
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/3e273272-2b9c-4913-89c1-3423bf76990c
         method: GET
       response:
         proto: HTTP/2.0
@@ -2558,18 +2558,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 329
+        content_length: 332
         uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:19.829417Z","gateway_network_id":"3c102c56-68a9-4da8-9fd6-d58c88441353","hostname":"tf-srv-funny-stonebraker","id":"1d82d8f6-cb7b-4a0f-bdb2-b393da83d382","ip_address":"192.168.1.1","mac_address":"02:00:00:13:ce:84","type":"reservation","updated_at":"2025-01-27T09:16:57.854308Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:15:10.833284Z","gateway_network_id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","hostname":"tf-srv-eager-panini","id":"3e273272-2b9c-4913-89c1-3423bf76990c","ip_address":"192.168.1.1","mac_address":"02:00:00:1f:a9:3e","type":"reservation","updated_at":"2025-02-12T16:15:48.633492Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "329"
+                - "332"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:58 GMT
+                - Wed, 12 Feb 2025 16:15:48 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2579,10 +2579,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f7184321-3411-4fbb-b0b9-f1493d9d51bf
+                - 7cb59033-bf25-4422-9198-8ace3038593d
         status: 200 OK
         code: 200
-        duration: 84.886541ms
+        duration: 86.816084ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -2598,8 +2598,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/1d82d8f6-cb7b-4a0f-bdb2-b393da83d382
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/3e273272-2b9c-4913-89c1-3423bf76990c
         method: GET
       response:
         proto: HTTP/2.0
@@ -2607,18 +2607,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 329
+        content_length: 332
         uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:19.829417Z","gateway_network_id":"3c102c56-68a9-4da8-9fd6-d58c88441353","hostname":"tf-srv-funny-stonebraker","id":"1d82d8f6-cb7b-4a0f-bdb2-b393da83d382","ip_address":"192.168.1.1","mac_address":"02:00:00:13:ce:84","type":"reservation","updated_at":"2025-01-27T09:16:57.854308Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:15:10.833284Z","gateway_network_id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","hostname":"tf-srv-eager-panini","id":"3e273272-2b9c-4913-89c1-3423bf76990c","ip_address":"192.168.1.1","mac_address":"02:00:00:1f:a9:3e","type":"reservation","updated_at":"2025-02-12T16:15:48.633492Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "329"
+                - "332"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:58 GMT
+                - Wed, 12 Feb 2025 16:15:49 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2628,10 +2628,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 81840038-65ce-4614-936a-239c8c2a9afd
+                - f57da0df-63ec-4f38-bf7f-295b774f795e
         status: 200 OK
         code: 200
-        duration: 64.033375ms
+        duration: 104.875083ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -2647,8 +2647,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/c7144bb0-d67d-4ef1-ba4c-0ec0ee3f69c7
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/f6a6b831-81a9-463c-9b7d-2b0f4c38bf0e
         method: GET
       response:
         proto: HTTP/2.0
@@ -2656,18 +2656,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 392
+        content_length: 405
         uncompressed: false
-        body: '{"address":"51.15.224.245","created_at":"2025-01-27T09:16:01.788664Z","gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"c7144bb0-d67d-4ef1-ba4c-0ec0ee3f69c7","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"245-224-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.788664Z","zone":"fr-par-1"}'
+        body: '{"address":"163.172.159.229","created_at":"2025-02-12T16:14:56.642158Z","gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"f6a6b831-81a9-463c-9b7d-2b0f4c38bf0e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.642158Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "392"
+                - "405"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:58 GMT
+                - Wed, 12 Feb 2025 16:15:49 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2677,10 +2677,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1f444ec7-88f5-4f6e-af85-1983ae741288
+                - da0fee8c-39b1-4c9b-8096-f09f15d51dbc
         status: 200 OK
         code: 200
-        duration: 26.942375ms
+        duration: 42.277667ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -2696,8 +2696,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/1ecc5e6f-8e74-41b0-b33a-f29a2448293c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/0a76d947-25bb-4d14-9c1c-4f48deceb1a6
         method: GET
       response:
         proto: HTTP/2.0
@@ -2705,18 +2705,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 568
+        content_length: 586
         uncompressed: false
-        body: '{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.045621Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecc5e6f-8e74-41b0-b33a-f29a2448293c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.045621Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+        body: '{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.950362Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0a76d947-25bb-4d14-9c1c-4f48deceb1a6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.950362Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "568"
+                - "586"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:58 GMT
+                - Wed, 12 Feb 2025 16:15:49 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2726,10 +2726,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6d1bd3aa-bba1-499c-bbe9-268450f80841
+                - 74c8fffa-9961-4cea-a592-54a828661991
         status: 200 OK
         code: 200
-        duration: 23.825583ms
+        duration: 41.963625ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -2745,8 +2745,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f96914f9-4114-4d1f-aa48-077fab624873
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7a3b6ed2-5295-4ce1-a78f-e24d90879aec
         method: GET
       response:
         proto: HTTP/2.0
@@ -2754,18 +2754,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1019
+        content_length: 1042
         uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:01.080341Z","dhcp_enabled":true,"id":"f96914f9-4114-4d1f-aa48-077fab624873","name":"pn_test_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T09:16:01.080341Z","id":"c6e3530a-51ec-428b-8e49-4863d5d267de","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:12.351404Z","vpc_id":"c77c01c3-0e24-4343-81fd-841906ccc123"},{"created_at":"2025-01-27T09:16:01.080341Z","id":"1498f716-3ced-4cf5-8f1c-8ef67fb0d50e","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:4c24::/64","updated_at":"2025-01-27T09:16:12.355245Z","vpc_id":"c77c01c3-0e24-4343-81fd-841906ccc123"}],"tags":[],"updated_at":"2025-01-27T09:16:20.799954Z","vpc_id":"c77c01c3-0e24-4343-81fd-841906ccc123"}'
+        body: '{"created_at":"2025-02-12T16:14:55.931102Z","dhcp_enabled":true,"id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","name":"pn_test_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:14:55.931102Z","id":"5e027010-cd96-4711-b69d-480bb60a697e","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:15:02.351322Z","vpc_id":"21689b9a-7cd1-4cf4-a47d-3bdd0f69315c"},{"created_at":"2025-02-12T16:14:55.931102Z","id":"e4dcfa97-3290-480c-a712-7c50de07a6ea","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:c29e::/64","updated_at":"2025-02-12T16:15:02.357183Z","vpc_id":"21689b9a-7cd1-4cf4-a47d-3bdd0f69315c"}],"tags":[],"updated_at":"2025-02-12T16:15:12.562058Z","vpc_id":"21689b9a-7cd1-4cf4-a47d-3bdd0f69315c"}'
         headers:
             Content-Length:
-                - "1019"
+                - "1042"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:59 GMT
+                - Wed, 12 Feb 2025 16:15:49 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2775,10 +2775,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1c708eb1-4dc7-441e-bd1e-134ce8e25a8c
+                - ed1a8183-1b04-4eaf-9b56-778ed2db4926
         status: 200 OK
         code: 200
-        duration: 25.63425ms
+        duration: 48.872417ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2794,8 +2794,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/7d99e9ca-2141-4914-8e5e-5526e22eea5e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/01fdf5a9-c2a0-4632-b5a5-03ccab13224f
         method: GET
       response:
         proto: HTTP/2.0
@@ -2803,18 +2803,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1932
+        content_length: 1996
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:01.901705Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:14.342411Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.045621Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecc5e6f-8e74-41b0-b33a-f29a2448293c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.045621Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"3c102c56-68a9-4da8-9fd6-d58c88441353","ipam_config":null,"mac_address":"02:00:00:13:DB:46","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","status":"ready","updated_at":"2025-01-27T09:16:24.704221Z","zone":"fr-par-1"}],"id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","ip":{"address":"51.15.224.245","created_at":"2025-01-27T09:16:01.788664Z","gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"c7144bb0-d67d-4ef1-ba4c-0ec0ee3f69c7","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"245-224-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.788664Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:24.893410Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.788246Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:05.808795Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.950362Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0a76d947-25bb-4d14-9c1c-4f48deceb1a6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.950362Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","ipam_config":null,"mac_address":"02:00:00:13:B7:CF","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","status":"ready","updated_at":"2025-02-12T16:15:16.433992Z","zone":"fr-par-1"}],"id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","ip":{"address":"163.172.159.229","created_at":"2025-02-12T16:14:56.642158Z","gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"f6a6b831-81a9-463c-9b7d-2b0f4c38bf0e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.642158Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:16.743346Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1932"
+                - "1996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:59 GMT
+                - Wed, 12 Feb 2025 16:15:49 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2824,10 +2824,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 306cd072-45e2-4277-bd1e-011a8cd730d8
+                - 601437ed-19d9-4dda-94a8-dc31475fffc1
         status: 200 OK
         code: 200
-        duration: 24.5855ms
+        duration: 44.124875ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2843,8 +2843,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3c102c56-68a9-4da8-9fd6-d58c88441353
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13
         method: GET
       response:
         proto: HTTP/2.0
@@ -2852,18 +2852,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 966
+        content_length: 996
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:14.342411Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.045621Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecc5e6f-8e74-41b0-b33a-f29a2448293c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.045621Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"3c102c56-68a9-4da8-9fd6-d58c88441353","ipam_config":null,"mac_address":"02:00:00:13:DB:46","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","status":"ready","updated_at":"2025-01-27T09:16:24.704221Z","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:05.808795Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.950362Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0a76d947-25bb-4d14-9c1c-4f48deceb1a6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.950362Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","ipam_config":null,"mac_address":"02:00:00:13:B7:CF","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","status":"ready","updated_at":"2025-02-12T16:15:16.433992Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "966"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:59 GMT
+                - Wed, 12 Feb 2025 16:15:49 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2873,10 +2873,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5e8af785-89dc-4c27-9fa4-a8879a8e32c2
+                - 809c04d5-4632-42a2-8bd8-08b2148e0838
         status: 200 OK
         code: 200
-        duration: 46.301292ms
+        duration: 66.761125ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -2892,8 +2892,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/7d99e9ca-2141-4914-8e5e-5526e22eea5e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/01fdf5a9-c2a0-4632-b5a5-03ccab13224f
         method: GET
       response:
         proto: HTTP/2.0
@@ -2901,18 +2901,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1932
+        content_length: 1996
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:01.901705Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:14.342411Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.045621Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecc5e6f-8e74-41b0-b33a-f29a2448293c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.045621Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"3c102c56-68a9-4da8-9fd6-d58c88441353","ipam_config":null,"mac_address":"02:00:00:13:DB:46","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","status":"ready","updated_at":"2025-01-27T09:16:24.704221Z","zone":"fr-par-1"}],"id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","ip":{"address":"51.15.224.245","created_at":"2025-01-27T09:16:01.788664Z","gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"c7144bb0-d67d-4ef1-ba4c-0ec0ee3f69c7","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"245-224-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.788664Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:24.893410Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.788246Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:05.808795Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.950362Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0a76d947-25bb-4d14-9c1c-4f48deceb1a6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.950362Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","ipam_config":null,"mac_address":"02:00:00:13:B7:CF","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","status":"ready","updated_at":"2025-02-12T16:15:16.433992Z","zone":"fr-par-1"}],"id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","ip":{"address":"163.172.159.229","created_at":"2025-02-12T16:14:56.642158Z","gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"f6a6b831-81a9-463c-9b7d-2b0f4c38bf0e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.642158Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:16.743346Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1932"
+                - "1996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:59 GMT
+                - Wed, 12 Feb 2025 16:15:49 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2922,10 +2922,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1767a663-7cb7-415f-8d2a-dcc89ca413bc
+                - 8a3c6d77-1981-485f-8aec-0a264f00fed5
         status: 200 OK
         code: 200
-        duration: 28.162958ms
+        duration: 49.574209ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -2941,8 +2941,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3c102c56-68a9-4da8-9fd6-d58c88441353
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13
         method: GET
       response:
         proto: HTTP/2.0
@@ -2950,18 +2950,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 966
+        content_length: 996
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:14.342411Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.045621Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecc5e6f-8e74-41b0-b33a-f29a2448293c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.045621Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"3c102c56-68a9-4da8-9fd6-d58c88441353","ipam_config":null,"mac_address":"02:00:00:13:DB:46","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","status":"ready","updated_at":"2025-01-27T09:16:24.704221Z","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:05.808795Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.950362Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0a76d947-25bb-4d14-9c1c-4f48deceb1a6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.950362Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","ipam_config":null,"mac_address":"02:00:00:13:B7:CF","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","status":"ready","updated_at":"2025-02-12T16:15:16.433992Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "966"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:59 GMT
+                - Wed, 12 Feb 2025 16:15:49 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2971,10 +2971,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e5206e59-247e-4b2f-a34f-50072b8ed8aa
+                - 029dcaba-c6f8-4366-888e-04bdf2f07f03
         status: 200 OK
         code: 200
-        duration: 47.449458ms
+        duration: 60.945834ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -2990,8 +2990,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664
         method: GET
       response:
         proto: HTTP/2.0
@@ -2999,18 +2999,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2739
+        content_length: 2282
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.059639+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-stonebraker","id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1401","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:1d","maintenances":[],"modification_date":"2025-01-27T09:16:15.581118+00:00","name":"tf-srv-funny-stonebraker","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:19.391848+00:00","id":"a6008d1e-b295-4a3a-a95e-ee520905082a","ipam_ip_ids":["1d82d8f6-cb7b-4a0f-bdb2-b393da83d382","9d60bed2-52c8-4ffa-a014-9edfeb74825a"],"mac_address":"02:00:00:13:ce:84","modification_date":"2025-01-27T09:16:51.719632+00:00","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","server_id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.059639+00:00","export_uri":null,"id":"89d36a9f-ba55-4c09-a3a6-ef9520673300","modification_date":"2025-01-27T09:16:02.059639+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","name":"tf-srv-funny-stonebraker"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.167923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-panini","id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"402","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d7","maintenances":[],"modification_date":"2025-02-12T16:15:05.175736+00:00","name":"tf-srv-eager-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:10.419887+00:00","id":"65a6cef8-6606-4214-a8db-3d3bafb8327a","ipam_ip_ids":["3e273272-2b9c-4913-89c1-3423bf76990c","e80124d6-c1fe-42be-a73e-82653465a258"],"mac_address":"02:00:00:1f:a9:3e","modification_date":"2025-02-12T16:15:42.433310+00:00","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","server_id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"b3862f05-55df-4387-ab1e-f975957752e5","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2739"
+                - "2282"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:59 GMT
+                - Wed, 12 Feb 2025 16:15:49 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3020,10 +3020,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 214c4c94-294a-4fc9-9fc1-9e56bdfbcb87
+                - 3e7df89c-c1b7-4049-963a-d8ebc1f20bbd
         status: 200 OK
         code: 200
-        duration: 179.859375ms
+        duration: 243.828291ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -3039,8 +3039,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/89d36a9f-ba55-4c09-a3a6-ef9520673300
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b3862f05-55df-4387-ab1e-f975957752e5
         method: GET
       response:
         proto: HTTP/2.0
@@ -3048,18 +3048,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 524
+        content_length: 143
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T09:16:02.059639+00:00","export_uri":null,"id":"89d36a9f-ba55-4c09-a3a6-ef9520673300","modification_date":"2025-01-27T09:16:02.059639+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","name":"tf-srv-funny-stonebraker"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"b3862f05-55df-4387-ab1e-f975957752e5","type":"not_found"}'
         headers:
             Content-Length:
-                - "524"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:59 GMT
+                - Wed, 12 Feb 2025 16:15:49 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3069,10 +3069,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 46e99de3-8d22-4764-a932-1188721be164
-        status: 200 OK
-        code: 200
-        duration: 141.156292ms
+                - d1d969fa-e720-4442-a3f7-6a262cd771b6
+        status: 404 Not Found
+        code: 404
+        duration: 45.924708ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -3088,8 +3088,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/b3862f05-55df-4387-ab1e-f975957752e5
         method: GET
       response:
         proto: HTTP/2.0
@@ -3097,18 +3097,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 701
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"created_at":"2025-02-12T16:14:57.634432Z","id":"b3862f05-55df-4387-ab1e-f975957752e5","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:14:57.634432Z","id":"2e55d1b6-aa93-4d99-91a5-cf2874697e34","product_resource_id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:14:57.634432Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "17"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:59 GMT
+                - Wed, 12 Feb 2025 16:15:49 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3118,10 +3118,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 82a21674-f00f-4f21-b33b-5df533788bae
+                - 0fbb6423-27bd-466c-801e-06a048a6ce42
         status: 200 OK
         code: 200
-        duration: 109.662667ms
+        duration: 86.4465ms
     - id: 63
       request:
         proto: HTTP/1.1
@@ -3137,551 +3137,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb/private_nics
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 478
-        uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T09:16:19.391848+00:00","id":"a6008d1e-b295-4a3a-a95e-ee520905082a","ipam_ip_ids":["1d82d8f6-cb7b-4a0f-bdb2-b393da83d382","9d60bed2-52c8-4ffa-a014-9edfeb74825a"],"mac_address":"02:00:00:13:ce:84","modification_date":"2025-01-27T09:16:51.719632+00:00","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","server_id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","state":"available","tags":[],"zone":"fr-par-1"}]}'
-        headers:
-            Content-Length:
-                - "478"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:16:59 GMT
-            Link:
-                - </servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb/private_nics?page=1&per_page=50&>; rel="last"
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - a14192b4-a3ef-4d7a-b5e3-0fd751da601e
-            X-Total-Count:
-                - "1"
-        status: 200 OK
-        code: 200
-        duration: 81.047084ms
-    - id: 64
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/1d82d8f6-cb7b-4a0f-bdb2-b393da83d382
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 329
-        uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:19.829417Z","gateway_network_id":"3c102c56-68a9-4da8-9fd6-d58c88441353","hostname":"tf-srv-funny-stonebraker","id":"1d82d8f6-cb7b-4a0f-bdb2-b393da83d382","ip_address":"192.168.1.1","mac_address":"02:00:00:13:ce:84","type":"reservation","updated_at":"2025-01-27T09:16:57.854308Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "329"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:16:59 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - cd928c3e-df5d-42b9-9b2f-b7db919af344
-        status: 200 OK
-        code: 200
-        duration: 75.584375ms
-    - id: 65
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/1ecc5e6f-8e74-41b0-b33a-f29a2448293c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 568
-        uncompressed: false
-        body: '{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.045621Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecc5e6f-8e74-41b0-b33a-f29a2448293c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.045621Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "568"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:00 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 49e4fc92-6386-4112-924c-cd02f0f95395
-        status: 200 OK
-        code: 200
-        duration: 41.44625ms
-    - id: 66
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f96914f9-4114-4d1f-aa48-077fab624873
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1019
-        uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:01.080341Z","dhcp_enabled":true,"id":"f96914f9-4114-4d1f-aa48-077fab624873","name":"pn_test_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T09:16:01.080341Z","id":"c6e3530a-51ec-428b-8e49-4863d5d267de","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:12.351404Z","vpc_id":"c77c01c3-0e24-4343-81fd-841906ccc123"},{"created_at":"2025-01-27T09:16:01.080341Z","id":"1498f716-3ced-4cf5-8f1c-8ef67fb0d50e","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:4c24::/64","updated_at":"2025-01-27T09:16:12.355245Z","vpc_id":"c77c01c3-0e24-4343-81fd-841906ccc123"}],"tags":[],"updated_at":"2025-01-27T09:16:20.799954Z","vpc_id":"c77c01c3-0e24-4343-81fd-841906ccc123"}'
-        headers:
-            Content-Length:
-                - "1019"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:00 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - b75f67d5-5a9e-4278-8693-4b507bf01fc6
-        status: 200 OK
-        code: 200
-        duration: 43.897791ms
-    - id: 67
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/c7144bb0-d67d-4ef1-ba4c-0ec0ee3f69c7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 392
-        uncompressed: false
-        body: '{"address":"51.15.224.245","created_at":"2025-01-27T09:16:01.788664Z","gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"c7144bb0-d67d-4ef1-ba4c-0ec0ee3f69c7","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"245-224-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.788664Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "392"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:00 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 4642ba9c-6ca7-411f-8bcd-28695dba62a0
-        status: 200 OK
-        code: 200
-        duration: 49.894875ms
-    - id: 68
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/7d99e9ca-2141-4914-8e5e-5526e22eea5e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1932
-        uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:01.901705Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:14.342411Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.045621Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecc5e6f-8e74-41b0-b33a-f29a2448293c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.045621Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"3c102c56-68a9-4da8-9fd6-d58c88441353","ipam_config":null,"mac_address":"02:00:00:13:DB:46","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","status":"ready","updated_at":"2025-01-27T09:16:24.704221Z","zone":"fr-par-1"}],"id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","ip":{"address":"51.15.224.245","created_at":"2025-01-27T09:16:01.788664Z","gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"c7144bb0-d67d-4ef1-ba4c-0ec0ee3f69c7","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"245-224-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.788664Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:24.893410Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "1932"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:00 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - a8885d85-36e5-448f-b1ab-1c0cfe56e8e7
-        status: 200 OK
-        code: 200
-        duration: 25.91675ms
-    - id: 69
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3c102c56-68a9-4da8-9fd6-d58c88441353
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 966
-        uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:14.342411Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.045621Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecc5e6f-8e74-41b0-b33a-f29a2448293c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.045621Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"3c102c56-68a9-4da8-9fd6-d58c88441353","ipam_config":null,"mac_address":"02:00:00:13:DB:46","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","status":"ready","updated_at":"2025-01-27T09:16:24.704221Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "966"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:00 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 7eb50a9e-c6a0-492c-95d3-68733cb885d4
-        status: 200 OK
-        code: 200
-        duration: 49.292916ms
-    - id: 70
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/7d99e9ca-2141-4914-8e5e-5526e22eea5e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1932
-        uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:01.901705Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:14.342411Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.045621Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecc5e6f-8e74-41b0-b33a-f29a2448293c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.045621Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"3c102c56-68a9-4da8-9fd6-d58c88441353","ipam_config":null,"mac_address":"02:00:00:13:DB:46","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","status":"ready","updated_at":"2025-01-27T09:16:24.704221Z","zone":"fr-par-1"}],"id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","ip":{"address":"51.15.224.245","created_at":"2025-01-27T09:16:01.788664Z","gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"c7144bb0-d67d-4ef1-ba4c-0ec0ee3f69c7","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"245-224-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.788664Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:24.893410Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "1932"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:00 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 62de3665-1d38-4287-97ba-abfa193ef3fa
-        status: 200 OK
-        code: 200
-        duration: 30.53475ms
-    - id: 71
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2739
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.059639+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-stonebraker","id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1401","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:1d","maintenances":[],"modification_date":"2025-01-27T09:16:15.581118+00:00","name":"tf-srv-funny-stonebraker","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:19.391848+00:00","id":"a6008d1e-b295-4a3a-a95e-ee520905082a","ipam_ip_ids":["1d82d8f6-cb7b-4a0f-bdb2-b393da83d382","9d60bed2-52c8-4ffa-a014-9edfeb74825a"],"mac_address":"02:00:00:13:ce:84","modification_date":"2025-01-27T09:16:51.719632+00:00","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","server_id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.059639+00:00","export_uri":null,"id":"89d36a9f-ba55-4c09-a3a6-ef9520673300","modification_date":"2025-01-27T09:16:02.059639+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","name":"tf-srv-funny-stonebraker"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2739"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:00 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - d0b593aa-3ae2-4273-9b44-d08265665a3c
-        status: 200 OK
-        code: 200
-        duration: 151.193458ms
-    - id: 72
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3c102c56-68a9-4da8-9fd6-d58c88441353
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 966
-        uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:14.342411Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.045621Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecc5e6f-8e74-41b0-b33a-f29a2448293c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.045621Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"3c102c56-68a9-4da8-9fd6-d58c88441353","ipam_config":null,"mac_address":"02:00:00:13:DB:46","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","status":"ready","updated_at":"2025-01-27T09:16:24.704221Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "966"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:00 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 761b5d7d-1010-45d3-8ff8-7cf616afe8a5
-        status: 200 OK
-        code: 200
-        duration: 46.339666ms
-    - id: 73
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/89d36a9f-ba55-4c09-a3a6-ef9520673300
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 524
-        uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T09:16:02.059639+00:00","export_uri":null,"id":"89d36a9f-ba55-4c09-a3a6-ef9520673300","modification_date":"2025-01-27T09:16:02.059639+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","name":"tf-srv-funny-stonebraker"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "524"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:00 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - ebc86701-8b95-4724-aa5e-ed15053fb883
-        status: 200 OK
-        code: 200
-        duration: 87.684625ms
-    - id: 74
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -3700,7 +3157,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:00 GMT
+                - Wed, 12 Feb 2025 16:15:49 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3710,10 +3167,553 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 06cc250b-7ff9-4c4f-989a-2cffe1becca1
+                - 888f7b8e-45a7-4937-84b5-a81dad2337b1
         status: 200 OK
         code: 200
-        duration: 144.663792ms
+        duration: 104.726417ms
+    - id: 64
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 478
+        uncompressed: false
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:15:10.419887+00:00","id":"65a6cef8-6606-4214-a8db-3d3bafb8327a","ipam_ip_ids":["3e273272-2b9c-4913-89c1-3423bf76990c","e80124d6-c1fe-42be-a73e-82653465a258"],"mac_address":"02:00:00:1f:a9:3e","modification_date":"2025-02-12T16:15:42.433310+00:00","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","server_id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        headers:
+            Content-Length:
+                - "478"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:49 GMT
+            Link:
+                - </servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664/private_nics?page=1&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2eabefe4-26f4-47d2-ba05-fc6af992d990
+            X-Total-Count:
+                - "1"
+        status: 200 OK
+        code: 200
+        duration: 126.805041ms
+    - id: 65
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/3e273272-2b9c-4913-89c1-3423bf76990c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 332
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:15:10.833284Z","gateway_network_id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","hostname":"tf-srv-eager-panini","id":"3e273272-2b9c-4913-89c1-3423bf76990c","ip_address":"192.168.1.1","mac_address":"02:00:00:1f:a9:3e","type":"reservation","updated_at":"2025-02-12T16:15:48.633492Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "332"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2bfb4a04-f907-4041-8969-db08eb180ecb
+        status: 200 OK
+        code: 200
+        duration: 86.177ms
+    - id: 66
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/0a76d947-25bb-4d14-9c1c-4f48deceb1a6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 586
+        uncompressed: false
+        body: '{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.950362Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0a76d947-25bb-4d14-9c1c-4f48deceb1a6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.950362Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "586"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9de3e6a0-c194-4f14-ac23-dfc2d31e7d21
+        status: 200 OK
+        code: 200
+        duration: 49.077375ms
+    - id: 67
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/f6a6b831-81a9-463c-9b7d-2b0f4c38bf0e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 405
+        uncompressed: false
+        body: '{"address":"163.172.159.229","created_at":"2025-02-12T16:14:56.642158Z","gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"f6a6b831-81a9-463c-9b7d-2b0f4c38bf0e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.642158Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "405"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1aa072f4-d81c-43fe-afa3-5f502ced70db
+        status: 200 OK
+        code: 200
+        duration: 50.812375ms
+    - id: 68
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7a3b6ed2-5295-4ce1-a78f-e24d90879aec
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1042
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:14:55.931102Z","dhcp_enabled":true,"id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","name":"pn_test_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:14:55.931102Z","id":"5e027010-cd96-4711-b69d-480bb60a697e","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:15:02.351322Z","vpc_id":"21689b9a-7cd1-4cf4-a47d-3bdd0f69315c"},{"created_at":"2025-02-12T16:14:55.931102Z","id":"e4dcfa97-3290-480c-a712-7c50de07a6ea","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:c29e::/64","updated_at":"2025-02-12T16:15:02.357183Z","vpc_id":"21689b9a-7cd1-4cf4-a47d-3bdd0f69315c"}],"tags":[],"updated_at":"2025-02-12T16:15:12.562058Z","vpc_id":"21689b9a-7cd1-4cf4-a47d-3bdd0f69315c"}'
+        headers:
+            Content-Length:
+                - "1042"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a141aead-24ed-4087-8919-259b197ac75d
+        status: 200 OK
+        code: 200
+        duration: 50.084125ms
+    - id: 69
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/01fdf5a9-c2a0-4632-b5a5-03ccab13224f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1996
+        uncompressed: false
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.788246Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:05.808795Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.950362Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0a76d947-25bb-4d14-9c1c-4f48deceb1a6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.950362Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","ipam_config":null,"mac_address":"02:00:00:13:B7:CF","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","status":"ready","updated_at":"2025-02-12T16:15:16.433992Z","zone":"fr-par-1"}],"id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","ip":{"address":"163.172.159.229","created_at":"2025-02-12T16:14:56.642158Z","gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"f6a6b831-81a9-463c-9b7d-2b0f4c38bf0e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.642158Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:16.743346Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "1996"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3876f9db-f7d9-4c18-8fee-27a0b681cb6d
+        status: 200 OK
+        code: 200
+        duration: 44.878875ms
+    - id: 70
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 996
+        uncompressed: false
+        body: '{"address":null,"created_at":"2025-02-12T16:15:05.808795Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.950362Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0a76d947-25bb-4d14-9c1c-4f48deceb1a6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.950362Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","ipam_config":null,"mac_address":"02:00:00:13:B7:CF","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","status":"ready","updated_at":"2025-02-12T16:15:16.433992Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "996"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c9b4be7b-de4d-45a8-9ec8-97d9f7f675a9
+        status: 200 OK
+        code: 200
+        duration: 67.990542ms
+    - id: 71
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/01fdf5a9-c2a0-4632-b5a5-03ccab13224f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1996
+        uncompressed: false
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.788246Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:05.808795Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.950362Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0a76d947-25bb-4d14-9c1c-4f48deceb1a6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.950362Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","ipam_config":null,"mac_address":"02:00:00:13:B7:CF","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","status":"ready","updated_at":"2025-02-12T16:15:16.433992Z","zone":"fr-par-1"}],"id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","ip":{"address":"163.172.159.229","created_at":"2025-02-12T16:14:56.642158Z","gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"f6a6b831-81a9-463c-9b7d-2b0f4c38bf0e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.642158Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:16.743346Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "1996"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ea608934-9ecf-4e5c-8b2b-056245be9812
+        status: 200 OK
+        code: 200
+        duration: 47.313209ms
+    - id: 72
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2282
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.167923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-panini","id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"402","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d7","maintenances":[],"modification_date":"2025-02-12T16:15:05.175736+00:00","name":"tf-srv-eager-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:10.419887+00:00","id":"65a6cef8-6606-4214-a8db-3d3bafb8327a","ipam_ip_ids":["3e273272-2b9c-4913-89c1-3423bf76990c","e80124d6-c1fe-42be-a73e-82653465a258"],"mac_address":"02:00:00:1f:a9:3e","modification_date":"2025-02-12T16:15:42.433310+00:00","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","server_id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"b3862f05-55df-4387-ab1e-f975957752e5","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2282"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 88c98ab2-3a58-43d0-927f-738612c6726e
+        status: 200 OK
+        code: 200
+        duration: 175.510584ms
+    - id: 73
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b3862f05-55df-4387-ab1e-f975957752e5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"b3862f05-55df-4387-ab1e-f975957752e5","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 10324cac-570b-4811-bb4b-de1f4c357cee
+        status: 404 Not Found
+        code: 404
+        duration: 50.738333ms
+    - id: 74
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 996
+        uncompressed: false
+        body: '{"address":null,"created_at":"2025-02-12T16:15:05.808795Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.950362Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0a76d947-25bb-4d14-9c1c-4f48deceb1a6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.950362Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","ipam_config":null,"mac_address":"02:00:00:13:B7:CF","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","status":"ready","updated_at":"2025-02-12T16:15:16.433992Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "996"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1827b938-5982-403c-85b2-6590b76d52cb
+        status: 200 OK
+        code: 200
+        duration: 69.841708ms
     - id: 75
       request:
         proto: HTTP/1.1
@@ -3729,8 +3729,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/b3862f05-55df-4387-ab1e-f975957752e5
         method: GET
       response:
         proto: HTTP/2.0
@@ -3738,20 +3738,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 478
+        content_length: 701
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T09:16:19.391848+00:00","id":"a6008d1e-b295-4a3a-a95e-ee520905082a","ipam_ip_ids":["1d82d8f6-cb7b-4a0f-bdb2-b393da83d382","9d60bed2-52c8-4ffa-a014-9edfeb74825a"],"mac_address":"02:00:00:13:ce:84","modification_date":"2025-01-27T09:16:51.719632+00:00","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","server_id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"created_at":"2025-02-12T16:14:57.634432Z","id":"b3862f05-55df-4387-ab1e-f975957752e5","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:14:57.634432Z","id":"2e55d1b6-aa93-4d99-91a5-cf2874697e34","product_resource_id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:14:57.634432Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "478"
+                - "701"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:00 GMT
-            Link:
-                - </servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb/private_nics?page=1&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 16:15:50 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3761,12 +3759,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - be08a859-ac6e-4ae9-9d0b-01a4d3b08cc3
-            X-Total-Count:
-                - "1"
+                - 0221fb18-1c8b-40fc-aa6f-8cb6e6fe1b43
         status: 200 OK
         code: 200
-        duration: 93.989958ms
+        duration: 88.789125ms
     - id: 76
       request:
         proto: HTTP/1.1
@@ -3782,8 +3778,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/1d82d8f6-cb7b-4a0f-bdb2-b393da83d382
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -3791,18 +3787,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 329
+        content_length: 17
         uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:19.829417Z","gateway_network_id":"3c102c56-68a9-4da8-9fd6-d58c88441353","hostname":"tf-srv-funny-stonebraker","id":"1d82d8f6-cb7b-4a0f-bdb2-b393da83d382","ip_address":"192.168.1.1","mac_address":"02:00:00:13:ce:84","type":"reservation","updated_at":"2025-01-27T09:16:57.854308Z","zone":"fr-par-1"}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "329"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:01 GMT
+                - Wed, 12 Feb 2025 16:15:50 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3812,10 +3808,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e32db4d6-4a67-403a-9186-b546d021179b
+                - 5a8b0d03-3083-4973-8199-409a0fb9da86
         status: 200 OK
         code: 200
-        duration: 68.582083ms
+        duration: 94.778291ms
     - id: 77
       request:
         proto: HTTP/1.1
@@ -3831,8 +3827,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3c102c56-68a9-4da8-9fd6-d58c88441353
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -3840,18 +3836,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 966
+        content_length: 478
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:14.342411Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.045621Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecc5e6f-8e74-41b0-b33a-f29a2448293c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.045621Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"3c102c56-68a9-4da8-9fd6-d58c88441353","ipam_config":null,"mac_address":"02:00:00:13:DB:46","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","status":"ready","updated_at":"2025-01-27T09:16:24.704221Z","zone":"fr-par-1"}'
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:15:10.419887+00:00","id":"65a6cef8-6606-4214-a8db-3d3bafb8327a","ipam_ip_ids":["3e273272-2b9c-4913-89c1-3423bf76990c","e80124d6-c1fe-42be-a73e-82653465a258"],"mac_address":"02:00:00:1f:a9:3e","modification_date":"2025-02-12T16:15:42.433310+00:00","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","server_id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "966"
+                - "478"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:02 GMT
+                - Wed, 12 Feb 2025 16:15:50 GMT
+            Link:
+                - </servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664/private_nics?page=1&per_page=50&>; rel="last"
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3861,11 +3859,111 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c6ea6c29-384b-44f6-a938-ab2be7575b2d
+                - 90c3063e-8b59-4b1d-a656-9a465aa9fa1b
+            X-Total-Count:
+                - "1"
         status: 200 OK
         code: 200
-        duration: 45.894958ms
+        duration: 120.805042ms
     - id: 78
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/3e273272-2b9c-4913-89c1-3423bf76990c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 332
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:15:10.833284Z","gateway_network_id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","hostname":"tf-srv-eager-panini","id":"3e273272-2b9c-4913-89c1-3423bf76990c","ip_address":"192.168.1.1","mac_address":"02:00:00:1f:a9:3e","type":"reservation","updated_at":"2025-02-12T16:15:48.633492Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "332"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2f2228ba-936c-48b0-afad-886fc893c495
+        status: 200 OK
+        code: 200
+        duration: 106.410666ms
+    - id: 79
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 996
+        uncompressed: false
+        body: '{"address":null,"created_at":"2025-02-12T16:15:05.808795Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.950362Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0a76d947-25bb-4d14-9c1c-4f48deceb1a6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.950362Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","ipam_config":null,"mac_address":"02:00:00:13:B7:CF","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","status":"ready","updated_at":"2025-02-12T16:15:16.433992Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "996"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4d9a83cd-3942-4fd1-9e70-725bda343627
+        status: 200 OK
+        code: 200
+        duration: 67.680208ms
+    - id: 80
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3882,8 +3980,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/1d82d8f6-cb7b-4a0f-bdb2-b393da83d382
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/3e273272-2b9c-4913-89c1-3423bf76990c
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -3891,18 +3989,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 329
+        content_length: 332
         uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:19.829417Z","gateway_network_id":"3c102c56-68a9-4da8-9fd6-d58c88441353","hostname":"tf-srv-funny-stonebraker","id":"1d82d8f6-cb7b-4a0f-bdb2-b393da83d382","ip_address":"192.168.1.2","mac_address":"02:00:00:13:ce:84","type":"reservation","updated_at":"2025-01-27T09:17:02.494817Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:15:10.833284Z","gateway_network_id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","hostname":"tf-srv-eager-panini","id":"3e273272-2b9c-4913-89c1-3423bf76990c","ip_address":"192.168.1.2","mac_address":"02:00:00:1f:a9:3e","type":"reservation","updated_at":"2025-02-12T16:15:51.771276Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "329"
+                - "332"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:02 GMT
+                - Wed, 12 Feb 2025 16:15:51 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3912,108 +4010,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8a1bd8cc-da6a-4468-9e0f-4418e593cd28
+                - 599a8adf-3d3c-4fce-80d5-14de56f5f4ee
         status: 200 OK
         code: 200
-        duration: 430.080708ms
-    - id: 79
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3c102c56-68a9-4da8-9fd6-d58c88441353
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 966
-        uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:14.342411Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.045621Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecc5e6f-8e74-41b0-b33a-f29a2448293c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.045621Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"3c102c56-68a9-4da8-9fd6-d58c88441353","ipam_config":null,"mac_address":"02:00:00:13:DB:46","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","status":"ready","updated_at":"2025-01-27T09:16:24.704221Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "966"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:02 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 91f284d8-0a53-4005-84be-198a09834525
-        status: 200 OK
-        code: 200
-        duration: 40.724542ms
-    - id: 80
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/1d82d8f6-cb7b-4a0f-bdb2-b393da83d382
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 329
-        uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:19.829417Z","gateway_network_id":"3c102c56-68a9-4da8-9fd6-d58c88441353","hostname":"tf-srv-funny-stonebraker","id":"1d82d8f6-cb7b-4a0f-bdb2-b393da83d382","ip_address":"192.168.1.2","mac_address":"02:00:00:13:ce:84","type":"reservation","updated_at":"2025-01-27T09:17:02.494817Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "329"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:02 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - c077658e-bdcf-43ae-bad3-1c1e35ceb171
-        status: 200 OK
-        code: 200
-        duration: 67.349542ms
+        duration: 428.550167ms
     - id: 81
       request:
         proto: HTTP/1.1
@@ -4029,8 +4029,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/1d82d8f6-cb7b-4a0f-bdb2-b393da83d382
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13
         method: GET
       response:
         proto: HTTP/2.0
@@ -4038,18 +4038,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 329
+        content_length: 996
         uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:19.829417Z","gateway_network_id":"3c102c56-68a9-4da8-9fd6-d58c88441353","hostname":"tf-srv-funny-stonebraker","id":"1d82d8f6-cb7b-4a0f-bdb2-b393da83d382","ip_address":"192.168.1.2","mac_address":"02:00:00:13:ce:84","type":"reservation","updated_at":"2025-01-27T09:17:02.494817Z","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:05.808795Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.950362Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0a76d947-25bb-4d14-9c1c-4f48deceb1a6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.950362Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","ipam_config":null,"mac_address":"02:00:00:13:B7:CF","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","status":"ready","updated_at":"2025-02-12T16:15:16.433992Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "329"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:02 GMT
+                - Wed, 12 Feb 2025 16:15:51 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4059,10 +4059,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 068e2d76-ebea-4050-b2d1-58045bbb57cf
+                - e99dffa0-ab06-4109-b245-096b33494e3d
         status: 200 OK
         code: 200
-        duration: 87.374208ms
+        duration: 71.447125ms
     - id: 82
       request:
         proto: HTTP/1.1
@@ -4078,8 +4078,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/c7144bb0-d67d-4ef1-ba4c-0ec0ee3f69c7
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/3e273272-2b9c-4913-89c1-3423bf76990c
         method: GET
       response:
         proto: HTTP/2.0
@@ -4087,18 +4087,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 392
+        content_length: 332
         uncompressed: false
-        body: '{"address":"51.15.224.245","created_at":"2025-01-27T09:16:01.788664Z","gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"c7144bb0-d67d-4ef1-ba4c-0ec0ee3f69c7","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"245-224-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.788664Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:15:10.833284Z","gateway_network_id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","hostname":"tf-srv-eager-panini","id":"3e273272-2b9c-4913-89c1-3423bf76990c","ip_address":"192.168.1.2","mac_address":"02:00:00:1f:a9:3e","type":"reservation","updated_at":"2025-02-12T16:15:51.771276Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "392"
+                - "332"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:03 GMT
+                - Wed, 12 Feb 2025 16:15:51 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4108,10 +4108,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 90aef1a3-9b89-42ec-9030-af851e3bbd4e
+                - 8a6479d1-ab52-4732-aa7b-bc6918293a74
         status: 200 OK
         code: 200
-        duration: 26.129833ms
+        duration: 75.515708ms
     - id: 83
       request:
         proto: HTTP/1.1
@@ -4127,8 +4127,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/1ecc5e6f-8e74-41b0-b33a-f29a2448293c
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/3e273272-2b9c-4913-89c1-3423bf76990c
         method: GET
       response:
         proto: HTTP/2.0
@@ -4136,18 +4136,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 568
+        content_length: 332
         uncompressed: false
-        body: '{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.045621Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecc5e6f-8e74-41b0-b33a-f29a2448293c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.045621Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:15:10.833284Z","gateway_network_id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","hostname":"tf-srv-eager-panini","id":"3e273272-2b9c-4913-89c1-3423bf76990c","ip_address":"192.168.1.2","mac_address":"02:00:00:1f:a9:3e","type":"reservation","updated_at":"2025-02-12T16:15:51.771276Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "568"
+                - "332"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:03 GMT
+                - Wed, 12 Feb 2025 16:15:52 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4157,10 +4157,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 564c8ec0-97f0-4747-9cfc-3dd9ec166f7d
+                - 28686c94-f1dc-40ea-987d-029707800d76
         status: 200 OK
         code: 200
-        duration: 23.715166ms
+        duration: 81.373292ms
     - id: 84
       request:
         proto: HTTP/1.1
@@ -4176,8 +4176,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f96914f9-4114-4d1f-aa48-077fab624873
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/f6a6b831-81a9-463c-9b7d-2b0f4c38bf0e
         method: GET
       response:
         proto: HTTP/2.0
@@ -4185,18 +4185,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1019
+        content_length: 405
         uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:01.080341Z","dhcp_enabled":true,"id":"f96914f9-4114-4d1f-aa48-077fab624873","name":"pn_test_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T09:16:01.080341Z","id":"c6e3530a-51ec-428b-8e49-4863d5d267de","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:12.351404Z","vpc_id":"c77c01c3-0e24-4343-81fd-841906ccc123"},{"created_at":"2025-01-27T09:16:01.080341Z","id":"1498f716-3ced-4cf5-8f1c-8ef67fb0d50e","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:4c24::/64","updated_at":"2025-01-27T09:16:12.355245Z","vpc_id":"c77c01c3-0e24-4343-81fd-841906ccc123"}],"tags":[],"updated_at":"2025-01-27T09:16:20.799954Z","vpc_id":"c77c01c3-0e24-4343-81fd-841906ccc123"}'
+        body: '{"address":"163.172.159.229","created_at":"2025-02-12T16:14:56.642158Z","gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"f6a6b831-81a9-463c-9b7d-2b0f4c38bf0e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.642158Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1019"
+                - "405"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:03 GMT
+                - Wed, 12 Feb 2025 16:15:52 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4206,10 +4206,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 355c68fa-009b-408b-b952-ab84c67dd7d9
+                - 5eaa6945-bb4d-491b-844e-72329a46104e
         status: 200 OK
         code: 200
-        duration: 33.131458ms
+        duration: 42.480625ms
     - id: 85
       request:
         proto: HTTP/1.1
@@ -4225,8 +4225,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/7d99e9ca-2141-4914-8e5e-5526e22eea5e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7a3b6ed2-5295-4ce1-a78f-e24d90879aec
         method: GET
       response:
         proto: HTTP/2.0
@@ -4234,18 +4234,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1932
+        content_length: 1042
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:01.901705Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:14.342411Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.045621Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecc5e6f-8e74-41b0-b33a-f29a2448293c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.045621Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"3c102c56-68a9-4da8-9fd6-d58c88441353","ipam_config":null,"mac_address":"02:00:00:13:DB:46","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","status":"ready","updated_at":"2025-01-27T09:16:24.704221Z","zone":"fr-par-1"}],"id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","ip":{"address":"51.15.224.245","created_at":"2025-01-27T09:16:01.788664Z","gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"c7144bb0-d67d-4ef1-ba4c-0ec0ee3f69c7","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"245-224-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.788664Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:24.893410Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:14:55.931102Z","dhcp_enabled":true,"id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","name":"pn_test_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:14:55.931102Z","id":"5e027010-cd96-4711-b69d-480bb60a697e","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:15:02.351322Z","vpc_id":"21689b9a-7cd1-4cf4-a47d-3bdd0f69315c"},{"created_at":"2025-02-12T16:14:55.931102Z","id":"e4dcfa97-3290-480c-a712-7c50de07a6ea","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:c29e::/64","updated_at":"2025-02-12T16:15:02.357183Z","vpc_id":"21689b9a-7cd1-4cf4-a47d-3bdd0f69315c"}],"tags":[],"updated_at":"2025-02-12T16:15:12.562058Z","vpc_id":"21689b9a-7cd1-4cf4-a47d-3bdd0f69315c"}'
         headers:
             Content-Length:
-                - "1932"
+                - "1042"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:03 GMT
+                - Wed, 12 Feb 2025 16:15:52 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4255,10 +4255,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7e5f0fd5-5a22-4603-8949-5fa177d2dc95
+                - f1dd3f7a-4320-4e4d-8041-31d15d0af30d
         status: 200 OK
         code: 200
-        duration: 27.939875ms
+        duration: 44.983666ms
     - id: 86
       request:
         proto: HTTP/1.1
@@ -4274,8 +4274,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3c102c56-68a9-4da8-9fd6-d58c88441353
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/0a76d947-25bb-4d14-9c1c-4f48deceb1a6
         method: GET
       response:
         proto: HTTP/2.0
@@ -4283,18 +4283,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 966
+        content_length: 586
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:14.342411Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.045621Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecc5e6f-8e74-41b0-b33a-f29a2448293c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.045621Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"3c102c56-68a9-4da8-9fd6-d58c88441353","ipam_config":null,"mac_address":"02:00:00:13:DB:46","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","status":"ready","updated_at":"2025-01-27T09:16:24.704221Z","zone":"fr-par-1"}'
+        body: '{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.950362Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0a76d947-25bb-4d14-9c1c-4f48deceb1a6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.950362Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "966"
+                - "586"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:03 GMT
+                - Wed, 12 Feb 2025 16:15:52 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4304,10 +4304,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e38fcb90-dfe1-43de-b2d2-0e17999f5d78
+                - 3deedc0d-0e54-4157-8c66-09eecbbad61d
         status: 200 OK
         code: 200
-        duration: 40.911708ms
+        duration: 49.448083ms
     - id: 87
       request:
         proto: HTTP/1.1
@@ -4323,8 +4323,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/7d99e9ca-2141-4914-8e5e-5526e22eea5e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/01fdf5a9-c2a0-4632-b5a5-03ccab13224f
         method: GET
       response:
         proto: HTTP/2.0
@@ -4332,18 +4332,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1932
+        content_length: 1996
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:01.901705Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:14.342411Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.045621Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecc5e6f-8e74-41b0-b33a-f29a2448293c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.045621Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"3c102c56-68a9-4da8-9fd6-d58c88441353","ipam_config":null,"mac_address":"02:00:00:13:DB:46","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","status":"ready","updated_at":"2025-01-27T09:16:24.704221Z","zone":"fr-par-1"}],"id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","ip":{"address":"51.15.224.245","created_at":"2025-01-27T09:16:01.788664Z","gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"c7144bb0-d67d-4ef1-ba4c-0ec0ee3f69c7","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"245-224-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.788664Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:24.893410Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.788246Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:05.808795Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.950362Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0a76d947-25bb-4d14-9c1c-4f48deceb1a6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.950362Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","ipam_config":null,"mac_address":"02:00:00:13:B7:CF","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","status":"ready","updated_at":"2025-02-12T16:15:16.433992Z","zone":"fr-par-1"}],"id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","ip":{"address":"163.172.159.229","created_at":"2025-02-12T16:14:56.642158Z","gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"f6a6b831-81a9-463c-9b7d-2b0f4c38bf0e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.642158Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:16.743346Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1932"
+                - "1996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:03 GMT
+                - Wed, 12 Feb 2025 16:15:52 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4353,10 +4353,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 250f354f-5fb0-49e6-ae87-25f4b8ad29e2
+                - 755cb8e1-2455-4f4f-9bb4-6b1eef08e0e4
         status: 200 OK
         code: 200
-        duration: 30.888084ms
+        duration: 45.126042ms
     - id: 88
       request:
         proto: HTTP/1.1
@@ -4372,8 +4372,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3c102c56-68a9-4da8-9fd6-d58c88441353
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13
         method: GET
       response:
         proto: HTTP/2.0
@@ -4381,18 +4381,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 966
+        content_length: 996
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:14.342411Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.045621Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecc5e6f-8e74-41b0-b33a-f29a2448293c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.045621Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"3c102c56-68a9-4da8-9fd6-d58c88441353","ipam_config":null,"mac_address":"02:00:00:13:DB:46","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","status":"ready","updated_at":"2025-01-27T09:16:24.704221Z","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:05.808795Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.950362Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0a76d947-25bb-4d14-9c1c-4f48deceb1a6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.950362Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","ipam_config":null,"mac_address":"02:00:00:13:B7:CF","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","status":"ready","updated_at":"2025-02-12T16:15:16.433992Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "966"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:03 GMT
+                - Wed, 12 Feb 2025 16:15:52 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4402,10 +4402,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f4ae501a-b4e4-4e70-8d16-faaca2970235
+                - 3ca2dca2-b003-44ad-9ad2-70feaa3ed72a
         status: 200 OK
         code: 200
-        duration: 46.272167ms
+        duration: 63.32825ms
     - id: 89
       request:
         proto: HTTP/1.1
@@ -4421,8 +4421,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/01fdf5a9-c2a0-4632-b5a5-03ccab13224f
         method: GET
       response:
         proto: HTTP/2.0
@@ -4430,18 +4430,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2739
+        content_length: 1996
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.059639+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-stonebraker","id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1401","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:1d","maintenances":[],"modification_date":"2025-01-27T09:16:15.581118+00:00","name":"tf-srv-funny-stonebraker","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:19.391848+00:00","id":"a6008d1e-b295-4a3a-a95e-ee520905082a","ipam_ip_ids":["1d82d8f6-cb7b-4a0f-bdb2-b393da83d382","9d60bed2-52c8-4ffa-a014-9edfeb74825a"],"mac_address":"02:00:00:13:ce:84","modification_date":"2025-01-27T09:16:51.719632+00:00","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","server_id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.059639+00:00","export_uri":null,"id":"89d36a9f-ba55-4c09-a3a6-ef9520673300","modification_date":"2025-01-27T09:16:02.059639+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","name":"tf-srv-funny-stonebraker"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.788246Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:05.808795Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.950362Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0a76d947-25bb-4d14-9c1c-4f48deceb1a6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.950362Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","ipam_config":null,"mac_address":"02:00:00:13:B7:CF","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","status":"ready","updated_at":"2025-02-12T16:15:16.433992Z","zone":"fr-par-1"}],"id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","ip":{"address":"163.172.159.229","created_at":"2025-02-12T16:14:56.642158Z","gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"f6a6b831-81a9-463c-9b7d-2b0f4c38bf0e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.642158Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:16.743346Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2739"
+                - "1996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:04 GMT
+                - Wed, 12 Feb 2025 16:15:52 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4451,10 +4451,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1049d561-3d97-4e3a-80bc-8c9e8a5316db
+                - 101c2901-1555-448e-b29b-ee463721a1db
         status: 200 OK
         code: 200
-        duration: 536.353292ms
+        duration: 44.82825ms
     - id: 90
       request:
         proto: HTTP/1.1
@@ -4470,8 +4470,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/89d36a9f-ba55-4c09-a3a6-ef9520673300
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664
         method: GET
       response:
         proto: HTTP/2.0
@@ -4479,18 +4479,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 524
+        content_length: 2282
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T09:16:02.059639+00:00","export_uri":null,"id":"89d36a9f-ba55-4c09-a3a6-ef9520673300","modification_date":"2025-01-27T09:16:02.059639+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","name":"tf-srv-funny-stonebraker"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.167923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-panini","id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"402","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d7","maintenances":[],"modification_date":"2025-02-12T16:15:05.175736+00:00","name":"tf-srv-eager-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:10.419887+00:00","id":"65a6cef8-6606-4214-a8db-3d3bafb8327a","ipam_ip_ids":["3e273272-2b9c-4913-89c1-3423bf76990c","e80124d6-c1fe-42be-a73e-82653465a258"],"mac_address":"02:00:00:1f:a9:3e","modification_date":"2025-02-12T16:15:42.433310+00:00","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","server_id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"b3862f05-55df-4387-ab1e-f975957752e5","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "524"
+                - "2282"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:04 GMT
+                - Wed, 12 Feb 2025 16:15:52 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4500,10 +4500,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 58aaee91-3b18-40c1-9c5e-9bff7a6b88f2
+                - e1fd4164-a1b4-42e3-bdb1-589f0e6cd444
         status: 200 OK
         code: 200
-        duration: 77.234375ms
+        duration: 193.625167ms
     - id: 91
       request:
         proto: HTTP/1.1
@@ -4519,8 +4519,155 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 996
+        uncompressed: false
+        body: '{"address":null,"created_at":"2025-02-12T16:15:05.808795Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.950362Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0a76d947-25bb-4d14-9c1c-4f48deceb1a6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.950362Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","ipam_config":null,"mac_address":"02:00:00:13:B7:CF","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","status":"ready","updated_at":"2025-02-12T16:15:16.433992Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "996"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c626f40f-ab89-447b-9100-2395ea241284
+        status: 200 OK
+        code: 200
+        duration: 67.386ms
+    - id: 92
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b3862f05-55df-4387-ab1e-f975957752e5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"b3862f05-55df-4387-ab1e-f975957752e5","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e5d9c1da-c8c8-48a2-b6d3-47d6b833f608
+        status: 404 Not Found
+        code: 404
+        duration: 94.6105ms
+    - id: 93
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/b3862f05-55df-4387-ab1e-f975957752e5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:14:57.634432Z","id":"b3862f05-55df-4387-ab1e-f975957752e5","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:14:57.634432Z","id":"2e55d1b6-aa93-4d99-91a5-cf2874697e34","product_resource_id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:14:57.634432Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - da8a978b-d6ee-4df9-a81a-6430270a06bf
+        status: 200 OK
+        code: 200
+        duration: 89.68675ms
+    - id: 94
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -4539,7 +4686,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:04 GMT
+                - Wed, 12 Feb 2025 16:15:52 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4549,161 +4696,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7740316f-164d-42b9-bba6-8ed409ff2635
+                - 495a7468-7e5f-4ee9-9019-812681bb072e
         status: 200 OK
         code: 200
-        duration: 391.570542ms
-    - id: 92
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb/private_nics
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 478
-        uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T09:16:19.391848+00:00","id":"a6008d1e-b295-4a3a-a95e-ee520905082a","ipam_ip_ids":["1d82d8f6-cb7b-4a0f-bdb2-b393da83d382","9d60bed2-52c8-4ffa-a014-9edfeb74825a"],"mac_address":"02:00:00:13:ce:84","modification_date":"2025-01-27T09:16:51.719632+00:00","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","server_id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","state":"available","tags":[],"zone":"fr-par-1"}]}'
-        headers:
-            Content-Length:
-                - "478"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:04 GMT
-            Link:
-                - </servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb/private_nics?page=1&per_page=50&>; rel="last"
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 053bd6b1-cb3d-427d-9411-666b730039ae
-            X-Total-Count:
-                - "1"
-        status: 200 OK
-        code: 200
-        duration: 77.10575ms
-    - id: 93
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/1d82d8f6-cb7b-4a0f-bdb2-b393da83d382
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 329
-        uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:19.829417Z","gateway_network_id":"3c102c56-68a9-4da8-9fd6-d58c88441353","hostname":"tf-srv-funny-stonebraker","id":"1d82d8f6-cb7b-4a0f-bdb2-b393da83d382","ip_address":"192.168.1.2","mac_address":"02:00:00:13:ce:84","type":"reservation","updated_at":"2025-01-27T09:17:02.494817Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "329"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:04 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 4744787e-2e06-4113-bc3f-6a2b3113a2c3
-        status: 200 OK
-        code: 200
-        duration: 77.823208ms
-    - id: 94
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3c102c56-68a9-4da8-9fd6-d58c88441353
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 966
-        uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:14.342411Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.045621Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecc5e6f-8e74-41b0-b33a-f29a2448293c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.045621Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"3c102c56-68a9-4da8-9fd6-d58c88441353","ipam_config":null,"mac_address":"02:00:00:13:DB:46","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","status":"ready","updated_at":"2025-01-27T09:16:24.704221Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "966"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:05 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - dce8d76d-e54c-4eb7-92ae-3ac751138846
-        status: 200 OK
-        code: 200
-        duration: 49.56725ms
+        duration: 190.865042ms
     - id: 95
       request:
         proto: HTTP/1.1
@@ -4719,25 +4715,29 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/1d82d8f6-cb7b-4a0f-bdb2-b393da83d382
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664/private_nics
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 478
         uncompressed: false
-        body: ""
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:15:10.419887+00:00","id":"65a6cef8-6606-4214-a8db-3d3bafb8327a","ipam_ip_ids":["3e273272-2b9c-4913-89c1-3423bf76990c","e80124d6-c1fe-42be-a73e-82653465a258"],"mac_address":"02:00:00:1f:a9:3e","modification_date":"2025-02-12T16:15:42.433310+00:00","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","server_id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
+            Content-Length:
+                - "478"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:05 GMT
+                - Wed, 12 Feb 2025 16:15:52 GMT
+            Link:
+                - </servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664/private_nics?page=1&per_page=50&>; rel="last"
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4747,10 +4747,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6ec9799b-eb64-4712-b826-ae90c0fe4349
-        status: 204 No Content
-        code: 204
-        duration: 73.691917ms
+                - 8655ab88-8cb5-4534-a5ac-141a467e772e
+            X-Total-Count:
+                - "1"
+        status: 200 OK
+        code: 200
+        duration: 97.569792ms
     - id: 96
       request:
         proto: HTTP/1.1
@@ -4766,8 +4768,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3c102c56-68a9-4da8-9fd6-d58c88441353
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/3e273272-2b9c-4913-89c1-3423bf76990c
         method: GET
       response:
         proto: HTTP/2.0
@@ -4775,18 +4777,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 966
+        content_length: 332
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:14.342411Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.045621Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecc5e6f-8e74-41b0-b33a-f29a2448293c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.045621Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"3c102c56-68a9-4da8-9fd6-d58c88441353","ipam_config":null,"mac_address":"02:00:00:13:DB:46","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","status":"ready","updated_at":"2025-01-27T09:16:24.704221Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:15:10.833284Z","gateway_network_id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","hostname":"tf-srv-eager-panini","id":"3e273272-2b9c-4913-89c1-3423bf76990c","ip_address":"192.168.1.2","mac_address":"02:00:00:1f:a9:3e","type":"reservation","updated_at":"2025-02-12T16:15:51.771276Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "966"
+                - "332"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:05 GMT
+                - Wed, 12 Feb 2025 16:15:53 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4796,10 +4798,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4befeb28-790f-4a25-8dcd-59028804e88b
+                - 2b94f7b8-d635-4176-963f-30c423ff0b7f
         status: 200 OK
         code: 200
-        duration: 46.917541ms
+        duration: 81.598916ms
     - id: 97
       request:
         proto: HTTP/1.1
@@ -4815,8 +4817,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3c102c56-68a9-4da8-9fd6-d58c88441353
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13
         method: GET
       response:
         proto: HTTP/2.0
@@ -4824,18 +4826,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 966
+        content_length: 996
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:14.342411Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.045621Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecc5e6f-8e74-41b0-b33a-f29a2448293c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.045621Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"3c102c56-68a9-4da8-9fd6-d58c88441353","ipam_config":null,"mac_address":"02:00:00:13:DB:46","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","status":"ready","updated_at":"2025-01-27T09:16:24.704221Z","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:05.808795Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.950362Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0a76d947-25bb-4d14-9c1c-4f48deceb1a6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.950362Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","ipam_config":null,"mac_address":"02:00:00:13:B7:CF","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","status":"ready","updated_at":"2025-02-12T16:15:16.433992Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "966"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:05 GMT
+                - Wed, 12 Feb 2025 16:15:53 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4845,10 +4847,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 17aafa45-c3db-444c-9833-8737fdd09cc8
+                - 3d403ea7-b637-4862-9542-e45b87f80c4d
         status: 200 OK
         code: 200
-        duration: 45.327959ms
+        duration: 64.105584ms
     - id: 98
       request:
         proto: HTTP/1.1
@@ -4864,8 +4866,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3c102c56-68a9-4da8-9fd6-d58c88441353?cleanup_dhcp=true
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/3e273272-2b9c-4913-89c1-3423bf76990c
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -4882,7 +4884,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:06 GMT
+                - Wed, 12 Feb 2025 16:15:53 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4892,10 +4894,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 23550cb6-5493-4286-aa63-6cc0d3d14c91
+                - a7eaa7ca-60be-4aaa-9130-35f50d68c002
         status: 204 No Content
         code: 204
-        duration: 78.560875ms
+        duration: 78.782291ms
     - id: 99
       request:
         proto: HTTP/1.1
@@ -4911,8 +4913,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13
         method: GET
       response:
         proto: HTTP/2.0
@@ -4920,18 +4922,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2739
+        content_length: 996
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.059639+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-stonebraker","id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1401","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:1d","maintenances":[],"modification_date":"2025-01-27T09:16:15.581118+00:00","name":"tf-srv-funny-stonebraker","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:19.391848+00:00","id":"a6008d1e-b295-4a3a-a95e-ee520905082a","ipam_ip_ids":["1d82d8f6-cb7b-4a0f-bdb2-b393da83d382","9d60bed2-52c8-4ffa-a014-9edfeb74825a"],"mac_address":"02:00:00:13:ce:84","modification_date":"2025-01-27T09:16:51.719632+00:00","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","server_id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.059639+00:00","export_uri":null,"id":"89d36a9f-ba55-4c09-a3a6-ef9520673300","modification_date":"2025-01-27T09:16:02.059639+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","name":"tf-srv-funny-stonebraker"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:05.808795Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.950362Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0a76d947-25bb-4d14-9c1c-4f48deceb1a6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.950362Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","ipam_config":null,"mac_address":"02:00:00:13:B7:CF","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","status":"ready","updated_at":"2025-02-12T16:15:16.433992Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2739"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:06 GMT
+                - Wed, 12 Feb 2025 16:15:53 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4941,10 +4943,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9e3d04ac-bcc6-4713-8782-11dd75bb845d
+                - 8bc80d2a-9c52-4a0a-9b4a-ec11b8fc36bd
         status: 200 OK
         code: 200
-        duration: 149.608541ms
+        duration: 69.233875ms
     - id: 100
       request:
         proto: HTTP/1.1
@@ -4960,8 +4962,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3c102c56-68a9-4da8-9fd6-d58c88441353
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13
         method: GET
       response:
         proto: HTTP/2.0
@@ -4969,18 +4971,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 970
+        content_length: 996
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:14.342411Z","dhcp":{"address":"192.168.1.1","created_at":"2025-01-27T09:16:01.045621Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1ecc5e6f-8e74-41b0-b33a-f29a2448293c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-01-27T09:16:01.045621Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"3c102c56-68a9-4da8-9fd6-d58c88441353","ipam_config":null,"mac_address":"02:00:00:13:DB:46","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","status":"detaching","updated_at":"2025-01-27T09:17:06.036968Z","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:05.808795Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.950362Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0a76d947-25bb-4d14-9c1c-4f48deceb1a6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.950362Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","ipam_config":null,"mac_address":"02:00:00:13:B7:CF","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","status":"ready","updated_at":"2025-02-12T16:15:16.433992Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "970"
+                - "996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:06 GMT
+                - Wed, 12 Feb 2025 16:15:53 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4990,11 +4992,205 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e4995bc6-46f2-4521-8a53-bd381b02f52f
+                - a567f5c6-0b2a-4208-a626-8b3954252151
         status: 200 OK
         code: 200
-        duration: 39.709958ms
+        duration: 71.697083ms
     - id: 101
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13?cleanup_dhcp=true
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d66246a9-5441-42ae-b30f-8518f8f8ce1e
+        status: 204 No Content
+        code: 204
+        duration: 91.252041ms
+    - id: 102
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2282
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.167923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-panini","id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"402","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d7","maintenances":[],"modification_date":"2025-02-12T16:15:05.175736+00:00","name":"tf-srv-eager-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:10.419887+00:00","id":"65a6cef8-6606-4214-a8db-3d3bafb8327a","ipam_ip_ids":["3e273272-2b9c-4913-89c1-3423bf76990c","e80124d6-c1fe-42be-a73e-82653465a258"],"mac_address":"02:00:00:1f:a9:3e","modification_date":"2025-02-12T16:15:42.433310+00:00","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","server_id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"b3862f05-55df-4387-ab1e-f975957752e5","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2282"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e3bc0faa-94e9-4630-bdd5-5aa169f1fba1
+        status: 200 OK
+        code: 200
+        duration: 219.712ms
+    - id: 103
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1000
+        uncompressed: false
+        body: '{"address":null,"created_at":"2025-02-12T16:15:05.808795Z","dhcp":{"address":"192.168.1.1","created_at":"2025-02-12T16:14:55.950362Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0a76d947-25bb-4d14-9c1c-4f48deceb1a6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2025-02-12T16:14:55.950362Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","ipam_config":null,"mac_address":"02:00:00:13:B7:CF","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","status":"detaching","updated_at":"2025-02-12T16:15:53.769811Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "1000"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - efd4af8d-3338-4e97-84c2-b139fa6fff3b
+        status: 200 OK
+        code: 200
+        duration: 59.830291ms
+    - id: 104
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/b3862f05-55df-4387-ab1e-f975957752e5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 701
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:14:57.634432Z","id":"b3862f05-55df-4387-ab1e-f975957752e5","last_detached_at":null,"name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:14:57.634432Z","id":"2e55d1b6-aa93-4d99-91a5-cf2874697e34","product_resource_id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:14:57.634432Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "701"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - edd9cc62-fbfa-4546-92ed-b2fd63f6cf7b
+        status: 200 OK
+        code: 200
+        duration: 87.437709ms
+    - id: 105
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -5011,8 +5207,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -5022,7 +5218,7 @@ interactions:
         trailer: {}
         content_length: 352
         uncompressed: false
-        body: '{"task":{"description":"server_poweroff","href_from":"/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb/action","href_result":"/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb","id":"b3533f5d-3cb1-4d98-9f01-264c85097a73","progress":0,"started_at":"2025-01-27T09:17:06.362335+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_poweroff","href_from":"/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664/action","href_result":"/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664","id":"0c0d3851-aa85-47eb-bea2-d516a916173a","progress":0,"started_at":"2025-02-12T16:15:54.192660+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "352"
@@ -5031,9 +5227,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:06 GMT
+                - Wed, 12 Feb 2025 16:15:53 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/b3533f5d-3cb1-4d98-9f01-264c85097a73
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/0c0d3851-aa85-47eb-bea2-d516a916173a
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5043,206 +5239,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5f8c2cfa-b1e2-4f81-8280-3ed021647fa6
+                - 273d3589-3b7f-42fe-afa1-aa99fc94f58c
         status: 202 Accepted
         code: 202
-        duration: 313.167417ms
-    - id: 102
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2699
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.059639+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-stonebraker","id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1401","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:1d","maintenances":[],"modification_date":"2025-01-27T09:17:06.122374+00:00","name":"tf-srv-funny-stonebraker","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:19.391848+00:00","id":"a6008d1e-b295-4a3a-a95e-ee520905082a","ipam_ip_ids":["1d82d8f6-cb7b-4a0f-bdb2-b393da83d382","9d60bed2-52c8-4ffa-a014-9edfeb74825a"],"mac_address":"02:00:00:13:ce:84","modification_date":"2025-01-27T09:16:51.719632+00:00","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","server_id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.059639+00:00","export_uri":null,"id":"89d36a9f-ba55-4c09-a3a6-ef9520673300","modification_date":"2025-01-27T09:16:02.059639+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","name":"tf-srv-funny-stonebraker"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2699"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:06 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 83eca740-ee88-4083-8087-be2857b4b965
-        status: 200 OK
-        code: 200
-        duration: 227.8505ms
-    - id: 103
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3c102c56-68a9-4da8-9fd6-d58c88441353
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 136
-        uncompressed: false
-        body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"3c102c56-68a9-4da8-9fd6-d58c88441353","type":"not_found"}'
-        headers:
-            Content-Length:
-                - "136"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:11 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 24ca2751-91a1-4d03-b5f5-c52891aff4fd
-        status: 404 Not Found
-        code: 404
-        duration: 20.78075ms
-    - id: 104
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/7d99e9ca-2141-4914-8e5e-5526e22eea5e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 966
-        uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:01.901705Z","gateway_networks":[],"id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","ip":{"address":"51.15.224.245","created_at":"2025-01-27T09:16:01.788664Z","gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"c7144bb0-d67d-4ef1-ba4c-0ec0ee3f69c7","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"245-224-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.788664Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:24.893410Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "966"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:11 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 2aedce76-3ccf-43d3-bd26-eee09bdda03f
-        status: 200 OK
-        code: 200
-        duration: 26.591625ms
-    - id: 105
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/1ecc5e6f-8e74-41b0-b33a-f29a2448293c
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 125
-        uncompressed: false
-        body: '{"message":"resource is not found","resource":"dhcp","resource_id":"1ecc5e6f-8e74-41b0-b33a-f29a2448293c","type":"not_found"}'
-        headers:
-            Content-Length:
-                - "125"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:11 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 3bb7aa32-32a4-47a7-8dac-ff4fb99a1d98
-        status: 404 Not Found
-        code: 404
-        duration: 23.458208ms
+        duration: 364.126459ms
     - id: 106
       request:
         proto: HTTP/1.1
@@ -5258,8 +5258,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/7d99e9ca-2141-4914-8e5e-5526e22eea5e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664
         method: GET
       response:
         proto: HTTP/2.0
@@ -5267,18 +5267,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 966
+        content_length: 2242
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:01.901705Z","gateway_networks":[],"id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","ip":{"address":"51.15.224.245","created_at":"2025-01-27T09:16:01.788664Z","gateway_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","id":"c7144bb0-d67d-4ef1-ba4c-0ec0ee3f69c7","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"245-224-15-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.788664Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:24.893410Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.167923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-panini","id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"402","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d7","maintenances":[],"modification_date":"2025-02-12T16:15:53.981077+00:00","name":"tf-srv-eager-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:10.419887+00:00","id":"65a6cef8-6606-4214-a8db-3d3bafb8327a","ipam_ip_ids":["3e273272-2b9c-4913-89c1-3423bf76990c","e80124d6-c1fe-42be-a73e-82653465a258"],"mac_address":"02:00:00:1f:a9:3e","modification_date":"2025-02-12T16:15:42.433310+00:00","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","server_id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"b3862f05-55df-4387-ab1e-f975957752e5","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "966"
+                - "2242"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:11 GMT
+                - Wed, 12 Feb 2025 16:15:54 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5288,10 +5288,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 77760208-f42f-4473-82d7-7589c6381615
+                - c176c022-be29-4920-bcbb-2dbd61903c45
         status: 200 OK
         code: 200
-        duration: 29.973125ms
+        duration: 170.959917ms
     - id: 107
       request:
         proto: HTTP/1.1
@@ -5307,25 +5307,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/7d99e9ca-2141-4914-8e5e-5526e22eea5e?cleanup_dhcp=false
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 136
         uncompressed: false
-        body: ""
+        body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"0d06aaed-76d2-4d6a-bcb6-f98c6dc02b13","type":"not_found"}'
         headers:
+            Content-Length:
+                - "136"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:11 GMT
+                - Wed, 12 Feb 2025 16:15:58 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5335,10 +5337,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 925fba5a-3909-4e79-bf17-d8e152428985
-        status: 204 No Content
-        code: 204
-        duration: 51.45275ms
+                - 8da5af3e-3fe9-47f2-90ef-efaa4e948fe8
+        status: 404 Not Found
+        code: 404
+        duration: 52.246708ms
     - id: 108
       request:
         proto: HTTP/1.1
@@ -5354,8 +5356,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/7d99e9ca-2141-4914-8e5e-5526e22eea5e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/01fdf5a9-c2a0-4632-b5a5-03ccab13224f
         method: GET
       response:
         proto: HTTP/2.0
@@ -5363,18 +5365,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 128
+        content_length: 1000
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"gateway","resource_id":"7d99e9ca-2141-4914-8e5e-5526e22eea5e","type":"not_found"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.788246Z","gateway_networks":[],"id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","ip":{"address":"163.172.159.229","created_at":"2025-02-12T16:14:56.642158Z","gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"f6a6b831-81a9-463c-9b7d-2b0f4c38bf0e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.642158Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:16.743346Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "128"
+                - "1000"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:11 GMT
+                - Wed, 12 Feb 2025 16:15:58 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5384,10 +5386,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f5b7fe34-52bf-4b3d-9e38-649bc59bef82
-        status: 404 Not Found
-        code: 404
-        duration: 24.87925ms
+                - 0ad5b872-a468-496b-b31f-ec967e629c66
+        status: 200 OK
+        code: 200
+        duration: 43.82475ms
     - id: 109
       request:
         proto: HTTP/1.1
@@ -5403,27 +5405,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/0a76d947-25bb-4d14-9c1c-4f48deceb1a6
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2699
+        content_length: 125
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.059639+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-stonebraker","id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1401","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:1d","maintenances":[],"modification_date":"2025-01-27T09:17:06.122374+00:00","name":"tf-srv-funny-stonebraker","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:19.391848+00:00","id":"a6008d1e-b295-4a3a-a95e-ee520905082a","ipam_ip_ids":["1d82d8f6-cb7b-4a0f-bdb2-b393da83d382","9d60bed2-52c8-4ffa-a014-9edfeb74825a"],"mac_address":"02:00:00:13:ce:84","modification_date":"2025-01-27T09:16:51.719632+00:00","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","server_id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.059639+00:00","export_uri":null,"id":"89d36a9f-ba55-4c09-a3a6-ef9520673300","modification_date":"2025-01-27T09:16:02.059639+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","name":"tf-srv-funny-stonebraker"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"dhcp","resource_id":"0a76d947-25bb-4d14-9c1c-4f48deceb1a6","type":"not_found"}'
         headers:
             Content-Length:
-                - "2699"
+                - "125"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:11 GMT
+                - Wed, 12 Feb 2025 16:15:59 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5433,10 +5435,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cb314271-7f27-4ccf-962a-4dc674dfa56e
-        status: 200 OK
-        code: 200
-        duration: 140.736084ms
+                - 1c50b36f-5e53-45c1-bdc3-1a64cd2e9eef
+        status: 404 Not Found
+        code: 404
+        duration: 42.0035ms
     - id: 110
       request:
         proto: HTTP/1.1
@@ -5452,25 +5454,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/c7144bb0-d67d-4ef1-ba4c-0ec0ee3f69c7
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/01fdf5a9-c2a0-4632-b5a5-03ccab13224f
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 1000
         uncompressed: false
-        body: ""
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.788246Z","gateway_networks":[],"id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","ip":{"address":"163.172.159.229","created_at":"2025-02-12T16:14:56.642158Z","gateway_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","id":"f6a6b831-81a9-463c-9b7d-2b0f4c38bf0e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"229-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.642158Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:16.743346Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
+            Content-Length:
+                - "1000"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:11 GMT
+                - Wed, 12 Feb 2025 16:15:59 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5480,10 +5484,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2072828d-c22d-478c-8b2d-ce43af31105b
-        status: 204 No Content
-        code: 204
-        duration: 659.352333ms
+                - 9036de8d-9e80-47ad-8187-46823f897b8e
+        status: 200 OK
+        code: 200
+        duration: 45.26225ms
     - id: 111
       request:
         proto: HTTP/1.1
@@ -5499,27 +5503,25 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/01fdf5a9-c2a0-4632-b5a5-03ccab13224f?cleanup_dhcp=false
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2699
+        content_length: 0
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.059639+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-stonebraker","id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1401","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:1d","maintenances":[],"modification_date":"2025-01-27T09:17:06.122374+00:00","name":"tf-srv-funny-stonebraker","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:19.391848+00:00","id":"a6008d1e-b295-4a3a-a95e-ee520905082a","ipam_ip_ids":["1d82d8f6-cb7b-4a0f-bdb2-b393da83d382","9d60bed2-52c8-4ffa-a014-9edfeb74825a"],"mac_address":"02:00:00:13:ce:84","modification_date":"2025-01-27T09:16:51.719632+00:00","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","server_id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.059639+00:00","export_uri":null,"id":"89d36a9f-ba55-4c09-a3a6-ef9520673300","modification_date":"2025-01-27T09:16:02.059639+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","name":"tf-srv-funny-stonebraker"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: ""
         headers:
-            Content-Length:
-                - "2699"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:16 GMT
+                - Wed, 12 Feb 2025 16:15:59 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5529,10 +5531,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c2690139-c775-4a3d-b40a-569ff3ca0347
-        status: 200 OK
-        code: 200
-        duration: 150.211375ms
+                - bd0628fc-4215-46f1-ace0-3b2e6e865b1d
+        status: 204 No Content
+        code: 204
+        duration: 65.978125ms
     - id: 112
       request:
         proto: HTTP/1.1
@@ -5548,8 +5550,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/01fdf5a9-c2a0-4632-b5a5-03ccab13224f
         method: GET
       response:
         proto: HTTP/2.0
@@ -5557,18 +5559,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2699
+        content_length: 128
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.059639+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-stonebraker","id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1401","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:1d","maintenances":[],"modification_date":"2025-01-27T09:17:06.122374+00:00","name":"tf-srv-funny-stonebraker","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:19.391848+00:00","id":"a6008d1e-b295-4a3a-a95e-ee520905082a","ipam_ip_ids":["1d82d8f6-cb7b-4a0f-bdb2-b393da83d382","9d60bed2-52c8-4ffa-a014-9edfeb74825a"],"mac_address":"02:00:00:13:ce:84","modification_date":"2025-01-27T09:16:51.719632+00:00","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","server_id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.059639+00:00","export_uri":null,"id":"89d36a9f-ba55-4c09-a3a6-ef9520673300","modification_date":"2025-01-27T09:16:02.059639+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","name":"tf-srv-funny-stonebraker"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"gateway","resource_id":"01fdf5a9-c2a0-4632-b5a5-03ccab13224f","type":"not_found"}'
         headers:
             Content-Length:
-                - "2699"
+                - "128"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:21 GMT
+                - Wed, 12 Feb 2025 16:15:59 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5578,10 +5580,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 93c7cae0-5287-485d-a0d0-88c68fbc8e44
-        status: 200 OK
-        code: 200
-        duration: 175.0425ms
+                - 7ed212e7-2e57-4595-93cb-ba133d28b49b
+        status: 404 Not Found
+        code: 404
+        duration: 473.484042ms
     - id: 113
       request:
         proto: HTTP/1.1
@@ -5597,8 +5599,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664
         method: GET
       response:
         proto: HTTP/2.0
@@ -5606,18 +5608,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2699
+        content_length: 2242
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.059639+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-stonebraker","id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"1401","node_id":"22","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:1d","maintenances":[],"modification_date":"2025-01-27T09:17:06.122374+00:00","name":"tf-srv-funny-stonebraker","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:19.391848+00:00","id":"a6008d1e-b295-4a3a-a95e-ee520905082a","ipam_ip_ids":["1d82d8f6-cb7b-4a0f-bdb2-b393da83d382","9d60bed2-52c8-4ffa-a014-9edfeb74825a"],"mac_address":"02:00:00:13:ce:84","modification_date":"2025-01-27T09:16:51.719632+00:00","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","server_id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.059639+00:00","export_uri":null,"id":"89d36a9f-ba55-4c09-a3a6-ef9520673300","modification_date":"2025-01-27T09:16:02.059639+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","name":"tf-srv-funny-stonebraker"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.167923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-panini","id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"402","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d7","maintenances":[],"modification_date":"2025-02-12T16:15:53.981077+00:00","name":"tf-srv-eager-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:10.419887+00:00","id":"65a6cef8-6606-4214-a8db-3d3bafb8327a","ipam_ip_ids":["3e273272-2b9c-4913-89c1-3423bf76990c","e80124d6-c1fe-42be-a73e-82653465a258"],"mac_address":"02:00:00:1f:a9:3e","modification_date":"2025-02-12T16:15:42.433310+00:00","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","server_id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"b3862f05-55df-4387-ab1e-f975957752e5","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2699"
+                - "2242"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:27 GMT
+                - Wed, 12 Feb 2025 16:15:59 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5627,10 +5629,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8724e728-6c87-4f34-9201-60a32fefbdc4
+                - fabbf1d9-e911-4731-80fd-40623a0fe900
         status: 200 OK
         code: 200
-        duration: 154.142166ms
+        duration: 284.223417ms
     - id: 114
       request:
         proto: HTTP/1.1
@@ -5646,27 +5648,25 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/f6a6b831-81a9-463c-9b7d-2b0f4c38bf0e
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2582
+        content_length: 0
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.059639+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-stonebraker","id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ea:1d","maintenances":[],"modification_date":"2025-01-27T09:17:31.118434+00:00","name":"tf-srv-funny-stonebraker","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:19.391848+00:00","id":"a6008d1e-b295-4a3a-a95e-ee520905082a","ipam_ip_ids":["1d82d8f6-cb7b-4a0f-bdb2-b393da83d382","9d60bed2-52c8-4ffa-a014-9edfeb74825a"],"mac_address":"02:00:00:13:ce:84","modification_date":"2025-01-27T09:16:51.719632+00:00","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","server_id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.059639+00:00","export_uri":null,"id":"89d36a9f-ba55-4c09-a3a6-ef9520673300","modification_date":"2025-01-27T09:16:02.059639+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","name":"tf-srv-funny-stonebraker"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: ""
         headers:
-            Content-Length:
-                - "2582"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:32 GMT
+                - Wed, 12 Feb 2025 16:16:00 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5676,10 +5676,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - df694f41-0017-4101-81ca-5d14c0dc666b
-        status: 200 OK
-        code: 200
-        duration: 122.888709ms
+                - 57d6f4fd-bc95-448e-bdc0-9f751a8d3bcf
+        status: 204 No Content
+        code: 204
+        duration: 815.862167ms
     - id: 115
       request:
         proto: HTTP/1.1
@@ -5695,8 +5695,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664
         method: GET
       response:
         proto: HTTP/2.0
@@ -5704,20 +5704,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 478
+        content_length: 2242
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T09:16:19.391848+00:00","id":"a6008d1e-b295-4a3a-a95e-ee520905082a","ipam_ip_ids":["1d82d8f6-cb7b-4a0f-bdb2-b393da83d382","9d60bed2-52c8-4ffa-a014-9edfeb74825a"],"mac_address":"02:00:00:13:ce:84","modification_date":"2025-01-27T09:16:51.719632+00:00","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","server_id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.167923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-panini","id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"402","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d7","maintenances":[],"modification_date":"2025-02-12T16:15:53.981077+00:00","name":"tf-srv-eager-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:10.419887+00:00","id":"65a6cef8-6606-4214-a8db-3d3bafb8327a","ipam_ip_ids":["3e273272-2b9c-4913-89c1-3423bf76990c","e80124d6-c1fe-42be-a73e-82653465a258"],"mac_address":"02:00:00:1f:a9:3e","modification_date":"2025-02-12T16:15:42.433310+00:00","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","server_id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"b3862f05-55df-4387-ab1e-f975957752e5","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "478"
+                - "2242"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:32 GMT
-            Link:
-                - </servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb/private_nics?page=1&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 16:16:04 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5727,12 +5725,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 88212064-d582-462c-b919-6bde8359fd16
-            X-Total-Count:
-                - "1"
+                - 9c7705b3-83d1-45a5-89ef-40fdd770e9a2
         status: 200 OK
         code: 200
-        duration: 85.386333ms
+        duration: 188.183208ms
     - id: 116
       request:
         proto: HTTP/1.1
@@ -5748,8 +5744,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb/private_nics/a6008d1e-b295-4a3a-a95e-ee520905082a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664
         method: GET
       response:
         proto: HTTP/2.0
@@ -5757,18 +5753,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 475
+        content_length: 2242
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:19.391848+00:00","id":"a6008d1e-b295-4a3a-a95e-ee520905082a","ipam_ip_ids":["1d82d8f6-cb7b-4a0f-bdb2-b393da83d382","9d60bed2-52c8-4ffa-a014-9edfeb74825a"],"mac_address":"02:00:00:13:ce:84","modification_date":"2025-01-27T09:16:51.719632+00:00","private_network_id":"f96914f9-4114-4d1f-aa48-077fab624873","server_id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.167923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-panini","id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"402","node_id":"24","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d7","maintenances":[],"modification_date":"2025-02-12T16:15:53.981077+00:00","name":"tf-srv-eager-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:10.419887+00:00","id":"65a6cef8-6606-4214-a8db-3d3bafb8327a","ipam_ip_ids":["3e273272-2b9c-4913-89c1-3423bf76990c","e80124d6-c1fe-42be-a73e-82653465a258"],"mac_address":"02:00:00:1f:a9:3e","modification_date":"2025-02-12T16:15:42.433310+00:00","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","server_id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"b3862f05-55df-4387-ab1e-f975957752e5","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "475"
+                - "2242"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:32 GMT
+                - Wed, 12 Feb 2025 16:16:09 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5778,10 +5774,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 00a41723-ee30-4149-a462-2cc9d1afe6a0
+                - 2f5339ef-cb4d-4fd6-96a2-bd876c1d99d4
         status: 200 OK
         code: 200
-        duration: 96.705083ms
+        duration: 226.63875ms
     - id: 117
       request:
         proto: HTTP/1.1
@@ -5797,25 +5793,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb/private_nics/a6008d1e-b295-4a3a-a95e-ee520905082a
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 2126
         uncompressed: false
-        body: ""
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.167923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-panini","id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:d7","maintenances":[],"modification_date":"2025-02-12T16:16:14.193030+00:00","name":"tf-srv-eager-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:10.419887+00:00","id":"65a6cef8-6606-4214-a8db-3d3bafb8327a","ipam_ip_ids":["3e273272-2b9c-4913-89c1-3423bf76990c","e80124d6-c1fe-42be-a73e-82653465a258"],"mac_address":"02:00:00:1f:a9:3e","modification_date":"2025-02-12T16:15:42.433310+00:00","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","server_id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"b3862f05-55df-4387-ab1e-f975957752e5","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
+            Content-Length:
+                - "2126"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:32 GMT
+                - Wed, 12 Feb 2025 16:16:15 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5825,10 +5823,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2c6747a6-23c9-4edb-845c-0b737907ca08
-        status: 204 No Content
-        code: 204
-        duration: 269.168542ms
+                - 9ff71bd2-100e-47a3-a640-6e961b034bce
+        status: 200 OK
+        code: 200
+        duration: 161.61825ms
     - id: 118
       request:
         proto: HTTP/1.1
@@ -5844,8 +5842,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb/private_nics/a6008d1e-b295-4a3a-a95e-ee520905082a
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -5853,18 +5851,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 148
+        content_length: 478
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"a6008d1e-b295-4a3a-a95e-ee520905082a","type":"not_found"}'
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:15:10.419887+00:00","id":"65a6cef8-6606-4214-a8db-3d3bafb8327a","ipam_ip_ids":["3e273272-2b9c-4913-89c1-3423bf76990c","e80124d6-c1fe-42be-a73e-82653465a258"],"mac_address":"02:00:00:1f:a9:3e","modification_date":"2025-02-12T16:15:42.433310+00:00","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","server_id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "148"
+                - "478"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:32 GMT
+                - Wed, 12 Feb 2025 16:16:15 GMT
+            Link:
+                - </servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664/private_nics?page=1&per_page=50&>; rel="last"
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5874,10 +5874,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a993fe82-b8e8-4a14-8a80-0041594d836e
-        status: 404 Not Found
-        code: 404
-        duration: 84.679459ms
+                - fc214806-70e9-4951-9b90-74358ad7b726
+            X-Total-Count:
+                - "1"
+        status: 200 OK
+        code: 200
+        duration: 113.293667ms
     - id: 119
       request:
         proto: HTTP/1.1
@@ -5893,8 +5895,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664/private_nics/65a6cef8-6606-4214-a8db-3d3bafb8327a
         method: GET
       response:
         proto: HTTP/2.0
@@ -5902,18 +5904,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2124
+        content_length: 475
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.059639+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-funny-stonebraker","id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:44.425699+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"5dbc71d9-cb05-4a0c-853d-0ba7a14d9c45","modification_date":"2024-10-14T09:05:44.425699+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"781c70f1-db12-4aa7-a697-839e030ebfca","name":"Ubuntu 20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ea:1d","maintenances":[],"modification_date":"2025-01-27T09:17:31.118434+00:00","name":"tf-srv-funny-stonebraker","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.059639+00:00","export_uri":null,"id":"89d36a9f-ba55-4c09-a3a6-ef9520673300","modification_date":"2025-01-27T09:16:02.059639+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","name":"tf-srv-funny-stonebraker"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.419887+00:00","id":"65a6cef8-6606-4214-a8db-3d3bafb8327a","ipam_ip_ids":["3e273272-2b9c-4913-89c1-3423bf76990c","e80124d6-c1fe-42be-a73e-82653465a258"],"mac_address":"02:00:00:1f:a9:3e","modification_date":"2025-02-12T16:15:42.433310+00:00","private_network_id":"7a3b6ed2-5295-4ce1-a78f-e24d90879aec","server_id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2124"
+                - "475"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:32 GMT
+                - Wed, 12 Feb 2025 16:16:15 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5923,10 +5925,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bab5ab42-244c-4819-a990-eb0aeddb3a68
+                - 4e1a6c44-038a-4fdd-a087-ece32ceae09b
         status: 200 OK
         code: 200
-        duration: 166.251458ms
+        duration: 111.010083ms
     - id: 120
       request:
         proto: HTTP/1.1
@@ -5942,8 +5944,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664/private_nics/65a6cef8-6606-4214-a8db-3d3bafb8327a
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5960,7 +5962,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:33 GMT
+                - Wed, 12 Feb 2025 16:16:15 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5970,10 +5972,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0060cfdf-caaf-4ce6-a277-610f48f1b81f
+                - e9d924f9-f356-4a7f-a90a-92deef7ab94d
         status: 204 No Content
         code: 204
-        duration: 165.9715ms
+        duration: 438.098ms
     - id: 121
       request:
         proto: HTTP/1.1
@@ -5989,8 +5991,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fed2a66e-f15b-4755-8f8d-2274ab0218fb
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664/private_nics/65a6cef8-6606-4214-a8db-3d3bafb8327a
         method: GET
       response:
         proto: HTTP/2.0
@@ -5998,18 +6000,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 143
+        content_length: 148
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"fed2a66e-f15b-4755-8f8d-2274ab0218fb","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"65a6cef8-6606-4214-a8db-3d3bafb8327a","type":"not_found"}'
         headers:
             Content-Length:
-                - "143"
+                - "148"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:33 GMT
+                - Wed, 12 Feb 2025 16:16:16 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -6019,10 +6021,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 34513028-aa3d-40e1-9fda-9b28e68d92fe
+                - 10f477b9-c9ce-450d-82d3-a813edd4a382
         status: 404 Not Found
         code: 404
-        duration: 91.882583ms
+        duration: 116.360125ms
     - id: 122
       request:
         proto: HTTP/1.1
@@ -6038,8 +6040,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/89d36a9f-ba55-4c09-a3a6-ef9520673300
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664
         method: GET
       response:
         proto: HTTP/2.0
@@ -6047,18 +6049,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 446
+        content_length: 1668
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T09:16:02.059639+00:00","export_uri":null,"id":"89d36a9f-ba55-4c09-a3a6-ef9520673300","modification_date":"2025-01-27T09:17:33.112338+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.167923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-panini","id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","image":{"arch":"x86_64","creation_date":"2024-10-14T09:05:33.350089+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"57509e82-ac3b-49b7-9970-97b60f40ff72","modification_date":"2024-10-14T09:05:33.350089+00:00","name":"Ubuntu 20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"703a3bad-5fc4-450a-9b35-c128312df5f5","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:d7","maintenances":[],"modification_date":"2025-02-12T16:16:14.193030+00:00","name":"tf-srv-eager-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"b3862f05-55df-4387-ab1e-f975957752e5","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "446"
+                - "1668"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:33 GMT
+                - Wed, 12 Feb 2025 16:16:15 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -6068,10 +6070,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f4b96221-2a04-4de9-aed7-f6434be95309
+                - e0b61b73-40b9-43e7-a248-0a538c4501b7
         status: 200 OK
         code: 200
-        duration: 76.390667ms
+        duration: 291.840667ms
     - id: 123
       request:
         proto: HTTP/1.1
@@ -6087,8 +6089,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/89d36a9f-ba55-4c09-a3a6-ef9520673300
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -6105,7 +6107,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:33 GMT
+                - Wed, 12 Feb 2025 16:16:16 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -6115,10 +6117,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b45142f9-3e68-46a9-9e31-c3cdc3259d57
+                - 8dbc1552-de22-4a74-a18c-0d60092c7e41
         status: 204 No Content
         code: 204
-        duration: 148.231792ms
+        duration: 311.136792ms
     - id: 124
       request:
         proto: HTTP/1.1
@@ -6134,8 +6136,155 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f96914f9-4114-4d1f-aa48-077fab624873
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1d3f3134-c9ff-4a73-aba4-9d13a0f98664
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"1d3f3134-c9ff-4a73-aba4-9d13a0f98664","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:16:16 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 594a6e20-2413-4252-a595-60b36bf6d0c0
+        status: 404 Not Found
+        code: 404
+        duration: 107.066584ms
+    - id: 125
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b3862f05-55df-4387-ab1e-f975957752e5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"b3862f05-55df-4387-ab1e-f975957752e5","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:16:16 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 57b9fccc-27c7-47d6-9491-c2dd6baeca29
+        status: 404 Not Found
+        code: 404
+        duration: 57.334417ms
+    - id: 126
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/b3862f05-55df-4387-ab1e-f975957752e5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 494
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:14:57.634432Z","id":"b3862f05-55df-4387-ab1e-f975957752e5","last_detached_at":"2025-02-12T16:16:16.754199Z","name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0","parent_snapshot_id":"703a3bad-5fc4-450a-9b35-c128312df5f5","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:16:16.754199Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "494"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:16:16 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e1c5ceb3-6b3e-475f-b1bc-907822913eaa
+        status: 200 OK
+        code: 200
+        duration: 88.0615ms
+    - id: 127
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/b3862f05-55df-4387-ab1e-f975957752e5
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -6152,7 +6301,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:34 GMT
+                - Wed, 12 Feb 2025 16:16:17 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -6162,11 +6311,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a11e7de5-d2d2-4420-91ff-70fbd493e91f
+                - 827d2975-824b-4563-911a-cd7a83382ad7
         status: 204 No Content
         code: 204
-        duration: 1.09231625s
-    - id: 125
+        duration: 145.191417ms
+    - id: 128
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -6181,27 +6330,25 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/1d82d8f6-cb7b-4a0f-bdb2-b393da83d382
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7a3b6ed2-5295-4ce1-a78f-e24d90879aec
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 131
+        content_length: 0
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"dhcp_entry","resource_id":"1d82d8f6-cb7b-4a0f-bdb2-b393da83d382","type":"not_found"}'
+        body: ""
         headers:
-            Content-Length:
-                - "131"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:34 GMT
+                - Wed, 12 Feb 2025 16:16:18 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -6211,7 +6358,56 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e193480d-70f0-4b3e-b002-1062e0d63f88
+                - b26222b4-5e46-4a19-8830-9063be2aabfd
+        status: 204 No Content
+        code: 204
+        duration: 1.115466833s
+    - id: 129
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/3e273272-2b9c-4913-89c1-3423bf76990c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 131
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"dhcp_entry","resource_id":"3e273272-2b9c-4913-89c1-3423bf76990c","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "131"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:16:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 92fdc0fd-beba-474a-97cd-95e0267eb1e0
         status: 404 Not Found
         code: 404
-        duration: 55.69925ms
+        duration: 69.149167ms

--- a/internal/services/vpcgw/testdata/vpc-public-gateway-pat-rule-with-instance.cassette.yaml
+++ b/internal/services/vpcgw/testdata/vpc-public-gateway-pat-rule-with-instance.cassette.yaml
@@ -18,7 +18,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps
         method: POST
       response:
@@ -27,18 +27,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 556
+        content_length: 574
         uncompressed: false
-        body: '{"address":"10.0.0.1","created_at":"2025-01-27T09:16:00.942421Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"36d90a94-94c0-4f3e-ad09-2686b4ca90cf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-27T09:16:00.942421Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+        body: '{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "556"
+                - "574"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:00 GMT
+                - Wed, 12 Feb 2025 16:14:55 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e397e05e-5b41-4e64-bb3d-6b4d61f33f61
+                - 53bd7f7d-32c4-4d64-be88-eb82c24cd792
         status: 200 OK
         code: 200
-        duration: 55.379625ms
+        duration: 300.860959ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,8 +67,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/36d90a94-94c0-4f3e-ad09-2686b4ca90cf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/432c2d3a-2399-43c2-a711-f68fb19dd665
         method: GET
       response:
         proto: HTTP/2.0
@@ -76,18 +76,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 556
+        content_length: 574
         uncompressed: false
-        body: '{"address":"10.0.0.1","created_at":"2025-01-27T09:16:00.942421Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"36d90a94-94c0-4f3e-ad09-2686b4ca90cf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-27T09:16:00.942421Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+        body: '{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "556"
+                - "574"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:00 GMT
+                - Wed, 12 Feb 2025 16:14:56 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f7006261-fa00-49ad-8a06-efd85b1ff705
+                - 1f550996-296a-4b0d-8546-c5ac3ec0860a
         status: 200 OK
         code: 200
-        duration: 20.921916ms
+        duration: 44.546667ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -118,7 +118,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
         method: POST
       response:
@@ -127,18 +127,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1022
+        content_length: 1045
         uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:01.013255Z","dhcp_enabled":true,"id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","name":"My Private Network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T09:16:01.013255Z","id":"1a2995db-4182-4a59-bef0-f43ec565f3d8","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.20.0/22","updated_at":"2025-01-27T09:16:01.013255Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T09:16:01.013255Z","id":"736e653c-3189-4f9c-8bd5-f1fa9634f267","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:6d3b::/64","updated_at":"2025-01-27T09:16:01.013255Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T09:16:01.013255Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"created_at":"2025-02-12T16:14:56.064699Z","dhcp_enabled":true,"id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","name":"My Private Network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:14:56.064699Z","id":"3fb46282-9a79-4012-af4e-e7826777179c","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.16.0/22","updated_at":"2025-02-12T16:14:56.064699Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-12T16:14:56.064699Z","id":"c00e429c-60c1-4133-a83a-370dedf98bc2","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:3cad::/64","updated_at":"2025-02-12T16:14:56.064699Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-12T16:14:56.064699Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "1022"
+                - "1045"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:01 GMT
+                - Wed, 12 Feb 2025 16:14:56 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -148,10 +148,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6da19099-90a3-4779-9071-801a9a326aaa
+                - 5a84cd4b-9f99-4cbb-bcbb-52a5825d2bc6
         status: 200 OK
         code: 200
-        duration: 618.348541ms
+        duration: 948.584834ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -167,8 +167,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/83515cde-cc20-4a98-a9b6-1ba52cb5f97d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/cf70fcfd-2aae-4a49-a49d-e4cfd7598043
         method: GET
       response:
         proto: HTTP/2.0
@@ -176,18 +176,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1022
+        content_length: 1045
         uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:01.013255Z","dhcp_enabled":true,"id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","name":"My Private Network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T09:16:01.013255Z","id":"1a2995db-4182-4a59-bef0-f43ec565f3d8","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.20.0/22","updated_at":"2025-01-27T09:16:01.013255Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-01-27T09:16:01.013255Z","id":"736e653c-3189-4f9c-8bd5-f1fa9634f267","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:6d3b::/64","updated_at":"2025-01-27T09:16:01.013255Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-01-27T09:16:01.013255Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"created_at":"2025-02-12T16:14:56.064699Z","dhcp_enabled":true,"id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","name":"My Private Network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:14:56.064699Z","id":"3fb46282-9a79-4012-af4e-e7826777179c","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.16.0/22","updated_at":"2025-02-12T16:14:56.064699Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-12T16:14:56.064699Z","id":"c00e429c-60c1-4133-a83a-370dedf98bc2","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:3cad::/64","updated_at":"2025-02-12T16:14:56.064699Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-12T16:14:56.064699Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "1022"
+                - "1045"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:01 GMT
+                - Wed, 12 Feb 2025 16:14:56 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -197,10 +197,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f2bc7d37-be37-4af2-aff6-be8e34f6e2dd
+                - aa8881ea-864e-418f-a0b4-c57730933f89
         status: 200 OK
         code: 200
-        duration: 26.760417ms
+        duration: 55.277ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -216,7 +216,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
         method: GET
       response:
@@ -225,18 +225,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 38539
+        content_length: 35639
         uncompressed: false
-        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
+        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","block_bandwidth":671088640,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","block_bandwidth":1342177280,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","block_bandwidth":335544320,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":209715200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":157286400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":104857600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":21474836480,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":1073741824,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":314572800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","block_bandwidth":167772160,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","block_bandwidth":83886080,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.4567,"mig_profile":null,"monthly_price":1063.391,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1823,"mig_profile":null,"monthly_price":133.079,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.9133,"mig_profile":null,"monthly_price":2126.709,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3637,"mig_profile":null,"monthly_price":265.501,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G-WIN":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7233,"mig_profile":null,"monthly_price":528.009,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","block_bandwidth":3355443200,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","block_bandwidth":6710886400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","block_bandwidth":13421772800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","block_bandwidth":1677721600,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-10":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7264,"mig_profile":null,"monthly_price":530.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-3":{"alt_names":[],"arch":"x86_64","block_bandwidth":419430400,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2554,"mig_profile":null,"monthly_price":186.49,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HN-5":{"alt_names":[],"arch":"x86_64","block_bandwidth":838860800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4524,"mig_profile":null,"monthly_price":330.29,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
         headers:
             Content-Length:
-                - "38539"
+                - "35639"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:01 GMT
+                - Wed, 12 Feb 2025 16:14:56 GMT
             Link:
                 - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
@@ -248,12 +248,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 43182803-633d-4523-a32e-81b46be0492a
+                - 43ed5af4-020a-4a3f-9c75-92f38f7b045c
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 82.494708ms
+        duration: 84.528208ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -269,7 +269,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
         method: GET
       response:
@@ -278,18 +278,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 14208
+        content_length: 13164
         uncompressed: false
-        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+        body: '{"servers":{"PRO2-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":2097152000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":1048576000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":524288000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":262144000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","block_bandwidth":131072000,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":2147483648,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":2000000000,"internet_bandwidth":2000000000}],"ipv6_support":true,"sum_internal_bandwidth":2000000000,"sum_internet_bandwidth":2000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":52428800,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","block_bandwidth":41943040,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
         headers:
             Content-Length:
-                - "14208"
+                - "13164"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:01 GMT
+                - Wed, 12 Feb 2025 16:14:56 GMT
             Link:
                 - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
@@ -301,12 +301,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 893082af-91fc-478d-bca3-8f27a9fa732b
+                - 9ae25d36-3f8e-49ab-a7d7-e69cafb65f00
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 46.3655ms
+        duration: 54.40925ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -324,7 +324,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips
         method: POST
       response:
@@ -333,18 +333,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 360
+        content_length: 369
         uncompressed: false
-        body: '{"address":"51.158.121.209","created_at":"2025-01-27T09:16:01.767610Z","gateway_id":null,"id":"88fd6ba4-8bc1-432f-987a-cc0edd3d863e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"209-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.767610Z","zone":"fr-par-1"}'
+        body: '{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":null,"id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "360"
+                - "369"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:01 GMT
+                - Wed, 12 Feb 2025 16:14:56 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -354,10 +354,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0ee2aaa0-157d-4359-8ed1-84911ce41041
+                - 46264f79-f527-420a-9d66-6ca192eb945d
         status: 200 OK
         code: 200
-        duration: 889.949125ms
+        duration: 1.168629459s
     - id: 7
       request:
         proto: HTTP/1.1
@@ -373,8 +373,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=debian_bullseye&order_by=type_asc&type=instance_local&zone=fr-par-1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/502d0462-a33e-4045-a010-4d7b5889b699
         method: GET
       response:
         proto: HTTP/2.0
@@ -382,18 +382,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1226
+        content_length: 369
         uncompressed: false
-        body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"dfed234f-dfb9-4269-aec1-91f355527c0d","label":"debian_bullseye","type":"instance_local","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"ed780432-12f8-4c42-b689-b99aa920af27","label":"debian_bullseye","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
+        body: '{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":null,"id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1226"
+                - "369"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:01 GMT
+                - Wed, 12 Feb 2025 16:14:56 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -403,10 +403,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c0c9fc71-ae98-437c-beae-537e31de0b7a
+                - 1d863647-86ad-4eea-a8fa-2bfe077788a6
         status: 200 OK
         code: 200
-        duration: 78.556708ms
+        duration: 49.942375ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -422,8 +422,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/88fd6ba4-8bc1-432f-987a-cc0edd3d863e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=debian_bullseye&order_by=type_asc&type=instance_sbs&zone=fr-par-1
         method: GET
       response:
         proto: HTTP/2.0
@@ -431,18 +431,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 360
+        content_length: 1302
         uncompressed: false
-        body: '{"address":"51.158.121.209","created_at":"2025-01-27T09:16:01.767610Z","gateway_id":null,"id":"88fd6ba4-8bc1-432f-987a-cc0edd3d863e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"209-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.767610Z","zone":"fr-par-1"}'
+        body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"id":"a805381b-7ce6-425f-a108-96d9ee019135","label":"debian_bullseye","type":"instance_sbs","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"ffd21d6b-939a-48b2-a100-ab0030fe0ec9","label":"debian_bullseye","type":"instance_sbs","zone":"fr-par-1"}],"total_count":2}'
         headers:
             Content-Length:
-                - "360"
+                - "1302"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:01 GMT
+                - Wed, 12 Feb 2025 16:14:56 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -452,10 +452,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 001344d3-9037-4b88-af54-6a4a674da28a
+                - 7d3520e4-14e4-4c03-a999-050c2445d842
         status: 200 OK
         code: 200
-        duration: 23.958459ms
+        duration: 100.614083ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -467,13 +467,13 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"The Public Gateway","tags":[],"type":"VPC-GW-S","upstream_dns_servers":[],"ip_id":"88fd6ba4-8bc1-432f-987a-cc0edd3d863e","enable_smtp":false,"enable_bastion":false}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"The Public Gateway","tags":[],"type":"VPC-GW-S","upstream_dns_servers":[],"ip_id":"502d0462-a33e-4045-a010-4d7b5889b699","enable_smtp":false,"enable_bastion":false}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
         method: POST
       response:
@@ -482,18 +482,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 982
+        content_length: 1012
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:01.880107Z","gateway_networks":[],"id":"cf55acee-d428-47ca-9fe0-c43c3907774d","ip":{"address":"51.158.121.209","created_at":"2025-01-27T09:16:01.767610Z","gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"88fd6ba4-8bc1-432f-987a-cc0edd3d863e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"209-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.767610Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:01.880107Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.960124Z","gateway_networks":[],"id":"4e178b28-3e98-42d9-8373-7ee292e623a7","ip":{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:14:56.960124Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "982"
+                - "1012"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:01 GMT
+                - Wed, 12 Feb 2025 16:14:56 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -503,10 +503,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c9bece79-8497-4836-8f54-4b0dea2affb0
+                - 0c2dd428-641b-45fb-ac8c-c00ddc9618db
         status: 200 OK
         code: 200
-        duration: 86.438916ms
+        duration: 109.252834ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -522,8 +522,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/cf55acee-d428-47ca-9fe0-c43c3907774d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7
         method: GET
       response:
         proto: HTTP/2.0
@@ -531,18 +531,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 984
+        content_length: 1014
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:01.880107Z","gateway_networks":[],"id":"cf55acee-d428-47ca-9fe0-c43c3907774d","ip":{"address":"51.158.121.209","created_at":"2025-01-27T09:16:01.767610Z","gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"88fd6ba4-8bc1-432f-987a-cc0edd3d863e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"209-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.767610Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:01.919418Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.960124Z","gateway_networks":[],"id":"4e178b28-3e98-42d9-8373-7ee292e623a7","ip":{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:14:57.004864Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "984"
+                - "1014"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:01 GMT
+                - Wed, 12 Feb 2025 16:14:57 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -552,28 +552,28 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 939ee520-5f48-4da3-a877-be9c8919e3e6
+                - 01f3cbfa-fcb9-469f-991a-89e3d085c9f5
         status: 200 OK
         code: 200
-        duration: 28.763291ms
+        duration: 63.025541ms
     - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 271
+        content_length: 230
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"Scaleway Instance","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"dfed234f-dfb9-4269-aec1-91f355527c0d","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+        body: '{"name":"Scaleway Instance","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"a805381b-7ce6-425f-a108-96d9ee019135","volumes":{"0":{"boot":false}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
         method: POST
       response:
@@ -582,20 +582,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2076
+        content_length: 1655
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.386885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ea:1f","maintenances":[],"modification_date":"2025-01-27T09:16:02.386885+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.386885+00:00","export_uri":null,"id":"66ded296-a0b7-4cd8-8375-a9c8cd3d4ee4","modification_date":"2025-01-27T09:16:02.386885+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","name":"Scaleway Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.586614+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"c972b90c-98ce-4fe4-ac18-b4e841110616","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:d9","maintenances":[],"modification_date":"2025-02-12T16:14:57.586614+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"69319b62-c889-49b4-bf5f-89a64c7a530c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2076"
+                - "1655"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:02 GMT
+                - Wed, 12 Feb 2025 16:14:57 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -605,10 +605,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 43d4c317-b158-4a95-b9f6-5b9acc4925f4
+                - 2da7d569-2072-45c7-8fc1-cb2abd6fc0eb
         status: 201 Created
         code: 201
-        duration: 1.10101975s
+        duration: 1.184052292s
     - id: 12
       request:
         proto: HTTP/1.1
@@ -624,8 +624,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616
         method: GET
       response:
         proto: HTTP/2.0
@@ -633,18 +633,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2076
+        content_length: 1655
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.386885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ea:1f","maintenances":[],"modification_date":"2025-01-27T09:16:02.386885+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.386885+00:00","export_uri":null,"id":"66ded296-a0b7-4cd8-8375-a9c8cd3d4ee4","modification_date":"2025-01-27T09:16:02.386885+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","name":"Scaleway Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.586614+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"c972b90c-98ce-4fe4-ac18-b4e841110616","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:d9","maintenances":[],"modification_date":"2025-02-12T16:14:57.586614+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"69319b62-c889-49b4-bf5f-89a64c7a530c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2076"
+                - "1655"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:02 GMT
+                - Wed, 12 Feb 2025 16:14:57 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -654,10 +654,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6a3ea034-0818-4e6d-90a1-b5e0ab8d1505
+                - 3628c836-07dc-4389-9790-2bddac150abc
         status: 200 OK
         code: 200
-        duration: 138.290333ms
+        duration: 540.587958ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -673,8 +673,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616
         method: GET
       response:
         proto: HTTP/2.0
@@ -682,18 +682,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2076
+        content_length: 1655
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.386885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ea:1f","maintenances":[],"modification_date":"2025-01-27T09:16:02.386885+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.386885+00:00","export_uri":null,"id":"66ded296-a0b7-4cd8-8375-a9c8cd3d4ee4","modification_date":"2025-01-27T09:16:02.386885+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","name":"Scaleway Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.586614+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"c972b90c-98ce-4fe4-ac18-b4e841110616","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:d9","maintenances":[],"modification_date":"2025-02-12T16:14:57.586614+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"69319b62-c889-49b4-bf5f-89a64c7a530c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2076"
+                - "1655"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:02 GMT
+                - Wed, 12 Feb 2025 16:14:58 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -703,11 +703,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 62fa1051-10a7-445e-b2dc-96eb8765ace7
+                - 68fcf18e-20d6-4be7-bb5a-8b2eb94308e9
         status: 200 OK
         code: 200
-        duration: 142.46225ms
+        duration: 172.525166ms
     - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/69319b62-c889-49b4-bf5f-89a64c7a530c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 692
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:14:57.789341Z","id":"69319b62-c889-49b4-bf5f-89a64c7a530c","last_detached_at":null,"name":"Debian Bullseye_sbs_volume_0","parent_snapshot_id":"a50e6921-21b9-4a69-83cc-191359208d4c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:14:57.789341Z","id":"427679d5-67d4-4f63-b880-f092ab65f28c","product_resource_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:14:57.789341Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "692"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:14:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9a238bc4-c8fb-4dfc-80e2-5f8838e9027e
+        status: 200 OK
+        code: 200
+        duration: 86.894916ms
+    - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -724,8 +773,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -735,7 +784,7 @@ interactions:
         trailer: {}
         content_length: 357
         uncompressed: false
-        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b/action","href_result":"/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","id":"ef4f2ad1-7f25-4ea3-a0b8-0b6471e2044f","progress":0,"started_at":"2025-01-27T09:16:03.642016+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/action","href_result":"/servers/c972b90c-98ce-4fe4-ac18-b4e841110616","id":"23607605-d9ce-4354-88c7-df49780a52f8","progress":0,"started_at":"2025-02-12T16:14:59.183437+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -744,9 +793,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:03 GMT
+                - Wed, 12 Feb 2025 16:14:58 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/ef4f2ad1-7f25-4ea3-a0b8-0b6471e2044f
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/23607605-d9ce-4354-88c7-df49780a52f8
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -756,59 +805,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ebf99082-73cb-494a-946e-cfc62961d0ee
+                - 5e210871-4a28-45f0-b365-1f0e62508eb0
         status: 202 Accepted
         code: 202
-        duration: 476.453584ms
-    - id: 15
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2098
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.386885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ea:1f","maintenances":[],"modification_date":"2025-01-27T09:16:03.222932+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.386885+00:00","export_uri":null,"id":"66ded296-a0b7-4cd8-8375-a9c8cd3d4ee4","modification_date":"2025-01-27T09:16:02.386885+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","name":"Scaleway Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2098"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:16:03 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 29c3f311-37e2-456d-b4eb-10da46f577be
-        status: 200 OK
-        code: 200
-        duration: 193.344166ms
+        duration: 303.102667ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -824,8 +824,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/cf55acee-d428-47ca-9fe0-c43c3907774d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616
         method: GET
       response:
         proto: HTTP/2.0
@@ -833,18 +833,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 981
+        content_length: 1677
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:01.880107Z","gateway_networks":[],"id":"cf55acee-d428-47ca-9fe0-c43c3907774d","ip":{"address":"51.158.121.209","created_at":"2025-01-27T09:16:01.767610Z","gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"88fd6ba4-8bc1-432f-987a-cc0edd3d863e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"209-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.767610Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:05.038207Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.586614+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"c972b90c-98ce-4fe4-ac18-b4e841110616","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:d9","maintenances":[],"modification_date":"2025-02-12T16:14:58.954345+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"id":"69319b62-c889-49b4-bf5f-89a64c7a530c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "981"
+                - "1677"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:06 GMT
+                - Wed, 12 Feb 2025 16:14:59 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -854,10 +854,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6b1c67ab-42f0-4ec7-b2c8-dc770c3c53c0
+                - a3359413-f301-4b2f-a6e3-a698caa03eb8
         status: 200 OK
         code: 200
-        duration: 36.847583ms
+        duration: 203.17875ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -873,8 +873,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/cf55acee-d428-47ca-9fe0-c43c3907774d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7
         method: GET
       response:
         proto: HTTP/2.0
@@ -882,18 +882,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 981
+        content_length: 1011
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:01.880107Z","gateway_networks":[],"id":"cf55acee-d428-47ca-9fe0-c43c3907774d","ip":{"address":"51.158.121.209","created_at":"2025-01-27T09:16:01.767610Z","gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"88fd6ba4-8bc1-432f-987a-cc0edd3d863e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"209-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.767610Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:05.038207Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.960124Z","gateway_networks":[],"id":"4e178b28-3e98-42d9-8373-7ee292e623a7","ip":{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:02.081729Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "981"
+                - "1011"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:07 GMT
+                - Wed, 12 Feb 2025 16:15:02 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -903,10 +903,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b81514d4-716a-4035-b462-2e9034017b03
+                - b188103f-e74b-4a1a-bc4d-474bf5665e13
         status: 200 OK
         code: 200
-        duration: 28.053792ms
+        duration: 54.366416ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -922,8 +922,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/cf55acee-d428-47ca-9fe0-c43c3907774d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7
         method: GET
       response:
         proto: HTTP/2.0
@@ -931,18 +931,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 981
+        content_length: 1011
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:01.880107Z","gateway_networks":[],"id":"cf55acee-d428-47ca-9fe0-c43c3907774d","ip":{"address":"51.158.121.209","created_at":"2025-01-27T09:16:01.767610Z","gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"88fd6ba4-8bc1-432f-987a-cc0edd3d863e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"209-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.767610Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:05.038207Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.960124Z","gateway_networks":[],"id":"4e178b28-3e98-42d9-8373-7ee292e623a7","ip":{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:02.081729Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "981"
+                - "1011"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:07 GMT
+                - Wed, 12 Feb 2025 16:15:02 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -952,10 +952,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d5401580-baf3-40eb-a281-e17e7848eacb
+                - 3ee28176-16ce-45e6-8833-2bea051b7bf6
         status: 200 OK
         code: 200
-        duration: 23.441542ms
+        duration: 47.678042ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -971,8 +971,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7
         method: GET
       response:
         proto: HTTP/2.0
@@ -980,18 +980,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2201
+        content_length: 1011
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.386885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"43","hypervisor_id":"602","node_id":"17","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:1f","maintenances":[],"modification_date":"2025-01-27T09:16:03.222932+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.386885+00:00","export_uri":null,"id":"66ded296-a0b7-4cd8-8375-a9c8cd3d4ee4","modification_date":"2025-01-27T09:16:02.386885+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","name":"Scaleway Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.960124Z","gateway_networks":[],"id":"4e178b28-3e98-42d9-8373-7ee292e623a7","ip":{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:02.081729Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2201"
+                - "1011"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:08 GMT
+                - Wed, 12 Feb 2025 16:15:02 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1001,11 +1001,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8631842e-b279-4c9b-a2c4-861f4587c2d9
+                - 2b3730d1-2753-4bdf-a993-b8aa3e333940
         status: 200 OK
         code: 200
-        duration: 174.16325ms
+        duration: 50.425375ms
     - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1780
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.586614+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"c972b90c-98ce-4fe4-ac18-b4e841110616","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"702","node_id":"10","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d9","maintenances":[],"modification_date":"2025-02-12T16:14:58.954345+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"id":"69319b62-c889-49b4-bf5f-89a64c7a530c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1780"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5c152bef-aee4-4501-8b12-c31aba9beec3
+        status: 200 OK
+        code: 200
+        duration: 211.782375ms
+    - id: 21
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1016,13 +1065,13 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"36d90a94-94c0-4f3e-ad09-2686b4ca90cf"}'
+        body: '{"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"432c2d3a-2399-43c2-a711-f68fb19dd665"}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
         url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
         method: POST
       response:
@@ -1031,18 +1080,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 941
+        content_length: 28
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:09.598679Z","dhcp":{"address":"10.0.0.1","created_at":"2025-01-27T09:16:00.942421Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"36d90a94-94c0-4f3e-ad09-2686b4ca90cf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-27T09:16:00.942421Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"ac63269b-f491-4f84-9013-9b5bb291022e","ipam_config":null,"mac_address":null,"private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","status":"created","updated_at":"2025-01-27T09:16:09.598679Z","zone":"fr-par-1"}'
+        body: '{"message":"internal error"}'
         headers:
             Content-Length:
-                - "941"
+                - "28"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:09 GMT
+                - Wed, 12 Feb 2025 16:15:06 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1052,95 +1101,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3e3fa654-630d-4e09-adde-1c4f64162f16
-        status: 200 OK
-        code: 200
-        duration: 2.714210375s
-    - id: 21
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/cf55acee-d428-47ca-9fe0-c43c3907774d
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1925
-        uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:01.880107Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:09.598679Z","dhcp":{"address":"10.0.0.1","created_at":"2025-01-27T09:16:00.942421Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"36d90a94-94c0-4f3e-ad09-2686b4ca90cf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-27T09:16:00.942421Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"ac63269b-f491-4f84-9013-9b5bb291022e","ipam_config":null,"mac_address":null,"private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","status":"created","updated_at":"2025-01-27T09:16:09.598679Z","zone":"fr-par-1"}],"id":"cf55acee-d428-47ca-9fe0-c43c3907774d","ip":{"address":"51.158.121.209","created_at":"2025-01-27T09:16:01.767610Z","gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"88fd6ba4-8bc1-432f-987a-cc0edd3d863e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"209-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.767610Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:09.754268Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "1925"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:16:09 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - cc267dd9-d6db-4fb3-972e-040a6c90de86
-        status: 200 OK
-        code: 200
-        duration: 26.045209ms
+                - 377815b8-1eeb-4bd1-b67f-a49137a2bc3e
+        status: 500 Internal Server Error
+        code: 500
+        duration: 4.556749834s
     - id: 22
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 206
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"432c2d3a-2399-43c2-a711-f68fb19dd665"}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2201
+        content_length: 28
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.386885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"43","hypervisor_id":"602","node_id":"17","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:1f","maintenances":[],"modification_date":"2025-01-27T09:16:03.222932+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.386885+00:00","export_uri":null,"id":"66ded296-a0b7-4cd8-8375-a9c8cd3d4ee4","modification_date":"2025-01-27T09:16:02.386885+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","name":"Scaleway Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"internal error"}'
         headers:
             Content-Length:
-                - "2201"
+                - "28"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:14 GMT
+                - Wed, 12 Feb 2025 16:15:09 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1150,10 +1152,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - efc67fde-313c-4930-a867-6501653c3b79
-        status: 200 OK
-        code: 200
-        duration: 251.203334ms
+                - 4ceb7a59-44b8-4e6d-89ee-49d7402a6063
+        status: 500 Internal Server Error
+        code: 500
+        duration: 354.470083ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1169,8 +1171,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/cf55acee-d428-47ca-9fe0-c43c3907774d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616
         method: GET
       response:
         proto: HTTP/2.0
@@ -1178,18 +1180,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1925
+        content_length: 1811
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:01.880107Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:09.598679Z","dhcp":{"address":"10.0.0.1","created_at":"2025-01-27T09:16:00.942421Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"36d90a94-94c0-4f3e-ad09-2686b4ca90cf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-27T09:16:00.942421Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"ac63269b-f491-4f84-9013-9b5bb291022e","ipam_config":null,"mac_address":null,"private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","status":"created","updated_at":"2025-01-27T09:16:09.598679Z","zone":"fr-par-1"}],"id":"cf55acee-d428-47ca-9fe0-c43c3907774d","ip":{"address":"51.158.121.209","created_at":"2025-01-27T09:16:01.767610Z","gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"88fd6ba4-8bc1-432f-987a-cc0edd3d863e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"209-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.767610Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:09.754268Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.586614+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"c972b90c-98ce-4fe4-ac18-b4e841110616","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"702","node_id":"10","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d9","maintenances":[],"modification_date":"2025-02-12T16:15:08.588756+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"69319b62-c889-49b4-bf5f-89a64c7a530c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1925"
+                - "1811"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:14 GMT
+                - Wed, 12 Feb 2025 16:15:09 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1199,10 +1201,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 23ae1670-436b-42fe-aa89-8e4db8eefd36
+                - cbc25586-4bef-4380-9aec-7f5816259fc5
         status: 200 OK
         code: 200
-        duration: 31.159208ms
+        duration: 184.405875ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1218,8 +1220,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/cf70fcfd-2aae-4a49-a49d-e4cfd7598043
         method: GET
       response:
         proto: HTTP/2.0
@@ -1227,18 +1229,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2201
+        content_length: 1045
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.386885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"43","hypervisor_id":"602","node_id":"17","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:1f","maintenances":[],"modification_date":"2025-01-27T09:16:03.222932+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.386885+00:00","export_uri":null,"id":"66ded296-a0b7-4cd8-8375-a9c8cd3d4ee4","modification_date":"2025-01-27T09:16:02.386885+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","name":"Scaleway Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-12T16:14:56.064699Z","dhcp_enabled":true,"id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","name":"My Private Network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:14:56.064699Z","id":"3fb46282-9a79-4012-af4e-e7826777179c","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.16.0/22","updated_at":"2025-02-12T16:14:56.064699Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-12T16:14:56.064699Z","id":"c00e429c-60c1-4133-a83a-370dedf98bc2","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:3cad::/64","updated_at":"2025-02-12T16:14:56.064699Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-12T16:14:56.064699Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "2201"
+                - "1045"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:19 GMT
+                - Wed, 12 Feb 2025 16:15:09 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1248,10 +1250,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 841bbeb0-ec45-448f-9b71-f08d3a8a82df
+                - c3cbd1ef-1621-44c0-a26f-847c5860095c
         status: 200 OK
         code: 200
-        duration: 136.940708ms
+        duration: 48.253833ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1267,8 +1269,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/cf55acee-d428-47ca-9fe0-c43c3907774d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616
         method: GET
       response:
         proto: HTTP/2.0
@@ -1276,18 +1278,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1934
+        content_length: 1811
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:01.880107Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:09.598679Z","dhcp":{"address":"10.0.0.1","created_at":"2025-01-27T09:16:00.942421Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"36d90a94-94c0-4f3e-ad09-2686b4ca90cf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-27T09:16:00.942421Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"ac63269b-f491-4f84-9013-9b5bb291022e","ipam_config":null,"mac_address":"02:00:00:17:EA:CB","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","status":"ready","updated_at":"2025-01-27T09:16:18.197353Z","zone":"fr-par-1"}],"id":"cf55acee-d428-47ca-9fe0-c43c3907774d","ip":{"address":"51.158.121.209","created_at":"2025-01-27T09:16:01.767610Z","gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"88fd6ba4-8bc1-432f-987a-cc0edd3d863e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"209-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.767610Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:19.700464Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.586614+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"c972b90c-98ce-4fe4-ac18-b4e841110616","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"702","node_id":"10","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d9","maintenances":[],"modification_date":"2025-02-12T16:15:08.588756+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"69319b62-c889-49b4-bf5f-89a64c7a530c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1934"
+                - "1811"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:19 GMT
+                - Wed, 12 Feb 2025 16:15:10 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1297,46 +1299,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 348de160-e71d-4c5d-9e1d-676141fb7663
+                - ebdca782-d995-424e-bb3e-d18d382c120e
         status: 200 OK
         code: 200
-        duration: 31.366083ms
+        duration: 211.358708ms
     - id: 26
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 61
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043"}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ac63269b-f491-4f84-9013-9b5bb291022e
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/private_nics
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 954
+        content_length: 473
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:09.598679Z","dhcp":{"address":"10.0.0.1","created_at":"2025-01-27T09:16:00.942421Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"36d90a94-94c0-4f3e-ad09-2686b4ca90cf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-27T09:16:00.942421Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"ac63269b-f491-4f84-9013-9b5bb291022e","ipam_config":null,"mac_address":"02:00:00:17:EA:CB","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","status":"ready","updated_at":"2025-01-27T09:16:18.197353Z","zone":"fr-par-1"}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:10.328211+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "954"
+                - "473"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:19 GMT
+                - Wed, 12 Feb 2025 16:15:11 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1346,10 +1350,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dde23621-f7f3-4b99-8fc7-ea4c03072ab9
-        status: 200 OK
-        code: 200
-        duration: 43.458166ms
+                - a0f85371-e0b2-4726-92fc-ab2123a9496c
+        status: 201 Created
+        code: 201
+        duration: 1.068275125s
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1365,8 +1369,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ac63269b-f491-4f84-9013-9b5bb291022e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/private_nics/f779056f-b24a-422b-98f1-e1e6b57219de
         method: GET
       response:
         proto: HTTP/2.0
@@ -1374,18 +1378,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 954
+        content_length: 473
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:09.598679Z","dhcp":{"address":"10.0.0.1","created_at":"2025-01-27T09:16:00.942421Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"36d90a94-94c0-4f3e-ad09-2686b4ca90cf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-27T09:16:00.942421Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"ac63269b-f491-4f84-9013-9b5bb291022e","ipam_config":null,"mac_address":"02:00:00:17:EA:CB","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","status":"ready","updated_at":"2025-01-27T09:16:18.197353Z","zone":"fr-par-1"}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:10.328211+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "954"
+                - "473"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:19 GMT
+                - Wed, 12 Feb 2025 16:15:11 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1395,46 +1399,48 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 37ca2b1c-f2ca-4a1c-9e53-474b57b5894c
+                - 2ff69ea8-c8e6-4baa-8de6-1e9595a00ab1
         status: 200 OK
         code: 200
-        duration: 57.36525ms
+        duration: 109.431416ms
     - id: 28
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 206
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: '{"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"432c2d3a-2399-43c2-a711-f68fb19dd665"}'
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/cf55acee-d428-47ca-9fe0-c43c3907774d
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1934
+        content_length: 971
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:01.880107Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:09.598679Z","dhcp":{"address":"10.0.0.1","created_at":"2025-01-27T09:16:00.942421Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"36d90a94-94c0-4f3e-ad09-2686b4ca90cf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-27T09:16:00.942421Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"ac63269b-f491-4f84-9013-9b5bb291022e","ipam_config":null,"mac_address":"02:00:00:17:EA:CB","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","status":"ready","updated_at":"2025-01-27T09:16:18.197353Z","zone":"fr-par-1"}],"id":"cf55acee-d428-47ca-9fe0-c43c3907774d","ip":{"address":"51.158.121.209","created_at":"2025-01-27T09:16:01.767610Z","gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"88fd6ba4-8bc1-432f-987a-cc0edd3d863e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"209-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.767610Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:19.700464Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":null,"private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"created","updated_at":"2025-02-12T16:15:15.041619Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1934"
+                - "971"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:19 GMT
+                - Wed, 12 Feb 2025 16:15:15 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1444,10 +1450,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1a2fbb7f-bdab-4039-b8c6-6946e84a079c
+                - 8355cea3-29bf-4678-b126-1ed44ba693a3
         status: 200 OK
         code: 200
-        duration: 29.405709ms
+        duration: 2.142525458s
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1463,8 +1469,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ac63269b-f491-4f84-9013-9b5bb291022e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1472,18 +1478,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 954
+        content_length: 1985
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:09.598679Z","dhcp":{"address":"10.0.0.1","created_at":"2025-01-27T09:16:00.942421Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"36d90a94-94c0-4f3e-ad09-2686b4ca90cf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-27T09:16:00.942421Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"ac63269b-f491-4f84-9013-9b5bb291022e","ipam_config":null,"mac_address":"02:00:00:17:EA:CB","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","status":"ready","updated_at":"2025-01-27T09:16:18.197353Z","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.960124Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":null,"private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"created","updated_at":"2025-02-12T16:15:15.041619Z","zone":"fr-par-1"}],"id":"4e178b28-3e98-42d9-8373-7ee292e623a7","ip":{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:15.177390Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "954"
+                - "1985"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:20 GMT
+                - Wed, 12 Feb 2025 16:15:15 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1493,10 +1499,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6f8119c1-cbfa-4155-a776-cc257afd5afc
+                - 2aa5e62a-1415-45cf-b72d-63d2790903ed
         status: 200 OK
         code: 200
-        duration: 43.4325ms
+        duration: 48.649458ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1512,8 +1518,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/private_nics/f779056f-b24a-422b-98f1-e1e6b57219de
         method: GET
       response:
         proto: HTTP/2.0
@@ -1521,18 +1527,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2201
+        content_length: 473
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.386885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"43","hypervisor_id":"602","node_id":"17","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:1f","maintenances":[],"modification_date":"2025-01-27T09:16:03.222932+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.386885+00:00","export_uri":null,"id":"66ded296-a0b7-4cd8-8375-a9c8cd3d4ee4","modification_date":"2025-01-27T09:16:02.386885+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","name":"Scaleway Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:10.328211+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2201"
+                - "473"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:24 GMT
+                - Wed, 12 Feb 2025 16:15:16 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1542,10 +1548,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ba7f0cf4-25c0-46a9-84ee-feb307b0da89
+                - 42ed934f-ab6e-4874-900f-20caaa4b564e
         status: 200 OK
         code: 200
-        duration: 179.664833ms
+        duration: 117.608375ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1561,8 +1567,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1570,18 +1576,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2201
+        content_length: 1985
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.386885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"43","hypervisor_id":"602","node_id":"17","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:1f","maintenances":[],"modification_date":"2025-01-27T09:16:03.222932+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.386885+00:00","export_uri":null,"id":"66ded296-a0b7-4cd8-8375-a9c8cd3d4ee4","modification_date":"2025-01-27T09:16:02.386885+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","name":"Scaleway Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.960124Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":null,"private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"created","updated_at":"2025-02-12T16:15:15.041619Z","zone":"fr-par-1"}],"id":"4e178b28-3e98-42d9-8373-7ee292e623a7","ip":{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:15.177390Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2201"
+                - "1985"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:29 GMT
+                - Wed, 12 Feb 2025 16:15:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1591,10 +1597,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ca91feeb-78c3-4a13-be3b-63e568ff88d7
+                - bd67f358-e995-4220-a3c2-8093cc281fc4
         status: 200 OK
         code: 200
-        duration: 186.4205ms
+        duration: 58.513917ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1610,8 +1616,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/private_nics/f779056f-b24a-422b-98f1-e1e6b57219de
         method: GET
       response:
         proto: HTTP/2.0
@@ -1619,18 +1625,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2201
+        content_length: 473
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.386885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"43","hypervisor_id":"602","node_id":"17","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:1f","maintenances":[],"modification_date":"2025-01-27T09:16:03.222932+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.386885+00:00","export_uri":null,"id":"66ded296-a0b7-4cd8-8375-a9c8cd3d4ee4","modification_date":"2025-01-27T09:16:02.386885+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","name":"Scaleway Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:10.328211+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2201"
+                - "473"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:34 GMT
+                - Wed, 12 Feb 2025 16:15:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1640,10 +1646,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 77554e69-ef53-4f69-99e5-053ed0d16850
+                - ac01b71c-8cdb-4f07-a371-a0fedc1b8853
         status: 200 OK
         code: 200
-        duration: 206.172833ms
+        duration: 115.579208ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1659,8 +1665,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1668,18 +1674,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2232
+        content_length: 1994
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.386885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"43","hypervisor_id":"602","node_id":"17","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:1f","maintenances":[],"modification_date":"2025-01-27T09:16:34.948396+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.386885+00:00","export_uri":null,"id":"66ded296-a0b7-4cd8-8375-a9c8cd3d4ee4","modification_date":"2025-01-27T09:16:02.386885+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","name":"Scaleway Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.960124Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}],"id":"4e178b28-3e98-42d9-8373-7ee292e623a7","ip":{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:23.527960Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2232"
+                - "1994"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:40 GMT
+                - Wed, 12 Feb 2025 16:15:25 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1689,10 +1695,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 47b3d285-26cc-4f70-b9a9-d7b3ba01f340
+                - eb9851fd-2386-463c-8625-768e593967bc
         status: 200 OK
         code: 200
-        duration: 187.95725ms
+        duration: 51.649625ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1708,8 +1714,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/83515cde-cc20-4a98-a9b6-1ba52cb5f97d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1a85191f-5f3c-4895-86f7-28b1d61a4f2e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1717,18 +1723,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1019
+        content_length: 984
         uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:01.013255Z","dhcp_enabled":true,"id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","name":"My Private Network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T09:16:01.013255Z","id":"1a2995db-4182-4a59-bef0-f43ec565f3d8","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"10.0.0.0/24","updated_at":"2025-01-27T09:16:07.371886Z","vpc_id":"63821fbf-3776-414c-b014-db386b1ba6e7"},{"created_at":"2025-01-27T09:16:01.013255Z","id":"736e653c-3189-4f9c-8bd5-f1fa9634f267","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:6d3b::/64","updated_at":"2025-01-27T09:16:07.376086Z","vpc_id":"63821fbf-3776-414c-b014-db386b1ba6e7"}],"tags":[],"updated_at":"2025-01-27T09:16:16.207697Z","vpc_id":"63821fbf-3776-414c-b014-db386b1ba6e7"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1019"
+                - "984"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:40 GMT
+                - Wed, 12 Feb 2025 16:15:25 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1738,10 +1744,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9206350b-5250-4c1b-a507-65cfd3d52f7b
+                - 7bce820e-677b-480b-8190-b5ddb081e4d9
         status: 200 OK
         code: 200
-        duration: 33.918792ms
+        duration: 67.289291ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1757,8 +1763,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1a85191f-5f3c-4895-86f7-28b1d61a4f2e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1766,18 +1772,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2232
+        content_length: 984
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.386885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"43","hypervisor_id":"602","node_id":"17","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:1f","maintenances":[],"modification_date":"2025-01-27T09:16:34.948396+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.386885+00:00","export_uri":null,"id":"66ded296-a0b7-4cd8-8375-a9c8cd3d4ee4","modification_date":"2025-01-27T09:16:02.386885+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","name":"Scaleway Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2232"
+                - "984"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:40 GMT
+                - Wed, 12 Feb 2025 16:15:25 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1787,48 +1793,46 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9d36f10b-8dc0-4599-812a-76851cb60328
+                - a6c2f637-73a7-4b35-8ed4-573a2f70392d
         status: 200 OK
         code: 200
-        duration: 198.688541ms
+        duration: 70.746375ms
     - id: 36
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 61
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d"}'
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b/private_nics
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 473
+        content_length: 1994
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:40.456736+00:00","id":"6b5c6c0f-7444-4b7e-b21c-8739c55fd0a0","ipam_ip_ids":["b9b673e8-309b-423d-8eb4-e08d2d2663b6","a8d9091b-37a6-40b8-8460-27b8e7aa68d4"],"mac_address":"02:00:00:1c:f4:96","modification_date":"2025-01-27T09:16:40.683622+00:00","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","server_id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.960124Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}],"id":"4e178b28-3e98-42d9-8373-7ee292e623a7","ip":{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:23.527960Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "473"
+                - "1994"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:41 GMT
+                - Wed, 12 Feb 2025 16:15:25 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1838,10 +1842,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 440818c3-ff45-4f8f-b084-79cd089cf374
-        status: 201 Created
-        code: 201
-        duration: 1.123245666s
+                - 09f2ab1a-d538-4251-863b-2cd709369d06
+        status: 200 OK
+        code: 200
+        duration: 48.067ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1857,8 +1861,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b/private_nics/6b5c6c0f-7444-4b7e-b21c-8739c55fd0a0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1a85191f-5f3c-4895-86f7-28b1d61a4f2e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1866,18 +1870,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 473
+        content_length: 984
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:40.456736+00:00","id":"6b5c6c0f-7444-4b7e-b21c-8739c55fd0a0","ipam_ip_ids":["b9b673e8-309b-423d-8eb4-e08d2d2663b6","a8d9091b-37a6-40b8-8460-27b8e7aa68d4"],"mac_address":"02:00:00:1c:f4:96","modification_date":"2025-01-27T09:16:40.683622+00:00","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","server_id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "473"
+                - "984"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:41 GMT
+                - Wed, 12 Feb 2025 16:15:25 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1887,10 +1891,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 635176ed-c3c6-4d9b-a6e6-17176c16e269
+                - 77147f6b-3b43-4f19-8ed9-a8dab060e314
         status: 200 OK
         code: 200
-        duration: 79.86775ms
+        duration: 70.08575ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1906,8 +1910,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b/private_nics/6b5c6c0f-7444-4b7e-b21c-8739c55fd0a0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/private_nics/f779056f-b24a-422b-98f1-e1e6b57219de
         method: GET
       response:
         proto: HTTP/2.0
@@ -1917,7 +1921,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:40.456736+00:00","id":"6b5c6c0f-7444-4b7e-b21c-8739c55fd0a0","ipam_ip_ids":["b9b673e8-309b-423d-8eb4-e08d2d2663b6","a8d9091b-37a6-40b8-8460-27b8e7aa68d4"],"mac_address":"02:00:00:1c:f4:96","modification_date":"2025-01-27T09:16:40.683622+00:00","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","server_id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:10.328211+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -1926,7 +1930,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:46 GMT
+                - Wed, 12 Feb 2025 16:15:26 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1936,10 +1940,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ea0af2f2-e42a-435b-94ea-dac419e7d32c
+                - 6b011f47-de78-4ef6-a6f9-0236aa956536
         status: 200 OK
         code: 200
-        duration: 69.016458ms
+        duration: 105.379708ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1955,8 +1959,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b/private_nics/6b5c6c0f-7444-4b7e-b21c-8739c55fd0a0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/private_nics/f779056f-b24a-422b-98f1-e1e6b57219de
         method: GET
       response:
         proto: HTTP/2.0
@@ -1966,7 +1970,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:40.456736+00:00","id":"6b5c6c0f-7444-4b7e-b21c-8739c55fd0a0","ipam_ip_ids":["b9b673e8-309b-423d-8eb4-e08d2d2663b6","a8d9091b-37a6-40b8-8460-27b8e7aa68d4"],"mac_address":"02:00:00:1c:f4:96","modification_date":"2025-01-27T09:16:40.683622+00:00","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","server_id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:10.328211+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -1975,7 +1979,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:52 GMT
+                - Wed, 12 Feb 2025 16:15:31 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -1985,10 +1989,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 48440111-6dcf-4866-9703-3d38071c87b0
+                - 92a037cb-c71d-4138-93dd-d57dc2118ad9
         status: 200 OK
         code: 200
-        duration: 781.659792ms
+        duration: 120.015958ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2004,8 +2008,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b/private_nics/6b5c6c0f-7444-4b7e-b21c-8739c55fd0a0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/private_nics/f779056f-b24a-422b-98f1-e1e6b57219de
         method: GET
       response:
         proto: HTTP/2.0
@@ -2015,7 +2019,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:40.456736+00:00","id":"6b5c6c0f-7444-4b7e-b21c-8739c55fd0a0","ipam_ip_ids":["b9b673e8-309b-423d-8eb4-e08d2d2663b6","a8d9091b-37a6-40b8-8460-27b8e7aa68d4"],"mac_address":"02:00:00:1c:f4:96","modification_date":"2025-01-27T09:16:40.683622+00:00","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","server_id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:10.328211+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -2024,7 +2028,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:16:57 GMT
+                - Wed, 12 Feb 2025 16:15:36 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2034,10 +2038,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 112b18f7-14a3-4163-b3c0-e2f665a78344
+                - 2a8a9fbb-c25d-40d5-a0eb-f6a5decc13c4
         status: 200 OK
         code: 200
-        duration: 90.771583ms
+        duration: 94.892541ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2053,8 +2057,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b/private_nics/6b5c6c0f-7444-4b7e-b21c-8739c55fd0a0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/private_nics/f779056f-b24a-422b-98f1-e1e6b57219de
         method: GET
       response:
         proto: HTTP/2.0
@@ -2062,18 +2066,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 473
+        content_length: 475
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:40.456736+00:00","id":"6b5c6c0f-7444-4b7e-b21c-8739c55fd0a0","ipam_ip_ids":["b9b673e8-309b-423d-8eb4-e08d2d2663b6","a8d9091b-37a6-40b8-8460-27b8e7aa68d4"],"mac_address":"02:00:00:1c:f4:96","modification_date":"2025-01-27T09:16:40.683622+00:00","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","server_id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:41.910409+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "473"
+                - "475"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:02 GMT
+                - Wed, 12 Feb 2025 16:15:42 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2083,10 +2087,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9dcd9c5e-3817-42e8-b511-7bea340baffa
+                - fab01ad2-c5fc-4371-aeac-83dc191b30e0
         status: 200 OK
         code: 200
-        duration: 90.568292ms
+        duration: 285.488292ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2102,8 +2106,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b/private_nics/6b5c6c0f-7444-4b7e-b21c-8739c55fd0a0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/private_nics/f779056f-b24a-422b-98f1-e1e6b57219de
         method: GET
       response:
         proto: HTTP/2.0
@@ -2111,18 +2115,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 473
+        content_length: 475
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:40.456736+00:00","id":"6b5c6c0f-7444-4b7e-b21c-8739c55fd0a0","ipam_ip_ids":["b9b673e8-309b-423d-8eb4-e08d2d2663b6","a8d9091b-37a6-40b8-8460-27b8e7aa68d4"],"mac_address":"02:00:00:1c:f4:96","modification_date":"2025-01-27T09:16:40.683622+00:00","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","server_id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:41.910409+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "473"
+                - "475"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:07 GMT
+                - Wed, 12 Feb 2025 16:15:42 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2132,10 +2136,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c8b80d64-55b0-4eea-9ba6-222fa6d9a371
+                - 469b7e63-b562-41f2-a81f-b6093182a49c
         status: 200 OK
         code: 200
-        duration: 87.438583ms
+        duration: 275.473958ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2151,8 +2155,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b/private_nics/6b5c6c0f-7444-4b7e-b21c-8739c55fd0a0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616
         method: GET
       response:
         proto: HTTP/2.0
@@ -2160,18 +2164,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 475
+        content_length: 2269
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:40.456736+00:00","id":"6b5c6c0f-7444-4b7e-b21c-8739c55fd0a0","ipam_ip_ids":["b9b673e8-309b-423d-8eb4-e08d2d2663b6","a8d9091b-37a6-40b8-8460-27b8e7aa68d4"],"mac_address":"02:00:00:1c:f4:96","modification_date":"2025-01-27T09:17:12.338455+00:00","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","server_id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.586614+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"c972b90c-98ce-4fe4-ac18-b4e841110616","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"702","node_id":"10","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d9","maintenances":[],"modification_date":"2025-02-12T16:15:08.588756+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:41.910409+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"69319b62-c889-49b4-bf5f-89a64c7a530c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "475"
+                - "2269"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:12 GMT
+                - Wed, 12 Feb 2025 16:15:42 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2181,10 +2185,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 685390b9-20ef-4e11-95e5-06cce4505e00
+                - 6411c441-80b7-4b15-bee2-86b11a2c4df3
         status: 200 OK
         code: 200
-        duration: 77.294291ms
+        duration: 173.552291ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2200,8 +2204,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b/private_nics/6b5c6c0f-7444-4b7e-b21c-8739c55fd0a0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/69319b62-c889-49b4-bf5f-89a64c7a530c
         method: GET
       response:
         proto: HTTP/2.0
@@ -2209,18 +2213,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 475
+        content_length: 143
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:40.456736+00:00","id":"6b5c6c0f-7444-4b7e-b21c-8739c55fd0a0","ipam_ip_ids":["b9b673e8-309b-423d-8eb4-e08d2d2663b6","a8d9091b-37a6-40b8-8460-27b8e7aa68d4"],"mac_address":"02:00:00:1c:f4:96","modification_date":"2025-01-27T09:17:12.338455+00:00","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","server_id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"69319b62-c889-49b4-bf5f-89a64c7a530c","type":"not_found"}'
         headers:
             Content-Length:
-                - "475"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:12 GMT
+                - Wed, 12 Feb 2025 16:15:42 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2230,10 +2234,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 42e158cd-6c3f-48d9-8ef9-8c6a36ca83c1
-        status: 200 OK
-        code: 200
-        duration: 101.220459ms
+                - 3bc1eafb-0289-4cff-b2a4-bda4629cf2f2
+        status: 404 Not Found
+        code: 404
+        duration: 60.319167ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2249,8 +2253,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/69319b62-c889-49b4-bf5f-89a64c7a530c
         method: GET
       response:
         proto: HTTP/2.0
@@ -2258,18 +2262,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2690
+        content_length: 692
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.386885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"43","hypervisor_id":"602","node_id":"17","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:1f","maintenances":[],"modification_date":"2025-01-27T09:16:34.948396+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:40.456736+00:00","id":"6b5c6c0f-7444-4b7e-b21c-8739c55fd0a0","ipam_ip_ids":["b9b673e8-309b-423d-8eb4-e08d2d2663b6","a8d9091b-37a6-40b8-8460-27b8e7aa68d4"],"mac_address":"02:00:00:1c:f4:96","modification_date":"2025-01-27T09:17:12.338455+00:00","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","server_id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.386885+00:00","export_uri":null,"id":"66ded296-a0b7-4cd8-8375-a9c8cd3d4ee4","modification_date":"2025-01-27T09:16:02.386885+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","name":"Scaleway Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-12T16:14:57.789341Z","id":"69319b62-c889-49b4-bf5f-89a64c7a530c","last_detached_at":null,"name":"Debian Bullseye_sbs_volume_0","parent_snapshot_id":"a50e6921-21b9-4a69-83cc-191359208d4c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:14:57.789341Z","id":"427679d5-67d4-4f63-b880-f092ab65f28c","product_resource_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:14:57.789341Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2690"
+                - "692"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:13 GMT
+                - Wed, 12 Feb 2025 16:15:42 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2279,10 +2283,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 57067518-f71b-4484-90ae-c3387a91dee4
+                - fdcf5a09-2415-4da3-998d-4ff11d0ab908
         status: 200 OK
         code: 200
-        duration: 180.508125ms
+        duration: 82.091458ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2298,8 +2302,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/66ded296-a0b7-4cd8-8375-a9c8cd3d4ee4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -2307,18 +2311,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 508
+        content_length: 17
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T09:16:02.386885+00:00","export_uri":null,"id":"66ded296-a0b7-4cd8-8375-a9c8cd3d4ee4","modification_date":"2025-01-27T09:16:02.386885+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","name":"Scaleway Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "508"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:12 GMT
+                - Wed, 12 Feb 2025 16:15:42 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2328,10 +2332,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5e1b9cf6-86d6-491d-bc37-584c2d790de2
+                - 3c07441b-f764-4866-8754-8da776254e00
         status: 200 OK
         code: 200
-        duration: 78.204041ms
+        duration: 542.436792ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2347,8 +2351,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -2356,18 +2360,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 478
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:41.910409+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "17"
+                - "478"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:13 GMT
+                - Wed, 12 Feb 2025 16:15:43 GMT
+            Link:
+                - </servers/c972b90c-98ce-4fe4-ac18-b4e841110616/private_nics?page=1&per_page=50&>; rel="last"
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2377,10 +2383,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7583ba5a-40d6-411d-a5d3-c9dea7f3e228
+                - 287b4dd5-016e-46b3-a1b1-5c5228a9f597
+            X-Total-Count:
+                - "1"
         status: 200 OK
         code: 200
-        duration: 83.859625ms
+        duration: 127.511708ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2396,8 +2404,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1a85191f-5f3c-4895-86f7-28b1d61a4f2e
         method: GET
       response:
         proto: HTTP/2.0
@@ -2405,20 +2413,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 478
+        content_length: 984
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T09:16:40.456736+00:00","id":"6b5c6c0f-7444-4b7e-b21c-8739c55fd0a0","ipam_ip_ids":["b9b673e8-309b-423d-8eb4-e08d2d2663b6","a8d9091b-37a6-40b8-8460-27b8e7aa68d4"],"mac_address":"02:00:00:1c:f4:96","modification_date":"2025-01-27T09:17:12.338455+00:00","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","server_id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "478"
+                - "984"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:13 GMT
-            Link:
-                - </servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b/private_nics?page=1&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 16:15:43 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2428,13 +2434,62 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 73d2c3ec-3719-4650-a8fc-a6986092d727
-            X-Total-Count:
-                - "1"
+                - 4674dce0-8cf4-46f6-b126-89ab6ebed835
         status: 200 OK
         code: 200
-        duration: 420.92575ms
+        duration: 68.022708ms
     - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 119
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"gateway_network_id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","mac_address":"02:00:00:19:57:16","ip_address":"10.0.0.3"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 327
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:15:10.531299Z","gateway_network_id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","hostname":"Scaleway Instance","id":"f83046a2-cd8c-43f7-9a11-55faf283cc0b","ip_address":"10.0.0.3","mac_address":"02:00:00:19:57:16","type":"reservation","updated_at":"2025-02-12T16:15:44.176239Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "327"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 02b3e220-8d60-4225-be9d-d2af1a1d2e8b
+        status: 200 OK
+        code: 200
+        duration: 741.374583ms
+    - id: 50
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2449,8 +2504,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ac63269b-f491-4f84-9013-9b5bb291022e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1a85191f-5f3c-4895-86f7-28b1d61a4f2e
         method: GET
       response:
         proto: HTTP/2.0
@@ -2458,18 +2513,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 954
+        content_length: 984
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:09.598679Z","dhcp":{"address":"10.0.0.1","created_at":"2025-01-27T09:16:00.942421Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"36d90a94-94c0-4f3e-ad09-2686b4ca90cf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-27T09:16:00.942421Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"ac63269b-f491-4f84-9013-9b5bb291022e","ipam_config":null,"mac_address":"02:00:00:17:EA:CB","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","status":"ready","updated_at":"2025-01-27T09:16:18.197353Z","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "954"
+                - "984"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:13 GMT
+                - Wed, 12 Feb 2025 16:15:44 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2479,61 +2534,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a387277c-0a02-4a3a-b09a-58b07e6c2273
+                - 93f83e9c-2398-4678-8c53-2aae58415990
         status: 200 OK
         code: 200
-        duration: 47.99325ms
-    - id: 50
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 119
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"gateway_network_id":"ac63269b-f491-4f84-9013-9b5bb291022e","mac_address":"02:00:00:1c:f4:96","ip_address":"10.0.0.3"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 319
-        uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:40.908644Z","gateway_network_id":"ac63269b-f491-4f84-9013-9b5bb291022e","hostname":"Scaleway Instance","id":"b9b673e8-309b-423d-8eb4-e08d2d2663b6","ip_address":"10.0.0.3","mac_address":"02:00:00:1c:f4:96","type":"reservation","updated_at":"2025-01-27T09:17:14.190711Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "319"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:14 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 04669372-f404-4693-aaf4-48390d38b8d9
-        status: 200 OK
-        code: 200
-        duration: 466.7905ms
+        duration: 65.183334ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2549,8 +2553,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ac63269b-f491-4f84-9013-9b5bb291022e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/f83046a2-cd8c-43f7-9a11-55faf283cc0b
         method: GET
       response:
         proto: HTTP/2.0
@@ -2558,18 +2562,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 954
+        content_length: 327
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:09.598679Z","dhcp":{"address":"10.0.0.1","created_at":"2025-01-27T09:16:00.942421Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"36d90a94-94c0-4f3e-ad09-2686b4ca90cf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-27T09:16:00.942421Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"ac63269b-f491-4f84-9013-9b5bb291022e","ipam_config":null,"mac_address":"02:00:00:17:EA:CB","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","status":"ready","updated_at":"2025-01-27T09:16:18.197353Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:15:10.531299Z","gateway_network_id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","hostname":"Scaleway Instance","id":"f83046a2-cd8c-43f7-9a11-55faf283cc0b","ip_address":"10.0.0.3","mac_address":"02:00:00:19:57:16","type":"reservation","updated_at":"2025-02-12T16:15:44.176239Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "954"
+                - "327"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:14 GMT
+                - Wed, 12 Feb 2025 16:15:44 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2579,10 +2583,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 30bf399f-d2d7-43c9-a514-3e63b96a6f6c
+                - af2e8d98-2dae-4921-94a5-1eedc3d3473e
         status: 200 OK
         code: 200
-        duration: 58.475208ms
+        duration: 101.002833ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -2598,8 +2602,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/b9b673e8-309b-423d-8eb4-e08d2d2663b6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2607,18 +2611,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 319
+        content_length: 1994
         uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:40.908644Z","gateway_network_id":"ac63269b-f491-4f84-9013-9b5bb291022e","hostname":"Scaleway Instance","id":"b9b673e8-309b-423d-8eb4-e08d2d2663b6","ip_address":"10.0.0.3","mac_address":"02:00:00:1c:f4:96","type":"reservation","updated_at":"2025-01-27T09:17:14.190711Z","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.960124Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}],"id":"4e178b28-3e98-42d9-8373-7ee292e623a7","ip":{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:23.527960Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "319"
+                - "1994"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:14 GMT
+                - Wed, 12 Feb 2025 16:15:44 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2628,10 +2632,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c266d5d4-5d27-4d1f-afa6-09c9b07c3c96
+                - 3b99de29-58e0-4f4f-b9cd-44cd884c4ace
         status: 200 OK
         code: 200
-        duration: 68.252542ms
+        duration: 58.612583ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -2647,8 +2651,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/cf55acee-d428-47ca-9fe0-c43c3907774d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2656,18 +2660,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1934
+        content_length: 1994
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:01.880107Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:09.598679Z","dhcp":{"address":"10.0.0.1","created_at":"2025-01-27T09:16:00.942421Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"36d90a94-94c0-4f3e-ad09-2686b4ca90cf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-27T09:16:00.942421Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"ac63269b-f491-4f84-9013-9b5bb291022e","ipam_config":null,"mac_address":"02:00:00:17:EA:CB","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","status":"ready","updated_at":"2025-01-27T09:16:18.197353Z","zone":"fr-par-1"}],"id":"cf55acee-d428-47ca-9fe0-c43c3907774d","ip":{"address":"51.158.121.209","created_at":"2025-01-27T09:16:01.767610Z","gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"88fd6ba4-8bc1-432f-987a-cc0edd3d863e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"209-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.767610Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:19.700464Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.960124Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}],"id":"4e178b28-3e98-42d9-8373-7ee292e623a7","ip":{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:23.527960Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1934"
+                - "1994"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:14 GMT
+                - Wed, 12 Feb 2025 16:15:44 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2677,11 +2681,62 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - aad8d2e3-9a01-43b5-a0d5-4b946c259d19
+                - 47409374-7cc8-474d-b95f-9fa2f484824f
         status: 200 OK
         code: 200
-        duration: 28.66325ms
+        duration: 49.79525ms
     - id: 54
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 131
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","public_port":2023,"private_ip":"10.0.0.3","private_port":22,"protocol":"tcp"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 287
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:15:44.555977Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"9380788b-3547-4ecb-9fee-ceabc3120645","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2025-02-12T16:15:44.555977Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "287"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3bf54b75-2d27-441c-a79b-e9ae430bb73e
+        status: 200 OK
+        code: 200
+        duration: 110.618291ms
+    - id: 55
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2696,8 +2751,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/cf55acee-d428-47ca-9fe0-c43c3907774d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2705,18 +2760,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1934
+        content_length: 1994
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:01.880107Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:09.598679Z","dhcp":{"address":"10.0.0.1","created_at":"2025-01-27T09:16:00.942421Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"36d90a94-94c0-4f3e-ad09-2686b4ca90cf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-27T09:16:00.942421Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"ac63269b-f491-4f84-9013-9b5bb291022e","ipam_config":null,"mac_address":"02:00:00:17:EA:CB","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","status":"ready","updated_at":"2025-01-27T09:16:18.197353Z","zone":"fr-par-1"}],"id":"cf55acee-d428-47ca-9fe0-c43c3907774d","ip":{"address":"51.158.121.209","created_at":"2025-01-27T09:16:01.767610Z","gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"88fd6ba4-8bc1-432f-987a-cc0edd3d863e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"209-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.767610Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:19.700464Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.960124Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}],"id":"4e178b28-3e98-42d9-8373-7ee292e623a7","ip":{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:23.527960Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1934"
+                - "1994"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:14 GMT
+                - Wed, 12 Feb 2025 16:15:44 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2726,61 +2781,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 735ca32f-9163-432a-aacb-251b33f523f4
+                - 3b1f45b7-356f-41c5-9136-ebd129f17c68
         status: 200 OK
         code: 200
-        duration: 27.980042ms
-    - id: 55
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 131
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","public_port":2023,"private_ip":"10.0.0.3","private_port":22,"protocol":"tcp"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 279
-        uncompressed: false
-        body: '{"created_at":"2025-01-27T09:17:14.453513Z","gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"5da0aa61-82c9-40b5-8a1c-f13589e3fec9","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2025-01-27T09:17:14.453513Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "279"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:14 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 6a017a4f-ab71-48bd-978a-e6f4fbd7ad36
-        status: 200 OK
-        code: 200
-        duration: 91.717333ms
+        duration: 47.395625ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2796,8 +2800,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/cf55acee-d428-47ca-9fe0-c43c3907774d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/9380788b-3547-4ecb-9fee-ceabc3120645
         method: GET
       response:
         proto: HTTP/2.0
@@ -2805,18 +2809,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1934
+        content_length: 287
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:01.880107Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:09.598679Z","dhcp":{"address":"10.0.0.1","created_at":"2025-01-27T09:16:00.942421Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"36d90a94-94c0-4f3e-ad09-2686b4ca90cf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-27T09:16:00.942421Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"ac63269b-f491-4f84-9013-9b5bb291022e","ipam_config":null,"mac_address":"02:00:00:17:EA:CB","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","status":"ready","updated_at":"2025-01-27T09:16:18.197353Z","zone":"fr-par-1"}],"id":"cf55acee-d428-47ca-9fe0-c43c3907774d","ip":{"address":"51.158.121.209","created_at":"2025-01-27T09:16:01.767610Z","gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"88fd6ba4-8bc1-432f-987a-cc0edd3d863e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"209-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.767610Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:19.700464Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:15:44.555977Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"9380788b-3547-4ecb-9fee-ceabc3120645","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2025-02-12T16:15:44.555977Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1934"
+                - "287"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:14 GMT
+                - Wed, 12 Feb 2025 16:15:44 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2826,10 +2830,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 860e501b-58fa-4cfa-9f67-e7ed9f86dce9
+                - 868fdd86-a1f4-4607-ac57-dbd3b36a0c32
         status: 200 OK
         code: 200
-        duration: 34.195083ms
+        duration: 45.760083ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2845,8 +2849,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/5da0aa61-82c9-40b5-8a1c-f13589e3fec9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/432c2d3a-2399-43c2-a711-f68fb19dd665
         method: GET
       response:
         proto: HTTP/2.0
@@ -2854,18 +2858,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 279
+        content_length: 574
         uncompressed: false
-        body: '{"created_at":"2025-01-27T09:17:14.453513Z","gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"5da0aa61-82c9-40b5-8a1c-f13589e3fec9","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2025-01-27T09:17:14.453513Z","zone":"fr-par-1"}'
+        body: '{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "279"
+                - "574"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:14 GMT
+                - Wed, 12 Feb 2025 16:15:44 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2875,10 +2879,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8b2a4d68-9dfb-4c5f-b27f-beddd5de11e0
+                - 843b863f-6277-4a9d-8d07-c96abf80e08f
         status: 200 OK
         code: 200
-        duration: 27.024917ms
+        duration: 42.482958ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -2894,8 +2898,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/36d90a94-94c0-4f3e-ad09-2686b4ca90cf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/9380788b-3547-4ecb-9fee-ceabc3120645
         method: GET
       response:
         proto: HTTP/2.0
@@ -2903,18 +2907,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 556
+        content_length: 287
         uncompressed: false
-        body: '{"address":"10.0.0.1","created_at":"2025-01-27T09:16:00.942421Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"36d90a94-94c0-4f3e-ad09-2686b4ca90cf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-27T09:16:00.942421Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:15:44.555977Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"9380788b-3547-4ecb-9fee-ceabc3120645","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2025-02-12T16:15:44.555977Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "556"
+                - "287"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:14 GMT
+                - Wed, 12 Feb 2025 16:15:44 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2924,10 +2928,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - eccb5119-09d8-457f-beeb-3d9539facc4c
+                - 7f6dea73-de92-44e0-ab13-628f76d82eeb
         status: 200 OK
         code: 200
-        duration: 23.846791ms
+        duration: 43.806542ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -2943,8 +2947,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/5da0aa61-82c9-40b5-8a1c-f13589e3fec9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/432c2d3a-2399-43c2-a711-f68fb19dd665
         method: GET
       response:
         proto: HTTP/2.0
@@ -2952,18 +2956,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 279
+        content_length: 574
         uncompressed: false
-        body: '{"created_at":"2025-01-27T09:17:14.453513Z","gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"5da0aa61-82c9-40b5-8a1c-f13589e3fec9","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2025-01-27T09:17:14.453513Z","zone":"fr-par-1"}'
+        body: '{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "279"
+                - "574"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:14 GMT
+                - Wed, 12 Feb 2025 16:15:45 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -2973,10 +2977,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ddf5bde3-54e3-4fb3-abd7-e7d45d063fdc
+                - efc785b1-1c4a-4fb2-9cc2-dbcf93834601
         status: 200 OK
         code: 200
-        duration: 23.651ms
+        duration: 45.358834ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -2992,8 +2996,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/88fd6ba4-8bc1-432f-987a-cc0edd3d863e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/502d0462-a33e-4045-a010-4d7b5889b699
         method: GET
       response:
         proto: HTTP/2.0
@@ -3001,18 +3005,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 394
+        content_length: 403
         uncompressed: false
-        body: '{"address":"51.158.121.209","created_at":"2025-01-27T09:16:01.767610Z","gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"88fd6ba4-8bc1-432f-987a-cc0edd3d863e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"209-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.767610Z","zone":"fr-par-1"}'
+        body: '{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "394"
+                - "403"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:15 GMT
+                - Wed, 12 Feb 2025 16:15:45 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3022,10 +3026,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f84d832c-8975-4df6-bf31-13ee269b6815
+                - c243fe68-3e26-4ae6-b98b-202f05c900cc
         status: 200 OK
         code: 200
-        duration: 31.344333ms
+        duration: 45.8215ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -3041,8 +3045,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/36d90a94-94c0-4f3e-ad09-2686b4ca90cf
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/cf70fcfd-2aae-4a49-a49d-e4cfd7598043
         method: GET
       response:
         proto: HTTP/2.0
@@ -3050,18 +3054,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 556
+        content_length: 1042
         uncompressed: false
-        body: '{"address":"10.0.0.1","created_at":"2025-01-27T09:16:00.942421Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"36d90a94-94c0-4f3e-ad09-2686b4ca90cf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-27T09:16:00.942421Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:14:56.064699Z","dhcp_enabled":true,"id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","name":"My Private Network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:14:56.064699Z","id":"3fb46282-9a79-4012-af4e-e7826777179c","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:15:13.465261Z","vpc_id":"cdfe9b38-23d2-41e0-9426-97f8b0214c36"},{"created_at":"2025-02-12T16:14:56.064699Z","id":"c00e429c-60c1-4133-a83a-370dedf98bc2","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:3cad::/64","updated_at":"2025-02-12T16:15:13.470659Z","vpc_id":"cdfe9b38-23d2-41e0-9426-97f8b0214c36"}],"tags":[],"updated_at":"2025-02-12T16:15:21.458032Z","vpc_id":"cdfe9b38-23d2-41e0-9426-97f8b0214c36"}'
         headers:
             Content-Length:
-                - "556"
+                - "1042"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:15 GMT
+                - Wed, 12 Feb 2025 16:15:45 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3071,10 +3075,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5fc81bad-43e1-4755-9788-5223f99c7d4d
+                - 551b7bb3-7b07-40a9-9b24-9dae21012f0a
         status: 200 OK
         code: 200
-        duration: 25.09975ms
+        duration: 51.150209ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -3090,8 +3094,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/83515cde-cc20-4a98-a9b6-1ba52cb5f97d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3099,18 +3103,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1019
+        content_length: 1994
         uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:01.013255Z","dhcp_enabled":true,"id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","name":"My Private Network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-01-27T09:16:01.013255Z","id":"1a2995db-4182-4a59-bef0-f43ec565f3d8","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"10.0.0.0/24","updated_at":"2025-01-27T09:16:07.371886Z","vpc_id":"63821fbf-3776-414c-b014-db386b1ba6e7"},{"created_at":"2025-01-27T09:16:01.013255Z","id":"736e653c-3189-4f9c-8bd5-f1fa9634f267","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:6d3b::/64","updated_at":"2025-01-27T09:16:07.376086Z","vpc_id":"63821fbf-3776-414c-b014-db386b1ba6e7"}],"tags":[],"updated_at":"2025-01-27T09:16:16.207697Z","vpc_id":"63821fbf-3776-414c-b014-db386b1ba6e7"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.960124Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}],"id":"4e178b28-3e98-42d9-8373-7ee292e623a7","ip":{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:23.527960Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1019"
+                - "1994"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:15 GMT
+                - Wed, 12 Feb 2025 16:15:45 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3120,10 +3124,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c9cde741-0e8d-4aac-9149-3c742ea9cca9
+                - 261899a2-08c5-46e6-990c-da0ef8ab1b63
         status: 200 OK
         code: 200
-        duration: 34.878ms
+        duration: 42.201625ms
     - id: 63
       request:
         proto: HTTP/1.1
@@ -3139,8 +3143,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/cf55acee-d428-47ca-9fe0-c43c3907774d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1a85191f-5f3c-4895-86f7-28b1d61a4f2e
         method: GET
       response:
         proto: HTTP/2.0
@@ -3148,18 +3152,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1934
+        content_length: 984
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:01.880107Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:09.598679Z","dhcp":{"address":"10.0.0.1","created_at":"2025-01-27T09:16:00.942421Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"36d90a94-94c0-4f3e-ad09-2686b4ca90cf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-27T09:16:00.942421Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"ac63269b-f491-4f84-9013-9b5bb291022e","ipam_config":null,"mac_address":"02:00:00:17:EA:CB","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","status":"ready","updated_at":"2025-01-27T09:16:18.197353Z","zone":"fr-par-1"}],"id":"cf55acee-d428-47ca-9fe0-c43c3907774d","ip":{"address":"51.158.121.209","created_at":"2025-01-27T09:16:01.767610Z","gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"88fd6ba4-8bc1-432f-987a-cc0edd3d863e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"209-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.767610Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:19.700464Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1934"
+                - "984"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:15 GMT
+                - Wed, 12 Feb 2025 16:15:45 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3169,10 +3173,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4fc4a497-b5ef-4e90-b858-7648bb1a1bf5
+                - 01b4bd3d-c965-498f-b5b9-e8ab3b4d5cef
         status: 200 OK
         code: 200
-        duration: 28.477792ms
+        duration: 64.235875ms
     - id: 64
       request:
         proto: HTTP/1.1
@@ -3188,8 +3192,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ac63269b-f491-4f84-9013-9b5bb291022e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3197,18 +3201,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 954
+        content_length: 1994
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:09.598679Z","dhcp":{"address":"10.0.0.1","created_at":"2025-01-27T09:16:00.942421Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"36d90a94-94c0-4f3e-ad09-2686b4ca90cf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-27T09:16:00.942421Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"ac63269b-f491-4f84-9013-9b5bb291022e","ipam_config":null,"mac_address":"02:00:00:17:EA:CB","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","status":"ready","updated_at":"2025-01-27T09:16:18.197353Z","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.960124Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}],"id":"4e178b28-3e98-42d9-8373-7ee292e623a7","ip":{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:23.527960Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "954"
+                - "1994"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:15 GMT
+                - Wed, 12 Feb 2025 16:15:45 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3218,10 +3222,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 79a0d73d-0197-4179-b478-0274e99b4bad
+                - d670b106-08f9-4f1a-aa57-6416e2db244f
         status: 200 OK
         code: 200
-        duration: 46.182125ms
+        duration: 48.177209ms
     - id: 65
       request:
         proto: HTTP/1.1
@@ -3237,8 +3241,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/cf55acee-d428-47ca-9fe0-c43c3907774d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616
         method: GET
       response:
         proto: HTTP/2.0
@@ -3246,18 +3250,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1934
+        content_length: 2269
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:01.880107Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:09.598679Z","dhcp":{"address":"10.0.0.1","created_at":"2025-01-27T09:16:00.942421Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"36d90a94-94c0-4f3e-ad09-2686b4ca90cf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-27T09:16:00.942421Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"ac63269b-f491-4f84-9013-9b5bb291022e","ipam_config":null,"mac_address":"02:00:00:17:EA:CB","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","status":"ready","updated_at":"2025-01-27T09:16:18.197353Z","zone":"fr-par-1"}],"id":"cf55acee-d428-47ca-9fe0-c43c3907774d","ip":{"address":"51.158.121.209","created_at":"2025-01-27T09:16:01.767610Z","gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"88fd6ba4-8bc1-432f-987a-cc0edd3d863e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"209-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.767610Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:19.700464Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.586614+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"c972b90c-98ce-4fe4-ac18-b4e841110616","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"702","node_id":"10","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d9","maintenances":[],"modification_date":"2025-02-12T16:15:08.588756+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:41.910409+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"69319b62-c889-49b4-bf5f-89a64c7a530c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1934"
+                - "2269"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:15 GMT
+                - Wed, 12 Feb 2025 16:15:45 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3267,10 +3271,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 355108b8-4f7d-4f07-8afd-2b4dc623618b
+                - 35eec91f-7e07-40dc-9363-a22be4e2cffc
         status: 200 OK
         code: 200
-        duration: 27.051875ms
+        duration: 180.830833ms
     - id: 66
       request:
         proto: HTTP/1.1
@@ -3286,8 +3290,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ac63269b-f491-4f84-9013-9b5bb291022e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1a85191f-5f3c-4895-86f7-28b1d61a4f2e
         method: GET
       response:
         proto: HTTP/2.0
@@ -3295,18 +3299,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 954
+        content_length: 984
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:09.598679Z","dhcp":{"address":"10.0.0.1","created_at":"2025-01-27T09:16:00.942421Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"36d90a94-94c0-4f3e-ad09-2686b4ca90cf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-27T09:16:00.942421Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"ac63269b-f491-4f84-9013-9b5bb291022e","ipam_config":null,"mac_address":"02:00:00:17:EA:CB","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","status":"ready","updated_at":"2025-01-27T09:16:18.197353Z","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "954"
+                - "984"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:15 GMT
+                - Wed, 12 Feb 2025 16:15:45 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3316,10 +3320,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6bdf1506-c37d-45cd-b711-c3942d21c950
+                - 0650b483-98c0-4789-8e07-d8d2e0eafcee
         status: 200 OK
         code: 200
-        duration: 45.894833ms
+        duration: 62.684625ms
     - id: 67
       request:
         proto: HTTP/1.1
@@ -3335,8 +3339,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/69319b62-c889-49b4-bf5f-89a64c7a530c
         method: GET
       response:
         proto: HTTP/2.0
@@ -3344,18 +3348,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2690
+        content_length: 143
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.386885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"43","hypervisor_id":"602","node_id":"17","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:1f","maintenances":[],"modification_date":"2025-01-27T09:16:34.948396+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:40.456736+00:00","id":"6b5c6c0f-7444-4b7e-b21c-8739c55fd0a0","ipam_ip_ids":["b9b673e8-309b-423d-8eb4-e08d2d2663b6","a8d9091b-37a6-40b8-8460-27b8e7aa68d4"],"mac_address":"02:00:00:1c:f4:96","modification_date":"2025-01-27T09:17:12.338455+00:00","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","server_id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.386885+00:00","export_uri":null,"id":"66ded296-a0b7-4cd8-8375-a9c8cd3d4ee4","modification_date":"2025-01-27T09:16:02.386885+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","name":"Scaleway Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"69319b62-c889-49b4-bf5f-89a64c7a530c","type":"not_found"}'
         headers:
             Content-Length:
-                - "2690"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:15 GMT
+                - Wed, 12 Feb 2025 16:15:45 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3365,10 +3369,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f97c76a2-80df-406a-b66c-bdd419c7a690
-        status: 200 OK
-        code: 200
-        duration: 164.409084ms
+                - 58ad5eb6-fd1b-406f-ad83-2f035fb5e711
+        status: 404 Not Found
+        code: 404
+        duration: 57.492541ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -3384,8 +3388,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/66ded296-a0b7-4cd8-8375-a9c8cd3d4ee4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/69319b62-c889-49b4-bf5f-89a64c7a530c
         method: GET
       response:
         proto: HTTP/2.0
@@ -3393,18 +3397,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 508
+        content_length: 692
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T09:16:02.386885+00:00","export_uri":null,"id":"66ded296-a0b7-4cd8-8375-a9c8cd3d4ee4","modification_date":"2025-01-27T09:16:02.386885+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","name":"Scaleway Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-12T16:14:57.789341Z","id":"69319b62-c889-49b4-bf5f-89a64c7a530c","last_detached_at":null,"name":"Debian Bullseye_sbs_volume_0","parent_snapshot_id":"a50e6921-21b9-4a69-83cc-191359208d4c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:14:57.789341Z","id":"427679d5-67d4-4f63-b880-f092ab65f28c","product_resource_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:14:57.789341Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "508"
+                - "692"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:15 GMT
+                - Wed, 12 Feb 2025 16:15:45 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3414,10 +3418,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 84797ebd-8df7-41e1-8d2e-61e3c16b6b0b
+                - 1d783c67-a940-49c6-891b-95ebc8ac689b
         status: 200 OK
         code: 200
-        duration: 86.154584ms
+        duration: 85.957625ms
     - id: 69
       request:
         proto: HTTP/1.1
@@ -3433,8 +3437,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b/user_data
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -3453,7 +3457,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:15 GMT
+                - Wed, 12 Feb 2025 16:15:45 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3463,10 +3467,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 74a5896f-15ef-46ea-98b8-9a76d601a1f5
+                - 1172b322-98f3-4d41-954c-6b89bdaeff84
         status: 200 OK
         code: 200
-        duration: 136.0875ms
+        duration: 99.197583ms
     - id: 70
       request:
         proto: HTTP/1.1
@@ -3482,8 +3486,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -3493,7 +3497,7 @@ interactions:
         trailer: {}
         content_length: 478
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T09:16:40.456736+00:00","id":"6b5c6c0f-7444-4b7e-b21c-8739c55fd0a0","ipam_ip_ids":["b9b673e8-309b-423d-8eb4-e08d2d2663b6","a8d9091b-37a6-40b8-8460-27b8e7aa68d4"],"mac_address":"02:00:00:1c:f4:96","modification_date":"2025-01-27T09:17:12.338455+00:00","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","server_id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:41.910409+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
                 - "478"
@@ -3502,9 +3506,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:15 GMT
+                - Wed, 12 Feb 2025 16:15:45 GMT
             Link:
-                - </servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b/private_nics?page=1&per_page=50&>; rel="last"
+                - </servers/c972b90c-98ce-4fe4-ac18-b4e841110616/private_nics?page=1&per_page=50&>; rel="last"
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3514,12 +3518,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 751363bb-9c59-4bc0-b51f-f59eded6dc06
+                - bbf4de5e-d2dd-43d0-b662-4186a08d13a7
             X-Total-Count:
                 - "1"
         status: 200 OK
         code: 200
-        duration: 111.167458ms
+        duration: 113.35125ms
     - id: 71
       request:
         proto: HTTP/1.1
@@ -3535,8 +3539,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/b9b673e8-309b-423d-8eb4-e08d2d2663b6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/f83046a2-cd8c-43f7-9a11-55faf283cc0b
         method: GET
       response:
         proto: HTTP/2.0
@@ -3544,18 +3548,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 319
+        content_length: 327
         uncompressed: false
-        body: '{"created_at":"2025-01-27T09:16:40.908644Z","gateway_network_id":"ac63269b-f491-4f84-9013-9b5bb291022e","hostname":"Scaleway Instance","id":"b9b673e8-309b-423d-8eb4-e08d2d2663b6","ip_address":"10.0.0.3","mac_address":"02:00:00:1c:f4:96","type":"reservation","updated_at":"2025-01-27T09:17:14.190711Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:15:10.531299Z","gateway_network_id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","hostname":"Scaleway Instance","id":"f83046a2-cd8c-43f7-9a11-55faf283cc0b","ip_address":"10.0.0.3","mac_address":"02:00:00:19:57:16","type":"reservation","updated_at":"2025-02-12T16:15:44.176239Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "319"
+                - "327"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:16 GMT
+                - Wed, 12 Feb 2025 16:15:45 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3565,10 +3569,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fedcfa0e-68f5-4b31-8446-f2fa0c2e3198
+                - a1a51022-77c9-410c-9648-7db3dda29f5a
         status: 200 OK
         code: 200
-        duration: 67.386167ms
+        duration: 85.677042ms
     - id: 72
       request:
         proto: HTTP/1.1
@@ -3584,8 +3588,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/5da0aa61-82c9-40b5-8a1c-f13589e3fec9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/9380788b-3547-4ecb-9fee-ceabc3120645
         method: GET
       response:
         proto: HTTP/2.0
@@ -3593,18 +3597,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 279
+        content_length: 287
         uncompressed: false
-        body: '{"created_at":"2025-01-27T09:17:14.453513Z","gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"5da0aa61-82c9-40b5-8a1c-f13589e3fec9","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2025-01-27T09:17:14.453513Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:15:44.555977Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"9380788b-3547-4ecb-9fee-ceabc3120645","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2025-02-12T16:15:44.555977Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "279"
+                - "287"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:16 GMT
+                - Wed, 12 Feb 2025 16:15:45 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3614,10 +3618,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f75043ff-10ec-488b-be9e-3c3784491f49
+                - d7fc3c30-73c7-46d1-af93-8ec5c73949dc
         status: 200 OK
         code: 200
-        duration: 28.523833ms
+        duration: 41.245042ms
     - id: 73
       request:
         proto: HTTP/1.1
@@ -3633,8 +3637,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/5da0aa61-82c9-40b5-8a1c-f13589e3fec9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/9380788b-3547-4ecb-9fee-ceabc3120645
         method: GET
       response:
         proto: HTTP/2.0
@@ -3642,18 +3646,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 279
+        content_length: 287
         uncompressed: false
-        body: '{"created_at":"2025-01-27T09:17:14.453513Z","gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"5da0aa61-82c9-40b5-8a1c-f13589e3fec9","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2025-01-27T09:17:14.453513Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:15:44.555977Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"9380788b-3547-4ecb-9fee-ceabc3120645","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2025-02-12T16:15:44.555977Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "279"
+                - "287"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:17 GMT
+                - Wed, 12 Feb 2025 16:15:46 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3663,10 +3667,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9f85452d-5531-4755-9d2d-e4ba85de6a7d
+                - 0f81251e-7d6e-426e-8589-4ba857cf7573
         status: 200 OK
         code: 200
-        duration: 21.064ms
+        duration: 47.018667ms
     - id: 74
       request:
         proto: HTTP/1.1
@@ -3682,8 +3686,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/cf55acee-d428-47ca-9fe0-c43c3907774d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3691,18 +3695,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1934
+        content_length: 1994
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:01.880107Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:09.598679Z","dhcp":{"address":"10.0.0.1","created_at":"2025-01-27T09:16:00.942421Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"36d90a94-94c0-4f3e-ad09-2686b4ca90cf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-27T09:16:00.942421Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"ac63269b-f491-4f84-9013-9b5bb291022e","ipam_config":null,"mac_address":"02:00:00:17:EA:CB","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","status":"ready","updated_at":"2025-01-27T09:16:18.197353Z","zone":"fr-par-1"}],"id":"cf55acee-d428-47ca-9fe0-c43c3907774d","ip":{"address":"51.158.121.209","created_at":"2025-01-27T09:16:01.767610Z","gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"88fd6ba4-8bc1-432f-987a-cc0edd3d863e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"209-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.767610Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:19.700464Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.960124Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}],"id":"4e178b28-3e98-42d9-8373-7ee292e623a7","ip":{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:23.527960Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1934"
+                - "1994"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:17 GMT
+                - Wed, 12 Feb 2025 16:15:46 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3712,10 +3716,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a79da1ee-ac01-4ad0-b14b-3378015b8770
+                - 4b275193-cc55-4aff-a2f3-2c87bb38d116
         status: 200 OK
         code: 200
-        duration: 33.660625ms
+        duration: 47.566542ms
     - id: 75
       request:
         proto: HTTP/1.1
@@ -3731,8 +3735,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/5da0aa61-82c9-40b5-8a1c-f13589e3fec9
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/9380788b-3547-4ecb-9fee-ceabc3120645
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3749,7 +3753,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:17 GMT
+                - Wed, 12 Feb 2025 16:15:46 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3759,10 +3763,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8d9e72fd-a737-42e1-8a0e-9547b9c43daf
+                - 3f371056-3bda-41e9-b40b-36b18b94ae9f
         status: 204 No Content
         code: 204
-        duration: 44.265167ms
+        duration: 66.693916ms
     - id: 76
       request:
         proto: HTTP/1.1
@@ -3778,8 +3782,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/cf55acee-d428-47ca-9fe0-c43c3907774d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3787,18 +3791,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1934
+        content_length: 1994
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:01.880107Z","gateway_networks":[{"address":null,"created_at":"2025-01-27T09:16:09.598679Z","dhcp":{"address":"10.0.0.1","created_at":"2025-01-27T09:16:00.942421Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"36d90a94-94c0-4f3e-ad09-2686b4ca90cf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-27T09:16:00.942421Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"ac63269b-f491-4f84-9013-9b5bb291022e","ipam_config":null,"mac_address":"02:00:00:17:EA:CB","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","status":"ready","updated_at":"2025-01-27T09:16:18.197353Z","zone":"fr-par-1"}],"id":"cf55acee-d428-47ca-9fe0-c43c3907774d","ip":{"address":"51.158.121.209","created_at":"2025-01-27T09:16:01.767610Z","gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"88fd6ba4-8bc1-432f-987a-cc0edd3d863e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"209-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.767610Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:19.700464Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.960124Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}],"id":"4e178b28-3e98-42d9-8373-7ee292e623a7","ip":{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:23.527960Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1934"
+                - "1994"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:17 GMT
+                - Wed, 12 Feb 2025 16:15:46 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3808,10 +3812,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c3d62ed9-e68d-4c0c-ae35-b3e807543632
+                - 28035b9c-b278-442e-8612-5bc4e66c8d1f
         status: 200 OK
         code: 200
-        duration: 27.184834ms
+        duration: 50.348667ms
     - id: 77
       request:
         proto: HTTP/1.1
@@ -3827,8 +3831,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ac63269b-f491-4f84-9013-9b5bb291022e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1a85191f-5f3c-4895-86f7-28b1d61a4f2e
         method: GET
       response:
         proto: HTTP/2.0
@@ -3836,18 +3840,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 954
+        content_length: 984
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:09.598679Z","dhcp":{"address":"10.0.0.1","created_at":"2025-01-27T09:16:00.942421Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"36d90a94-94c0-4f3e-ad09-2686b4ca90cf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-27T09:16:00.942421Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"ac63269b-f491-4f84-9013-9b5bb291022e","ipam_config":null,"mac_address":"02:00:00:17:EA:CB","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","status":"ready","updated_at":"2025-01-27T09:16:18.197353Z","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "954"
+                - "984"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:17 GMT
+                - Wed, 12 Feb 2025 16:15:46 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3857,10 +3861,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d8c966d3-626d-4070-9786-ee238d404ed6
+                - 9c6fba69-7af7-4784-998a-81202280a64e
         status: 200 OK
         code: 200
-        duration: 43.50425ms
+        duration: 65.820709ms
     - id: 78
       request:
         proto: HTTP/1.1
@@ -3876,8 +3880,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/b9b673e8-309b-423d-8eb4-e08d2d2663b6
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/f83046a2-cd8c-43f7-9a11-55faf283cc0b
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3894,7 +3898,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:17 GMT
+                - Wed, 12 Feb 2025 16:15:46 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3904,10 +3908,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f23026fd-c093-4999-bc70-2750525c9b13
+                - 2c5119ba-09c6-46c0-ade4-fb8b1fe66e70
         status: 204 No Content
         code: 204
-        duration: 66.75675ms
+        duration: 99.280041ms
     - id: 79
       request:
         proto: HTTP/1.1
@@ -3923,8 +3927,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ac63269b-f491-4f84-9013-9b5bb291022e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1a85191f-5f3c-4895-86f7-28b1d61a4f2e
         method: GET
       response:
         proto: HTTP/2.0
@@ -3932,18 +3936,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 954
+        content_length: 984
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:09.598679Z","dhcp":{"address":"10.0.0.1","created_at":"2025-01-27T09:16:00.942421Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"36d90a94-94c0-4f3e-ad09-2686b4ca90cf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-27T09:16:00.942421Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"ac63269b-f491-4f84-9013-9b5bb291022e","ipam_config":null,"mac_address":"02:00:00:17:EA:CB","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","status":"ready","updated_at":"2025-01-27T09:16:18.197353Z","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "954"
+                - "984"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:17 GMT
+                - Wed, 12 Feb 2025 16:15:46 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -3953,10 +3957,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 04aea37d-205a-43fe-a68c-21b496102f42
+                - aac6ab58-3fbe-4908-aa63-a42863a6f4fd
         status: 200 OK
         code: 200
-        duration: 48.077375ms
+        duration: 73.677042ms
     - id: 80
       request:
         proto: HTTP/1.1
@@ -3972,8 +3976,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ac63269b-f491-4f84-9013-9b5bb291022e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1a85191f-5f3c-4895-86f7-28b1d61a4f2e
         method: GET
       response:
         proto: HTTP/2.0
@@ -3981,18 +3985,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 954
+        content_length: 984
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:09.598679Z","dhcp":{"address":"10.0.0.1","created_at":"2025-01-27T09:16:00.942421Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"36d90a94-94c0-4f3e-ad09-2686b4ca90cf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-27T09:16:00.942421Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"ac63269b-f491-4f84-9013-9b5bb291022e","ipam_config":null,"mac_address":"02:00:00:17:EA:CB","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","status":"ready","updated_at":"2025-01-27T09:16:18.197353Z","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "954"
+                - "984"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:17 GMT
+                - Wed, 12 Feb 2025 16:15:46 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4002,10 +4006,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0f0d20e0-521b-454b-9d38-14a8f742f453
+                - 7b9ef007-c804-4d8f-bdb4-3753625df2ff
         status: 200 OK
         code: 200
-        duration: 40.501792ms
+        duration: 60.031833ms
     - id: 81
       request:
         proto: HTTP/1.1
@@ -4021,8 +4025,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ac63269b-f491-4f84-9013-9b5bb291022e?cleanup_dhcp=true
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1a85191f-5f3c-4895-86f7-28b1d61a4f2e?cleanup_dhcp=true
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -4039,7 +4043,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:17 GMT
+                - Wed, 12 Feb 2025 16:15:46 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4049,10 +4053,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7cbb3847-c969-417f-9e80-1b2db4e979bc
+                - b95b913e-be6e-4c99-90b9-b36b1cd2533b
         status: 204 No Content
         code: 204
-        duration: 69.5355ms
+        duration: 87.901541ms
     - id: 82
       request:
         proto: HTTP/1.1
@@ -4068,8 +4072,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ac63269b-f491-4f84-9013-9b5bb291022e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616
         method: GET
       response:
         proto: HTTP/2.0
@@ -4077,18 +4081,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 958
+        content_length: 2269
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-01-27T09:16:09.598679Z","dhcp":{"address":"10.0.0.1","created_at":"2025-01-27T09:16:00.942421Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"36d90a94-94c0-4f3e-ad09-2686b4ca90cf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-01-27T09:16:00.942421Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"ac63269b-f491-4f84-9013-9b5bb291022e","ipam_config":null,"mac_address":"02:00:00:17:EA:CB","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","status":"detaching","updated_at":"2025-01-27T09:17:17.367979Z","zone":"fr-par-1"}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.586614+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"c972b90c-98ce-4fe4-ac18-b4e841110616","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"702","node_id":"10","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d9","maintenances":[],"modification_date":"2025-02-12T16:15:08.588756+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:41.910409+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"69319b62-c889-49b4-bf5f-89a64c7a530c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "958"
+                - "2269"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:17 GMT
+                - Wed, 12 Feb 2025 16:15:46 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4098,10 +4102,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b07b2d67-c7ab-439d-b08e-0e69c50443d3
+                - 787059f4-f23c-44ba-b4b8-a3e504b5f2f2
         status: 200 OK
         code: 200
-        duration: 42.939417ms
+        duration: 200.637875ms
     - id: 83
       request:
         proto: HTTP/1.1
@@ -4117,8 +4121,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1a85191f-5f3c-4895-86f7-28b1d61a4f2e
         method: GET
       response:
         proto: HTTP/2.0
@@ -4126,18 +4130,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2690
+        content_length: 988
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.386885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"43","hypervisor_id":"602","node_id":"17","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:1f","maintenances":[],"modification_date":"2025-01-27T09:16:34.948396+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:40.456736+00:00","id":"6b5c6c0f-7444-4b7e-b21c-8739c55fd0a0","ipam_ip_ids":["b9b673e8-309b-423d-8eb4-e08d2d2663b6","a8d9091b-37a6-40b8-8460-27b8e7aa68d4"],"mac_address":"02:00:00:1c:f4:96","modification_date":"2025-01-27T09:17:12.338455+00:00","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","server_id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.386885+00:00","export_uri":null,"id":"66ded296-a0b7-4cd8-8375-a9c8cd3d4ee4","modification_date":"2025-01-27T09:16:02.386885+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","name":"Scaleway Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"detaching","updated_at":"2025-02-12T16:15:46.746880Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2690"
+                - "988"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:16 GMT
+                - Wed, 12 Feb 2025 16:15:46 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4147,11 +4151,60 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 11ad3405-2d8a-42e3-b19d-4ced028be7d1
+                - 384ac975-361c-49b3-b6b4-d53d6eea8fea
         status: 200 OK
         code: 200
-        duration: 162.543ms
+        duration: 65.46825ms
     - id: 84
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/69319b62-c889-49b4-bf5f-89a64c7a530c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 692
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:14:57.789341Z","id":"69319b62-c889-49b4-bf5f-89a64c7a530c","last_detached_at":null,"name":"Debian Bullseye_sbs_volume_0","parent_snapshot_id":"a50e6921-21b9-4a69-83cc-191359208d4c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:14:57.789341Z","id":"427679d5-67d4-4f63-b880-f092ab65f28c","product_resource_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:14:57.789341Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "692"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:15:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3ac2c561-5184-4809-8562-5c15237ac006
+        status: 200 OK
+        code: 200
+        duration: 84.014667ms
+    - id: 85
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4168,8 +4221,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b/action
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -4179,7 +4232,7 @@ interactions:
         trailer: {}
         content_length: 352
         uncompressed: false
-        body: '{"task":{"description":"server_poweroff","href_from":"/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b/action","href_result":"/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","id":"731a5350-14c8-4c43-b321-3c26e565f16c","progress":0,"started_at":"2025-01-27T09:17:17.649979+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_poweroff","href_from":"/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/action","href_result":"/servers/c972b90c-98ce-4fe4-ac18-b4e841110616","id":"9ca0f2c6-50c3-4217-9e34-aa4e811d0bbf","progress":0,"started_at":"2025-02-12T16:15:47.218190+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "352"
@@ -4188,9 +4241,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:17 GMT
+                - Wed, 12 Feb 2025 16:15:47 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/731a5350-14c8-4c43-b321-3c26e565f16c
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/9ca0f2c6-50c3-4217-9e34-aa4e811d0bbf
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4200,59 +4253,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3f7d7c20-759a-4a58-af50-dd2b0f2157c7
+                - aa42b80f-e3e1-40a8-a659-4e40746ca51c
         status: 202 Accepted
         code: 202
-        duration: 231.762292ms
-    - id: 85
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2650
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.386885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"43","hypervisor_id":"602","node_id":"17","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:1f","maintenances":[],"modification_date":"2025-01-27T09:17:17.467777+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:40.456736+00:00","id":"6b5c6c0f-7444-4b7e-b21c-8739c55fd0a0","ipam_ip_ids":["b9b673e8-309b-423d-8eb4-e08d2d2663b6","a8d9091b-37a6-40b8-8460-27b8e7aa68d4"],"mac_address":"02:00:00:1c:f4:96","modification_date":"2025-01-27T09:17:12.338455+00:00","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","server_id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.386885+00:00","export_uri":null,"id":"66ded296-a0b7-4cd8-8375-a9c8cd3d4ee4","modification_date":"2025-01-27T09:16:02.386885+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","name":"Scaleway Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "2650"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 27 Jan 2025 09:17:17 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 816e6e4a-3b24-45b0-8f95-835e34334314
-        status: 200 OK
-        code: 200
-        duration: 167.082708ms
+        duration: 374.785875ms
     - id: 86
       request:
         proto: HTTP/1.1
@@ -4268,8 +4272,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ac63269b-f491-4f84-9013-9b5bb291022e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616
         method: GET
       response:
         proto: HTTP/2.0
@@ -4277,18 +4281,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 136
+        content_length: 2229
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"ac63269b-f491-4f84-9013-9b5bb291022e","type":"not_found"}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.586614+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"c972b90c-98ce-4fe4-ac18-b4e841110616","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"702","node_id":"10","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d9","maintenances":[],"modification_date":"2025-02-12T16:15:46.957765+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:41.910409+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"69319b62-c889-49b4-bf5f-89a64c7a530c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "136"
+                - "2229"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:22 GMT
+                - Wed, 12 Feb 2025 16:15:47 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4298,10 +4302,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fa8fa83b-b93e-41c9-971c-9611d2befd61
-        status: 404 Not Found
-        code: 404
-        duration: 22.347125ms
+                - e85b76be-415b-4fb8-b3b0-42b8370972e0
+        status: 200 OK
+        code: 200
+        duration: 514.293417ms
     - id: 87
       request:
         proto: HTTP/1.1
@@ -4317,8 +4321,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/cf55acee-d428-47ca-9fe0-c43c3907774d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1a85191f-5f3c-4895-86f7-28b1d61a4f2e
         method: GET
       response:
         proto: HTTP/2.0
@@ -4326,18 +4330,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 980
+        content_length: 136
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:01.880107Z","gateway_networks":[],"id":"cf55acee-d428-47ca-9fe0-c43c3907774d","ip":{"address":"51.158.121.209","created_at":"2025-01-27T09:16:01.767610Z","gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"88fd6ba4-8bc1-432f-987a-cc0edd3d863e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"209-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.767610Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:19.700464Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","type":"not_found"}'
         headers:
             Content-Length:
-                - "980"
+                - "136"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:22 GMT
+                - Wed, 12 Feb 2025 16:15:51 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4347,10 +4351,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 064366df-29c2-4a61-8361-5fd45e0faae3
-        status: 200 OK
-        code: 200
-        duration: 28.669834ms
+                - 79393053-87fc-4782-b828-0f33fcf48250
+        status: 404 Not Found
+        code: 404
+        duration: 44.276917ms
     - id: 88
       request:
         proto: HTTP/1.1
@@ -4366,27 +4370,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/36d90a94-94c0-4f3e-ad09-2686b4ca90cf
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 125
+        content_length: 1010
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"dhcp","resource_id":"36d90a94-94c0-4f3e-ad09-2686b4ca90cf","type":"not_found"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.960124Z","gateway_networks":[],"id":"4e178b28-3e98-42d9-8373-7ee292e623a7","ip":{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:23.527960Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "125"
+                - "1010"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:22 GMT
+                - Wed, 12 Feb 2025 16:15:51 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4396,10 +4400,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - db08463b-b68b-4c7a-a6bb-ea967dfae46f
-        status: 404 Not Found
-        code: 404
-        duration: 23.101917ms
+                - 47f50dce-312c-476a-b37f-f7884d659181
+        status: 200 OK
+        code: 200
+        duration: 51.500083ms
     - id: 89
       request:
         proto: HTTP/1.1
@@ -4415,27 +4419,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/cf55acee-d428-47ca-9fe0-c43c3907774d
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/432c2d3a-2399-43c2-a711-f68fb19dd665
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 980
+        content_length: 125
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-01-27T09:16:01.880107Z","gateway_networks":[],"id":"cf55acee-d428-47ca-9fe0-c43c3907774d","ip":{"address":"51.158.121.209","created_at":"2025-01-27T09:16:01.767610Z","gateway_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","id":"88fd6ba4-8bc1-432f-987a-cc0edd3d863e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"209-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2025-01-27T09:16:01.767610Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-01-27T09:16:19.700464Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"message":"resource is not found","resource":"dhcp","resource_id":"432c2d3a-2399-43c2-a711-f68fb19dd665","type":"not_found"}'
         headers:
             Content-Length:
-                - "980"
+                - "125"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:22 GMT
+                - Wed, 12 Feb 2025 16:15:51 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4445,10 +4449,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1c043ff6-773b-46be-88bb-0ee091a40d13
-        status: 200 OK
-        code: 200
-        duration: 30.147292ms
+                - 0d9bfe69-6713-47c7-a431-1dbfa7298b54
+        status: 404 Not Found
+        code: 404
+        duration: 43.248459ms
     - id: 90
       request:
         proto: HTTP/1.1
@@ -4464,25 +4468,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/cf55acee-d428-47ca-9fe0-c43c3907774d?cleanup_dhcp=false
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 1010
         uncompressed: false
-        body: ""
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.960124Z","gateway_networks":[],"id":"4e178b28-3e98-42d9-8373-7ee292e623a7","ip":{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:23.527960Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
+            Content-Length:
+                - "1010"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:22 GMT
+                - Wed, 12 Feb 2025 16:15:51 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4492,10 +4498,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5d50f9d5-fc53-4606-97e5-dc97f5e4dc36
-        status: 204 No Content
-        code: 204
-        duration: 45.040208ms
+                - 7abe498a-84f1-4641-a431-412859b8de09
+        status: 200 OK
+        code: 200
+        duration: 45.766333ms
     - id: 91
       request:
         proto: HTTP/1.1
@@ -4511,27 +4517,25 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/cf55acee-d428-47ca-9fe0-c43c3907774d
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7?cleanup_dhcp=false
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 128
+        content_length: 0
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"gateway","resource_id":"cf55acee-d428-47ca-9fe0-c43c3907774d","type":"not_found"}'
+        body: ""
         headers:
-            Content-Length:
-                - "128"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:22 GMT
+                - Wed, 12 Feb 2025 16:15:52 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4541,10 +4545,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3e52f2c2-da42-4320-87ae-6109b7936b4d
-        status: 404 Not Found
-        code: 404
-        duration: 20.767792ms
+                - 74aba7c6-8309-425b-8d59-13b876204b24
+        status: 204 No Content
+        code: 204
+        duration: 76.645125ms
     - id: 92
       request:
         proto: HTTP/1.1
@@ -4560,8 +4564,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7
         method: GET
       response:
         proto: HTTP/2.0
@@ -4569,18 +4573,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2650
+        content_length: 128
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.386885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"43","hypervisor_id":"602","node_id":"17","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:1f","maintenances":[],"modification_date":"2025-01-27T09:17:17.467777+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:40.456736+00:00","id":"6b5c6c0f-7444-4b7e-b21c-8739c55fd0a0","ipam_ip_ids":["b9b673e8-309b-423d-8eb4-e08d2d2663b6","a8d9091b-37a6-40b8-8460-27b8e7aa68d4"],"mac_address":"02:00:00:1c:f4:96","modification_date":"2025-01-27T09:17:12.338455+00:00","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","server_id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.386885+00:00","export_uri":null,"id":"66ded296-a0b7-4cd8-8375-a9c8cd3d4ee4","modification_date":"2025-01-27T09:16:02.386885+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","name":"Scaleway Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"gateway","resource_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","type":"not_found"}'
         headers:
             Content-Length:
-                - "2650"
+                - "128"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:22 GMT
+                - Wed, 12 Feb 2025 16:15:52 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4590,10 +4594,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 33807c81-8daf-446e-9792-8e15b738181c
-        status: 200 OK
-        code: 200
-        duration: 127.889125ms
+                - f87caef8-c139-48b2-bb9c-336421cf5859
+        status: 404 Not Found
+        code: 404
+        duration: 45.052708ms
     - id: 93
       request:
         proto: HTTP/1.1
@@ -4609,8 +4613,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/88fd6ba4-8bc1-432f-987a-cc0edd3d863e
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/502d0462-a33e-4045-a010-4d7b5889b699
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -4627,7 +4631,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:23 GMT
+                - Wed, 12 Feb 2025 16:15:52 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4637,10 +4641,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4024601f-f0f0-4ecc-86d5-433dffc556cf
+                - 09440735-914c-4148-8565-f40e3a9a3445
         status: 204 No Content
         code: 204
-        duration: 582.557083ms
+        duration: 646.527791ms
     - id: 94
       request:
         proto: HTTP/1.1
@@ -4656,8 +4660,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616
         method: GET
       response:
         proto: HTTP/2.0
@@ -4665,18 +4669,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2650
+        content_length: 2229
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.386885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"43","hypervisor_id":"602","node_id":"17","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:1f","maintenances":[],"modification_date":"2025-01-27T09:17:17.467777+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:40.456736+00:00","id":"6b5c6c0f-7444-4b7e-b21c-8739c55fd0a0","ipam_ip_ids":["b9b673e8-309b-423d-8eb4-e08d2d2663b6","a8d9091b-37a6-40b8-8460-27b8e7aa68d4"],"mac_address":"02:00:00:1c:f4:96","modification_date":"2025-01-27T09:17:12.338455+00:00","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","server_id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.386885+00:00","export_uri":null,"id":"66ded296-a0b7-4cd8-8375-a9c8cd3d4ee4","modification_date":"2025-01-27T09:16:02.386885+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","name":"Scaleway Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.586614+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"c972b90c-98ce-4fe4-ac18-b4e841110616","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"702","node_id":"10","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d9","maintenances":[],"modification_date":"2025-02-12T16:15:46.957765+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:41.910409+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"69319b62-c889-49b4-bf5f-89a64c7a530c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2650"
+                - "2229"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:28 GMT
+                - Wed, 12 Feb 2025 16:15:53 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4686,10 +4690,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5e6f0cd1-e4bc-4d4a-b481-cc97ad2df6b4
+                - 0de1efbc-6cd8-49c3-967f-51b080eaf253
         status: 200 OK
         code: 200
-        duration: 172.155667ms
+        duration: 290.907917ms
     - id: 95
       request:
         proto: HTTP/1.1
@@ -4705,8 +4709,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616
         method: GET
       response:
         proto: HTTP/2.0
@@ -4714,18 +4718,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2650
+        content_length: 2229
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.386885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"43","hypervisor_id":"602","node_id":"17","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:1f","maintenances":[],"modification_date":"2025-01-27T09:17:17.467777+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:40.456736+00:00","id":"6b5c6c0f-7444-4b7e-b21c-8739c55fd0a0","ipam_ip_ids":["b9b673e8-309b-423d-8eb4-e08d2d2663b6","a8d9091b-37a6-40b8-8460-27b8e7aa68d4"],"mac_address":"02:00:00:1c:f4:96","modification_date":"2025-01-27T09:17:12.338455+00:00","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","server_id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.386885+00:00","export_uri":null,"id":"66ded296-a0b7-4cd8-8375-a9c8cd3d4ee4","modification_date":"2025-01-27T09:16:02.386885+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","name":"Scaleway Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.586614+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"c972b90c-98ce-4fe4-ac18-b4e841110616","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"702","node_id":"10","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d9","maintenances":[],"modification_date":"2025-02-12T16:15:46.957765+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:41.910409+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"69319b62-c889-49b4-bf5f-89a64c7a530c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2650"
+                - "2229"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:32 GMT
+                - Wed, 12 Feb 2025 16:15:58 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4735,10 +4739,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 76346f95-6bde-40c7-abc5-2b70077c50e7
+                - fb240d6c-97c4-42ed-9296-8eb6dbd73fdd
         status: 200 OK
         code: 200
-        duration: 161.222708ms
+        duration: 446.67075ms
     - id: 96
       request:
         proto: HTTP/1.1
@@ -4754,8 +4758,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616
         method: GET
       response:
         proto: HTTP/2.0
@@ -4763,18 +4767,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2650
+        content_length: 2113
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.386885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"43","hypervisor_id":"602","node_id":"17","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:8f:ea:1f","maintenances":[],"modification_date":"2025-01-27T09:17:17.467777+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:40.456736+00:00","id":"6b5c6c0f-7444-4b7e-b21c-8739c55fd0a0","ipam_ip_ids":["b9b673e8-309b-423d-8eb4-e08d2d2663b6","a8d9091b-37a6-40b8-8460-27b8e7aa68d4"],"mac_address":"02:00:00:1c:f4:96","modification_date":"2025-01-27T09:17:12.338455+00:00","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","server_id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.386885+00:00","export_uri":null,"id":"66ded296-a0b7-4cd8-8375-a9c8cd3d4ee4","modification_date":"2025-01-27T09:16:02.386885+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","name":"Scaleway Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.586614+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"c972b90c-98ce-4fe4-ac18-b4e841110616","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:d9","maintenances":[],"modification_date":"2025-02-12T16:16:02.414891+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:41.910409+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"69319b62-c889-49b4-bf5f-89a64c7a530c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2650"
+                - "2113"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:38 GMT
+                - Wed, 12 Feb 2025 16:16:03 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4784,10 +4788,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b7c4bbd4-d4d1-4070-8c57-3a93f0a4d61d
+                - ccdff8cc-50b8-4fcd-bb2c-35c0eb24b7f1
         status: 200 OK
         code: 200
-        duration: 852.656167ms
+        duration: 172.4965ms
     - id: 97
       request:
         proto: HTTP/1.1
@@ -4803,8 +4807,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -4812,18 +4816,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2534
+        content_length: 478
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.386885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ea:1f","maintenances":[],"modification_date":"2025-01-27T09:17:40.150066+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-01-27T09:16:40.456736+00:00","id":"6b5c6c0f-7444-4b7e-b21c-8739c55fd0a0","ipam_ip_ids":["b9b673e8-309b-423d-8eb4-e08d2d2663b6","a8d9091b-37a6-40b8-8460-27b8e7aa68d4"],"mac_address":"02:00:00:1c:f4:96","modification_date":"2025-01-27T09:17:12.338455+00:00","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","server_id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.386885+00:00","export_uri":null,"id":"66ded296-a0b7-4cd8-8375-a9c8cd3d4ee4","modification_date":"2025-01-27T09:16:02.386885+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","name":"Scaleway Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:41.910409+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "2534"
+                - "478"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:43 GMT
+                - Wed, 12 Feb 2025 16:16:03 GMT
+            Link:
+                - </servers/c972b90c-98ce-4fe4-ac18-b4e841110616/private_nics?page=1&per_page=50&>; rel="last"
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4833,10 +4839,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8a1098fb-9ba2-4151-b857-0ca0c8434a4c
+                - ccdbfb4c-c3af-486a-b508-86553d4d0184
+            X-Total-Count:
+                - "1"
         status: 200 OK
         code: 200
-        duration: 139.818084ms
+        duration: 89.933625ms
     - id: 98
       request:
         proto: HTTP/1.1
@@ -4852,8 +4860,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b/private_nics
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/private_nics/f779056f-b24a-422b-98f1-e1e6b57219de
         method: GET
       response:
         proto: HTTP/2.0
@@ -4861,20 +4869,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 478
+        content_length: 475
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-01-27T09:16:40.456736+00:00","id":"6b5c6c0f-7444-4b7e-b21c-8739c55fd0a0","ipam_ip_ids":["b9b673e8-309b-423d-8eb4-e08d2d2663b6","a8d9091b-37a6-40b8-8460-27b8e7aa68d4"],"mac_address":"02:00:00:1c:f4:96","modification_date":"2025-01-27T09:17:12.338455+00:00","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","server_id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:41.910409+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "478"
+                - "475"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:44 GMT
-            Link:
-                - </servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b/private_nics?page=1&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 16:16:03 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4884,12 +4890,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 88e49602-e6e7-4d20-8acf-25c1de6e6e80
-            X-Total-Count:
-                - "1"
+                - 89a25508-736f-4221-b866-6f4d75d051c7
         status: 200 OK
         code: 200
-        duration: 91.708ms
+        duration: 98.2995ms
     - id: 99
       request:
         proto: HTTP/1.1
@@ -4905,27 +4909,25 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b/private_nics/6b5c6c0f-7444-4b7e-b21c-8739c55fd0a0
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/private_nics/f779056f-b24a-422b-98f1-e1e6b57219de
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 475
+        content_length: 0
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-01-27T09:16:40.456736+00:00","id":"6b5c6c0f-7444-4b7e-b21c-8739c55fd0a0","ipam_ip_ids":["b9b673e8-309b-423d-8eb4-e08d2d2663b6","a8d9091b-37a6-40b8-8460-27b8e7aa68d4"],"mac_address":"02:00:00:1c:f4:96","modification_date":"2025-01-27T09:17:12.338455+00:00","private_network_id":"83515cde-cc20-4a98-a9b6-1ba52cb5f97d","server_id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: ""
         headers:
-            Content-Length:
-                - "475"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:44 GMT
+                - Wed, 12 Feb 2025 16:16:04 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4935,10 +4937,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 115b18d3-7430-415f-a823-481e365de15c
-        status: 200 OK
-        code: 200
-        duration: 84.284292ms
+                - 517b251a-42c6-4d3b-8773-22cd48b975de
+        status: 204 No Content
+        code: 204
+        duration: 325.796291ms
     - id: 100
       request:
         proto: HTTP/1.1
@@ -4954,25 +4956,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b/private_nics/6b5c6c0f-7444-4b7e-b21c-8739c55fd0a0
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/private_nics/f779056f-b24a-422b-98f1-e1e6b57219de
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 148
         uncompressed: false
-        body: ""
+        body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"f779056f-b24a-422b-98f1-e1e6b57219de","type":"not_found"}'
         headers:
+            Content-Length:
+                - "148"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:44 GMT
+                - Wed, 12 Feb 2025 16:16:04 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -4982,10 +4986,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 83c8a339-68d7-43b4-b60c-0ed12c7bd435
-        status: 204 No Content
-        code: 204
-        duration: 254.824167ms
+                - 7928ce7b-26a7-499f-ad10-80285a0a6c72
+        status: 404 Not Found
+        code: 404
+        duration: 115.330084ms
     - id: 101
       request:
         proto: HTTP/1.1
@@ -5001,8 +5005,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b/private_nics/6b5c6c0f-7444-4b7e-b21c-8739c55fd0a0
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616
         method: GET
       response:
         proto: HTTP/2.0
@@ -5010,18 +5014,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 148
+        content_length: 1655
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"6b5c6c0f-7444-4b7e-b21c-8739c55fd0a0","type":"not_found"}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.586614+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"c972b90c-98ce-4fe4-ac18-b4e841110616","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:d9","maintenances":[],"modification_date":"2025-02-12T16:16:02.414891+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"69319b62-c889-49b4-bf5f-89a64c7a530c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "148"
+                - "1655"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:44 GMT
+                - Wed, 12 Feb 2025 16:16:04 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5031,10 +5035,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6ee944a7-a6ff-4303-9ea3-4dd2f54662e5
-        status: 404 Not Found
-        code: 404
-        duration: 80.524584ms
+                - 62e202b8-c9b8-4a9b-9cf8-a59fcad6e597
+        status: 200 OK
+        code: 200
+        duration: 174.928208ms
     - id: 102
       request:
         proto: HTTP/1.1
@@ -5050,27 +5054,25 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2076
+        content_length: 0
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-01-27T09:16:02.386885+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:22.408500+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"dfed234f-dfb9-4269-aec1-91f355527c0d","modification_date":"2024-10-07T11:32:22.408500+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"05f6e820-234c-4e39-a035-07aac53da279","name":"Debian Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:8f:ea:1f","maintenances":[],"modification_date":"2025-01-27T09:17:40.150066+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2025-01-27T09:16:02.386885+00:00","export_uri":null,"id":"66ded296-a0b7-4cd8-8375-a9c8cd3d4ee4","modification_date":"2025-01-27T09:16:02.386885+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","name":"Scaleway Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: ""
         headers:
-            Content-Length:
-                - "2076"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:44 GMT
+                - Wed, 12 Feb 2025 16:16:04 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5080,10 +5082,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f4a69c04-cf71-4ca6-bd8d-bafba74f6104
-        status: 200 OK
-        code: 200
-        duration: 165.774209ms
+                - fff0d517-31b6-47af-8f6e-45c00eebae01
+        status: 204 No Content
+        code: 204
+        duration: 289.839166ms
     - id: 103
       request:
         proto: HTTP/1.1
@@ -5099,25 +5101,27 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 143
         uncompressed: false
-        body: ""
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","type":"not_found"}'
         headers:
+            Content-Length:
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:44 GMT
+                - Wed, 12 Feb 2025 16:16:04 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5127,10 +5131,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7fe1dd28-0381-40ae-aaca-07fc0c55415c
-        status: 204 No Content
-        code: 204
-        duration: 181.30675ms
+                - 687bd91f-0c76-4086-8b8d-9c4b6d4dbe25
+        status: 404 Not Found
+        code: 404
+        duration: 141.89675ms
     - id: 104
       request:
         proto: HTTP/1.1
@@ -5146,8 +5150,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2d18ace-8289-4b41-a2c6-b2fbdbe7707b
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/69319b62-c889-49b4-bf5f-89a64c7a530c
         method: GET
       response:
         proto: HTTP/2.0
@@ -5157,7 +5161,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"f2d18ace-8289-4b41-a2c6-b2fbdbe7707b","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"69319b62-c889-49b4-bf5f-89a64c7a530c","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -5166,7 +5170,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:45 GMT
+                - Wed, 12 Feb 2025 16:16:04 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5176,10 +5180,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4f6d939f-99ae-43bf-9ea6-f75c2140ea65
+                - 97a96ef9-3d6b-4faa-8f91-d88dfa77025a
         status: 404 Not Found
         code: 404
-        duration: 76.30125ms
+        duration: 50.820917ms
     - id: 105
       request:
         proto: HTTP/1.1
@@ -5195,8 +5199,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/66ded296-a0b7-4cd8-8375-a9c8cd3d4ee4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/69319b62-c889-49b4-bf5f-89a64c7a530c
         method: GET
       response:
         proto: HTTP/2.0
@@ -5204,18 +5208,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 437
+        content_length: 485
         uncompressed: false
-        body: '{"volume":{"creation_date":"2025-01-27T09:16:02.386885+00:00","export_uri":null,"id":"66ded296-a0b7-4cd8-8375-a9c8cd3d4ee4","modification_date":"2025-01-27T09:17:45.008497+00:00","name":"Debian Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+        body: '{"created_at":"2025-02-12T16:14:57.789341Z","id":"69319b62-c889-49b4-bf5f-89a64c7a530c","last_detached_at":"2025-02-12T16:16:04.893698Z","name":"Debian Bullseye_sbs_volume_0","parent_snapshot_id":"a50e6921-21b9-4a69-83cc-191359208d4c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:16:04.893698Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "437"
+                - "485"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:44 GMT
+                - Wed, 12 Feb 2025 16:16:05 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5225,10 +5229,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c4cf2db4-50d8-400c-9739-738b44850760
+                - bc9c1fb5-ea6e-4dc9-9f28-7cb7728addd3
         status: 200 OK
         code: 200
-        duration: 73.123833ms
+        duration: 90.009417ms
     - id: 106
       request:
         proto: HTTP/1.1
@@ -5244,8 +5248,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/66ded296-a0b7-4cd8-8375-a9c8cd3d4ee4
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/69319b62-c889-49b4-bf5f-89a64c7a530c
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5262,7 +5266,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:45 GMT
+                - Wed, 12 Feb 2025 16:16:05 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5272,10 +5276,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3a6f73df-60f3-44d9-a50d-3518abb830d4
+                - 5cd9fded-442a-4554-90f1-270e60ec670e
         status: 204 No Content
         code: 204
-        duration: 164.422916ms
+        duration: 138.849458ms
     - id: 107
       request:
         proto: HTTP/1.1
@@ -5291,8 +5295,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.3; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/83515cde-cc20-4a98-a9b6-1ba52cb5f97d
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/cf70fcfd-2aae-4a49-a49d-e4cfd7598043
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5309,7 +5313,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 27 Jan 2025 09:17:46 GMT
+                - Wed, 12 Feb 2025 16:16:06 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
@@ -5319,7 +5323,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a41e6388-53f7-483d-9c7a-5c138a0183e4
+                - 9e091df9-eed7-40fa-9b93-c51108de4f4b
         status: 204 No Content
         code: 204
-        duration: 1.481862333s
+        duration: 1.243151125s

--- a/internal/services/vpcgw/testdata/vpc-public-gateway-pat-rule-with-instance.cassette.yaml
+++ b/internal/services/vpcgw/testdata/vpc-public-gateway-pat-rule-with-instance.cassette.yaml
@@ -29,7 +29,7 @@ interactions:
         trailer: {}
         content_length: 574
         uncompressed: false
-        body: '{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+        body: '{"address":"10.0.0.1","created_at":"2025-02-12T16:24:15.738170Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"caa611d1-c0ae-4232-8a3e-1d7405c19b12","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:24:15.738170Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "574"
@@ -38,9 +38,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:14:55 GMT
+                - Wed, 12 Feb 2025 16:24:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -48,10 +48,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 53bd7f7d-32c4-4d64-be88-eb82c24cd792
+                - d8ab0b79-936b-4cd3-a592-015a18a69d74
         status: 200 OK
         code: 200
-        duration: 300.860959ms
+        duration: 282.138ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -68,7 +68,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/432c2d3a-2399-43c2-a711-f68fb19dd665
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/caa611d1-c0ae-4232-8a3e-1d7405c19b12
         method: GET
       response:
         proto: HTTP/2.0
@@ -78,7 +78,7 @@ interactions:
         trailer: {}
         content_length: 574
         uncompressed: false
-        body: '{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+        body: '{"address":"10.0.0.1","created_at":"2025-02-12T16:24:15.738170Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"caa611d1-c0ae-4232-8a3e-1d7405c19b12","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:24:15.738170Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "574"
@@ -87,9 +87,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:14:56 GMT
+                - Wed, 12 Feb 2025 16:24:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1f550996-296a-4b0d-8546-c5ac3ec0860a
+                - 21a6bc6a-203c-46dd-8e21-3ae6eda1c4fd
         status: 200 OK
         code: 200
-        duration: 44.546667ms
+        duration: 44.325959ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -127,20 +127,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1045
+        content_length: 1044
         uncompressed: false
-        body: '{"created_at":"2025-02-12T16:14:56.064699Z","dhcp_enabled":true,"id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","name":"My Private Network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:14:56.064699Z","id":"3fb46282-9a79-4012-af4e-e7826777179c","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.16.0/22","updated_at":"2025-02-12T16:14:56.064699Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-12T16:14:56.064699Z","id":"c00e429c-60c1-4133-a83a-370dedf98bc2","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:3cad::/64","updated_at":"2025-02-12T16:14:56.064699Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-12T16:14:56.064699Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"created_at":"2025-02-12T16:24:15.729901Z","dhcp_enabled":true,"id":"a100296c-6bde-43ca-bd37-960b05298469","name":"My Private Network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:24:15.729901Z","id":"bf902737-8d9f-4392-b904-74c271ab3f11","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.0.0/22","updated_at":"2025-02-12T16:24:15.729901Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-12T16:24:15.729901Z","id":"dff2513f-839c-4891-a6b6-90cf662a39d0","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:8a43::/64","updated_at":"2025-02-12T16:24:15.729901Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-12T16:24:15.729901Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "1045"
+                - "1044"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:14:56 GMT
+                - Wed, 12 Feb 2025 16:24:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -148,10 +148,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5a84cd4b-9f99-4cbb-bcbb-52a5825d2bc6
+                - 0b9d8899-5c5c-4115-8f3c-26093986a538
         status: 200 OK
         code: 200
-        duration: 948.584834ms
+        duration: 897.417792ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -168,7 +168,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/cf70fcfd-2aae-4a49-a49d-e4cfd7598043
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a100296c-6bde-43ca-bd37-960b05298469
         method: GET
       response:
         proto: HTTP/2.0
@@ -176,20 +176,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1045
+        content_length: 1044
         uncompressed: false
-        body: '{"created_at":"2025-02-12T16:14:56.064699Z","dhcp_enabled":true,"id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","name":"My Private Network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:14:56.064699Z","id":"3fb46282-9a79-4012-af4e-e7826777179c","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.16.0/22","updated_at":"2025-02-12T16:14:56.064699Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-12T16:14:56.064699Z","id":"c00e429c-60c1-4133-a83a-370dedf98bc2","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:3cad::/64","updated_at":"2025-02-12T16:14:56.064699Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-12T16:14:56.064699Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        body: '{"created_at":"2025-02-12T16:24:15.729901Z","dhcp_enabled":true,"id":"a100296c-6bde-43ca-bd37-960b05298469","name":"My Private Network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:24:15.729901Z","id":"bf902737-8d9f-4392-b904-74c271ab3f11","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.0.0/22","updated_at":"2025-02-12T16:24:15.729901Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-12T16:24:15.729901Z","id":"dff2513f-839c-4891-a6b6-90cf662a39d0","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:8a43::/64","updated_at":"2025-02-12T16:24:15.729901Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-12T16:24:15.729901Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
         headers:
             Content-Length:
-                - "1045"
+                - "1044"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:14:56 GMT
+                - Wed, 12 Feb 2025 16:24:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -197,11 +197,62 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - aa8881ea-864e-418f-a0b4-c57730933f89
+                - 6831c3f2-0b67-4672-b3cf-f1d9578098d3
         status: 200 OK
         code: 200
-        duration: 55.277ms
+        duration: 46.994875ms
     - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 63
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[]}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 371
+        uncompressed: false
+        body: '{"address":"163.172.162.186","created_at":"2025-02-12T16:24:16.504200Z","gateway_id":null,"id":"34cc7b82-72c0-4b4b-95a2-2cc0daebf1b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.504200Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "371"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:24:16 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6c5e3a3d-b833-4c37-93a6-227816cfb65b
+        status: 200 OK
+        code: 200
+        duration: 1.070742958s
+    - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -236,11 +287,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:14:56 GMT
+                - Wed, 12 Feb 2025 16:24:16 GMT
             Link:
                 - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -248,13 +299,62 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 43ed5af4-020a-4a3f-9c75-92f38f7b045c
+                - dbbf7363-3763-4e6b-a0dc-931ad773621d
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 84.528208ms
-    - id: 5
+        duration: 80.128167ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/34cc7b82-72c0-4b4b-95a2-2cc0daebf1b8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 371
+        uncompressed: false
+        body: '{"address":"163.172.162.186","created_at":"2025-02-12T16:24:16.504200Z","gateway_id":null,"id":"34cc7b82-72c0-4b4b-95a2-2cc0daebf1b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.504200Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "371"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:24:16 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 015f945b-9bac-492f-b8d5-346640204303
+        status: 200 OK
+        code: 200
+        duration: 41.568375ms
+    - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -289,11 +389,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:14:56 GMT
+                - Wed, 12 Feb 2025 16:24:16 GMT
             Link:
                 - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -301,31 +401,31 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9ae25d36-3f8e-49ab-a7d7-e69cafb65f00
+                - 9cac7057-b5ff-457d-b39e-1cf601a53586
             X-Total-Count:
                 - "68"
         status: 200 OK
         code: 200
-        duration: 54.40925ms
-    - id: 6
+        duration: 58.152208ms
+    - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 63
+        content_length: 225
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[]}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"The Public Gateway","tags":[],"type":"VPC-GW-S","upstream_dns_servers":[],"ip_id":"34cc7b82-72c0-4b4b-95a2-2cc0daebf1b8","enable_smtp":false,"enable_bastion":false}'
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
         method: POST
       response:
         proto: HTTP/2.0
@@ -333,20 +433,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 369
+        content_length: 1014
         uncompressed: false
-        body: '{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":null,"id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:24:16.671456Z","gateway_networks":[],"id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:24:16.504200Z","gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"34cc7b82-72c0-4b4b-95a2-2cc0daebf1b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.504200Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:24:16.671456Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "369"
+                - "1014"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:14:56 GMT
+                - Wed, 12 Feb 2025 16:24:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -354,60 +454,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 46264f79-f527-420a-9d66-6ca192eb945d
+                - c20df0c2-ded6-4955-9b11-3c8a7efc66af
         status: 200 OK
         code: 200
-        duration: 1.168629459s
-    - id: 7
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/502d0462-a33e-4045-a010-4d7b5889b699
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 369
-        uncompressed: false
-        body: '{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":null,"id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "369"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 16:14:56 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 1d863647-86ad-4eea-a8fa-2bfe077788a6
-        status: 200 OK
-        code: 200
-        duration: 49.942375ms
-    - id: 8
+        duration: 100.202ms
+    - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -442,9 +493,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:14:56 GMT
+                - Wed, 12 Feb 2025 16:24:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -452,61 +503,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7d3520e4-14e4-4c03-a999-050c2445d842
+                - c8f67b08-b8a3-427c-b062-2deb0a6becb2
         status: 200 OK
         code: 200
-        duration: 100.614083ms
-    - id: 9
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 225
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"The Public Gateway","tags":[],"type":"VPC-GW-S","upstream_dns_servers":[],"ip_id":"502d0462-a33e-4045-a010-4d7b5889b699","enable_smtp":false,"enable_bastion":false}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1012
-        uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.960124Z","gateway_networks":[],"id":"4e178b28-3e98-42d9-8373-7ee292e623a7","ip":{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:14:56.960124Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "1012"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 16:14:56 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 0c2dd428-641b-45fb-ac8c-c00ddc9618db
-        status: 200 OK
-        code: 200
-        duration: 109.252834ms
+        duration: 98.179584ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -523,7 +523,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/21853ec7-231b-4ed9-a7d4-4694e59a3f14
         method: GET
       response:
         proto: HTTP/2.0
@@ -531,20 +531,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1014
+        content_length: 1016
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.960124Z","gateway_networks":[],"id":"4e178b28-3e98-42d9-8373-7ee292e623a7","ip":{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:14:57.004864Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:24:16.671456Z","gateway_networks":[],"id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:24:16.504200Z","gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"34cc7b82-72c0-4b4b-95a2-2cc0daebf1b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.504200Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:24:16.717454Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1014"
+                - "1016"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:14:57 GMT
+                - Wed, 12 Feb 2025 16:24:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -552,10 +552,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 01f3cbfa-fcb9-469f-991a-89e3d085c9f5
+                - 5cbd48b4-a44c-4d43-9ad5-87bf39b132ab
         status: 200 OK
         code: 200
-        duration: 63.025541ms
+        duration: 47.127292ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -584,7 +584,7 @@ interactions:
         trailer: {}
         content_length: 1655
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.586614+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"c972b90c-98ce-4fe4-ac18-b4e841110616","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:d9","maintenances":[],"modification_date":"2025-02-12T16:14:57.586614+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"69319b62-c889-49b4-bf5f-89a64c7a530c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:24:16.951639+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c8:69","maintenances":[],"modification_date":"2025-02-12T16:24:16.951639+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"811d24a7-f24f-48ca-a17a-8f6f1d80acf2","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "1655"
@@ -593,11 +593,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:14:57 GMT
+                - Wed, 12 Feb 2025 16:24:17 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -605,10 +605,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2da7d569-2072-45c7-8fc1-cb2abd6fc0eb
+                - 00491812-560a-48c9-8129-2a5b1bdaf3a2
         status: 201 Created
         code: 201
-        duration: 1.184052292s
+        duration: 998.411417ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -625,7 +625,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3
         method: GET
       response:
         proto: HTTP/2.0
@@ -635,7 +635,7 @@ interactions:
         trailer: {}
         content_length: 1655
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.586614+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"c972b90c-98ce-4fe4-ac18-b4e841110616","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:d9","maintenances":[],"modification_date":"2025-02-12T16:14:57.586614+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"69319b62-c889-49b4-bf5f-89a64c7a530c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:24:16.951639+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c8:69","maintenances":[],"modification_date":"2025-02-12T16:24:16.951639+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"811d24a7-f24f-48ca-a17a-8f6f1d80acf2","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "1655"
@@ -644,9 +644,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:14:57 GMT
+                - Wed, 12 Feb 2025 16:24:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -654,10 +654,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3628c836-07dc-4389-9790-2bddac150abc
+                - d3089c1e-496e-475f-acb7-8abbea7b39de
         status: 200 OK
         code: 200
-        duration: 540.587958ms
+        duration: 305.138708ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -674,7 +674,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3
         method: GET
       response:
         proto: HTTP/2.0
@@ -684,7 +684,7 @@ interactions:
         trailer: {}
         content_length: 1655
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.586614+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"c972b90c-98ce-4fe4-ac18-b4e841110616","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:d9","maintenances":[],"modification_date":"2025-02-12T16:14:57.586614+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"69319b62-c889-49b4-bf5f-89a64c7a530c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:24:16.951639+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c8:69","maintenances":[],"modification_date":"2025-02-12T16:24:16.951639+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"811d24a7-f24f-48ca-a17a-8f6f1d80acf2","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "1655"
@@ -693,9 +693,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:14:58 GMT
+                - Wed, 12 Feb 2025 16:24:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -703,10 +703,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 68fcf18e-20d6-4be7-bb5a-8b2eb94308e9
+                - f36616e7-7935-44e0-a360-54687500b931
         status: 200 OK
         code: 200
-        duration: 172.525166ms
+        duration: 176.058125ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -723,7 +723,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/69319b62-c889-49b4-bf5f-89a64c7a530c
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/811d24a7-f24f-48ca-a17a-8f6f1d80acf2
         method: GET
       response:
         proto: HTTP/2.0
@@ -733,7 +733,7 @@ interactions:
         trailer: {}
         content_length: 692
         uncompressed: false
-        body: '{"created_at":"2025-02-12T16:14:57.789341Z","id":"69319b62-c889-49b4-bf5f-89a64c7a530c","last_detached_at":null,"name":"Debian Bullseye_sbs_volume_0","parent_snapshot_id":"a50e6921-21b9-4a69-83cc-191359208d4c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:14:57.789341Z","id":"427679d5-67d4-4f63-b880-f092ab65f28c","product_resource_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:14:57.789341Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:24:17.161631Z","id":"811d24a7-f24f-48ca-a17a-8f6f1d80acf2","last_detached_at":null,"name":"Debian Bullseye_sbs_volume_0","parent_snapshot_id":"a50e6921-21b9-4a69-83cc-191359208d4c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:24:17.161631Z","id":"a2055bef-d48d-44c0-9395-a15a3cafca8d","product_resource_id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:24:17.161631Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "692"
@@ -742,9 +742,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:14:58 GMT
+                - Wed, 12 Feb 2025 16:24:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -752,10 +752,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9a238bc4-c8fb-4dfc-80e2-5f8838e9027e
+                - 5971f68f-0687-4fbc-9b68-51ffd4e66edc
         status: 200 OK
         code: 200
-        duration: 86.894916ms
+        duration: 86.219541ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -774,7 +774,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/action
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -784,7 +784,7 @@ interactions:
         trailer: {}
         content_length: 357
         uncompressed: false
-        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/action","href_result":"/servers/c972b90c-98ce-4fe4-ac18-b4e841110616","id":"23607605-d9ce-4354-88c7-df49780a52f8","progress":0,"started_at":"2025-02-12T16:14:59.183437+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3/action","href_result":"/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3","id":"4f477f20-fa9a-4c2f-9c45-f6fe3410ed53","progress":0,"started_at":"2025-02-12T16:24:18.533539+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -793,11 +793,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:14:58 GMT
+                - Wed, 12 Feb 2025 16:24:18 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/23607605-d9ce-4354-88c7-df49780a52f8
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/4f477f20-fa9a-4c2f-9c45-f6fe3410ed53
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -805,10 +805,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5e210871-4a28-45f0-b365-1f0e62508eb0
+                - 8669ebcd-d6b0-434d-9259-09fac4d703e7
         status: 202 Accepted
         code: 202
-        duration: 303.102667ms
+        duration: 350.326125ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -825,7 +825,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3
         method: GET
       response:
         proto: HTTP/2.0
@@ -835,7 +835,7 @@ interactions:
         trailer: {}
         content_length: 1677
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.586614+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"c972b90c-98ce-4fe4-ac18-b4e841110616","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:d9","maintenances":[],"modification_date":"2025-02-12T16:14:58.954345+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"id":"69319b62-c889-49b4-bf5f-89a64c7a530c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:24:16.951639+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c8:69","maintenances":[],"modification_date":"2025-02-12T16:24:18.329294+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"id":"811d24a7-f24f-48ca-a17a-8f6f1d80acf2","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "1677"
@@ -844,9 +844,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:14:59 GMT
+                - Wed, 12 Feb 2025 16:24:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -854,10 +854,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a3359413-f301-4b2f-a6e3-a698caa03eb8
+                - 0942654b-875b-40ca-8a53-e19746055474
         status: 200 OK
         code: 200
-        duration: 203.17875ms
+        duration: 308.605042ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -874,7 +874,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/21853ec7-231b-4ed9-a7d4-4694e59a3f14
         method: GET
       response:
         proto: HTTP/2.0
@@ -882,20 +882,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1011
+        content_length: 1013
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.960124Z","gateway_networks":[],"id":"4e178b28-3e98-42d9-8373-7ee292e623a7","ip":{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:02.081729Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:24:16.671456Z","gateway_networks":[],"id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:24:16.504200Z","gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"34cc7b82-72c0-4b4b-95a2-2cc0daebf1b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.504200Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:24:21.669777Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1011"
+                - "1013"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:02 GMT
+                - Wed, 12 Feb 2025 16:24:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -903,10 +903,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b188103f-e74b-4a1a-bc4d-474bf5665e13
+                - 86ac6b32-d76d-4102-8907-dfbf1b85553d
         status: 200 OK
         code: 200
-        duration: 54.366416ms
+        duration: 57.628875ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -923,7 +923,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/21853ec7-231b-4ed9-a7d4-4694e59a3f14
         method: GET
       response:
         proto: HTTP/2.0
@@ -931,20 +931,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1011
+        content_length: 1013
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.960124Z","gateway_networks":[],"id":"4e178b28-3e98-42d9-8373-7ee292e623a7","ip":{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:02.081729Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:24:16.671456Z","gateway_networks":[],"id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:24:16.504200Z","gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"34cc7b82-72c0-4b4b-95a2-2cc0daebf1b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.504200Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:24:21.669777Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1011"
+                - "1013"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:02 GMT
+                - Wed, 12 Feb 2025 16:24:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -952,10 +952,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3ee28176-16ce-45e6-8833-2bea051b7bf6
+                - a136ebb5-f761-478d-8c6d-27ce151a0593
         status: 200 OK
         code: 200
-        duration: 47.678042ms
+        duration: 48.262375ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -972,7 +972,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/21853ec7-231b-4ed9-a7d4-4694e59a3f14
         method: GET
       response:
         proto: HTTP/2.0
@@ -980,20 +980,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1011
+        content_length: 1013
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.960124Z","gateway_networks":[],"id":"4e178b28-3e98-42d9-8373-7ee292e623a7","ip":{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:02.081729Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:24:16.671456Z","gateway_networks":[],"id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:24:16.504200Z","gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"34cc7b82-72c0-4b4b-95a2-2cc0daebf1b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.504200Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":false,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:24:21.669777Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1011"
+                - "1013"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:02 GMT
+                - Wed, 12 Feb 2025 16:24:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1001,10 +1001,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2b3730d1-2753-4bdf-a993-b8aa3e333940
+                - b6e15131-a4d5-4ac6-bb0d-af9fb28cf53c
         status: 200 OK
         code: 200
-        duration: 50.425375ms
+        duration: 46.987ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1021,7 +1021,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3
         method: GET
       response:
         proto: HTTP/2.0
@@ -1031,7 +1031,7 @@ interactions:
         trailer: {}
         content_length: 1780
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.586614+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"c972b90c-98ce-4fe4-ac18-b4e841110616","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"702","node_id":"10","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d9","maintenances":[],"modification_date":"2025-02-12T16:14:58.954345+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"id":"69319b62-c889-49b4-bf5f-89a64c7a530c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:24:16.951639+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"401","node_id":"14","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c8:69","maintenances":[],"modification_date":"2025-02-12T16:24:18.329294+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"id":"811d24a7-f24f-48ca-a17a-8f6f1d80acf2","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "1780"
@@ -1040,9 +1040,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:04 GMT
+                - Wed, 12 Feb 2025 16:24:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1050,10 +1050,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5c152bef-aee4-4501-8b12-c31aba9beec3
+                - 21d4997f-21b6-45ad-a065-5b0c4c125f5f
         status: 200 OK
         code: 200
-        duration: 211.782375ms
+        duration: 188.489875ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1065,356 +1065,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"432c2d3a-2399-43c2-a711-f68fb19dd665"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 28
-        uncompressed: false
-        body: '{"message":"internal error"}'
-        headers:
-            Content-Length:
-                - "28"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 16:15:06 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 377815b8-1eeb-4bd1-b67f-a49137a2bc3e
-        status: 500 Internal Server Error
-        code: 500
-        duration: 4.556749834s
-    - id: 22
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 206
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"432c2d3a-2399-43c2-a711-f68fb19dd665"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 28
-        uncompressed: false
-        body: '{"message":"internal error"}'
-        headers:
-            Content-Length:
-                - "28"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 16:15:09 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 4ceb7a59-44b8-4e6d-89ee-49d7402a6063
-        status: 500 Internal Server Error
-        code: 500
-        duration: 354.470083ms
-    - id: 23
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1811
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.586614+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"c972b90c-98ce-4fe4-ac18-b4e841110616","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"702","node_id":"10","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d9","maintenances":[],"modification_date":"2025-02-12T16:15:08.588756+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"69319b62-c889-49b4-bf5f-89a64c7a530c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "1811"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 16:15:09 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - cbc25586-4bef-4380-9aec-7f5816259fc5
-        status: 200 OK
-        code: 200
-        duration: 184.405875ms
-    - id: 24
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/cf70fcfd-2aae-4a49-a49d-e4cfd7598043
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1045
-        uncompressed: false
-        body: '{"created_at":"2025-02-12T16:14:56.064699Z","dhcp_enabled":true,"id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","name":"My Private Network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:14:56.064699Z","id":"3fb46282-9a79-4012-af4e-e7826777179c","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"172.16.16.0/22","updated_at":"2025-02-12T16:14:56.064699Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"},{"created_at":"2025-02-12T16:14:56.064699Z","id":"c00e429c-60c1-4133-a83a-370dedf98bc2","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:3cad::/64","updated_at":"2025-02-12T16:14:56.064699Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}],"tags":[],"updated_at":"2025-02-12T16:14:56.064699Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
-        headers:
-            Content-Length:
-                - "1045"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 16:15:09 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - c3cbd1ef-1621-44c0-a26f-847c5860095c
-        status: 200 OK
-        code: 200
-        duration: 48.253833ms
-    - id: 25
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1811
-        uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.586614+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"c972b90c-98ce-4fe4-ac18-b4e841110616","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"702","node_id":"10","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d9","maintenances":[],"modification_date":"2025-02-12T16:15:08.588756+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"69319b62-c889-49b4-bf5f-89a64c7a530c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "1811"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 16:15:10 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - ebdca782-d995-424e-bb3e-d18d382c120e
-        status: 200 OK
-        code: 200
-        duration: 211.358708ms
-    - id: 26
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 61
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043"}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/private_nics
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 473
-        uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:10.328211+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"syncing","tags":[],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "473"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 16:15:11 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - a0f85371-e0b2-4726-92fc-ab2123a9496c
-        status: 201 Created
-        code: 201
-        duration: 1.068275125s
-    - id: 27
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/private_nics/f779056f-b24a-422b-98f1-e1e6b57219de
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 473
-        uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:10.328211+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"syncing","tags":[],"zone":"fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "473"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 16:15:11 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 2ff69ea8-c8e6-4baa-8de6-1e9595a00ab1
-        status: 200 OK
-        code: 200
-        duration: 109.431416ms
-    - id: 28
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 206
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"432c2d3a-2399-43c2-a711-f68fb19dd665"}'
+        body: '{"gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"caa611d1-c0ae-4232-8a3e-1d7405c19b12"}'
         form: {}
         headers:
             Content-Type:
@@ -1431,7 +1082,7 @@ interactions:
         trailer: {}
         content_length: 971
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":null,"private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"created","updated_at":"2025-02-12T16:15:15.041619Z","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:24:25.147240Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:24:15.738170Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"caa611d1-c0ae-4232-8a3e-1d7405c19b12","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:24:15.738170Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"ca847b1f-dc9d-4d88-b58b-af1b39421b87","ipam_config":null,"mac_address":null,"private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","status":"created","updated_at":"2025-02-12T16:24:25.147240Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "971"
@@ -1440,9 +1091,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:15 GMT
+                - Wed, 12 Feb 2025 16:24:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1450,10 +1101,355 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8355cea3-29bf-4678-b126-1ed44ba693a3
+                - 349335cd-1a4d-4e75-9102-daa38ef1f94c
         status: 200 OK
         code: 200
-        duration: 2.142525458s
+        duration: 3.466775875s
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/21853ec7-231b-4ed9-a7d4-4694e59a3f14
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1987
+        uncompressed: false
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:24:16.671456Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:24:25.147240Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:24:15.738170Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"caa611d1-c0ae-4232-8a3e-1d7405c19b12","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:24:15.738170Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"ca847b1f-dc9d-4d88-b58b-af1b39421b87","ipam_config":null,"mac_address":null,"private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","status":"created","updated_at":"2025-02-12T16:24:25.147240Z","zone":"fr-par-1"}],"id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:24:16.504200Z","gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"34cc7b82-72c0-4b4b-95a2-2cc0daebf1b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.504200Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:24:25.299167Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "1987"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:24:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 93726423-1882-4602-9b74-266050c898a0
+        status: 200 OK
+        code: 200
+        duration: 49.717917ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1811
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:24:16.951639+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"401","node_id":"14","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c8:69","maintenances":[],"modification_date":"2025-02-12T16:24:24.801877+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"811d24a7-f24f-48ca-a17a-8f6f1d80acf2","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1811"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:24:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 088a8b5d-fcf5-4375-a1df-54a7857e8831
+        status: 200 OK
+        code: 200
+        duration: 169.751084ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a100296c-6bde-43ca-bd37-960b05298469
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1042
+        uncompressed: false
+        body: '{"created_at":"2025-02-12T16:24:15.729901Z","dhcp_enabled":true,"id":"a100296c-6bde-43ca-bd37-960b05298469","name":"My Private Network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:24:15.729901Z","id":"bf902737-8d9f-4392-b904-74c271ab3f11","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:24:22.232802Z","vpc_id":"d096aa1f-515e-4175-8a7b-be9900ad158a"},{"created_at":"2025-02-12T16:24:15.729901Z","id":"dff2513f-839c-4891-a6b6-90cf662a39d0","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:8a43::/64","updated_at":"2025-02-12T16:24:22.236968Z","vpc_id":"d096aa1f-515e-4175-8a7b-be9900ad158a"}],"tags":[],"updated_at":"2025-02-12T16:24:22.230587Z","vpc_id":"d096aa1f-515e-4175-8a7b-be9900ad158a"}'
+        headers:
+            Content-Length:
+                - "1042"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:24:29 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 59facd93-45cf-400c-991c-dbdaacc558e7
+        status: 200 OK
+        code: 200
+        duration: 66.072ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1811
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:24:16.951639+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"401","node_id":"14","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c8:69","maintenances":[],"modification_date":"2025-02-12T16:24:24.801877+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"811d24a7-f24f-48ca-a17a-8f6f1d80acf2","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "1811"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:24:29 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7527ada9-4a7a-4dc8-b46c-3a20dd88cbca
+        status: 200 OK
+        code: 200
+        duration: 254.899416ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/21853ec7-231b-4ed9-a7d4-4694e59a3f14
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1987
+        uncompressed: false
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:24:16.671456Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:24:25.147240Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:24:15.738170Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"caa611d1-c0ae-4232-8a3e-1d7405c19b12","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:24:15.738170Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"ca847b1f-dc9d-4d88-b58b-af1b39421b87","ipam_config":null,"mac_address":null,"private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","status":"created","updated_at":"2025-02-12T16:24:25.147240Z","zone":"fr-par-1"}],"id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:24:16.504200Z","gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"34cc7b82-72c0-4b4b-95a2-2cc0daebf1b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.504200Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:24:25.299167Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "1987"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:24:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 09b54893-b795-4fe3-b9af-6cc8dc45cf5e
+        status: 200 OK
+        code: 200
+        duration: 57.682625ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 61
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"private_network_id":"a100296c-6bde-43ca-bd37-960b05298469"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3/private_nics
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 473
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:24:29.671381+00:00","id":"0611a4a0-e528-4ebf-8548-d635c01ca08a","ipam_ip_ids":["142df25d-25e2-4f18-8561-3f3f877891d3","96302d29-79b9-413b-a5bd-2d7c269891d9"],"mac_address":"02:00:00:1c:b1:e9","modification_date":"2025-02-12T16:24:29.884031+00:00","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","server_id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "473"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:24:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d536e2e4-d9d2-446e-a5b8-124c2fee2206
+        status: 201 Created
+        code: 201
+        duration: 1.066914334s
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3/private_nics/0611a4a0-e528-4ebf-8548-d635c01ca08a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 473
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:24:29.671381+00:00","id":"0611a4a0-e528-4ebf-8548-d635c01ca08a","ipam_ip_ids":["142df25d-25e2-4f18-8561-3f3f877891d3","96302d29-79b9-413b-a5bd-2d7c269891d9"],"mac_address":"02:00:00:1c:b1:e9","modification_date":"2025-02-12T16:24:29.884031+00:00","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","server_id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "473"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:24:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - db6a92d6-9802-44b5-9a24-fff2ba4511c2
+        status: 200 OK
+        code: 200
+        duration: 102.546708ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1470,7 +1466,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/21853ec7-231b-4ed9-a7d4-4694e59a3f14
         method: GET
       response:
         proto: HTTP/2.0
@@ -1478,20 +1474,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1985
+        content_length: 1996
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.960124Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":null,"private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"created","updated_at":"2025-02-12T16:15:15.041619Z","zone":"fr-par-1"}],"id":"4e178b28-3e98-42d9-8373-7ee292e623a7","ip":{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:15.177390Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:24:16.671456Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:24:25.147240Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:24:15.738170Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"caa611d1-c0ae-4232-8a3e-1d7405c19b12","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:24:15.738170Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"ca847b1f-dc9d-4d88-b58b-af1b39421b87","ipam_config":null,"mac_address":"02:00:00:1F:BF:5A","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","status":"ready","updated_at":"2025-02-12T16:24:35.344045Z","zone":"fr-par-1"}],"id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:24:16.504200Z","gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"34cc7b82-72c0-4b4b-95a2-2cc0daebf1b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.504200Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:24:35.474636Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1985"
+                - "1996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:15 GMT
+                - Wed, 12 Feb 2025 16:24:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1499,10 +1495,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2aa5e62a-1415-45cf-b72d-63d2790903ed
+                - 17d56b30-5193-45e1-a050-bdf8c44e15c3
         status: 200 OK
         code: 200
-        duration: 48.649458ms
+        duration: 49.921083ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1519,7 +1515,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/private_nics/f779056f-b24a-422b-98f1-e1e6b57219de
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ca847b1f-dc9d-4d88-b58b-af1b39421b87
         method: GET
       response:
         proto: HTTP/2.0
@@ -1527,20 +1523,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 473
+        content_length: 984
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:10.328211+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"address":null,"created_at":"2025-02-12T16:24:25.147240Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:24:15.738170Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"caa611d1-c0ae-4232-8a3e-1d7405c19b12","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:24:15.738170Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"ca847b1f-dc9d-4d88-b58b-af1b39421b87","ipam_config":null,"mac_address":"02:00:00:1F:BF:5A","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","status":"ready","updated_at":"2025-02-12T16:24:35.344045Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "473"
+                - "984"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:16 GMT
+                - Wed, 12 Feb 2025 16:24:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1548,10 +1544,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 42ed934f-ab6e-4874-900f-20caaa4b564e
+                - 18cdf0dc-fbc4-4e96-bd00-d4fcb16966d0
         status: 200 OK
         code: 200
-        duration: 117.608375ms
+        duration: 70.990208ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1568,7 +1564,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ca847b1f-dc9d-4d88-b58b-af1b39421b87
         method: GET
       response:
         proto: HTTP/2.0
@@ -1576,20 +1572,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1985
+        content_length: 984
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.960124Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":null,"private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"created","updated_at":"2025-02-12T16:15:15.041619Z","zone":"fr-par-1"}],"id":"4e178b28-3e98-42d9-8373-7ee292e623a7","ip":{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:15.177390Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:24:25.147240Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:24:15.738170Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"caa611d1-c0ae-4232-8a3e-1d7405c19b12","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:24:15.738170Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"ca847b1f-dc9d-4d88-b58b-af1b39421b87","ipam_config":null,"mac_address":"02:00:00:1F:BF:5A","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","status":"ready","updated_at":"2025-02-12T16:24:35.344045Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1985"
+                - "984"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:20 GMT
+                - Wed, 12 Feb 2025 16:24:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1597,10 +1593,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bd67f358-e995-4220-a3c2-8093cc281fc4
+                - cf4ad500-acf4-413b-91a0-db45efddede8
         status: 200 OK
         code: 200
-        duration: 58.513917ms
+        duration: 64.888625ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1617,7 +1613,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/private_nics/f779056f-b24a-422b-98f1-e1e6b57219de
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/21853ec7-231b-4ed9-a7d4-4694e59a3f14
         method: GET
       response:
         proto: HTTP/2.0
@@ -1625,20 +1621,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 473
+        content_length: 1996
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:10.328211+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:24:16.671456Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:24:25.147240Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:24:15.738170Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"caa611d1-c0ae-4232-8a3e-1d7405c19b12","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:24:15.738170Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"ca847b1f-dc9d-4d88-b58b-af1b39421b87","ipam_config":null,"mac_address":"02:00:00:1F:BF:5A","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","status":"ready","updated_at":"2025-02-12T16:24:35.344045Z","zone":"fr-par-1"}],"id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:24:16.504200Z","gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"34cc7b82-72c0-4b4b-95a2-2cc0daebf1b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.504200Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:24:35.474636Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "473"
+                - "1996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:21 GMT
+                - Wed, 12 Feb 2025 16:24:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1646,10 +1642,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ac01b71c-8cdb-4f07-a371-a0fedc1b8853
+                - 5c06a87a-2791-48b3-9e41-c8c927bb2821
         status: 200 OK
         code: 200
-        duration: 115.579208ms
+        duration: 47.836958ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1666,7 +1662,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ca847b1f-dc9d-4d88-b58b-af1b39421b87
         method: GET
       response:
         proto: HTTP/2.0
@@ -1674,20 +1670,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1994
+        content_length: 984
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.960124Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}],"id":"4e178b28-3e98-42d9-8373-7ee292e623a7","ip":{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:23.527960Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:24:25.147240Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:24:15.738170Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"caa611d1-c0ae-4232-8a3e-1d7405c19b12","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:24:15.738170Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"ca847b1f-dc9d-4d88-b58b-af1b39421b87","ipam_config":null,"mac_address":"02:00:00:1F:BF:5A","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","status":"ready","updated_at":"2025-02-12T16:24:35.344045Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1994"
+                - "984"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:25 GMT
+                - Wed, 12 Feb 2025 16:24:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1695,10 +1691,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - eb9851fd-2386-463c-8625-768e593967bc
+                - e1204e43-9e44-4306-9f8a-d117e4799d9b
         status: 200 OK
         code: 200
-        duration: 51.649625ms
+        duration: 70.788917ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1715,7 +1711,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1a85191f-5f3c-4895-86f7-28b1d61a4f2e
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3/private_nics/0611a4a0-e528-4ebf-8548-d635c01ca08a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1723,20 +1719,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 984
+        content_length: 473
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:24:29.671381+00:00","id":"0611a4a0-e528-4ebf-8548-d635c01ca08a","ipam_ip_ids":["142df25d-25e2-4f18-8561-3f3f877891d3","96302d29-79b9-413b-a5bd-2d7c269891d9"],"mac_address":"02:00:00:1c:b1:e9","modification_date":"2025-02-12T16:24:29.884031+00:00","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","server_id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "984"
+                - "473"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:25 GMT
+                - Wed, 12 Feb 2025 16:24:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1744,10 +1740,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7bce820e-677b-480b-8190-b5ddb081e4d9
+                - b03c959f-bf22-40a7-a9c5-1c3861cbc0f4
         status: 200 OK
         code: 200
-        duration: 67.289291ms
+        duration: 98.681875ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1764,7 +1760,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1a85191f-5f3c-4895-86f7-28b1d61a4f2e
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3/private_nics/0611a4a0-e528-4ebf-8548-d635c01ca08a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1772,20 +1768,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 984
+        content_length: 473
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:24:29.671381+00:00","id":"0611a4a0-e528-4ebf-8548-d635c01ca08a","ipam_ip_ids":["142df25d-25e2-4f18-8561-3f3f877891d3","96302d29-79b9-413b-a5bd-2d7c269891d9"],"mac_address":"02:00:00:1c:b1:e9","modification_date":"2025-02-12T16:24:29.884031+00:00","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","server_id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "984"
+                - "473"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:25 GMT
+                - Wed, 12 Feb 2025 16:24:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1793,10 +1789,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a6c2f637-73a7-4b35-8ed4-573a2f70392d
+                - f4044de1-7480-4d35-9f1b-d36d00f56d04
         status: 200 OK
         code: 200
-        duration: 70.746375ms
+        duration: 123.5405ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1813,7 +1809,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3/private_nics/0611a4a0-e528-4ebf-8548-d635c01ca08a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1821,20 +1817,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1994
+        content_length: 473
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.960124Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}],"id":"4e178b28-3e98-42d9-8373-7ee292e623a7","ip":{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:23.527960Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:24:29.671381+00:00","id":"0611a4a0-e528-4ebf-8548-d635c01ca08a","ipam_ip_ids":["142df25d-25e2-4f18-8561-3f3f877891d3","96302d29-79b9-413b-a5bd-2d7c269891d9"],"mac_address":"02:00:00:1c:b1:e9","modification_date":"2025-02-12T16:24:29.884031+00:00","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","server_id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1994"
+                - "473"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:25 GMT
+                - Wed, 12 Feb 2025 16:24:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1842,10 +1838,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 09f2ab1a-d538-4251-863b-2cd709369d06
+                - 8290095c-1f2d-4010-b98d-ca6174500195
         status: 200 OK
         code: 200
-        duration: 48.067ms
+        duration: 116.273792ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1862,7 +1858,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1a85191f-5f3c-4895-86f7-28b1d61a4f2e
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3/private_nics/0611a4a0-e528-4ebf-8548-d635c01ca08a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1870,20 +1866,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 984
+        content_length: 473
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:24:29.671381+00:00","id":"0611a4a0-e528-4ebf-8548-d635c01ca08a","ipam_ip_ids":["142df25d-25e2-4f18-8561-3f3f877891d3","96302d29-79b9-413b-a5bd-2d7c269891d9"],"mac_address":"02:00:00:1c:b1:e9","modification_date":"2025-02-12T16:24:29.884031+00:00","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","server_id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "984"
+                - "473"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:25 GMT
+                - Wed, 12 Feb 2025 16:24:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1891,10 +1887,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 77147f6b-3b43-4f19-8ed9-a8dab060e314
+                - bc89872b-d985-4426-9626-807d368be2b9
         status: 200 OK
         code: 200
-        duration: 70.08575ms
+        duration: 114.940458ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1911,7 +1907,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/private_nics/f779056f-b24a-422b-98f1-e1e6b57219de
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3/private_nics/0611a4a0-e528-4ebf-8548-d635c01ca08a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1921,7 +1917,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:10.328211+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:24:29.671381+00:00","id":"0611a4a0-e528-4ebf-8548-d635c01ca08a","ipam_ip_ids":["142df25d-25e2-4f18-8561-3f3f877891d3","96302d29-79b9-413b-a5bd-2d7c269891d9"],"mac_address":"02:00:00:1c:b1:e9","modification_date":"2025-02-12T16:24:29.884031+00:00","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","server_id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -1930,9 +1926,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:26 GMT
+                - Wed, 12 Feb 2025 16:24:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1940,10 +1936,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6b011f47-de78-4ef6-a6f9-0236aa956536
+                - f2fa8f4b-b813-4193-b0f4-007380fefd80
         status: 200 OK
         code: 200
-        duration: 105.379708ms
+        duration: 105.25575ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1960,7 +1956,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/private_nics/f779056f-b24a-422b-98f1-e1e6b57219de
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3/private_nics/0611a4a0-e528-4ebf-8548-d635c01ca08a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1970,7 +1966,7 @@ interactions:
         trailer: {}
         content_length: 473
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:10.328211+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:24:29.671381+00:00","id":"0611a4a0-e528-4ebf-8548-d635c01ca08a","ipam_ip_ids":["142df25d-25e2-4f18-8561-3f3f877891d3","96302d29-79b9-413b-a5bd-2d7c269891d9"],"mac_address":"02:00:00:1c:b1:e9","modification_date":"2025-02-12T16:24:29.884031+00:00","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","server_id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","state":"syncing","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "473"
@@ -1979,9 +1975,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:31 GMT
+                - Wed, 12 Feb 2025 16:25:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1989,10 +1985,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 92a037cb-c71d-4138-93dd-d57dc2118ad9
+                - 0202b6e9-e34a-43af-95e9-4bf00eb38239
         status: 200 OK
         code: 200
-        duration: 120.015958ms
+        duration: 110.362166ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2009,7 +2005,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/private_nics/f779056f-b24a-422b-98f1-e1e6b57219de
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3/private_nics/0611a4a0-e528-4ebf-8548-d635c01ca08a
         method: GET
       response:
         proto: HTTP/2.0
@@ -2017,20 +2013,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 473
+        content_length: 475
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:10.328211+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:24:29.671381+00:00","id":"0611a4a0-e528-4ebf-8548-d635c01ca08a","ipam_ip_ids":["142df25d-25e2-4f18-8561-3f3f877891d3","96302d29-79b9-413b-a5bd-2d7c269891d9"],"mac_address":"02:00:00:1c:b1:e9","modification_date":"2025-02-12T16:25:01.593495+00:00","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","server_id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "473"
+                - "475"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:36 GMT
+                - Wed, 12 Feb 2025 16:25:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2038,10 +2034,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2a8a9fbb-c25d-40d5-a0eb-f6a5decc13c4
+                - 986dbf0b-4456-4ee2-b141-009ce40a78e1
         status: 200 OK
         code: 200
-        duration: 94.892541ms
+        duration: 111.537875ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2058,7 +2054,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/private_nics/f779056f-b24a-422b-98f1-e1e6b57219de
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3/private_nics/0611a4a0-e528-4ebf-8548-d635c01ca08a
         method: GET
       response:
         proto: HTTP/2.0
@@ -2068,7 +2064,7 @@ interactions:
         trailer: {}
         content_length: 475
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:41.910409+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:24:29.671381+00:00","id":"0611a4a0-e528-4ebf-8548-d635c01ca08a","ipam_ip_ids":["142df25d-25e2-4f18-8561-3f3f877891d3","96302d29-79b9-413b-a5bd-2d7c269891d9"],"mac_address":"02:00:00:1c:b1:e9","modification_date":"2025-02-12T16:25:01.593495+00:00","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","server_id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "475"
@@ -2077,9 +2073,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:42 GMT
+                - Wed, 12 Feb 2025 16:25:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2087,10 +2083,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fab01ad2-c5fc-4371-aeac-83dc191b30e0
+                - 63a5a5ee-db6a-4eef-b5f5-5a043e6489f2
         status: 200 OK
         code: 200
-        duration: 285.488292ms
+        duration: 111.891ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2107,7 +2103,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/private_nics/f779056f-b24a-422b-98f1-e1e6b57219de
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3
         method: GET
       response:
         proto: HTTP/2.0
@@ -2115,20 +2111,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 475
+        content_length: 2269
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:41.910409+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:24:16.951639+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"401","node_id":"14","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c8:69","maintenances":[],"modification_date":"2025-02-12T16:24:24.801877+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:24:29.671381+00:00","id":"0611a4a0-e528-4ebf-8548-d635c01ca08a","ipam_ip_ids":["142df25d-25e2-4f18-8561-3f3f877891d3","96302d29-79b9-413b-a5bd-2d7c269891d9"],"mac_address":"02:00:00:1c:b1:e9","modification_date":"2025-02-12T16:25:01.593495+00:00","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","server_id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"811d24a7-f24f-48ca-a17a-8f6f1d80acf2","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "475"
+                - "2269"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:42 GMT
+                - Wed, 12 Feb 2025 16:25:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2136,10 +2132,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 469b7e63-b562-41f2-a81f-b6093182a49c
+                - 7b342b47-7f6e-4c0b-8f9f-ec54a365c1a0
         status: 200 OK
         code: 200
-        duration: 275.473958ms
+        duration: 224.436916ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2156,7 +2152,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/811d24a7-f24f-48ca-a17a-8f6f1d80acf2
         method: GET
       response:
         proto: HTTP/2.0
@@ -2164,20 +2160,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2269
+        content_length: 143
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.586614+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"c972b90c-98ce-4fe4-ac18-b4e841110616","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"702","node_id":"10","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d9","maintenances":[],"modification_date":"2025-02-12T16:15:08.588756+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:41.910409+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"69319b62-c889-49b4-bf5f-89a64c7a530c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"811d24a7-f24f-48ca-a17a-8f6f1d80acf2","type":"not_found"}'
         headers:
             Content-Length:
-                - "2269"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:42 GMT
+                - Wed, 12 Feb 2025 16:25:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2185,10 +2181,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6411c441-80b7-4b15-bee2-86b11a2c4df3
-        status: 200 OK
-        code: 200
-        duration: 173.552291ms
+                - a03cee26-0777-4576-b469-c894de7873e0
+        status: 404 Not Found
+        code: 404
+        duration: 54.395625ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2205,7 +2201,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/69319b62-c889-49b4-bf5f-89a64c7a530c
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/811d24a7-f24f-48ca-a17a-8f6f1d80acf2
         method: GET
       response:
         proto: HTTP/2.0
@@ -2213,20 +2209,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 143
+        content_length: 692
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"69319b62-c889-49b4-bf5f-89a64c7a530c","type":"not_found"}'
+        body: '{"created_at":"2025-02-12T16:24:17.161631Z","id":"811d24a7-f24f-48ca-a17a-8f6f1d80acf2","last_detached_at":null,"name":"Debian Bullseye_sbs_volume_0","parent_snapshot_id":"a50e6921-21b9-4a69-83cc-191359208d4c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:24:17.161631Z","id":"a2055bef-d48d-44c0-9395-a15a3cafca8d","product_resource_id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:24:17.161631Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "143"
+                - "692"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:42 GMT
+                - Wed, 12 Feb 2025 16:25:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2234,10 +2230,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3bc1eafb-0289-4cff-b2a4-bda4629cf2f2
-        status: 404 Not Found
-        code: 404
-        duration: 60.319167ms
+                - 96ef0738-cf6c-4239-bf7d-f6d91cc7a94a
+        status: 200 OK
+        code: 200
+        duration: 82.677708ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2254,7 +2250,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/69319b62-c889-49b4-bf5f-89a64c7a530c
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -2262,20 +2258,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 692
+        content_length: 17
         uncompressed: false
-        body: '{"created_at":"2025-02-12T16:14:57.789341Z","id":"69319b62-c889-49b4-bf5f-89a64c7a530c","last_detached_at":null,"name":"Debian Bullseye_sbs_volume_0","parent_snapshot_id":"a50e6921-21b9-4a69-83cc-191359208d4c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:14:57.789341Z","id":"427679d5-67d4-4f63-b880-f092ab65f28c","product_resource_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:14:57.789341Z","zone":"fr-par-1"}'
+        body: '{"user_data":[]}'
         headers:
             Content-Length:
-                - "692"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:42 GMT
+                - Wed, 12 Feb 2025 16:25:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2283,10 +2279,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fdcf5a09-2415-4da3-998d-4ff11d0ab908
+                - 0be8efd2-1d5c-4baf-8ddf-646d6cb87925
         status: 200 OK
         code: 200
-        duration: 82.091458ms
+        duration: 98.489417ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2303,7 +2299,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/user_data
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -2311,20 +2307,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 17
+        content_length: 478
         uncompressed: false
-        body: '{"user_data":[]}'
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:24:29.671381+00:00","id":"0611a4a0-e528-4ebf-8548-d635c01ca08a","ipam_ip_ids":["142df25d-25e2-4f18-8561-3f3f877891d3","96302d29-79b9-413b-a5bd-2d7c269891d9"],"mac_address":"02:00:00:1c:b1:e9","modification_date":"2025-02-12T16:25:01.593495+00:00","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","server_id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "17"
+                - "478"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:42 GMT
+                - Wed, 12 Feb 2025 16:25:07 GMT
+            Link:
+                - </servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3/private_nics?page=1&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2332,10 +2330,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3c07441b-f764-4866-8754-8da776254e00
+                - 10f3c7fc-6ea2-4ac3-a742-3581584e2fab
+            X-Total-Count:
+                - "1"
         status: 200 OK
         code: 200
-        duration: 542.436792ms
+        duration: 114.474375ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2352,60 +2352,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/private_nics
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 478
-        uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:41.910409+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"available","tags":[],"zone":"fr-par-1"}]}'
-        headers:
-            Content-Length:
-                - "478"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 16:15:43 GMT
-            Link:
-                - </servers/c972b90c-98ce-4fe4-ac18-b4e841110616/private_nics?page=1&per_page=50&>; rel="last"
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 287b4dd5-016e-46b3-a1b1-5c5228a9f597
-            X-Total-Count:
-                - "1"
-        status: 200 OK
-        code: 200
-        duration: 127.511708ms
-    - id: 48
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1a85191f-5f3c-4895-86f7-28b1d61a4f2e
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ca847b1f-dc9d-4d88-b58b-af1b39421b87
         method: GET
       response:
         proto: HTTP/2.0
@@ -2415,7 +2362,7 @@ interactions:
         trailer: {}
         content_length: 984
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:24:25.147240Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:24:15.738170Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"caa611d1-c0ae-4232-8a3e-1d7405c19b12","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:24:15.738170Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"ca847b1f-dc9d-4d88-b58b-af1b39421b87","ipam_config":null,"mac_address":"02:00:00:1F:BF:5A","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","status":"ready","updated_at":"2025-02-12T16:24:35.344045Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "984"
@@ -2424,9 +2371,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:43 GMT
+                - Wed, 12 Feb 2025 16:25:07 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2434,11 +2381,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4674dce0-8cf4-46f6-b126-89ab6ebed835
+                - f213b071-0e9e-4140-aeb4-bad881677403
         status: 200 OK
         code: 200
-        duration: 68.022708ms
-    - id: 49
+        duration: 77.077208ms
+    - id: 48
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2449,7 +2396,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"gateway_network_id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","mac_address":"02:00:00:19:57:16","ip_address":"10.0.0.3"}'
+        body: '{"gateway_network_id":"ca847b1f-dc9d-4d88-b58b-af1b39421b87","mac_address":"02:00:00:1c:b1:e9","ip_address":"10.0.0.3"}'
         form: {}
         headers:
             Content-Type:
@@ -2466,7 +2413,7 @@ interactions:
         trailer: {}
         content_length: 327
         uncompressed: false
-        body: '{"created_at":"2025-02-12T16:15:10.531299Z","gateway_network_id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","hostname":"Scaleway Instance","id":"f83046a2-cd8c-43f7-9a11-55faf283cc0b","ip_address":"10.0.0.3","mac_address":"02:00:00:19:57:16","type":"reservation","updated_at":"2025-02-12T16:15:44.176239Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:24:30.117014Z","gateway_network_id":"ca847b1f-dc9d-4d88-b58b-af1b39421b87","hostname":"Scaleway Instance","id":"142df25d-25e2-4f18-8561-3f3f877891d3","ip_address":"10.0.0.3","mac_address":"02:00:00:1c:b1:e9","type":"reservation","updated_at":"2025-02-12T16:25:08.157021Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "327"
@@ -2475,9 +2422,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:44 GMT
+                - Wed, 12 Feb 2025 16:25:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2485,10 +2432,59 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 02b3e220-8d60-4225-be9d-d2af1a1d2e8b
+                - ee7ae047-5b58-4691-a739-e9963b01f5df
         status: 200 OK
         code: 200
-        duration: 741.374583ms
+        duration: 803.782458ms
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ca847b1f-dc9d-4d88-b58b-af1b39421b87
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 984
+        uncompressed: false
+        body: '{"address":null,"created_at":"2025-02-12T16:24:25.147240Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:24:15.738170Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"caa611d1-c0ae-4232-8a3e-1d7405c19b12","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:24:15.738170Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"ca847b1f-dc9d-4d88-b58b-af1b39421b87","ipam_config":null,"mac_address":"02:00:00:1F:BF:5A","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","status":"ready","updated_at":"2025-02-12T16:24:35.344045Z","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "984"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:25:08 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7f11801d-1666-416d-89f3-a0f7cbd3d2be
+        status: 200 OK
+        code: 200
+        duration: 60.17775ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -2505,7 +2501,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1a85191f-5f3c-4895-86f7-28b1d61a4f2e
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/142df25d-25e2-4f18-8561-3f3f877891d3
         method: GET
       response:
         proto: HTTP/2.0
@@ -2513,20 +2509,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 984
+        content_length: 327
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:24:30.117014Z","gateway_network_id":"ca847b1f-dc9d-4d88-b58b-af1b39421b87","hostname":"Scaleway Instance","id":"142df25d-25e2-4f18-8561-3f3f877891d3","ip_address":"10.0.0.3","mac_address":"02:00:00:1c:b1:e9","type":"reservation","updated_at":"2025-02-12T16:25:08.157021Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "984"
+                - "327"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:44 GMT
+                - Wed, 12 Feb 2025 16:25:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2534,10 +2530,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 93f83e9c-2398-4678-8c53-2aae58415990
+                - 8b61ef79-c571-45a4-9a71-6c17e4c4d1d7
         status: 200 OK
         code: 200
-        duration: 65.183334ms
+        duration: 97.077917ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2554,7 +2550,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/f83046a2-cd8c-43f7-9a11-55faf283cc0b
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/21853ec7-231b-4ed9-a7d4-4694e59a3f14
         method: GET
       response:
         proto: HTTP/2.0
@@ -2562,20 +2558,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 327
+        content_length: 1996
         uncompressed: false
-        body: '{"created_at":"2025-02-12T16:15:10.531299Z","gateway_network_id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","hostname":"Scaleway Instance","id":"f83046a2-cd8c-43f7-9a11-55faf283cc0b","ip_address":"10.0.0.3","mac_address":"02:00:00:19:57:16","type":"reservation","updated_at":"2025-02-12T16:15:44.176239Z","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:24:16.671456Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:24:25.147240Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:24:15.738170Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"caa611d1-c0ae-4232-8a3e-1d7405c19b12","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:24:15.738170Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"ca847b1f-dc9d-4d88-b58b-af1b39421b87","ipam_config":null,"mac_address":"02:00:00:1F:BF:5A","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","status":"ready","updated_at":"2025-02-12T16:24:35.344045Z","zone":"fr-par-1"}],"id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:24:16.504200Z","gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"34cc7b82-72c0-4b4b-95a2-2cc0daebf1b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.504200Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:24:35.474636Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "327"
+                - "1996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:44 GMT
+                - Wed, 12 Feb 2025 16:25:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2583,10 +2579,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - af2e8d98-2dae-4921-94a5-1eedc3d3473e
+                - 645b4b96-a089-46a7-b4eb-b2203abe9dfe
         status: 200 OK
         code: 200
-        duration: 101.002833ms
+        duration: 49.006125ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -2603,7 +2599,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/21853ec7-231b-4ed9-a7d4-4694e59a3f14
         method: GET
       response:
         proto: HTTP/2.0
@@ -2611,20 +2607,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1994
+        content_length: 1996
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.960124Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}],"id":"4e178b28-3e98-42d9-8373-7ee292e623a7","ip":{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:23.527960Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:24:16.671456Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:24:25.147240Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:24:15.738170Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"caa611d1-c0ae-4232-8a3e-1d7405c19b12","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:24:15.738170Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"ca847b1f-dc9d-4d88-b58b-af1b39421b87","ipam_config":null,"mac_address":"02:00:00:1F:BF:5A","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","status":"ready","updated_at":"2025-02-12T16:24:35.344045Z","zone":"fr-par-1"}],"id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:24:16.504200Z","gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"34cc7b82-72c0-4b4b-95a2-2cc0daebf1b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.504200Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:24:35.474636Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1994"
+                - "1996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:44 GMT
+                - Wed, 12 Feb 2025 16:25:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2632,60 +2628,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3b99de29-58e0-4f4f-b9cd-44cd884c4ace
+                - 5c2c6f8c-84cf-4366-a620-97acf7ba9622
         status: 200 OK
         code: 200
-        duration: 58.612583ms
+        duration: 48.978125ms
     - id: 53
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 1994
-        uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.960124Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}],"id":"4e178b28-3e98-42d9-8373-7ee292e623a7","ip":{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:23.527960Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "1994"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 16:15:44 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 47409374-7cc8-474d-b95f-9fa2f484824f
-        status: 200 OK
-        code: 200
-        duration: 49.79525ms
-    - id: 54
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2696,7 +2643,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","public_port":2023,"private_ip":"10.0.0.3","private_port":22,"protocol":"tcp"}'
+        body: '{"gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","public_port":2023,"private_ip":"10.0.0.3","private_port":22,"protocol":"tcp"}'
         form: {}
         headers:
             Content-Type:
@@ -2713,7 +2660,7 @@ interactions:
         trailer: {}
         content_length: 287
         uncompressed: false
-        body: '{"created_at":"2025-02-12T16:15:44.555977Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"9380788b-3547-4ecb-9fee-ceabc3120645","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2025-02-12T16:15:44.555977Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:25:08.511785Z","gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"6a14aeef-2a7a-4b2c-bd05-7a490c0faec6","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2025-02-12T16:25:08.511785Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "287"
@@ -2722,9 +2669,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:44 GMT
+                - Wed, 12 Feb 2025 16:25:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2732,10 +2679,59 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3bf54b75-2d27-441c-a79b-e9ae430bb73e
+                - 698c3c3f-5097-4e6c-a969-d6365177fef4
         status: 200 OK
         code: 200
-        duration: 110.618291ms
+        duration: 107.75775ms
+    - id: 54
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/21853ec7-231b-4ed9-a7d4-4694e59a3f14
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1996
+        uncompressed: false
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:24:16.671456Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:24:25.147240Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:24:15.738170Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"caa611d1-c0ae-4232-8a3e-1d7405c19b12","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:24:15.738170Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"ca847b1f-dc9d-4d88-b58b-af1b39421b87","ipam_config":null,"mac_address":"02:00:00:1F:BF:5A","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","status":"ready","updated_at":"2025-02-12T16:24:35.344045Z","zone":"fr-par-1"}],"id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:24:16.504200Z","gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"34cc7b82-72c0-4b4b-95a2-2cc0daebf1b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.504200Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:24:35.474636Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        headers:
+            Content-Length:
+                - "1996"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:25:08 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f57b32bc-fb23-44dd-9dd4-94b15fc281d8
+        status: 200 OK
+        code: 200
+        duration: 49.937042ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -2752,7 +2748,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/6a14aeef-2a7a-4b2c-bd05-7a490c0faec6
         method: GET
       response:
         proto: HTTP/2.0
@@ -2760,20 +2756,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1994
+        content_length: 287
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.960124Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}],"id":"4e178b28-3e98-42d9-8373-7ee292e623a7","ip":{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:23.527960Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:25:08.511785Z","gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"6a14aeef-2a7a-4b2c-bd05-7a490c0faec6","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2025-02-12T16:25:08.511785Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1994"
+                - "287"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:44 GMT
+                - Wed, 12 Feb 2025 16:25:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2781,10 +2777,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3b1f45b7-356f-41c5-9136-ebd129f17c68
+                - 66128a59-b089-4ba7-87ca-e880ea9708a4
         status: 200 OK
         code: 200
-        duration: 47.395625ms
+        duration: 41.116667ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2801,7 +2797,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/9380788b-3547-4ecb-9fee-ceabc3120645
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/caa611d1-c0ae-4232-8a3e-1d7405c19b12
         method: GET
       response:
         proto: HTTP/2.0
@@ -2809,20 +2805,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 574
         uncompressed: false
-        body: '{"created_at":"2025-02-12T16:15:44.555977Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"9380788b-3547-4ecb-9fee-ceabc3120645","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2025-02-12T16:15:44.555977Z","zone":"fr-par-1"}'
+        body: '{"address":"10.0.0.1","created_at":"2025-02-12T16:24:15.738170Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"caa611d1-c0ae-4232-8a3e-1d7405c19b12","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:24:15.738170Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "287"
+                - "574"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:44 GMT
+                - Wed, 12 Feb 2025 16:25:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2830,10 +2826,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 868fdd86-a1f4-4607-ac57-dbd3b36a0c32
+                - ee98d4b6-aeeb-4f96-bad6-a0030f8869aa
         status: 200 OK
         code: 200
-        duration: 45.760083ms
+        duration: 40.7585ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2850,7 +2846,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/432c2d3a-2399-43c2-a711-f68fb19dd665
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/6a14aeef-2a7a-4b2c-bd05-7a490c0faec6
         method: GET
       response:
         proto: HTTP/2.0
@@ -2858,20 +2854,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 574
+        content_length: 287
         uncompressed: false
-        body: '{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:25:08.511785Z","gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"6a14aeef-2a7a-4b2c-bd05-7a490c0faec6","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2025-02-12T16:25:08.511785Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "574"
+                - "287"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:44 GMT
+                - Wed, 12 Feb 2025 16:25:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2879,10 +2875,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 843b863f-6277-4a9d-8d07-c96abf80e08f
+                - 03e6cc9d-fc88-45ec-811e-599feb76987b
         status: 200 OK
         code: 200
-        duration: 42.482958ms
+        duration: 63.179125ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -2899,7 +2895,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/9380788b-3547-4ecb-9fee-ceabc3120645
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/34cc7b82-72c0-4b4b-95a2-2cc0daebf1b8
         method: GET
       response:
         proto: HTTP/2.0
@@ -2907,20 +2903,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 405
         uncompressed: false
-        body: '{"created_at":"2025-02-12T16:15:44.555977Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"9380788b-3547-4ecb-9fee-ceabc3120645","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2025-02-12T16:15:44.555977Z","zone":"fr-par-1"}'
+        body: '{"address":"163.172.162.186","created_at":"2025-02-12T16:24:16.504200Z","gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"34cc7b82-72c0-4b4b-95a2-2cc0daebf1b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.504200Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "287"
+                - "405"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:44 GMT
+                - Wed, 12 Feb 2025 16:25:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2928,10 +2924,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7f6dea73-de92-44e0-ab13-628f76d82eeb
+                - 6316bfaf-f403-4ce4-86db-78a48999b6d2
         status: 200 OK
         code: 200
-        duration: 43.806542ms
+        duration: 43.005125ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -2948,7 +2944,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/432c2d3a-2399-43c2-a711-f68fb19dd665
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/caa611d1-c0ae-4232-8a3e-1d7405c19b12
         method: GET
       response:
         proto: HTTP/2.0
@@ -2958,7 +2954,7 @@ interactions:
         trailer: {}
         content_length: 574
         uncompressed: false
-        body: '{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+        body: '{"address":"10.0.0.1","created_at":"2025-02-12T16:24:15.738170Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"caa611d1-c0ae-4232-8a3e-1d7405c19b12","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:24:15.738170Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "574"
@@ -2967,9 +2963,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:45 GMT
+                - Wed, 12 Feb 2025 16:25:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -2977,10 +2973,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - efc785b1-1c4a-4fb2-9cc2-dbcf93834601
+                - f0b86cb1-060d-4e74-9e8c-8f1e333e6fe5
         status: 200 OK
         code: 200
-        duration: 45.358834ms
+        duration: 42.725959ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -2997,7 +2993,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/502d0462-a33e-4045-a010-4d7b5889b699
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a100296c-6bde-43ca-bd37-960b05298469
         method: GET
       response:
         proto: HTTP/2.0
@@ -3005,20 +3001,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 403
+        content_length: 1042
         uncompressed: false
-        body: '{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:24:15.729901Z","dhcp_enabled":true,"id":"a100296c-6bde-43ca-bd37-960b05298469","name":"My Private Network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:24:15.729901Z","id":"bf902737-8d9f-4392-b904-74c271ab3f11","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:24:22.232802Z","vpc_id":"d096aa1f-515e-4175-8a7b-be9900ad158a"},{"created_at":"2025-02-12T16:24:15.729901Z","id":"dff2513f-839c-4891-a6b6-90cf662a39d0","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:8a43::/64","updated_at":"2025-02-12T16:24:22.236968Z","vpc_id":"d096aa1f-515e-4175-8a7b-be9900ad158a"}],"tags":[],"updated_at":"2025-02-12T16:24:31.599629Z","vpc_id":"d096aa1f-515e-4175-8a7b-be9900ad158a"}'
         headers:
             Content-Length:
-                - "403"
+                - "1042"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:45 GMT
+                - Wed, 12 Feb 2025 16:25:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3026,10 +3022,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c243fe68-3e26-4ae6-b98b-202f05c900cc
+                - cc585b18-0917-46cf-acf5-4ee0c4da9786
         status: 200 OK
         code: 200
-        duration: 45.8215ms
+        duration: 47.325417ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -3046,7 +3042,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/cf70fcfd-2aae-4a49-a49d-e4cfd7598043
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/21853ec7-231b-4ed9-a7d4-4694e59a3f14
         method: GET
       response:
         proto: HTTP/2.0
@@ -3054,20 +3050,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1042
+        content_length: 1996
         uncompressed: false
-        body: '{"created_at":"2025-02-12T16:14:56.064699Z","dhcp_enabled":true,"id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","name":"My Private Network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2025-02-12T16:14:56.064699Z","id":"3fb46282-9a79-4012-af4e-e7826777179c","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:15:13.465261Z","vpc_id":"cdfe9b38-23d2-41e0-9426-97f8b0214c36"},{"created_at":"2025-02-12T16:14:56.064699Z","id":"c00e429c-60c1-4133-a83a-370dedf98bc2","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"fd5f:519c:6d46:3cad::/64","updated_at":"2025-02-12T16:15:13.470659Z","vpc_id":"cdfe9b38-23d2-41e0-9426-97f8b0214c36"}],"tags":[],"updated_at":"2025-02-12T16:15:21.458032Z","vpc_id":"cdfe9b38-23d2-41e0-9426-97f8b0214c36"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:24:16.671456Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:24:25.147240Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:24:15.738170Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"caa611d1-c0ae-4232-8a3e-1d7405c19b12","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:24:15.738170Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"ca847b1f-dc9d-4d88-b58b-af1b39421b87","ipam_config":null,"mac_address":"02:00:00:1F:BF:5A","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","status":"ready","updated_at":"2025-02-12T16:24:35.344045Z","zone":"fr-par-1"}],"id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:24:16.504200Z","gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"34cc7b82-72c0-4b4b-95a2-2cc0daebf1b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.504200Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:24:35.474636Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1042"
+                - "1996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:45 GMT
+                - Wed, 12 Feb 2025 16:25:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3075,10 +3071,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 551b7bb3-7b07-40a9-9b24-9dae21012f0a
+                - 5755a5ab-f7bb-432b-a628-275ff836ad2d
         status: 200 OK
         code: 200
-        duration: 51.150209ms
+        duration: 47.064917ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -3095,7 +3091,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ca847b1f-dc9d-4d88-b58b-af1b39421b87
         method: GET
       response:
         proto: HTTP/2.0
@@ -3103,20 +3099,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1994
+        content_length: 984
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.960124Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}],"id":"4e178b28-3e98-42d9-8373-7ee292e623a7","ip":{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:23.527960Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:24:25.147240Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:24:15.738170Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"caa611d1-c0ae-4232-8a3e-1d7405c19b12","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:24:15.738170Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"ca847b1f-dc9d-4d88-b58b-af1b39421b87","ipam_config":null,"mac_address":"02:00:00:1F:BF:5A","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","status":"ready","updated_at":"2025-02-12T16:24:35.344045Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1994"
+                - "984"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:45 GMT
+                - Wed, 12 Feb 2025 16:25:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3124,10 +3120,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 261899a2-08c5-46e6-990c-da0ef8ab1b63
+                - 2cbbf860-8d4c-4ff0-8b5f-2efa73cd989f
         status: 200 OK
         code: 200
-        duration: 42.201625ms
+        duration: 61.259042ms
     - id: 63
       request:
         proto: HTTP/1.1
@@ -3144,7 +3140,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1a85191f-5f3c-4895-86f7-28b1d61a4f2e
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/21853ec7-231b-4ed9-a7d4-4694e59a3f14
         method: GET
       response:
         proto: HTTP/2.0
@@ -3152,20 +3148,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 984
+        content_length: 1996
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:24:16.671456Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:24:25.147240Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:24:15.738170Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"caa611d1-c0ae-4232-8a3e-1d7405c19b12","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:24:15.738170Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"ca847b1f-dc9d-4d88-b58b-af1b39421b87","ipam_config":null,"mac_address":"02:00:00:1F:BF:5A","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","status":"ready","updated_at":"2025-02-12T16:24:35.344045Z","zone":"fr-par-1"}],"id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:24:16.504200Z","gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"34cc7b82-72c0-4b4b-95a2-2cc0daebf1b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.504200Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:24:35.474636Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "984"
+                - "1996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:45 GMT
+                - Wed, 12 Feb 2025 16:25:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3173,10 +3169,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 01b4bd3d-c965-498f-b5b9-e8ab3b4d5cef
+                - f384ed28-b1b6-465f-809a-e6c8a248a1f4
         status: 200 OK
         code: 200
-        duration: 64.235875ms
+        duration: 45.280792ms
     - id: 64
       request:
         proto: HTTP/1.1
@@ -3193,7 +3189,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3
         method: GET
       response:
         proto: HTTP/2.0
@@ -3201,20 +3197,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1994
+        content_length: 2269
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.960124Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}],"id":"4e178b28-3e98-42d9-8373-7ee292e623a7","ip":{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:23.527960Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:24:16.951639+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"401","node_id":"14","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c8:69","maintenances":[],"modification_date":"2025-02-12T16:24:24.801877+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:24:29.671381+00:00","id":"0611a4a0-e528-4ebf-8548-d635c01ca08a","ipam_ip_ids":["142df25d-25e2-4f18-8561-3f3f877891d3","96302d29-79b9-413b-a5bd-2d7c269891d9"],"mac_address":"02:00:00:1c:b1:e9","modification_date":"2025-02-12T16:25:01.593495+00:00","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","server_id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"811d24a7-f24f-48ca-a17a-8f6f1d80acf2","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "1994"
+                - "2269"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:45 GMT
+                - Wed, 12 Feb 2025 16:25:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3222,10 +3218,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d670b106-08f9-4f1a-aa57-6416e2db244f
+                - 64a65bbb-232c-4d2e-8b9d-5afc83e8c83e
         status: 200 OK
         code: 200
-        duration: 48.177209ms
+        duration: 186.078334ms
     - id: 65
       request:
         proto: HTTP/1.1
@@ -3242,7 +3238,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ca847b1f-dc9d-4d88-b58b-af1b39421b87
         method: GET
       response:
         proto: HTTP/2.0
@@ -3250,20 +3246,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2269
+        content_length: 984
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.586614+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"c972b90c-98ce-4fe4-ac18-b4e841110616","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"702","node_id":"10","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d9","maintenances":[],"modification_date":"2025-02-12T16:15:08.588756+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:41.910409+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"69319b62-c889-49b4-bf5f-89a64c7a530c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"address":null,"created_at":"2025-02-12T16:24:25.147240Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:24:15.738170Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"caa611d1-c0ae-4232-8a3e-1d7405c19b12","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:24:15.738170Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"ca847b1f-dc9d-4d88-b58b-af1b39421b87","ipam_config":null,"mac_address":"02:00:00:1F:BF:5A","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","status":"ready","updated_at":"2025-02-12T16:24:35.344045Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2269"
+                - "984"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:45 GMT
+                - Wed, 12 Feb 2025 16:25:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3271,10 +3267,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 35eec91f-7e07-40dc-9363-a22be4e2cffc
+                - b9b3638e-ab2a-4a7c-8b6d-8d8397fba783
         status: 200 OK
         code: 200
-        duration: 180.830833ms
+        duration: 61.959625ms
     - id: 66
       request:
         proto: HTTP/1.1
@@ -3291,7 +3287,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1a85191f-5f3c-4895-86f7-28b1d61a4f2e
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/811d24a7-f24f-48ca-a17a-8f6f1d80acf2
         method: GET
       response:
         proto: HTTP/2.0
@@ -3299,20 +3295,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 984
+        content_length: 143
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"811d24a7-f24f-48ca-a17a-8f6f1d80acf2","type":"not_found"}'
         headers:
             Content-Length:
-                - "984"
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:45 GMT
+                - Wed, 12 Feb 2025 16:25:08 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3320,10 +3316,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0650b483-98c0-4789-8e07-d8d2e0eafcee
-        status: 200 OK
-        code: 200
-        duration: 62.684625ms
+                - f4683f25-aecc-49c2-813e-58841a890b61
+        status: 404 Not Found
+        code: 404
+        duration: 58.280375ms
     - id: 67
       request:
         proto: HTTP/1.1
@@ -3340,7 +3336,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/69319b62-c889-49b4-bf5f-89a64c7a530c
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/811d24a7-f24f-48ca-a17a-8f6f1d80acf2
         method: GET
       response:
         proto: HTTP/2.0
@@ -3348,20 +3344,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 143
+        content_length: 692
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"69319b62-c889-49b4-bf5f-89a64c7a530c","type":"not_found"}'
+        body: '{"created_at":"2025-02-12T16:24:17.161631Z","id":"811d24a7-f24f-48ca-a17a-8f6f1d80acf2","last_detached_at":null,"name":"Debian Bullseye_sbs_volume_0","parent_snapshot_id":"a50e6921-21b9-4a69-83cc-191359208d4c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:24:17.161631Z","id":"a2055bef-d48d-44c0-9395-a15a3cafca8d","product_resource_id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:24:17.161631Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "143"
+                - "692"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:45 GMT
+                - Wed, 12 Feb 2025 16:25:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3369,10 +3365,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 58ad5eb6-fd1b-406f-ad83-2f035fb5e711
-        status: 404 Not Found
-        code: 404
-        duration: 57.492541ms
+                - 3ce26b6b-94fd-4bf2-bc00-45bb858aae9d
+        status: 200 OK
+        code: 200
+        duration: 100.987208ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -3389,56 +3385,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/69319b62-c889-49b4-bf5f-89a64c7a530c
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 692
-        uncompressed: false
-        body: '{"created_at":"2025-02-12T16:14:57.789341Z","id":"69319b62-c889-49b4-bf5f-89a64c7a530c","last_detached_at":null,"name":"Debian Bullseye_sbs_volume_0","parent_snapshot_id":"a50e6921-21b9-4a69-83cc-191359208d4c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:14:57.789341Z","id":"427679d5-67d4-4f63-b880-f092ab65f28c","product_resource_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:14:57.789341Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "692"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 16:15:45 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 1d783c67-a940-49c6-891b-95ebc8ac689b
-        status: 200 OK
-        code: 200
-        duration: 85.957625ms
-    - id: 69
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/user_data
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3/user_data
         method: GET
       response:
         proto: HTTP/2.0
@@ -3457,9 +3404,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:45 GMT
+                - Wed, 12 Feb 2025 16:25:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3467,10 +3414,63 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1172b322-98f3-4d41-954c-6b89bdaeff84
+                - a270625d-2d8f-4c94-839c-59b089e3cfe0
         status: 200 OK
         code: 200
-        duration: 99.197583ms
+        duration: 125.368ms
+    - id: 69
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 478
+        uncompressed: false
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:24:29.671381+00:00","id":"0611a4a0-e528-4ebf-8548-d635c01ca08a","ipam_ip_ids":["142df25d-25e2-4f18-8561-3f3f877891d3","96302d29-79b9-413b-a5bd-2d7c269891d9"],"mac_address":"02:00:00:1c:b1:e9","modification_date":"2025-02-12T16:25:01.593495+00:00","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","server_id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        headers:
+            Content-Length:
+                - "478"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:25:09 GMT
+            Link:
+                - </servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3/private_nics?page=1&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b66d4ebf-3fd1-47d4-bdc8-e907ca97adf2
+            X-Total-Count:
+                - "1"
+        status: 200 OK
+        code: 200
+        duration: 133.440708ms
     - id: 70
       request:
         proto: HTTP/1.1
@@ -3487,7 +3487,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/private_nics
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/142df25d-25e2-4f18-8561-3f3f877891d3
         method: GET
       response:
         proto: HTTP/2.0
@@ -3495,22 +3495,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 478
+        content_length: 327
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:41.910409+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"created_at":"2025-02-12T16:24:30.117014Z","gateway_network_id":"ca847b1f-dc9d-4d88-b58b-af1b39421b87","hostname":"Scaleway Instance","id":"142df25d-25e2-4f18-8561-3f3f877891d3","ip_address":"10.0.0.3","mac_address":"02:00:00:1c:b1:e9","type":"reservation","updated_at":"2025-02-12T16:25:08.157021Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "478"
+                - "327"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:45 GMT
-            Link:
-                - </servers/c972b90c-98ce-4fe4-ac18-b4e841110616/private_nics?page=1&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 16:25:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3518,12 +3516,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bbf4de5e-d2dd-43d0-b662-4186a08d13a7
-            X-Total-Count:
-                - "1"
+                - fd987990-7ed8-4c52-accc-2585feeb0e51
         status: 200 OK
         code: 200
-        duration: 113.35125ms
+        duration: 78.485833ms
     - id: 71
       request:
         proto: HTTP/1.1
@@ -3540,7 +3536,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/f83046a2-cd8c-43f7-9a11-55faf283cc0b
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/6a14aeef-2a7a-4b2c-bd05-7a490c0faec6
         method: GET
       response:
         proto: HTTP/2.0
@@ -3548,20 +3544,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 327
+        content_length: 287
         uncompressed: false
-        body: '{"created_at":"2025-02-12T16:15:10.531299Z","gateway_network_id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","hostname":"Scaleway Instance","id":"f83046a2-cd8c-43f7-9a11-55faf283cc0b","ip_address":"10.0.0.3","mac_address":"02:00:00:19:57:16","type":"reservation","updated_at":"2025-02-12T16:15:44.176239Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:25:08.511785Z","gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"6a14aeef-2a7a-4b2c-bd05-7a490c0faec6","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2025-02-12T16:25:08.511785Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "327"
+                - "287"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:45 GMT
+                - Wed, 12 Feb 2025 16:25:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3569,10 +3565,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a1a51022-77c9-410c-9648-7db3dda29f5a
+                - e4ec6c12-46bc-45f3-a35b-23574ed6b2b4
         status: 200 OK
         code: 200
-        duration: 85.677042ms
+        duration: 48.421875ms
     - id: 72
       request:
         proto: HTTP/1.1
@@ -3589,7 +3585,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/9380788b-3547-4ecb-9fee-ceabc3120645
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/6a14aeef-2a7a-4b2c-bd05-7a490c0faec6
         method: GET
       response:
         proto: HTTP/2.0
@@ -3599,7 +3595,7 @@ interactions:
         trailer: {}
         content_length: 287
         uncompressed: false
-        body: '{"created_at":"2025-02-12T16:15:44.555977Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"9380788b-3547-4ecb-9fee-ceabc3120645","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2025-02-12T16:15:44.555977Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:25:08.511785Z","gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"6a14aeef-2a7a-4b2c-bd05-7a490c0faec6","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2025-02-12T16:25:08.511785Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "287"
@@ -3608,9 +3604,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:45 GMT
+                - Wed, 12 Feb 2025 16:25:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3618,10 +3614,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d7fc3c30-73c7-46d1-af93-8ec5c73949dc
+                - d26048a0-4285-4033-b41d-ca1decb5d527
         status: 200 OK
         code: 200
-        duration: 41.245042ms
+        duration: 41.470584ms
     - id: 73
       request:
         proto: HTTP/1.1
@@ -3638,7 +3634,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/9380788b-3547-4ecb-9fee-ceabc3120645
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/21853ec7-231b-4ed9-a7d4-4694e59a3f14
         method: GET
       response:
         proto: HTTP/2.0
@@ -3646,20 +3642,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 1996
         uncompressed: false
-        body: '{"created_at":"2025-02-12T16:15:44.555977Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"9380788b-3547-4ecb-9fee-ceabc3120645","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2025-02-12T16:15:44.555977Z","zone":"fr-par-1"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:24:16.671456Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:24:25.147240Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:24:15.738170Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"caa611d1-c0ae-4232-8a3e-1d7405c19b12","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:24:15.738170Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"ca847b1f-dc9d-4d88-b58b-af1b39421b87","ipam_config":null,"mac_address":"02:00:00:1F:BF:5A","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","status":"ready","updated_at":"2025-02-12T16:24:35.344045Z","zone":"fr-par-1"}],"id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:24:16.504200Z","gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"34cc7b82-72c0-4b4b-95a2-2cc0daebf1b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.504200Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:24:35.474636Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "287"
+                - "1996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:46 GMT
+                - Wed, 12 Feb 2025 16:25:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3667,10 +3663,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0f81251e-7d6e-426e-8589-4ba857cf7573
+                - d13c50fb-ee7f-4e43-8067-318c8fa3e4da
         status: 200 OK
         code: 200
-        duration: 47.018667ms
+        duration: 45.118208ms
     - id: 74
       request:
         proto: HTTP/1.1
@@ -3687,28 +3683,26 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7
-        method: GET
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/6a14aeef-2a7a-4b2c-bd05-7a490c0faec6
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1994
+        content_length: 0
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.960124Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}],"id":"4e178b28-3e98-42d9-8373-7ee292e623a7","ip":{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:23.527960Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: ""
         headers:
-            Content-Length:
-                - "1994"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:46 GMT
+                - Wed, 12 Feb 2025 16:25:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3716,10 +3710,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4b275193-cc55-4aff-a2f3-2c87bb38d116
-        status: 200 OK
-        code: 200
-        duration: 47.566542ms
+                - 5229ee87-da6f-4eb1-80fc-060565d9be3e
+        status: 204 No Content
+        code: 204
+        duration: 65.910209ms
     - id: 75
       request:
         proto: HTTP/1.1
@@ -3736,26 +3730,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/9380788b-3547-4ecb-9fee-ceabc3120645
-        method: DELETE
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/21853ec7-231b-4ed9-a7d4-4694e59a3f14
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 1996
         uncompressed: false
-        body: ""
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:24:16.671456Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:24:25.147240Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:24:15.738170Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"caa611d1-c0ae-4232-8a3e-1d7405c19b12","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:24:15.738170Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"ca847b1f-dc9d-4d88-b58b-af1b39421b87","ipam_config":null,"mac_address":"02:00:00:1F:BF:5A","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","status":"ready","updated_at":"2025-02-12T16:24:35.344045Z","zone":"fr-par-1"}],"id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:24:16.504200Z","gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"34cc7b82-72c0-4b4b-95a2-2cc0daebf1b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.504200Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:24:35.474636Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
+            Content-Length:
+                - "1996"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:46 GMT
+                - Wed, 12 Feb 2025 16:25:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3763,10 +3759,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3f371056-3bda-41e9-b40b-36b18b94ae9f
-        status: 204 No Content
-        code: 204
-        duration: 66.693916ms
+                - 3990d9b9-1b5c-4e70-832d-90c153795bd6
+        status: 200 OK
+        code: 200
+        duration: 49.028917ms
     - id: 76
       request:
         proto: HTTP/1.1
@@ -3783,7 +3779,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ca847b1f-dc9d-4d88-b58b-af1b39421b87
         method: GET
       response:
         proto: HTTP/2.0
@@ -3791,20 +3787,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1994
+        content_length: 984
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.960124Z","gateway_networks":[{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}],"id":"4e178b28-3e98-42d9-8373-7ee292e623a7","ip":{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:23.527960Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:24:25.147240Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:24:15.738170Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"caa611d1-c0ae-4232-8a3e-1d7405c19b12","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:24:15.738170Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"ca847b1f-dc9d-4d88-b58b-af1b39421b87","ipam_config":null,"mac_address":"02:00:00:1F:BF:5A","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","status":"ready","updated_at":"2025-02-12T16:24:35.344045Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "1994"
+                - "984"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:46 GMT
+                - Wed, 12 Feb 2025 16:25:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3812,10 +3808,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 28035b9c-b278-442e-8612-5bc4e66c8d1f
+                - df4af14c-4176-4ec4-bec1-65e8d603b05b
         status: 200 OK
         code: 200
-        duration: 50.348667ms
+        duration: 70.111666ms
     - id: 77
       request:
         proto: HTTP/1.1
@@ -3832,28 +3828,26 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1a85191f-5f3c-4895-86f7-28b1d61a4f2e
-        method: GET
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/142df25d-25e2-4f18-8561-3f3f877891d3
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 984
+        content_length: 0
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}'
+        body: ""
         headers:
-            Content-Length:
-                - "984"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:46 GMT
+                - Wed, 12 Feb 2025 16:25:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3861,10 +3855,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9c6fba69-7af7-4784-998a-81202280a64e
-        status: 200 OK
-        code: 200
-        duration: 65.820709ms
+                - 8628e14e-b474-4dcb-b362-3ff96e7edac7
+        status: 204 No Content
+        code: 204
+        duration: 81.626208ms
     - id: 78
       request:
         proto: HTTP/1.1
@@ -3881,26 +3875,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/f83046a2-cd8c-43f7-9a11-55faf283cc0b
-        method: DELETE
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ca847b1f-dc9d-4d88-b58b-af1b39421b87
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 984
         uncompressed: false
-        body: ""
+        body: '{"address":null,"created_at":"2025-02-12T16:24:25.147240Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:24:15.738170Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"caa611d1-c0ae-4232-8a3e-1d7405c19b12","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:24:15.738170Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"ca847b1f-dc9d-4d88-b58b-af1b39421b87","ipam_config":null,"mac_address":"02:00:00:1F:BF:5A","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","status":"ready","updated_at":"2025-02-12T16:24:35.344045Z","zone":"fr-par-1"}'
         headers:
+            Content-Length:
+                - "984"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:46 GMT
+                - Wed, 12 Feb 2025 16:25:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3908,10 +3904,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2c5119ba-09c6-46c0-ade4-fb8b1fe66e70
-        status: 204 No Content
-        code: 204
-        duration: 99.280041ms
+                - 33699ac5-eaf5-44b5-809a-c62cbb119f0a
+        status: 200 OK
+        code: 200
+        duration: 63.394958ms
     - id: 79
       request:
         proto: HTTP/1.1
@@ -3928,7 +3924,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1a85191f-5f3c-4895-86f7-28b1d61a4f2e
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ca847b1f-dc9d-4d88-b58b-af1b39421b87
         method: GET
       response:
         proto: HTTP/2.0
@@ -3938,7 +3934,7 @@ interactions:
         trailer: {}
         content_length: 984
         uncompressed: false
-        body: '{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}'
+        body: '{"address":null,"created_at":"2025-02-12T16:24:25.147240Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:24:15.738170Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"caa611d1-c0ae-4232-8a3e-1d7405c19b12","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:24:15.738170Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"ca847b1f-dc9d-4d88-b58b-af1b39421b87","ipam_config":null,"mac_address":"02:00:00:1F:BF:5A","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","status":"ready","updated_at":"2025-02-12T16:24:35.344045Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "984"
@@ -3947,9 +3943,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:46 GMT
+                - Wed, 12 Feb 2025 16:25:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -3957,10 +3953,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - aac6ab58-3fbe-4908-aa63-a42863a6f4fd
+                - 512be9d9-ec11-4dc2-833b-67ad75bbc11c
         status: 200 OK
         code: 200
-        duration: 73.677042ms
+        duration: 66.113ms
     - id: 80
       request:
         proto: HTTP/1.1
@@ -3977,56 +3973,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1a85191f-5f3c-4895-86f7-28b1d61a4f2e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 984
-        uncompressed: false
-        body: '{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"ready","updated_at":"2025-02-12T16:15:23.407943Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "984"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 16:15:46 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 7b9ef007-c804-4d8f-bdb4-3753625df2ff
-        status: 200 OK
-        code: 200
-        duration: 60.031833ms
-    - id: 81
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1a85191f-5f3c-4895-86f7-28b1d61a4f2e?cleanup_dhcp=true
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ca847b1f-dc9d-4d88-b58b-af1b39421b87?cleanup_dhcp=true
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -4043,9 +3990,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:46 GMT
+                - Wed, 12 Feb 2025 16:25:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4053,10 +4000,59 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b95b913e-be6e-4c99-90b9-b36b1cd2533b
+                - 30a39a09-6d02-48c4-9efb-f41e1fc7a9f1
         status: 204 No Content
         code: 204
-        duration: 87.901541ms
+        duration: 90.768375ms
+    - id: 81
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2269
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:24:16.951639+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"401","node_id":"14","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c8:69","maintenances":[],"modification_date":"2025-02-12T16:24:24.801877+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:24:29.671381+00:00","id":"0611a4a0-e528-4ebf-8548-d635c01ca08a","ipam_ip_ids":["142df25d-25e2-4f18-8561-3f3f877891d3","96302d29-79b9-413b-a5bd-2d7c269891d9"],"mac_address":"02:00:00:1c:b1:e9","modification_date":"2025-02-12T16:25:01.593495+00:00","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","server_id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"811d24a7-f24f-48ca-a17a-8f6f1d80acf2","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2269"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:25:10 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a1887156-ce61-4777-8d0d-7f1e381234e0
+        status: 200 OK
+        code: 200
+        duration: 183.29925ms
     - id: 82
       request:
         proto: HTTP/1.1
@@ -4073,7 +4069,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ca847b1f-dc9d-4d88-b58b-af1b39421b87
         method: GET
       response:
         proto: HTTP/2.0
@@ -4081,20 +4077,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2269
+        content_length: 988
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.586614+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"c972b90c-98ce-4fe4-ac18-b4e841110616","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"702","node_id":"10","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d9","maintenances":[],"modification_date":"2025-02-12T16:15:08.588756+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:41.910409+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"id":"69319b62-c889-49b4-bf5f-89a64c7a530c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"address":null,"created_at":"2025-02-12T16:24:25.147240Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:24:15.738170Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"caa611d1-c0ae-4232-8a3e-1d7405c19b12","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:24:15.738170Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"ca847b1f-dc9d-4d88-b58b-af1b39421b87","ipam_config":null,"mac_address":"02:00:00:1F:BF:5A","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","status":"detaching","updated_at":"2025-02-12T16:25:10.693604Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "2269"
+                - "988"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:46 GMT
+                - Wed, 12 Feb 2025 16:25:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4102,10 +4098,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 787059f4-f23c-44ba-b4b8-a3e504b5f2f2
+                - 6036e84c-fee7-4930-ae1b-395ef1be11cf
         status: 200 OK
         code: 200
-        duration: 200.637875ms
+        duration: 64.285375ms
     - id: 83
       request:
         proto: HTTP/1.1
@@ -4122,56 +4118,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1a85191f-5f3c-4895-86f7-28b1d61a4f2e
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 988
-        uncompressed: false
-        body: '{"address":null,"created_at":"2025-02-12T16:15:15.041619Z","dhcp":{"address":"10.0.0.1","created_at":"2025-02-12T16:14:55.943934Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"432c2d3a-2399-43c2-a711-f68fb19dd665","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2025-02-12T16:14:55.943934Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","ipam_config":null,"mac_address":"02:00:00:1D:AC:4D","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","status":"detaching","updated_at":"2025-02-12T16:15:46.746880Z","zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "988"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 16:15:46 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 384ac975-361c-49b3-b6b4-d53d6eea8fea
-        status: 200 OK
-        code: 200
-        duration: 65.46825ms
-    - id: 84
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/69319b62-c889-49b4-bf5f-89a64c7a530c
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/811d24a7-f24f-48ca-a17a-8f6f1d80acf2
         method: GET
       response:
         proto: HTTP/2.0
@@ -4181,7 +4128,7 @@ interactions:
         trailer: {}
         content_length: 692
         uncompressed: false
-        body: '{"created_at":"2025-02-12T16:14:57.789341Z","id":"69319b62-c889-49b4-bf5f-89a64c7a530c","last_detached_at":null,"name":"Debian Bullseye_sbs_volume_0","parent_snapshot_id":"a50e6921-21b9-4a69-83cc-191359208d4c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:14:57.789341Z","id":"427679d5-67d4-4f63-b880-f092ab65f28c","product_resource_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:14:57.789341Z","zone":"fr-par-1"}'
+        body: '{"created_at":"2025-02-12T16:24:17.161631Z","id":"811d24a7-f24f-48ca-a17a-8f6f1d80acf2","last_detached_at":null,"name":"Debian Bullseye_sbs_volume_0","parent_snapshot_id":"a50e6921-21b9-4a69-83cc-191359208d4c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2025-02-12T16:24:17.161631Z","id":"a2055bef-d48d-44c0-9395-a15a3cafca8d","product_resource_id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:24:17.161631Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
                 - "692"
@@ -4190,9 +4137,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:46 GMT
+                - Wed, 12 Feb 2025 16:25:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4200,11 +4147,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3ac2c561-5184-4809-8562-5c15237ac006
+                - 90635a40-bbc5-4a13-af42-18e58ebc73c9
         status: 200 OK
         code: 200
-        duration: 84.014667ms
-    - id: 85
+        duration: 85.366ms
+    - id: 84
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4222,7 +4169,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/action
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3/action
         method: POST
       response:
         proto: HTTP/2.0
@@ -4232,7 +4179,7 @@ interactions:
         trailer: {}
         content_length: 352
         uncompressed: false
-        body: '{"task":{"description":"server_poweroff","href_from":"/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/action","href_result":"/servers/c972b90c-98ce-4fe4-ac18-b4e841110616","id":"9ca0f2c6-50c3-4217-9e34-aa4e811d0bbf","progress":0,"started_at":"2025-02-12T16:15:47.218190+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
+        body: '{"task":{"description":"server_poweroff","href_from":"/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3/action","href_result":"/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3","id":"d8a061e0-9ab7-4596-b5bf-12714cdd3a96","progress":0,"started_at":"2025-02-12T16:25:11.061795+00:00","status":"pending","terminated_at":null,"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "352"
@@ -4241,11 +4188,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:47 GMT
+                - Wed, 12 Feb 2025 16:25:11 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/9ca0f2c6-50c3-4217-9e34-aa4e811d0bbf
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/d8a061e0-9ab7-4596-b5bf-12714cdd3a96
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4253,10 +4200,59 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - aa42b80f-e3e1-40a8-a659-4e40746ca51c
+                - 10d3cc1b-5625-4b3e-b63e-d5802d569018
         status: 202 Accepted
         code: 202
-        duration: 374.785875ms
+        duration: 255.97475ms
+    - id: 85
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2229
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:24:16.951639+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"401","node_id":"14","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c8:69","maintenances":[],"modification_date":"2025-02-12T16:25:10.876534+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:24:29.671381+00:00","id":"0611a4a0-e528-4ebf-8548-d635c01ca08a","ipam_ip_ids":["142df25d-25e2-4f18-8561-3f3f877891d3","96302d29-79b9-413b-a5bd-2d7c269891d9"],"mac_address":"02:00:00:1c:b1:e9","modification_date":"2025-02-12T16:25:01.593495+00:00","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","server_id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"811d24a7-f24f-48ca-a17a-8f6f1d80acf2","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2229"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 12 Feb 2025 16:25:11 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2315d6db-c4be-488e-80e1-9c48d7fb2e1e
+        status: 200 OK
+        code: 200
+        duration: 197.576667ms
     - id: 86
       request:
         proto: HTTP/1.1
@@ -4273,7 +4269,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/ca847b1f-dc9d-4d88-b58b-af1b39421b87
         method: GET
       response:
         proto: HTTP/2.0
@@ -4281,20 +4277,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2229
+        content_length: 136
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.586614+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"c972b90c-98ce-4fe4-ac18-b4e841110616","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"702","node_id":"10","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d9","maintenances":[],"modification_date":"2025-02-12T16:15:46.957765+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:41.910409+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"69319b62-c889-49b4-bf5f-89a64c7a530c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"ca847b1f-dc9d-4d88-b58b-af1b39421b87","type":"not_found"}'
         headers:
             Content-Length:
-                - "2229"
+                - "136"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:47 GMT
+                - Wed, 12 Feb 2025 16:25:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4302,10 +4298,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e85b76be-415b-4fb8-b3b0-42b8370972e0
-        status: 200 OK
-        code: 200
-        duration: 514.293417ms
+                - 622eeace-3ac8-481f-942b-eb2f53f3445b
+        status: 404 Not Found
+        code: 404
+        duration: 50.59675ms
     - id: 87
       request:
         proto: HTTP/1.1
@@ -4322,7 +4318,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1a85191f-5f3c-4895-86f7-28b1d61a4f2e
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/21853ec7-231b-4ed9-a7d4-4694e59a3f14
         method: GET
       response:
         proto: HTTP/2.0
@@ -4330,20 +4326,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 136
+        content_length: 1012
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"1a85191f-5f3c-4895-86f7-28b1d61a4f2e","type":"not_found"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:24:16.671456Z","gateway_networks":[],"id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:24:16.504200Z","gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"34cc7b82-72c0-4b4b-95a2-2cc0daebf1b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.504200Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:24:35.474636Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "136"
+                - "1012"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:51 GMT
+                - Wed, 12 Feb 2025 16:25:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4351,10 +4347,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 79393053-87fc-4782-b828-0f33fcf48250
-        status: 404 Not Found
-        code: 404
-        duration: 44.276917ms
+                - fd7537c4-0016-45ce-9e8f-7ebb7cff6d4f
+        status: 200 OK
+        code: 200
+        duration: 55.3565ms
     - id: 88
       request:
         proto: HTTP/1.1
@@ -4371,28 +4367,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7
-        method: GET
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/caa611d1-c0ae-4232-8a3e-1d7405c19b12
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1010
+        content_length: 125
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.960124Z","gateway_networks":[],"id":"4e178b28-3e98-42d9-8373-7ee292e623a7","ip":{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:23.527960Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: '{"message":"resource is not found","resource":"dhcp","resource_id":"caa611d1-c0ae-4232-8a3e-1d7405c19b12","type":"not_found"}'
         headers:
             Content-Length:
-                - "1010"
+                - "125"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:51 GMT
+                - Wed, 12 Feb 2025 16:25:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4400,10 +4396,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 47f50dce-312c-476a-b37f-f7884d659181
-        status: 200 OK
-        code: 200
-        duration: 51.500083ms
+                - 84cc2462-004e-481e-af92-29b96af59755
+        status: 404 Not Found
+        code: 404
+        duration: 47.870292ms
     - id: 89
       request:
         proto: HTTP/1.1
@@ -4420,28 +4416,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/432c2d3a-2399-43c2-a711-f68fb19dd665
-        method: DELETE
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/21853ec7-231b-4ed9-a7d4-4694e59a3f14
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 125
+        content_length: 1012
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"dhcp","resource_id":"432c2d3a-2399-43c2-a711-f68fb19dd665","type":"not_found"}'
+        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:24:16.671456Z","gateway_networks":[],"id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","ip":{"address":"163.172.162.186","created_at":"2025-02-12T16:24:16.504200Z","gateway_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","id":"34cc7b82-72c0-4b4b-95a2-2cc0daebf1b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"186-162-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:24:16.504200Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:24:35.474636Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "125"
+                - "1012"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:51 GMT
+                - Wed, 12 Feb 2025 16:25:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4449,10 +4445,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0d9bfe69-6713-47c7-a431-1dbfa7298b54
-        status: 404 Not Found
-        code: 404
-        duration: 43.248459ms
+                - a9c5421b-e791-4adc-9d3c-c49f8a85ce9d
+        status: 200 OK
+        code: 200
+        duration: 52.155667ms
     - id: 90
       request:
         proto: HTTP/1.1
@@ -4469,28 +4465,26 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7
-        method: GET
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/21853ec7-231b-4ed9-a7d4-4694e59a3f14?cleanup_dhcp=false
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1010
+        content_length: 0
         uncompressed: false
-        body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2025-02-12T16:14:56.960124Z","gateway_networks":[],"id":"4e178b28-3e98-42d9-8373-7ee292e623a7","ip":{"address":"163.172.159.84","created_at":"2025-02-12T16:14:56.805825Z","gateway_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","id":"502d0462-a33e-4045-a010-4d7b5889b699","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"84-159-172-163.instances.scw.cloud","tags":[],"updated_at":"2025-02-12T16:14:56.805825Z","zone":"fr-par-1"},"ip_mobility_enabled":true,"is_legacy":true,"name":"The Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2025-02-12T16:15:23.527960Z","upstream_dns_servers":[],"version":"0.7.3","zone":"fr-par-1"}'
+        body: ""
         headers:
-            Content-Length:
-                - "1010"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:51 GMT
+                - Wed, 12 Feb 2025 16:25:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4498,10 +4492,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7abe498a-84f1-4641-a431-412859b8de09
-        status: 200 OK
-        code: 200
-        duration: 45.766333ms
+                - 03279e74-0d9b-490e-8c62-0682a3784a0c
+        status: 204 No Content
+        code: 204
+        duration: 70.659875ms
     - id: 91
       request:
         proto: HTTP/1.1
@@ -4518,26 +4512,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7?cleanup_dhcp=false
-        method: DELETE
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/21853ec7-231b-4ed9-a7d4-4694e59a3f14
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 128
         uncompressed: false
-        body: ""
+        body: '{"message":"resource is not found","resource":"gateway","resource_id":"21853ec7-231b-4ed9-a7d4-4694e59a3f14","type":"not_found"}'
         headers:
+            Content-Length:
+                - "128"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:52 GMT
+                - Wed, 12 Feb 2025 16:25:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4545,10 +4541,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 74aba7c6-8309-425b-8d59-13b876204b24
-        status: 204 No Content
-        code: 204
-        duration: 76.645125ms
+                - 23b3f8ba-3b79-4d02-bebc-ce94beabfebe
+        status: 404 Not Found
+        code: 404
+        duration: 41.174792ms
     - id: 92
       request:
         proto: HTTP/1.1
@@ -4565,7 +4561,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4e178b28-3e98-42d9-8373-7ee292e623a7
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3
         method: GET
       response:
         proto: HTTP/2.0
@@ -4573,20 +4569,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 128
+        content_length: 2229
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"gateway","resource_id":"4e178b28-3e98-42d9-8373-7ee292e623a7","type":"not_found"}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:24:16.951639+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"401","node_id":"14","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c8:69","maintenances":[],"modification_date":"2025-02-12T16:25:10.876534+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:24:29.671381+00:00","id":"0611a4a0-e528-4ebf-8548-d635c01ca08a","ipam_ip_ids":["142df25d-25e2-4f18-8561-3f3f877891d3","96302d29-79b9-413b-a5bd-2d7c269891d9"],"mac_address":"02:00:00:1c:b1:e9","modification_date":"2025-02-12T16:25:01.593495+00:00","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","server_id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"811d24a7-f24f-48ca-a17a-8f6f1d80acf2","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "128"
+                - "2229"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:52 GMT
+                - Wed, 12 Feb 2025 16:25:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4594,10 +4590,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f87caef8-c139-48b2-bb9c-336421cf5859
-        status: 404 Not Found
-        code: 404
-        duration: 45.052708ms
+                - 796250de-cd9e-4490-a086-55ef125f26fd
+        status: 200 OK
+        code: 200
+        duration: 193.784667ms
     - id: 93
       request:
         proto: HTTP/1.1
@@ -4614,7 +4610,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/502d0462-a33e-4045-a010-4d7b5889b699
+        url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/34cc7b82-72c0-4b4b-95a2-2cc0daebf1b8
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -4631,9 +4627,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:52 GMT
+                - Wed, 12 Feb 2025 16:25:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4641,10 +4637,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 09440735-914c-4148-8565-f40e3a9a3445
+                - 081ad7e1-3551-4af0-ac38-13e9b749f376
         status: 204 No Content
         code: 204
-        duration: 646.527791ms
+        duration: 1.007284125s
     - id: 94
       request:
         proto: HTTP/1.1
@@ -4661,7 +4657,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3
         method: GET
       response:
         proto: HTTP/2.0
@@ -4671,7 +4667,7 @@ interactions:
         trailer: {}
         content_length: 2229
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.586614+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"c972b90c-98ce-4fe4-ac18-b4e841110616","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"702","node_id":"10","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d9","maintenances":[],"modification_date":"2025-02-12T16:15:46.957765+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:41.910409+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"69319b62-c889-49b4-bf5f-89a64c7a530c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:24:16.951639+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"401","node_id":"14","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c8:69","maintenances":[],"modification_date":"2025-02-12T16:25:10.876534+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:24:29.671381+00:00","id":"0611a4a0-e528-4ebf-8548-d635c01ca08a","ipam_ip_ids":["142df25d-25e2-4f18-8561-3f3f877891d3","96302d29-79b9-413b-a5bd-2d7c269891d9"],"mac_address":"02:00:00:1c:b1:e9","modification_date":"2025-02-12T16:25:01.593495+00:00","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","server_id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"811d24a7-f24f-48ca-a17a-8f6f1d80acf2","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
                 - "2229"
@@ -4680,9 +4676,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:53 GMT
+                - Wed, 12 Feb 2025 16:25:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4690,10 +4686,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0de1efbc-6cd8-49c3-967f-51b080eaf253
+                - 8cf43d83-2850-466a-896c-fca054f8d2c5
         status: 200 OK
         code: 200
-        duration: 290.907917ms
+        duration: 267.04275ms
     - id: 95
       request:
         proto: HTTP/1.1
@@ -4710,7 +4706,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3
         method: GET
       response:
         proto: HTTP/2.0
@@ -4718,20 +4714,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2229
+        content_length: 2113
         uncompressed: false
-        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.586614+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"c972b90c-98ce-4fe4-ac18-b4e841110616","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"702","node_id":"10","platform_id":"14","zone_id":"fr-par-1"},"mac_address":"de:00:00:93:c7:d9","maintenances":[],"modification_date":"2025-02-12T16:15:46.957765+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:41.910409+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"id":"69319b62-c889-49b4-bf5f-89a64c7a530c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:24:16.951639+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c8:69","maintenances":[],"modification_date":"2025-02-12T16:25:26.495408+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:24:29.671381+00:00","id":"0611a4a0-e528-4ebf-8548-d635c01ca08a","ipam_ip_ids":["142df25d-25e2-4f18-8561-3f3f877891d3","96302d29-79b9-413b-a5bd-2d7c269891d9"],"mac_address":"02:00:00:1c:b1:e9","modification_date":"2025-02-12T16:25:01.593495+00:00","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","server_id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"811d24a7-f24f-48ca-a17a-8f6f1d80acf2","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "2229"
+                - "2113"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:15:58 GMT
+                - Wed, 12 Feb 2025 16:25:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4739,10 +4735,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fb240d6c-97c4-42ed-9296-8eb6dbd73fdd
+                - 1af454b6-6835-4cc4-8334-f83cb5f9fa93
         status: 200 OK
         code: 200
-        duration: 446.67075ms
+        duration: 184.634916ms
     - id: 96
       request:
         proto: HTTP/1.1
@@ -4759,7 +4755,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3/private_nics
         method: GET
       response:
         proto: HTTP/2.0
@@ -4767,20 +4763,22 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2113
+        content_length: 478
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.586614+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"c972b90c-98ce-4fe4-ac18-b4e841110616","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:d9","maintenances":[],"modification_date":"2025-02-12T16:16:02.414891+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:41.910409+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"69319b62-c889-49b4-bf5f-89a64c7a530c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: '{"private_nics":[{"creation_date":"2025-02-12T16:24:29.671381+00:00","id":"0611a4a0-e528-4ebf-8548-d635c01ca08a","ipam_ip_ids":["142df25d-25e2-4f18-8561-3f3f877891d3","96302d29-79b9-413b-a5bd-2d7c269891d9"],"mac_address":"02:00:00:1c:b1:e9","modification_date":"2025-02-12T16:25:01.593495+00:00","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","server_id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","state":"available","tags":[],"zone":"fr-par-1"}]}'
         headers:
             Content-Length:
-                - "2113"
+                - "478"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:16:03 GMT
+                - Wed, 12 Feb 2025 16:25:26 GMT
+            Link:
+                - </servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3/private_nics?page=1&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4788,10 +4786,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ccdff8cc-50b8-4fcd-bb2c-35c0eb24b7f1
+                - 77178bf8-8747-45b3-a2c8-5cc8efa2fc2c
+            X-Total-Count:
+                - "1"
         status: 200 OK
         code: 200
-        duration: 172.4965ms
+        duration: 104.502291ms
     - id: 97
       request:
         proto: HTTP/1.1
@@ -4808,7 +4808,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/private_nics
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3/private_nics/0611a4a0-e528-4ebf-8548-d635c01ca08a
         method: GET
       response:
         proto: HTTP/2.0
@@ -4816,22 +4816,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 478
+        content_length: 475
         uncompressed: false
-        body: '{"private_nics":[{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:41.910409+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        body: '{"private_nic":{"creation_date":"2025-02-12T16:24:29.671381+00:00","id":"0611a4a0-e528-4ebf-8548-d635c01ca08a","ipam_ip_ids":["142df25d-25e2-4f18-8561-3f3f877891d3","96302d29-79b9-413b-a5bd-2d7c269891d9"],"mac_address":"02:00:00:1c:b1:e9","modification_date":"2025-02-12T16:25:01.593495+00:00","private_network_id":"a100296c-6bde-43ca-bd37-960b05298469","server_id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","state":"available","tags":[],"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "478"
+                - "475"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:16:03 GMT
-            Link:
-                - </servers/c972b90c-98ce-4fe4-ac18-b4e841110616/private_nics?page=1&per_page=50&>; rel="last"
+                - Wed, 12 Feb 2025 16:25:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4839,12 +4837,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ccdbfb4c-c3af-486a-b508-86553d4d0184
-            X-Total-Count:
-                - "1"
+                - def1c795-7fe8-46cc-b2f8-46f05726df6b
         status: 200 OK
         code: 200
-        duration: 89.933625ms
+        duration: 107.445833ms
     - id: 98
       request:
         proto: HTTP/1.1
@@ -4861,28 +4857,26 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/private_nics/f779056f-b24a-422b-98f1-e1e6b57219de
-        method: GET
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3/private_nics/0611a4a0-e528-4ebf-8548-d635c01ca08a
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 475
+        content_length: 0
         uncompressed: false
-        body: '{"private_nic":{"creation_date":"2025-02-12T16:15:10.131048+00:00","id":"f779056f-b24a-422b-98f1-e1e6b57219de","ipam_ip_ids":["f83046a2-cd8c-43f7-9a11-55faf283cc0b","04910273-19f7-4f06-82ea-78a23caa0c7f"],"mac_address":"02:00:00:19:57:16","modification_date":"2025-02-12T16:15:41.910409+00:00","private_network_id":"cf70fcfd-2aae-4a49-a49d-e4cfd7598043","server_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","state":"available","tags":[],"zone":"fr-par-1"}}'
+        body: ""
         headers:
-            Content-Length:
-                - "475"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:16:03 GMT
+                - Wed, 12 Feb 2025 16:25:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4890,10 +4884,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 89a25508-736f-4221-b866-6f4d75d051c7
-        status: 200 OK
-        code: 200
-        duration: 98.2995ms
+                - e9d43ef7-bdf2-4eed-ad5f-4dd4df3a8753
+        status: 204 No Content
+        code: 204
+        duration: 358.0455ms
     - id: 99
       request:
         proto: HTTP/1.1
@@ -4910,26 +4904,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/private_nics/f779056f-b24a-422b-98f1-e1e6b57219de
-        method: DELETE
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3/private_nics/0611a4a0-e528-4ebf-8548-d635c01ca08a
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 148
         uncompressed: false
-        body: ""
+        body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"0611a4a0-e528-4ebf-8548-d635c01ca08a","type":"not_found"}'
         headers:
+            Content-Length:
+                - "148"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:16:04 GMT
+                - Wed, 12 Feb 2025 16:25:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4937,10 +4933,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 517b251a-42c6-4d3b-8773-22cd48b975de
-        status: 204 No Content
-        code: 204
-        duration: 325.796291ms
+                - f7bdddd2-3e89-4a58-be39-84c1174a7ac1
+        status: 404 Not Found
+        code: 404
+        duration: 97.521375ms
     - id: 100
       request:
         proto: HTTP/1.1
@@ -4957,7 +4953,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616/private_nics/f779056f-b24a-422b-98f1-e1e6b57219de
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3
         method: GET
       response:
         proto: HTTP/2.0
@@ -4965,20 +4961,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 148
+        content_length: 1655
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"f779056f-b24a-422b-98f1-e1e6b57219de","type":"not_found"}'
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:24:16.951639+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c8:69","maintenances":[],"modification_date":"2025-02-12T16:25:26.495408+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"811d24a7-f24f-48ca-a17a-8f6f1d80acf2","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
         headers:
             Content-Length:
-                - "148"
+                - "1655"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:16:04 GMT
+                - Wed, 12 Feb 2025 16:25:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -4986,10 +4982,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7928ce7b-26a7-499f-ad10-80285a0a6c72
-        status: 404 Not Found
-        code: 404
-        duration: 115.330084ms
+                - 206286a7-b1ce-4700-af1c-6a8509cd1ef2
+        status: 200 OK
+        code: 200
+        duration: 236.933208ms
     - id: 101
       request:
         proto: HTTP/1.1
@@ -5006,28 +5002,26 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616
-        method: GET
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1655
+        content_length: 0
         uncompressed: false
-        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":null,"commercial_type":"DEV1-S","creation_date":"2025-02-12T16:14:57.586614+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"c972b90c-98ce-4fe4-ac18-b4e841110616","image":{"arch":"x86_64","creation_date":"2024-10-07T11:32:23.548676+00:00","default_bootscript":null,"extra_volumes":{},"from_server":"","id":"a805381b-7ce6-425f-a108-96d9ee019135","modification_date":"2024-10-07T11:32:23.548676+00:00","name":"Debian Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"a50e6921-21b9-4a69-83cc-191359208d4c","name":"","size":0,"volume_type":"sbs_snapshot"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:93:c7:d9","maintenances":[],"modification_date":"2025-02-12T16:16:02.414891+00:00","name":"Scaleway Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"id":"69319b62-c889-49b4-bf5f-89a64c7a530c","volume_type":"sbs_volume","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        body: ""
         headers:
-            Content-Length:
-                - "1655"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:16:04 GMT
+                - Wed, 12 Feb 2025 16:25:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5035,10 +5029,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 62e202b8-c9b8-4a9b-9cf8-a59fcad6e597
-        status: 200 OK
-        code: 200
-        duration: 174.928208ms
+                - 707542ec-35c7-40ff-bbf6-b1dd4218d56b
+        status: 204 No Content
+        code: 204
+        duration: 516.336625ms
     - id: 102
       request:
         proto: HTTP/1.1
@@ -5055,26 +5049,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616
-        method: DELETE
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/23a1d963-1b47-45ca-8aeb-834d8d97d4f3
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 143
         uncompressed: false
-        body: ""
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"23a1d963-1b47-45ca-8aeb-834d8d97d4f3","type":"not_found"}'
         headers:
+            Content-Length:
+                - "143"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:16:04 GMT
+                - Wed, 12 Feb 2025 16:25:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5082,10 +5078,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fff0d517-31b6-47af-8f6e-45c00eebae01
-        status: 204 No Content
-        code: 204
-        duration: 289.839166ms
+                - a47c86f7-c082-4e91-809c-c1f748881742
+        status: 404 Not Found
+        code: 404
+        duration: 118.749125ms
     - id: 103
       request:
         proto: HTTP/1.1
@@ -5102,7 +5098,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c972b90c-98ce-4fe4-ac18-b4e841110616
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/811d24a7-f24f-48ca-a17a-8f6f1d80acf2
         method: GET
       response:
         proto: HTTP/2.0
@@ -5112,7 +5108,7 @@ interactions:
         trailer: {}
         content_length: 143
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"c972b90c-98ce-4fe4-ac18-b4e841110616","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"811d24a7-f24f-48ca-a17a-8f6f1d80acf2","type":"not_found"}'
         headers:
             Content-Length:
                 - "143"
@@ -5121,9 +5117,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:16:04 GMT
+                - Wed, 12 Feb 2025 16:25:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5131,10 +5127,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 687bd91f-0c76-4086-8b8d-9c4b6d4dbe25
+                - c28ae44a-503a-4034-adb7-2cae56cbb81e
         status: 404 Not Found
         code: 404
-        duration: 141.89675ms
+        duration: 77.401416ms
     - id: 104
       request:
         proto: HTTP/1.1
@@ -5151,7 +5147,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/69319b62-c889-49b4-bf5f-89a64c7a530c
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/811d24a7-f24f-48ca-a17a-8f6f1d80acf2
         method: GET
       response:
         proto: HTTP/2.0
@@ -5159,20 +5155,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 143
+        content_length: 485
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"69319b62-c889-49b4-bf5f-89a64c7a530c","type":"not_found"}'
+        body: '{"created_at":"2025-02-12T16:24:17.161631Z","id":"811d24a7-f24f-48ca-a17a-8f6f1d80acf2","last_detached_at":"2025-02-12T16:25:28.241342Z","name":"Debian Bullseye_sbs_volume_0","parent_snapshot_id":"a50e6921-21b9-4a69-83cc-191359208d4c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:25:28.241342Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "143"
+                - "485"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:16:04 GMT
+                - Wed, 12 Feb 2025 16:25:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5180,10 +5176,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 97a96ef9-3d6b-4faa-8f91-d88dfa77025a
-        status: 404 Not Found
-        code: 404
-        duration: 50.820917ms
+                - ae52ce7c-1da6-4f64-8d11-10f0bfdfafaa
+        status: 200 OK
+        code: 200
+        duration: 91.387334ms
     - id: 105
       request:
         proto: HTTP/1.1
@@ -5200,28 +5196,26 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/69319b62-c889-49b4-bf5f-89a64c7a530c
-        method: GET
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/811d24a7-f24f-48ca-a17a-8f6f1d80acf2
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 485
+        content_length: 0
         uncompressed: false
-        body: '{"created_at":"2025-02-12T16:14:57.789341Z","id":"69319b62-c889-49b4-bf5f-89a64c7a530c","last_detached_at":"2025-02-12T16:16:04.893698Z","name":"Debian Bullseye_sbs_volume_0","parent_snapshot_id":"a50e6921-21b9-4a69-83cc-191359208d4c","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2025-02-12T16:16:04.893698Z","zone":"fr-par-1"}'
+        body: ""
         headers:
-            Content-Length:
-                - "485"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:16:05 GMT
+                - Wed, 12 Feb 2025 16:25:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5229,10 +5223,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bc9c1fb5-ea6e-4dc9-9f28-7cb7728addd3
-        status: 200 OK
-        code: 200
-        duration: 90.009417ms
+                - a6887180-6e5d-486e-a376-3af6f0630639
+        status: 204 No Content
+        code: 204
+        duration: 153.342834ms
     - id: 106
       request:
         proto: HTTP/1.1
@@ -5249,7 +5243,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/69319b62-c889-49b4-bf5f-89a64c7a530c
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a100296c-6bde-43ca-bd37-960b05298469
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5266,9 +5260,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 12 Feb 2025 16:16:05 GMT
+                - Wed, 12 Feb 2025 16:25:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -5276,54 +5270,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5cd9fded-442a-4554-90f1-270e60ec670e
+                - 5689ac30-11f3-4e02-9d08-8570e7d666b8
         status: 204 No Content
         code: 204
-        duration: 138.849458ms
-    - id: 107
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.5; darwin; arm64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/cf70fcfd-2aae-4a49-a49d-e4cfd7598043
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 12 Feb 2025 16:16:06 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 9e091df9-eed7-40fa-9b93-c51108de4f4b
-        status: 204 No Content
-        code: 204
-        duration: 1.243151125s
+        duration: 1.1948145s


### PR DESCRIPTION
l_ssd servers are planned to disappear with the arrival of high perfomance block.
Before, if `l_ssd` was available for requested commercial type, it would be picked as default root volume type.
We now always take SBS as a default.